### PR TITLE
feat(rs-dpp): backports of identity/stateTransition from js-dpp

### DIFF
--- a/packages/rs-dpp/src/identity/state_transition/identity_create_transition/apply_identity_create_transition.rs
+++ b/packages/rs-dpp/src/identity/state_transition/identity_create_transition/apply_identity_create_transition.rs
@@ -74,7 +74,10 @@ where
             .ok_or_else(|| anyhow!("Out point is missing from asset lock proof"))?;
 
         self.state_repository
-            .mark_asset_lock_transaction_out_point_as_used(&out_point)
+            .mark_asset_lock_transaction_out_point_as_used(
+                &out_point,
+                state_transition.get_execution_context(),
+            )
             .await?;
 
         Ok(())

--- a/packages/rs-dpp/src/identity/state_transition/identity_create_transition/validation/state/mod.rs
+++ b/packages/rs-dpp/src/identity/state_transition/identity_create_transition/validation/state/mod.rs
@@ -28,7 +28,7 @@ pub async fn validate_identity_create_transition_state(
         return Ok(result);
     }
 
-    if let Some(_balance) = balance {
+    if balance.is_some() {
         result.add_error(IdentityAlreadyExistsError::new(identity_id.to_buffer()));
     }
 

--- a/packages/rs-dpp/src/identity/state_transition/identity_create_transition/validation/state/mod.rs
+++ b/packages/rs-dpp/src/identity/state_transition/identity_create_transition/validation/state/mod.rs
@@ -4,7 +4,6 @@ use crate::state_repository::StateRepositoryLike;
 use crate::state_transition::StateTransitionLike;
 use crate::validation::ValidationResult;
 use crate::NonConsensusError;
-use std::convert::TryInto;
 
 /// Validate that identity exists
 ///
@@ -20,19 +19,16 @@ pub async fn validate_identity_create_transition_state(
     let mut result = ValidationResult::default();
 
     let identity_id = state_transition.get_identity_id();
-    let maybe_identity = state_repository
-        .fetch_identity(identity_id, state_transition.get_execution_context())
-        .await?
-        .map(TryInto::try_into)
-        .transpose()
-        .map_err(Into::into)
+    let balance = state_repository
+        .fetch_identity_balance(identity_id, state_transition.get_execution_context())
+        .await
         .map_err(|e| NonConsensusError::StateRepositoryFetchError(e.to_string()))?;
 
     if state_transition.get_execution_context().is_dry_run() {
         return Ok(result);
     }
 
-    if let Some(_identity) = maybe_identity {
+    if let Some(_balance) = balance {
         result.add_error(IdentityAlreadyExistsError::new(identity_id.to_buffer()));
     }
 
@@ -43,8 +39,7 @@ pub async fn validate_identity_create_transition_state(
 mod test {
     use crate::{
         identity::state_transition::identity_create_transition::IdentityCreateTransition,
-        prelude::Identity, state_repository::MockStateRepositoryLike,
-        state_transition::StateTransitionLike,
+        state_repository::MockStateRepositoryLike, state_transition::StateTransitionLike,
         tests::fixtures::identity_create_transition_fixture_json,
     };
 
@@ -58,8 +53,8 @@ mod test {
 
         transition.get_execution_context().enable_dry_run();
         state_repository
-            .expect_fetch_identity()
-            .return_once(|_, _| Ok(Some(Identity::default())));
+            .expect_fetch_identity_balance()
+            .return_once(|_, _| Ok(Some(1)));
 
         let result = validate_identity_create_transition_state(&state_repository, transition).await;
         assert!(result.is_ok());

--- a/packages/rs-dpp/src/identity/state_transition/identity_topup_transition/apply_identity_topup_transition.rs
+++ b/packages/rs-dpp/src/identity/state_transition/identity_topup_transition/apply_identity_topup_transition.rs
@@ -73,7 +73,10 @@ where
             .await?;
 
         self.state_repository
-            .mark_asset_lock_transaction_out_point_as_used(&out_point)
+            .mark_asset_lock_transaction_out_point_as_used(
+                &out_point,
+                state_transition.get_execution_context(),
+            )
             .await?;
 
         Ok(())
@@ -132,7 +135,7 @@ mod test {
 
         state_repository_for_apply
             .expect_mark_asset_lock_transaction_out_point_as_used()
-            .returning(|_| Ok(()));
+            .returning(|_, _| Ok(()));
 
         let apply_identity_topup_transition = ApplyIdentityTopUpTransition::new(
             Arc::new(state_repository_for_apply),
@@ -181,7 +184,7 @@ mod test {
 
         state_repository_for_apply
             .expect_mark_asset_lock_transaction_out_point_as_used()
-            .returning(|_| Ok(()));
+            .returning(|_, _| Ok(()));
 
         let apply_identity_topup_transition = ApplyIdentityTopUpTransition::new(
             Arc::new(state_repository_for_apply),
@@ -230,7 +233,7 @@ mod test {
 
         state_repository_for_apply
             .expect_mark_asset_lock_transaction_out_point_as_used()
-            .returning(|_| Ok(()));
+            .returning(|_, _| Ok(()));
 
         state_transition.get_execution_context().enable_dry_run();
 

--- a/packages/rs-dpp/src/state_repository.rs
+++ b/packages/rs-dpp/src/state_repository.rs
@@ -200,6 +200,7 @@ pub trait StateRepositoryLike: Sync {
     async fn mark_asset_lock_transaction_out_point_as_used(
         &self,
         out_point_buffer: &[u8],
+        execution_context: &StateTransitionExecutionContext,
     ) -> AnyResult<()>;
 
     /// Fetch Simplified Masternode List Store

--- a/packages/wasm-dpp/src/state_repository.rs
+++ b/packages/wasm-dpp/src/state_repository.rs
@@ -171,6 +171,7 @@ extern "C" {
     pub async fn mark_asset_lock_transaction_out_point_as_used(
         this: &ExternalStateRepositoryLike,
         out_point_buffer: Buffer,
+        execution_context: StateTransitionExecutionContextWasm,
     ) -> Result<(), JsValue>;
 
     #[wasm_bindgen(catch, structural, method, js_name=fetchLatestPlatformBlockHeader)]
@@ -587,9 +588,13 @@ impl StateRepositoryLike for ExternalStateRepositoryLikeWrapper {
     async fn mark_asset_lock_transaction_out_point_as_used(
         &self,
         out_point_buffer: &[u8],
+        execution_context: &StateTransitionExecutionContext,
     ) -> Result<()> {
         self.0
-            .mark_asset_lock_transaction_out_point_as_used(Buffer::from_bytes(out_point_buffer))
+            .mark_asset_lock_transaction_out_point_as_used(
+                Buffer::from_bytes(out_point_buffer),
+                execution_context.clone().into(),
+            )
             .await
             .map_err(from_js_error)
     }

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreateTransition/applyIdentityCreateTransitionFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreateTransition/applyIdentityCreateTransitionFactory.spec.js
@@ -80,11 +80,11 @@ describe('applyIdentityCreateTransitionFactory', () => {
       match.instanceOf(StateTransitionExecutionContext),
     );
 
-    // TODO: It should pass execution context as well
     const outPoint = stateTransition.getAssetLockProof().getOutPoint();
     expect(stateRepositoryMock.markAssetLockTransactionOutPointAsUsed).to.have.been
       .calledOnceWithExactly(
         match((arg) => Buffer.from(arg).equals(outPoint)),
+        match.instanceOf(StateTransitionExecutionContext),
       );
   });
 });

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreateTransition/validation/state/validateIdentityCreateTransitionStateFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreateTransition/validation/state/validateIdentityCreateTransitionStateFactory.spec.js
@@ -11,7 +11,6 @@ describe('validateIdentityCreateTransitionStateFactory', () => {
   let validateIdentityCreateTransitionState;
   let stateTransition;
   let stateRepositoryMock;
-  let identity;
 
   let IdentityCreateTransition;
   let IdentityPublicKey;
@@ -48,28 +47,10 @@ describe('validateIdentityCreateTransitionStateFactory', () => {
       data: Buffer.from(rawTransaction, 'hex'),
       height: 42,
     });
-
-    identity = new Identity({
-      protocolVersion: protocolVersion.latestVersion,
-      id: await generateRandomIdentifierAsync(),
-      publicKeys: [
-        {
-          id: 0,
-          type: 0,
-          data: Buffer.alloc(36).fill('a'),
-          purpose: 0,
-          securityLevel: 0,
-          readOnly: false,
-          signature: Buffer.alloc(36).fill('a'),
-        },
-      ],
-      balance: 0,
-      revision: 0,
-    });
   });
 
   it('should return invalid result if identity already exists', async () => {
-    stateRepositoryMock.fetchIdentity.resolves(identity);
+    stateRepositoryMock.fetchIdentityBalance.resolves(1);
 
     const result = await validateIdentityCreateTransitionState(stateTransition);
 
@@ -83,14 +64,14 @@ describe('validateIdentityCreateTransitionStateFactory', () => {
   });
 
   it('should return valid result if state transition is valid', async () => {
-    stateRepositoryMock.fetchIdentity.resolves();
+    stateRepositoryMock.fetchIdentityBalance.resolves();
     const result = await validateIdentityCreateTransitionState(stateTransition);
 
     expect(result.isValid()).to.be.true();
   });
 
   it('should return valid result on dry run', async () => {
-    stateRepositoryMock.fetchIdentity.resolves(identity);
+    stateRepositoryMock.fetchIdentityBalance.resolves(1);
 
     stateTransition.getExecutionContext().enableDryRun();
 

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreateTransition/validation/state/validateIdentityCreateTransitionStateFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreateTransition/validation/state/validateIdentityCreateTransitionStateFactory.spec.js
@@ -2,9 +2,7 @@ const getIdentityCreateTransitionFixture = require('@dashevo/dpp/lib/test/fixtur
 
 const createStateRepositoryMock = require('@dashevo/dpp/lib/test/mocks/createStateRepositoryMock');
 
-const protocolVersion = require('@dashevo/dpp/lib/version/protocolVersion');
 const { default: loadWasmDpp } = require('../../../../../../../dist');
-const generateRandomIdentifierAsync = require('../../../../../../../lib/test/utils/generateRandomIdentifierAsync');
 const { expectValidationError } = require('../../../../../../../lib/test/expect/expectError');
 
 describe('validateIdentityCreateTransitionStateFactory', () => {
@@ -15,7 +13,6 @@ describe('validateIdentityCreateTransitionStateFactory', () => {
   let IdentityCreateTransition;
   let IdentityPublicKey;
   let IdentityAlreadyExistsError;
-  let Identity;
   let IdentityCreateTransitionStateValidator;
 
   before(async () => {
@@ -23,7 +20,6 @@ describe('validateIdentityCreateTransitionStateFactory', () => {
       IdentityCreateTransition,
       IdentityAlreadyExistsError,
       IdentityPublicKey,
-      Identity,
       IdentityCreateTransitionStateValidator,
     } = await loadWasmDpp());
   });

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityTopUpTransition/applyIdentityTopUpTransitionFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityTopUpTransition/applyIdentityTopUpTransitionFactory.spec.js
@@ -75,10 +75,10 @@ describe('applyIdentityTopUpTransitionFactory', () => {
 
     const outPoint = stateTransition.getAssetLockProof().getOutPoint();
 
-    // TODO: It should pass execution context as well
     expect(stateRepositoryMock.markAssetLockTransactionOutPointAsUsed).to.have.been
       .calledOnceWithExactly(
         match((arg) => Buffer.from(arg).equals(outPoint)),
+        match.instanceOf(StateTransitionExecutionContext),
       );
   });
 
@@ -106,10 +106,10 @@ describe('applyIdentityTopUpTransitionFactory', () => {
 
     const outPoint = stateTransition.getAssetLockProof().getOutPoint();
 
-    // TODO: It should pass execution context as well
     expect(stateRepositoryMock.markAssetLockTransactionOutPointAsUsed).to.have.been
       .calledOnceWithExactly(
         match((arg) => Buffer.from(arg).equals(outPoint)),
+        match.instanceOf(StateTransitionExecutionContext),
       );
   });
 
@@ -134,10 +134,10 @@ describe('applyIdentityTopUpTransitionFactory', () => {
 
     const outPoint = stateTransition.getAssetLockProof().getOutPoint();
 
-    // TODO: It should pass execution context as well
     expect(stateRepositoryMock.markAssetLockTransactionOutPointAsUsed).to.have.been
       .calledOnceWithExactly(
         match((arg) => Buffer.from(arg).equals(outPoint)),
+        match.instanceOf(StateTransitionExecutionContext),
       );
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PR ensures that identity/stateTransition logic in rs-dpp matches js-dpp


## What was done?
<!--- Describe your changes in detail -->
- Provided executionContext to mark_asset_lock_transaction_as_used
- Fetch identity balance instead of identity in identity create transition state validator


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
