### PR TITLE
feat(drive): skip process proposal if prepare proposal is already called

### DIFF
--- a/packages/js-drive/lib/abci/handlers/prepareProposalHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/prepareProposalHandlerFactory.js
@@ -145,6 +145,15 @@ function prepareProposalHandlerFactory(
       + ` (valid txs = ${validTxCount}, invalid txs = ${invalidTxCount})`,
     );
 
+    proposalBlockExecutionContext.setPrepareProposalResult({
+      appHash,
+      txResults,
+      consensusParamUpdates,
+      validatorSetUpdate,
+      coreChainLockUpdate,
+      txRecords,
+    });
+
     return new ResponsePrepareProposal({
       appHash,
       txResults,

--- a/packages/js-drive/lib/abci/handlers/processProposalHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/processProposalHandlerFactory.js
@@ -60,6 +60,29 @@ function processProposalHandlerFactory(
     consensusLogger.debug('ProcessProposal ABCI method requested');
     consensusLogger.trace({ abciRequest: request });
 
+    if (proposalBlockExecutionContext.getHeight()
+      && proposalBlockExecutionContext.getHeight().toNumber() === height.toNumber()
+      && proposalBlockExecutionContext.getRound() === round) {
+      consensusLogger.debug('Returning cached result');
+
+      const prepareProposalResult = proposalBlockExecutionContext.getPrepareProposalResult();
+
+      const {
+        appHash,
+        txResults,
+        consensusParamUpdates,
+        validatorSetUpdate,
+      } = prepareProposalResult;
+
+      return new ResponseProcessProposal({
+        status: proposalStatus.ACCEPT,
+        appHash,
+        txResults,
+        consensusParamUpdates,
+        validatorSetUpdate,
+      });
+    }
+
     if (coreChainLockUpdate) {
       const chainLockIsValid = await verifyChainLock(coreChainLockUpdate);
 

--- a/packages/js-drive/lib/blockExecution/BlockExecutionContext.js
+++ b/packages/js-drive/lib/blockExecution/BlockExecutionContext.js
@@ -220,6 +220,28 @@ class BlockExecutionContext {
   }
 
   /**
+   * Set PrepareProposal Result
+   *
+   * @param {Object} prepareProposalResult
+   *
+   * @returns {BlockExecutionContext}
+   */
+  setPrepareProposalResult(prepareProposalResult) {
+    this.prepareProposalResult = prepareProposalResult;
+
+    return this;
+  }
+
+  /**
+   * Get PrepareProposal Result
+   *
+   * @return {Object}
+   */
+  getPrepareProposalResult() {
+    return this.prepareProposalResult;
+  }
+
+  /**
    * Reset state
    */
   reset() {
@@ -234,6 +256,7 @@ class BlockExecutionContext {
     this.round = null;
     this.epochInfo = null;
     this.timeMs = null;
+    this.prepareProposalResult = null;
   }
 
   /**
@@ -257,11 +280,12 @@ class BlockExecutionContext {
     this.height = blockExecutionContext.height;
     this.coreChainLockedHeight = blockExecutionContext.coreChainLockedHeight;
     this.version = blockExecutionContext.version;
-    this.consensusLogger = blockExecutionContext.consensusLogger;
+    this.consensusLogger = blockExecutionContext.consensusLogger || null;
     this.withdrawalTransactionsMap = blockExecutionContext.withdrawalTransactionsMap;
     this.round = blockExecutionContext.round;
     this.epochInfo = blockExecutionContext.epochInfo;
     this.timeMs = blockExecutionContext.timeMs;
+    this.prepareProposalResult = blockExecutionContext.prepareProposalResult || null;
   }
 
   /**
@@ -281,11 +305,13 @@ class BlockExecutionContext {
     this.version = Consensus.fromObject(object.version);
     this.withdrawalTransactionsMap = object.withdrawalTransactionsMap;
     this.round = object.round;
+    this.prepareProposalResult = object.prepareProposalResult;
   }
 
   /**
    * @param {Object} options
    * @param {boolean} [options.skipConsensusLogger=false]
+   * @param {boolean} [options.skipPrepareProposalResult=false]
    * @return {{
    *  dataContracts: Object[],
    *  height: number,
@@ -320,6 +346,10 @@ class BlockExecutionContext {
 
     if (!options.skipConsensusLogger) {
       object.consensusLogger = this.consensusLogger;
+    }
+
+    if (!options.skipPrepareProposalResult) {
+      object.prepareProposalResult = this.prepareProposalResult;
     }
 
     return object;

--- a/packages/js-drive/lib/blockExecution/BlockExecutionContextRepository.js
+++ b/packages/js-drive/lib/blockExecution/BlockExecutionContextRepository.js
@@ -24,6 +24,7 @@ class BlockExecutionContextRepository {
       BlockExecutionContextRepository.EXTERNAL_STORE_KEY_NAME,
       await cbor.encodeAsync(blockExecutionContext.toObject({
         skipConsensusLogger: true,
+        skipPrepareProposalResult: true,
       })),
       options,
     );

--- a/packages/js-drive/lib/test/fixtures/getBlockExecutionContextObjectFixture.js
+++ b/packages/js-drive/lib/test/fixtures/getBlockExecutionContextObjectFixture.js
@@ -2,6 +2,10 @@ const {
   tendermint: {
     abci: {
       CommitInfo,
+      ValidatorSetUpdate,
+    },
+    types: {
+      ConsensusParams,
     },
   },
 } = require('@dashevo/abci/types');
@@ -60,6 +64,34 @@ function getBlockExecutionContextObjectFixture(dataContract = getDataContractFix
       [hash(txTwoBytes).toString('hex')]: txTwoBytes,
     },
     round: 42,
+    prepareProposalResult: {
+      appHash: Buffer.alloc(32, 3),
+      txResults: new Array(3).fill({ code: 0 }),
+      consensusParamUpdates: new ConsensusParams({
+        block: {
+          maxBytes: 1,
+          maxGas: 2,
+        },
+        evidence: {
+          maxAgeDuration: null,
+          maxAgeNumBlocks: 1,
+          maxBytes: 2,
+        },
+        version: {
+          appVersion: 1,
+        },
+      }),
+      validatorSetUpdate: new ValidatorSetUpdate(),
+      coreChainLockUpdate: {
+        coreBlockHeight: 42,
+        coreBlockHash: '1528e523f4c20fa84ba70dd96372d34e00ce260f357d53ad1a8bc892ebf20e2d',
+        signature: '1897ce8f54d2070f44ca5c29983b68b391e8137c25e44f67416e579f3e3bdfef7b4fd22db7818399147e52907998857b0fbc8edfdc40a64f2c7df0e88544d31d12ca8c15e73d50dda25ca23f754ed3f789ed4bcb392161995f464017c10df404',
+      },
+      txRecords: [{
+        tx: Buffer.alloc(5, 0),
+        action: 1,
+      }],
+    },
   };
 }
 

--- a/packages/js-drive/lib/test/mock/BlockExecutionContextMock.js
+++ b/packages/js-drive/lib/test/mock/BlockExecutionContextMock.js
@@ -55,6 +55,8 @@ class BlockExecutionContextMock {
     this.getTimeMs = sinon.stub();
     this.setRound = sinon.stub();
     this.getRound = sinon.stub();
+    this.getPrepareProposalResult = sinon.stub();
+    this.setPrepareProposalResult = sinon.stub();
   }
 }
 

--- a/packages/js-drive/test/integration/blockExecution/BlockExecutionContextRepository.spec.js
+++ b/packages/js-drive/test/integration/blockExecution/BlockExecutionContextRepository.spec.js
@@ -58,6 +58,7 @@ describe('BlockExecutionContextRepository', () => {
 
     expect(rawBlockExecutionContext).to.deep.equal(blockExecutionContext.toObject({
       skipConsensusLogger: true,
+      skipPrepareProposalResult: true,
     }));
   });
 
@@ -76,8 +77,10 @@ describe('BlockExecutionContextRepository', () => {
 
     expect(fetchedBlockExecutionContext.toObject({
       skipConsensusLogger: true,
+      skipPrepareProposalResult: true,
     })).to.deep.equal(blockExecutionContext.toObject({
       skipConsensusLogger: true,
+      skipPrepareProposalResult: true,
     }));
   });
 
@@ -100,8 +103,10 @@ describe('BlockExecutionContextRepository', () => {
 
     expect(fetchedBlockExecutionContext.toObject({
       skipConsensusLogger: true,
+      skipPrepareProposalResult: true,
     })).to.deep.equal(blockExecutionContext.toObject({
       skipConsensusLogger: true,
+      skipPrepareProposalResult: true,
     }));
   });
 });

--- a/packages/js-drive/test/unit/abci/handlers/prepareProposalHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/prepareProposalHandlerFactory.spec.js
@@ -30,7 +30,7 @@ describe('prepareProposalHandlerFactory', () => {
   let validatorSetUpdate;
   let coreChainLockUpdate;
   let endBlockResult;
-  let proposalBlockExecutionMock;
+  let proposalBlockExecutionContextMock;
   let round;
 
   beforeEach(function beforeEach() {
@@ -58,7 +58,7 @@ describe('prepareProposalHandlerFactory', () => {
     });
     validatorSetUpdate = new ValidatorSetUpdate();
 
-    proposalBlockExecutionMock = new BlockExecutionContextMock(this.sinon);
+    proposalBlockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
 
     loggerMock = new LoggerMock(this.sinon);
 
@@ -83,7 +83,7 @@ describe('prepareProposalHandlerFactory', () => {
     prepareProposalHandler = prepareProposalHandlerFactory(
       deliverTxMock,
       loggerMock,
-      proposalBlockExecutionMock,
+      proposalBlockExecutionContextMock,
       beginBlockMock,
       endBlockMock,
       updateCoreChainLockMock,
@@ -166,6 +166,15 @@ describe('prepareProposalHandlerFactory', () => {
       },
       loggerMock,
     );
+
+    expect(proposalBlockExecutionContextMock.setPrepareProposalResult).to.be.calledOnceWithExactly({
+      appHash,
+      txResults: new Array(3).fill({ code: 0 }),
+      consensusParamUpdates,
+      validatorSetUpdate,
+      coreChainLockUpdate,
+      txRecords,
+    });
   });
 
   it('should cut txs that are not fit into the size limit', async () => {

--- a/packages/js-drive/test/unit/abci/handlers/processProposalHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/processProposalHandlerFactory.spec.js
@@ -157,4 +157,35 @@ describe('processProposalHandlerFactory', () => {
     expect(result).to.be.an.instanceOf(ResponseProcessProposal);
     expect(result.status).to.equal(2);
   });
+
+  it('should return prepareProposalResult from execution context', async () => {
+    proposalBlockExecutionContextMock.getHeight.returns(request.height);
+    proposalBlockExecutionContextMock.getRound.returns(request.round);
+
+    proposalBlockExecutionContextMock.getPrepareProposalResult.returns({
+      appHash,
+      txResults: new Array(3).fill({ code: 0 }),
+      consensusParamUpdates,
+      validatorSetUpdate,
+    });
+
+    const result = await processProposalHandler(request);
+
+    expect(proposalBlockExecutionContextMock.getPrepareProposalResult).to.be.calledOnce();
+
+    expect(result).to.be.an.instanceOf(ResponseProcessProposal);
+    expect(result.status).to.equal(1);
+    expect(result.appHash).to.equal(appHash);
+    expect(result.txResults).to.be.deep.equal(new Array(3).fill({ code: 0 }));
+    expect(result.consensusParamUpdates).to.be.equal(consensusParamUpdates);
+    expect(result.validatorSetUpdate).to.be.equal(validatorSetUpdate);
+
+    expect(beginBlockMock).to.not.be.called();
+
+    expect(deliverTxMock).to.not.be.called();
+
+    expect(verifyChainLockMock).to.not.be.called();
+
+    expect(endBlockMock).to.not.be.called();
+  });
 });

--- a/packages/js-drive/test/unit/blockExecution/BlockExecutionContext.spec.js
+++ b/packages/js-drive/test/unit/blockExecution/BlockExecutionContext.spec.js
@@ -26,6 +26,7 @@ describe('BlockExecutionContext', () => {
   let version;
   let epochInfo;
   let timeMs;
+  let prepareProposalResult;
 
   beforeEach(() => {
     blockExecutionContext = new BlockExecutionContext();
@@ -42,6 +43,7 @@ describe('BlockExecutionContext', () => {
     version = Consensus.fromObject(plainObject.version);
     epochInfo = plainObject.epochInfo;
     timeMs = plainObject.timeMs;
+    prepareProposalResult = plainObject.prepareProposalResult;
   });
 
   describe('#addDataContract', () => {
@@ -224,6 +226,30 @@ describe('BlockExecutionContext', () => {
     });
   });
 
+  describe('#setPrepareProposalResult', () => {
+    it('should set PrepareProposal result', async () => {
+      const result = blockExecutionContext.setPrepareProposalResult(
+        plainObject.prepareProposalResult,
+      );
+
+      expect(result).to.equal(blockExecutionContext);
+
+      expect(blockExecutionContext.prepareProposalResult).to.deep.equal(
+        plainObject.prepareProposalResult,
+      );
+    });
+  });
+
+  describe('#getPrepareProposalResult', () => {
+    it('should get PrepareProposal result', async () => {
+      blockExecutionContext.prepareProposalResult = plainObject.prepareProposalResult;
+
+      expect(blockExecutionContext.getPrepareProposalResult()).to.deep.equal(
+        plainObject.prepareProposalResult,
+      );
+    });
+  });
+
   describe('#setTimeMs', () => {
     it('should set time', async () => {
       blockExecutionContext.setTimeMs(timeMs);
@@ -307,6 +333,7 @@ describe('BlockExecutionContext', () => {
       blockExecutionContext.timeMs = timeMs;
       blockExecutionContext.withdrawalTransactionsMap = plainObject.withdrawalTransactionsMap;
       blockExecutionContext.round = plainObject.round;
+      blockExecutionContext.prepareProposalResult = plainObject.prepareProposalResult;
 
       expect(blockExecutionContext.toObject()).to.deep.equal(plainObject);
     });
@@ -322,10 +349,30 @@ describe('BlockExecutionContext', () => {
       blockExecutionContext.round = plainObject.round;
       blockExecutionContext.epochInfo = epochInfo;
       blockExecutionContext.timeMs = timeMs;
+      blockExecutionContext.prepareProposalResult = prepareProposalResult;
 
       const result = blockExecutionContext.toObject({ skipConsensusLogger: true });
 
       delete plainObject.consensusLogger;
+
+      expect(result).to.deep.equal(plainObject);
+    });
+
+    it('should skipPrepareProposalResult if the option passed', () => {
+      blockExecutionContext.dataContracts = [dataContract];
+      blockExecutionContext.lastCommitInfo = lastCommitInfo;
+      blockExecutionContext.height = height;
+      blockExecutionContext.coreChainLockedHeight = coreChainLockedHeight;
+      blockExecutionContext.version = version;
+      blockExecutionContext.consensusLogger = logger;
+      blockExecutionContext.withdrawalTransactionsMap = plainObject.withdrawalTransactionsMap;
+      blockExecutionContext.round = plainObject.round;
+      blockExecutionContext.epochInfo = epochInfo;
+      blockExecutionContext.timeMs = timeMs;
+
+      const result = blockExecutionContext.toObject({ skipPrepareProposalResult: true });
+
+      delete plainObject.prepareProposalResult;
 
       expect(result).to.deep.equal(plainObject);
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Don't need to process transactions twice in case process proposal called after prepare proposal on the same node

## What was done?
<!--- Describe your changes in detail -->
Skip process proposal if prepare proposal is already called

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
