### PR TITLE
fix(dashmate): make dashmate helper run commands as host user

### DIFF
--- a/packages/dashmate/Dockerfile
+++ b/packages/dashmate/Dockerfile
@@ -63,3 +63,5 @@ LABEL description="Dashmate Helper Node.JS"
 WORKDIR /platform
 
 COPY --from=builder /platform /platform
+
+ENTRYPOINT ["/platform/packages/dashmate/docker/entrypoint.sh"]

--- a/packages/dashmate/configs/migrations.js
+++ b/packages/dashmate/configs/migrations.js
@@ -422,6 +422,8 @@ module.exports = {
     Object.entries(configFile.configs)
       .forEach(([, config]) => {
         if (config.platform) {
+          delete config.platform.dapi.envoy.grpc;
+
           if (config.group === 'local') {
             config.platform.drive.tenderdash.moniker = config.name;
           } else {

--- a/packages/dashmate/docker-compose.platform.yml
+++ b/packages/dashmate/docker-compose.platform.yml
@@ -115,9 +115,12 @@ services:
   dashmate_helper:
     image: ${DASHMATE_HELPER_DOCKER_IMAGE:?err}
     restart: unless-stopped
+    environment:
+      - DASHMATE_HOME_DIR=/home/dashmate/.dashmate
+    user: ${DASHMATE_USER:?err}
     command: yarn workspace dashmate helper ${CONFIG_NAME:?err}
     volumes:
-      - ${DASHMATE_HOME_DIR:?err}:/root/.dashmate
+      - ${DASHMATE_HOME_DIR:?err}:/home/dashmate/.dashmate
       - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:

--- a/packages/dashmate/docker-compose.platform.yml
+++ b/packages/dashmate/docker-compose.platform.yml
@@ -113,11 +113,12 @@ services:
     stop_grace_period: 10s
 
   dashmate_helper:
-    image: ${DASHMATE_HELPER_DOCKER_IMAGE:?err}
+    image: pshenmic/dashmate_helper
     restart: unless-stopped
     environment:
       - DASHMATE_HOME_DIR=/home/dashmate/.dashmate
-    user: ${DASHMATE_USER:?err}
+      - LOCAL_UID=${LOCAL_UID:?err}
+      - LOCAL_GID=${LOCAL_GID:?err}
     command: yarn workspace dashmate helper ${CONFIG_NAME:?err}
     volumes:
       - ${DASHMATE_HOME_DIR:?err}:/home/dashmate/.dashmate

--- a/packages/dashmate/docker-compose.platform.yml
+++ b/packages/dashmate/docker-compose.platform.yml
@@ -113,7 +113,7 @@ services:
     stop_grace_period: 10s
 
   dashmate_helper:
-    image: pshenmic/dashmate_helper
+    image: ${DASHMATE_HELPER_DOCKER_IMAGE:?err}
     restart: unless-stopped
     environment:
       - DASHMATE_HOME_DIR=/home/dashmate/.dashmate

--- a/packages/dashmate/docker/entrypoint.sh
+++ b/packages/dashmate/docker/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+USER_ID=${LOCAL_UID:?err}
+GROUP_ID=${LOCAL_GID:?err}
+DOCKER_GROUP_ID=$(stat -c %g /var/run/docker.sock)
+USERNAME=dashmate
+GROUP=docker
+
+# check if user with our uid exists in the system
+if [ ! $(getent passwd $USER_ID | grep $USER_ID -q) ]; then
+  echo "Creating user $USERNAME ($USER_ID)"
+  adduser -u $USER_ID -D -H $USERNAME
+else
+  USERNAME=$(getent passwd $USER_ID | cut -d: -f1)
+  echo "User exist: $USERNAME $USER_ID"
+fi
+
+# check if docker group exists in the container
+if [ -z $(getent group $DOCKER_GROUP_ID) ] ; then
+  echo "Creating group $DOCKER_GROUP_ID $GROUP"
+  addgroup -g $DOCKER_GROUP_ID $GROUP
+else
+  GROUP=$(getent group $DOCKER_GROUP_ID | cut -d: -f1)
+  echo "Group exist: $GROUP $DOCKER_GROUP_ID"
+fi
+
+# check if our user belongs to docker group
+if [ ! $(id -nG $USERNAME | grep -q $GROUP) ]; then
+  echo "Adding $USERNAME to group $GROUP"
+  adduser $USERNAME $GROUP
+fi
+
+echo "Starting with: USERNAME: $USERNAME, UID: $USER_ID, GID: $GROUP_ID, USER: $USERNAME, GROUP: $GROUP"
+
+su $USERNAME
+
+exec "$@"

--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -8,6 +8,7 @@ const dockerCompose = require('@dashevo/docker-compose');
 
 const hasbin = require('hasbin');
 const semver = require('semver');
+const { statSync } = require('fs')
 
 const DockerComposeError = require('./errors/DockerComposeError');
 const ServiceAlreadyRunningError = require('./errors/ServiceAlreadyRunningError');
@@ -398,7 +399,8 @@ class DockerCompose {
    * @return {{cwd: string, env: Object}}
    */
   getOptions(envs) {
-    const {uid, gid} = os.userInfo();
+    const { uid } = os.userInfo();
+    const { gid } = statSync('/var/run/docker.sock');
 
     const env = {
       ...process.env,

--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const path = require('path');
 const { Observable } = require('rxjs');
 
@@ -397,10 +398,13 @@ class DockerCompose {
    * @return {{cwd: string, env: Object}}
    */
   getOptions(envs) {
+    const {uid, gid} = os.userInfo();
+
     const env = {
       ...process.env,
       ...envs,
       DASHMATE_HOME_DIR: HOME_DIR_PATH,
+      DASHMATE_USER: `${uid}:${gid}`
     };
 
     if (isWsl) {

--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -8,7 +8,6 @@ const dockerCompose = require('@dashevo/docker-compose');
 
 const hasbin = require('hasbin');
 const semver = require('semver');
-const { statSync } = require('fs')
 
 const DockerComposeError = require('./errors/DockerComposeError');
 const ServiceAlreadyRunningError = require('./errors/ServiceAlreadyRunningError');

--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -399,14 +399,14 @@ class DockerCompose {
    * @return {{cwd: string, env: Object}}
    */
   getOptions(envs) {
-    const { uid } = os.userInfo();
-    const { gid } = statSync('/var/run/docker.sock');
+    const { uid, gid } = os.userInfo();
 
     const env = {
       ...process.env,
       ...envs,
       DASHMATE_HOME_DIR: HOME_DIR_PATH,
-      DASHMATE_USER: `${uid}:${gid}`
+      LOCAL_UID: uid,
+      LOCAL_GID: gid,
     };
 
     if (isWsl) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
dashmate-helper container is being run as root user, and when you try to execute commands from inside the container, it re-renders the configuration with the `root:root` owner. This PR passes host user and group ids for dashmate-helper container

## What was done?
<!--- Describe your changes in detail -->
Made dashmate grab the current executing user uid and gid and pass it to the docker compose, allowing to execute docker commands inside container without any issues

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On the devnet via dash-network-deploy tool

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
