### PR TITLE
feat(rs-dpp): validate indices are backwards compatible backport

### DIFF
--- a/packages/js-dpp/test/unit/dataContract/stateTransition/DataContractUpdateTransition/validation/basic/validateIndicesAreBackwardCompatible.spec.js
+++ b/packages/js-dpp/test/unit/dataContract/stateTransition/DataContractUpdateTransition/validation/basic/validateIndicesAreBackwardCompatible.spec.js
@@ -18,7 +18,7 @@ describe('validateIndicesAreBackwardCompatible', () => {
   });
 
   it('should return invalid result if some of unique indices have changed', async () => {
-    newDocumentsSchema.indexedDocument.indices[0].properties[0].lastName = 'asc';
+    newDocumentsSchema.indexedDocument.indices[0].properties[1].firstName = 'desc';
 
     const result = validateIndicesAreBackwardCompatible(oldDocumentsSchema, newDocumentsSchema);
 
@@ -31,7 +31,7 @@ describe('validateIndicesAreBackwardCompatible', () => {
   });
 
   it('should return invalid result if already defined properties are changed in existing index', async () => {
-    newDocumentsSchema.indexedDocument.indices[2].properties[0].otherName = 'asc';
+    newDocumentsSchema.indexedDocument.indices[2].properties[0].lastName = 'desc';
 
     const result = validateIndicesAreBackwardCompatible(oldDocumentsSchema, newDocumentsSchema);
 

--- a/packages/rs-dpp/src/data_contract/state_transition/data_contract_update_transition/validation/basic/validate_indices_are_backward_compatible.rs
+++ b/packages/rs-dpp/src/data_contract/state_transition/data_contract_update_transition/validation/basic/validate_indices_are_backward_compatible.rs
@@ -230,8 +230,22 @@ fn get_wrongly_updated_non_unique_index<'a>(
             for property in
                 new_index_definition.properties[index_definition.properties.len()..].iter()
             {
-                if existing_schema.get_value(&property.name).is_ok() {
-                    return Some(index_definition);
+                if let Some(indices) = existing_schema.get_value("indices").ok() {
+                    let indices_array = indices.as_array().expect("Indices must be an array");
+                    for index in indices_array {
+                        let properties_value = index
+                            .get_value("properties")
+                            .expect("Indices must have properties");
+                        let properties_array = properties_value
+                            .as_array()
+                            .expect("Properties must be an array");
+
+                        for property_to_check in properties_array {
+                            if property_to_check.get_value(&property.name).is_ok() {
+                                return Some(index_definition);
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/packages/rs-dpp/src/data_contract/state_transition/data_contract_update_transition/validation/basic/validate_indices_are_backward_compatible.rs
+++ b/packages/rs-dpp/src/data_contract/state_transition/data_contract_update_transition/validation/basic/validate_indices_are_backward_compatible.rs
@@ -230,15 +230,11 @@ fn get_wrongly_updated_non_unique_index<'a>(
             for property in
                 new_index_definition.properties[index_definition.properties.len()..].iter()
             {
-                if let Some(indices) = existing_schema.get_value("indices").ok() {
-                    let indices_array = indices.as_array().expect("Indices must be an array");
+                if let Ok(indices) = existing_schema.get_value("indices") {
+                    let indices_array = indices.as_array().unwrap();
                     for index in indices_array {
-                        let properties_value = index
-                            .get_value("properties")
-                            .expect("Indices must have properties");
-                        let properties_array = properties_value
-                            .as_array()
-                            .expect("Properties must be an array");
+                        let properties_value = index.get_value("properties").unwrap();
+                        let properties_array = properties_value.as_array().unwrap();
 
                         for property_to_check in properties_array {
                             if property_to_check.get_value(&property.name).is_ok() {

--- a/packages/rs-dpp/src/data_contract/state_transition/data_contract_update_transition/validation/basic/validate_indices_are_backward_compatible.rs
+++ b/packages/rs-dpp/src/data_contract/state_transition/data_contract_update_transition/validation/basic/validate_indices_are_backward_compatible.rs
@@ -75,7 +75,7 @@ pub fn validate_indices_are_backward_compatible<'a>(
             &existing_schema_indices,
             &name_new_index_map,
             existing_schema,
-        );
+        )?;
         if let Some(index) = maybe_wrongly_updated_index {
             result.add_error(BasicError::DataContractInvalidIndexDefinitionUpdateError {
                 document_type: document_type.to_owned(),
@@ -211,7 +211,7 @@ fn get_wrongly_updated_non_unique_index<'a>(
     existing_schema_indices: &'a [Index],
     new_indices: &'a BTreeMap<IndexName, Index>,
     existing_schema: &'a JsonSchema,
-) -> Option<&'a Index> {
+) -> Result<Option<&'a Index>, ProtocolError> {
     // Checking every existing non-unique index, and it's respective new index
     // if they are changed per spec
     for index_definition in existing_schema_indices.iter().filter(|i| !i.unique) {
@@ -223,7 +223,7 @@ fn get_wrongly_updated_non_unique_index<'a>(
             if new_index_definition.properties[0..index_properties_len]
                 != index_definition.properties
             {
-                return Some(index_definition);
+                return Ok(Some(index_definition));
             }
 
             // Check if the rest of new indexes are defined in the existing schema
@@ -231,14 +231,23 @@ fn get_wrongly_updated_non_unique_index<'a>(
                 new_index_definition.properties[index_definition.properties.len()..].iter()
             {
                 if let Ok(indices) = existing_schema.get_value("indices") {
-                    let indices_array = indices.as_array().unwrap();
+                    let indices_array = indices.as_array().ok_or_else(|| {
+                        ProtocolError::ParsingError(
+                            "Error parsing schema: indices is not an array".to_string(),
+                        )
+                    })?;
+
                     for index in indices_array {
-                        let properties_value = index.get_value("properties").unwrap();
-                        let properties_array = properties_value.as_array().unwrap();
+                        let properties_value = index.get_value("properties")?;
+                        let properties_array = properties_value.as_array().ok_or_else(|| {
+                            ProtocolError::ParsingError(
+                                "Error parsing schema: properties is not an array".to_string(),
+                            )
+                        })?;
 
                         for property_to_check in properties_array {
                             if property_to_check.get_value(&property.name).is_ok() {
-                                return Some(index_definition);
+                                return Ok(Some(index_definition));
                             }
                         }
                     }
@@ -246,7 +255,7 @@ fn get_wrongly_updated_non_unique_index<'a>(
             }
         }
     }
-    None
+    Ok(None)
 }
 
 #[cfg(test)]

--- a/packages/rs-dpp/src/tests/data_contract/state_transition/data_contract_update_transition/validation/basic/validate_indices_are_backward_compatible_spec.rs
+++ b/packages/rs-dpp/src/tests/data_contract/state_transition/data_contract_update_transition/validation/basic/validate_indices_are_backward_compatible_spec.rs
@@ -130,14 +130,15 @@ fn should_return_invalid_result_if_non_unique_index_update_failed_due_to_changed
 }
 
 #[test]
-fn should_return_invalid_result_if_non_unique_index_update_failed_due_old_properties_used() {
+fn should_return_invalid_result_if_already_indexed_properties_are_added_to_existing_index() {
     let TestData {
         old_documents_schema,
         mut new_documents_schema,
         ..
     } = setup_test();
-    new_documents_schema.get_mut("indexedDocument").unwrap()["indices"][2]["properties"][0] =
-        json!({ "firstName": "asc" });
+    new_documents_schema.get_mut("indexedDocument").unwrap()["indices"][2]["properties"]
+        .push(json!({ "firstName": "asc" }))
+        .expect("the new index property should be added");
 
     let result = validate_indices_are_backward_compatible(
         old_documents_schema.iter(),

--- a/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractUpdateTransition/validation/basic/validateIndicesAreBackwardCompatible.spec.js
+++ b/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractUpdateTransition/validation/basic/validateIndicesAreBackwardCompatible.spec.js
@@ -23,31 +23,13 @@ describe('validateIndicesAreBackwardCompatible', () => {
     const oldDataContract = getDataContractFixture();
     const newDataContract = getDataContractFixture();
 
-    newDataContract.getDocumentSchema('indexedDocument').properties.otherName = {
-      type: 'string',
-    };
-
-    newDataContract.getDocumentSchema('indexedDocument').indices.push({
-      name: 'index42',
-      unique: false,
-      properties: [
-        { otherName: 'asc' },
-      ],
-    });
-
-    newDataContract.getDocumentSchema('indexedDocument').indices.push({
-      name: 'index42',
-      properties: [
-        { otherName: 'asc' },
-      ],
-    });
-
     oldDocumentsSchema = oldDataContract.getDocuments();
     newDocumentsSchema = newDataContract.getDocuments();
   });
 
   it('should return invalid result if some of unique indices have changed', async () => {
     newDocumentsSchema.indexedDocument.indices[0].properties[1].firstName = 'desc';
+
     const result = validateIndicesAreBackwardCompatible(oldDocumentsSchema, newDocumentsSchema);
 
     expect(result.isValid()).to.be.false();
@@ -58,7 +40,7 @@ describe('validateIndicesAreBackwardCompatible', () => {
     expect(error.getIndexName()).to.equal(newDocumentsSchema.indexedDocument.indices[0].name);
   });
 
-  it('should return invalid result if non-unique index update failed due to changed old properties', async () => {
+  it('should return invalid result if already defined properties are changed in existing index', async () => {
     newDocumentsSchema.indexedDocument.indices[2].properties[0].lastName = 'desc';
 
     const result = validateIndicesAreBackwardCompatible(oldDocumentsSchema, newDocumentsSchema);
@@ -71,24 +53,17 @@ describe('validateIndicesAreBackwardCompatible', () => {
     expect(error.getIndexName()).to.equal(newDocumentsSchema.indexedDocument.indices[2].name);
   });
 
-  it('should return invalid result if non-unique index update failed due old properties used', async () => {
-    newDocumentsSchema.indexedDocument.indices.push({
-      name: 'oldFieldIndex',
-      properties: [
-        {
-          otherProperty: 'asc',
-        },
-      ],
-    });
+  it('should return invalid result if already indexed properties are added to existing index', async () => {
+    newDocumentsSchema.indexedDocument.indices[2].properties.push({ firstName: 'asc' });
 
     const result = validateIndicesAreBackwardCompatible(oldDocumentsSchema, newDocumentsSchema);
 
     expect(result.isValid()).to.be.false();
 
-    const error = result.getErrors()[0];
+    const [error] = result.getErrors();
 
     expect(error).to.be.an.instanceOf(DataContractInvalidIndexDefinitionUpdateError);
-    expect(error.getIndexName()).to.equal('oldFieldIndex');
+    expect(error.getIndexName()).to.equal(newDocumentsSchema.indexedDocument.indices[2].name);
   });
 
   it('should return invalid result if one of new indices contains old properties in the wrong order', async () => {
@@ -128,6 +103,25 @@ describe('validateIndicesAreBackwardCompatible', () => {
 
     expect(error).to.be.an.instanceOf(DataContractHaveNewUniqueIndexError);
     expect(error.getIndexName()).to.equal('index_other');
+  });
+
+  it('should return invalid result if existing property was used in a new index', async () => {
+    newDocumentsSchema.indexedDocument.indices.push({
+      name: 'oldFieldIndex',
+      properties: [
+        {
+          otherProperty: 'asc',
+        },
+      ],
+    });
+
+    const result = validateIndicesAreBackwardCompatible(oldDocumentsSchema, newDocumentsSchema);
+
+    expect(result.isValid()).to.be.false();
+
+    const [error] = result.getErrors();
+    expect(error).to.be.an.instanceOf(DataContractInvalidIndexDefinitionUpdateError);
+    expect(error.getIndexName()).to.equal('oldFieldIndex');
   });
 
   it('should return valid result if indices are not changed', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PR ensures that validateIndicesAreBackwardCompatible logic in rs-dpp is up to date


## What was done?
<!--- Describe your changes in detail -->
Matched `validateIndicesAreBackwardCompatible` tests on `js-dpp` and `wasm-dpp` sides 
Fixed bug with validation on `rs-dpp` side

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
