### PR TITLE
chore: use core 18.2.0 on testnet

### DIFF
--- a/packages/dashmate/configs/system/testnet.js
+++ b/packages/dashmate/configs/system/testnet.js
@@ -16,6 +16,9 @@ module.exports = lodashMerge({}, baseConfig, {
     },
   },
   core: {
+    docker: {
+      image: 'dashpay/dashd:18.2.0',
+    },
     p2p: {
       port: 19999,
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to use core 18.2.0 to sync to the right chain on testnet

## What was done?
<!--- Describe your changes in detail -->
Add testnet override, because 18.2.0 shouldn't be used on any other networks

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a VPS

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
