### PR TITLE
fix(dapi): caching of headers prone to reorgs

### DIFF
--- a/packages/dapi/test/integration/grpcServer/handlers/blockheaders-stream/subscribeToNewBlockHeaders.spec.js
+++ b/packages/dapi/test/integration/grpcServer/handlers/blockheaders-stream/subscribeToNewBlockHeaders.spec.js
@@ -31,6 +31,8 @@ describe('subscribeToNewBlockHeaders', () => {
       blockHash: Buffer.from('fakeHash'),
     });
 
+    this.sinon.stub(dashCoreRpcClient, 'getBestBlockHeight').resolves(100);
+
     zmqClient = new ZmqClient();
 
     blockHeadersCache = new BlockHeadersCache();

--- a/packages/dapi/test/integration/grpcServer/handlers/blockheaders-stream/subscribeToNewBlockHeaders.spec.js
+++ b/packages/dapi/test/integration/grpcServer/handlers/blockheaders-stream/subscribeToNewBlockHeaders.spec.js
@@ -331,4 +331,23 @@ describe('subscribeToNewBlockHeaders', () => {
 
     expect(dashCoreRpcClient.getBlockHeader.callCount).to.be.equal(0);
   });
+
+  it('should update chain height on new block', async () => {
+    subscribeToNewBlockHeaders(
+      mediator,
+      chainDataProvider,
+    );
+
+    const hashes = Object.keys(blockHeaders);
+
+    const newChainHeight = 105;
+    dashCoreRpcClient.getBestBlockHeight.resolves(newChainHeight);
+
+    zmqClient.subscriberSocket
+      .emit('message', zmqClient.topics.hashblock, Buffer.from(hashes[0], 'hex'));
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(chainDataProvider.chainHeight).to.equal(newChainHeight);
+  });
 });

--- a/packages/dapi/test/unit/chainDataProvider/chainDataProvider.spec.js
+++ b/packages/dapi/test/unit/chainDataProvider/chainDataProvider.spec.js
@@ -8,7 +8,7 @@ const headers = [
     prevHash: '00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c',
     merkleRoot: 'b4fd581bc4bfe51a5a66d8b823bd6ee2b492f0ddc44cf7e820550714cedc117f',
     time: 1398712771,
-    bits: '1e0fffff',
+    bits: 504365055,
     nonce: 31475,
   },
   {
@@ -17,7 +17,7 @@ const headers = [
     merkleRoot: '0d6d332e68eb8ecc66a5baaa95dc4b10c0b32841aed57dc99a5ae0b2f9e4294d',
     time: 1398712772,
     nonce: 6523,
-    bits: '1e0ffff0',
+    bits: 504365055,
   },
   {
     version: 2,
@@ -25,7 +25,7 @@ const headers = [
     merkleRoot: '1cc711129405a328c58d1948e748c3b8f3d610e66d9901db88c42c5247829658',
     time: 1398712774,
     nonce: 53194,
-    bits: '1e0ffff0',
+    bits: 504365055,
   },
   {
     version: 2,
@@ -33,7 +33,7 @@ const headers = [
     merkleRoot: '7e6b1b1457308bf6ccb1e325c64607ba7dfac05e26c08887cd28f97d4d4ab3e2',
     time: 1398712782,
     nonce: 193159,
-    bits: '1e0ffff0',
+    bits: 504365055,
   },
   {
     version: 2,
@@ -41,7 +41,7 @@ const headers = [
     merkleRoot: '4cf4f3b788e8dc847a9e0ff3b279340207c555a6bc0736f93e95dbdc2e3c2f16',
     time: 1398712784,
     nonce: 41103,
-    bits: '1e0ffff0',
+    bits: 504365055,
   }];
 
 describe('ChainDataProvider', () => {
@@ -180,19 +180,27 @@ describe('ChainDataProvider', () => {
       fifth.toString()]);
 
     // should use cache and does not hit rpc
-    blockHeadersCache.set(1, first);
-    blockHeadersCache.set(2, second);
-    blockHeadersCache.set(3, third);
-    blockHeadersCache.set(4, undefined);
-    blockHeadersCache.set(5, undefined);
+    blockHeadersCache.set(10, first);
+    blockHeadersCache.set(11, second);
+    blockHeadersCache.set(12, third);
+    blockHeadersCache.set(13, undefined);
+    blockHeadersCache.set(14, undefined);
     cacheSpy.set.resetHistory();
 
-    await chainDataProvider.getBlockHeaders(first.hash, 1, 5);
+    await chainDataProvider.getBlockHeaders(first.hash, 10, 5);
 
     expect(coreAPIMock.getBlockHeaders).to.be.calledOnceWithExactly(third.hash, 3);
 
     expect(cacheSpy.get.callCount).to.be.equal(5);
     expect(cacheSpy.set.callCount).to.be.equal(3);
+
+    const expectedHeaders = [third, fourth, fifth];
+    const expectedStartHeight = 12;
+    for (let i = 0; i < 3; i++) {
+      expect(cacheSpy.set.getCall(i).args[0]).to.equal(expectedStartHeight + i);
+      expect(cacheSpy.set.getCall(i).args[1].toString())
+        .to.equal(expectedHeaders[i].toString());
+    }
 
     expect(cacheSpy.get.getCall(0).returnValue.toString()).to.deep.equal(first.toString());
     expect(cacheSpy.get.getCall(1).returnValue.toString()).to.deep.equal(second.toString());
@@ -222,6 +230,14 @@ describe('ChainDataProvider', () => {
 
     expect(cacheSpy.get.callCount).to.be.equal(5);
     expect(cacheSpy.set.callCount).to.be.equal(4);
+
+    const expectedHeaders = [second, third, fourth, fifth];
+    const expectedStartHeight = 2;
+    for (let i = 0; i < 3; i++) {
+      expect(cacheSpy.set.getCall(i).args[0]).to.equal(expectedStartHeight + i);
+      expect(cacheSpy.set.getCall(i).args[1].toString())
+        .to.equal(expectedHeaders[i].toString());
+    }
 
     expect(cacheSpy.get.getCall(0).returnValue.toString()).to.deep.equal(first.toString());
     expect(cacheSpy.get.getCall(1).returnValue.toString()).to.deep.equal(second.toString());
@@ -253,6 +269,14 @@ describe('ChainDataProvider', () => {
     expect(cacheSpy.get.callCount).to.be.equal(5);
     expect(cacheSpy.set.callCount).to.be.equal(5);
 
+    const expectedHeaders = fakeHeaders;
+    const expectedStartHeight = 1;
+    for (let i = 0; i < 3; i++) {
+      expect(cacheSpy.set.getCall(i).args[0]).to.equal(expectedStartHeight + i);
+      expect(cacheSpy.set.getCall(i).args[1].toString())
+        .to.equal(expectedHeaders[i].toString());
+    }
+
     expect(cacheSpy.get.getCall(0).returnValue).to.deep.equal(undefined);
     expect(cacheSpy.get.getCall(1).returnValue).to.deep.equal(undefined);
     expect(cacheSpy.get.getCall(2).returnValue.toString()).to.deep.equal(third.toString());
@@ -283,5 +307,13 @@ describe('ChainDataProvider', () => {
 
     expect(cacheSpy.get.callCount).to.be.equal(5);
     expect(cacheSpy.set.callCount).to.be.equal(5);
+
+    const expectedHeaders = fakeHeaders;
+    const expectedStartHeight = 1;
+    for (let i = 0; i < 3; i++) {
+      expect(cacheSpy.set.getCall(i).args[0]).to.equal(expectedStartHeight + i);
+      expect(cacheSpy.set.getCall(i).args[1].toString())
+        .to.equal(expectedHeaders[i].toString());
+    }
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The fix makes dapi to cache only chainlocked headers, or in the absence of the chainlock, headers with height less than current chain height - 6

## What was done?
<!--- Describe your changes in detail -->
- Fixed bug with wrong header heights assigned to cached items
- Tweaked cache logic to save only headers behind certain height (chain locked or latest chain height - 6)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Manual tests with block headers sync worker on wallet 


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
