### PR TITLE
fix(drive): initChain handler is not idempotent

### DIFF
--- a/packages/js-drive/lib/abci/handlers/initChainHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/initChainHandlerFactory.js
@@ -99,10 +99,6 @@ function initChainHandlerFactory(
       'Synchronized masternode identities',
     );
 
-    await groveDBStore.commitTransaction();
-
-    const appHash = await groveDBStore.getRootHash();
-
     // Set initial validator set
 
     await validatorSet.initialize(initialCoreChainLockedHeight);
@@ -116,6 +112,10 @@ function initChainHandlerFactory(
       0,
       consensusLogger,
     );
+
+    const appHash = await groveDBStore.getRootHash({ useTransaction: true });
+
+    await groveDBStore.commitTransaction();
 
     consensusLogger.trace(validatorSetUpdate, `Validator set initialized with ${quorumHash} quorum`);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If something goes wrong in initChain command, after groveDB commit, it breaks the whole node.

## What was done?
<!--- Describe your changes in detail -->
GroveDB commit command was replaced to the end of initChain function

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
