### PR TITLE
fix(dapi): `getConsensusParamsHandler` was handling wrong Tendermint error

### DIFF
--- a/packages/dapi/lib/grpcServer/handlers/platform/getConsensusParamsHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/getConsensusParamsHandlerFactory.js
@@ -49,7 +49,7 @@ function getConsensusParamsHandlerFactory(getConsensusParams) {
       consensusParams = await getConsensusParams(height);
     } catch (e) {
       if (e instanceof RPCError) {
-        if (e.code === 32603) {
+        if (e.code === -32603) {
           throw new FailedPreconditionGrpcError(`Invalid height: ${e.data}`);
         }
 

--- a/packages/dapi/test/unit/grpcServer/handlers/platform/getConsensusParamsHandlerFactory.spec.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/platform/getConsensusParamsHandlerFactory.spec.js
@@ -80,7 +80,7 @@ describe('getConsensusParamsHandlerFactory', () => {
   });
 
   it('should throw FailedPreconditionGrpcError', async () => {
-    const error = new RPCError(32603, 'invalid height', 'some data');
+    const error = new RPCError(-32603, 'invalid height', 'some data');
     getConsensusParamsMock.throws(error);
 
     try {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`getConsensusParamsHandler`  was handling error without a minus sign `32603` instead of `-32603`

## What was done?
<!--- Describe your changes in detail -->
- updated error code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
