### PR TITLE
Fix oclif pack command

### DIFF
--- a/scripts/pack_dashmate.sh
+++ b/scripts/pack_dashmate.sh
@@ -31,7 +31,7 @@ mkdir .yarn
 echo "nodeLinker: node-modules"  > .yarnrc.yml
 yarn install
 yarn oclif manifest
-yarn oclif pack macos
+yarn oclif pack $COMMAND
 cd ..  || exit 1
 rm package.tgz
 cp -R package/dist "$ROOT_PATH/packages/dashmate"


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fix oclif pack command in which OS parameter is hardcoded to macos.


## What was done?
Replace `macos` parameter for `yarn oclif pack` command in pack_dashmate.sh file to relevant variable.


## How Has This Been Tested?
Run pack_dashmate.sh locally on Ubuntu.


## Breaking Changes


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
