### PR TITLE
chore: update protoc builder to upstream image

### DIFF
--- a/packages/dapi-grpc/scripts/build.sh
+++ b/packages/dapi-grpc/scripts/build.sh
@@ -18,7 +18,7 @@ PLATFORM_OBJ_C_OUT_PATH="$PLATFORM_CLIENTS_PATH/objective-c"
 CORE_PYTHON_OUT_PATH="$CORE_CLIENTS_PATH/python"
 PLATFORM_PYTHON_OUT_PATH="$PLATFORM_CLIENTS_PATH/python"
 
-PROTOC_IMAGE="strophy/protoc:4.0.0"
+PROTOC_IMAGE="rvolosatovs/protoc:4.0.0"
 
 #################################################
 # Generate JavaScript client for `Core` service #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have been using a custom `protoc` builder image in order to enable `arm64` and `protoc-ts-gen` support. Support for these features has now been added to a stable release upstream, so we should go back to using that. 

## What was done?
<!--- Describe your changes in detail -->
Update protoc image to `rvolosatovs/protoc`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
