### PR TITLE
ci: increase cache-max-size

### DIFF
--- a/.github/workflows/all-packages.yml
+++ b/.github/workflows/all-packages.yml
@@ -159,7 +159,6 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
 
-      # Maybe adding some vars here can change the way we do mount cache?
       - name: Enable Rust cache
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/all-packages.yml
+++ b/.github/workflows/all-packages.yml
@@ -121,11 +121,11 @@ jobs:
             ${{ runner.os }}-buildkit-
 
       - name: Load buildkit state from cache
-        uses: dashevo/gh-action-cache-buildkit-state@v1
+        uses: dashevo/gh-action-cache-buildkit-state@skip-cachemount
         with:
           builder: buildx_buildkit_${{ steps.buildx.outputs.name }}0
           cache-path: /tmp/buildkit-cache
-          cache-max-size: 3g
+          cache-max-size: 6gb
 
       - name: Setup local network
         run: yarn configure

--- a/.github/workflows/all-packages.yml
+++ b/.github/workflows/all-packages.yml
@@ -159,6 +159,7 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
 
+      # Maybe adding some vars here can change the way we do mount cache?
       - name: Enable Rust cache
         uses: Swatinem/rust-cache@v2
 
@@ -199,11 +200,11 @@ jobs:
             ${{ runner.os }}-buildkit-
 
       - name: Load buildkit state from cache
-        uses: dashevo/gh-action-cache-buildkit-state@v1
+        uses: dashevo/gh-action-cache-buildkit-state@skip-cachemount
         with:
           builder: buildx_buildkit_${{ steps.buildx.outputs.name }}0
           cache-path: /tmp/buildkit-cache
-          cache-max-size: 3g
+          cache-max-size: 6gb
 
       - name: Setup local network
         run: yarn configure


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
CI builds were slow, even though cache mounts were apparently restored correctly

## What was done?
<!--- Describe your changes in detail -->
Both the syntax and threshold for the `cache-max-size` var were incorrect. Running a clean build on the `v0.24-dev` branch results in the following cache mounts:
```
ID:             kh4zvi2qo3wf0srh9jq6sfr2w
Created at:     2022-12-30 05:11:12.539157381 +0000 UTC
Mutable:        true
Reclaimable:    true
Shared:         false
Size:           3.748GB
Description:    cached mount /platform/target from exec /bin/sh -c yarn workspace @dashevo/rs-drive build
Usage count:    2
Last used:      21 seconds ago
Type:           exec.cachemount

ID:             myxa6zdsi3uqmjoq11xs0scct
Created at:     2022-12-30 05:11:12.804387549 +0000 UTC
Mutable:        true
Reclaimable:    true
Shared:         false
Size:           272.2MB
Description:    cached mount /usr/local/cargo/registry from exec /bin/sh -c yarn workspace @dashevo/rs-drive build
Usage count:    2
Last used:      21 seconds ago
Type:           exec.cachemount

ID:             i0dkk7jjv97b1dxmlhi3duoot
Created at:     2022-12-30 05:11:12.684470718 +0000 UTC
Mutable:        true
Reclaimable:    true
Shared:         false
Size:           45.4MB
Description:    cached mount /usr/local/cargo/git from exec /bin/sh -c yarn workspace @dashevo/rs-drive build
Usage count:    2
Last used:      21 seconds ago
Type:           exec.cachemount
```

While the ~3.8GB cache mount was correctly created each run, it was not correctly processed by `dashevo/gh-action-cache-buildkit-state` due to the size difference and some weird behaviour in the `docker buildx prune` command. As a result, it was incorrectly pruned before pushing cache in most runs, when the CI runs `docker buildx prune --force --filter type=exec.cachemount --keep-storage ${core.getInput('cache-max-size')}`:


```
stdout:
ID						RECLAIMABLE	SIZE		LAST ACCESSED
o4nrttsjtiunwn92g3r7dupxz*              	true 		49.46MB   	7 minutes ago
w44c9p4o4cgdfpk9pvhcz73rn*              	true 	3.757GB   	7 minutes ago
Total:	3.806GB
```


I'm not sure if this will give use the full speedup we expect, but it should make a difference. We'll avoid evicting cache for now and see if the size grows before switching back to the main branch of the action.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `strophy/platform`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
