### PR TITLE
fix(dapi): fail to reconnect to tenderdash in case of ENOTFOUND

### DIFF
--- a/packages/dapi/lib/externalApis/tenderdash/WsClient.js
+++ b/packages/dapi/lib/externalApis/tenderdash/WsClient.js
@@ -73,6 +73,9 @@ class WsClient extends EventEmitter {
 
     const onErrorListener = (e) => {
       switch (e.code) {
+        case 'ENOTFOUND':
+          reconnect();
+          break;
         case 'EAI_AGAIN':
           reconnect();
           break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DAPI exits in case Tanderdash is not running, instead of trying to reconnect

## What was done?
<!--- Describe your changes in detail -->
Fixed DAPI reconnect logic

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
