### PR TITLE
fix commenting

### DIFF
--- a/packages/rs-drive/src/common/helpers/setup.rs
+++ b/packages/rs-drive/src/common/helpers/setup.rs
@@ -51,7 +51,7 @@ impl Default for SetupFeePoolsOptions {
     }
 }
 
-/// Sets up Drive using the optionally given Drive configuration settings.
+/// Sets up Drive using a temporary directory and the optionally given Drive configuration settings.
 pub fn setup_drive(drive_config: Option<DriveConfig>) -> Drive {
     let tmp_dir = TempDir::new().unwrap();
     let drive: Drive = Drive::open(tmp_dir, drive_config).expect("should open Drive successfully");
@@ -59,7 +59,7 @@ pub fn setup_drive(drive_config: Option<DriveConfig>) -> Drive {
     drive
 }
 
-/// Sets up Drive with the initial state structure.
+/// Sets up Drive using a temporary directory and the default initial state structure.
 pub fn setup_drive_with_initial_state_structure() -> Drive {
     let drive = setup_drive(Some(DriveConfig {
         batching_consistency_verification: true,


### PR DESCRIPTION
setup_drive() comment didn't specify that it sets up a temporary directory

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
