### PR TITLE
docs: supported Node.JS version and dashmate command description

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ this repository may be used on the following networks:
 
 - Clone the repo
 - Install prerequisites:
-  - [node.js](https://nodejs.org/) Any v16 version
+  - [node.js](https://nodejs.org/) v16
   - [docker](https://docs.docker.com/get-docker/) v20.10+
 - Run `corepack enable` to enable [corepack](https://nodejs.org/dist/latest/docs/api/corepack.html) and install yarn
 - Run `yarn setup` to install dependencies and configure and build all packages

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ this repository may be used on the following networks:
 
 - Clone the repo
 - Install prerequisites:
-  - [node.js](https://nodejs.org/) v16.10.0+
+  - [node.js](https://nodejs.org/) v16
   - [docker](https://docs.docker.com/get-docker/) v20.10+
 - Run `corepack enable` to enable [corepack](https://nodejs.org/dist/latest/docs/api/corepack.html) and install yarn
 - Run `yarn setup` to install dependencies and configure and build all packages

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ this repository may be used on the following networks:
 
 - Clone the repo
 - Install prerequisites:
-  - [node.js](https://nodejs.org/) v16
+  - [node.js](https://nodejs.org/) v16+
   - [docker](https://docs.docker.com/get-docker/) v20.10+
 - Run `corepack enable` to enable [corepack](https://nodejs.org/dist/latest/docs/api/corepack.html) and install yarn
 - Run `yarn setup` to install dependencies and configure and build all packages

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ this repository may be used on the following networks:
 
 - Clone the repo
 - Install prerequisites:
-  - [node.js](https://nodejs.org/) v16+
+  - [node.js](https://nodejs.org/) Any v16 version
   - [docker](https://docs.docker.com/get-docker/) v20.10+
 - Run `corepack enable` to enable [corepack](https://nodejs.org/dist/latest/docs/api/corepack.html) and install yarn
 - Run `yarn setup` to install dependencies and configure and build all packages

--- a/packages/dapi/README.md
+++ b/packages/dapi/README.md
@@ -23,7 +23,7 @@ npm install
 
 ### Dependencies
 
-DAPI targets the latest LTS release of Node.js. Currently, this is Node v10.13.
+DAPI targets the latest LTS release of Node.js.
 
 DAPI requires the latest version of [dashcore](https://github.com/dashevo/dash-evo-branches/tree/evo) with Evolution features (special branch repo).
 

--- a/packages/dapi/README.md
+++ b/packages/dapi/README.md
@@ -23,7 +23,7 @@ npm install
 
 ### Dependencies
 
-DAPI targets the latest LTS release of Node.js.
+DAPI targets the latest v16 release of Node.js.
 
 DAPI requires the latest version of [dashcore](https://github.com/dashevo/dash-evo-branches/tree/evo) with Evolution features (special branch repo).
 

--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -245,6 +245,7 @@ $ dashmate reset --hard
 ```
 
 With the hard reset mode enabled, the corresponding config will be reset in addition to the platform data. After a hard reset, it is necessary to run the node [setup](#setup-node) to proceed.
+
 #### Manual reset
 Manual reset is used when local setup corrupts and hard reset does not fix it. This could happen, when dashmate configuration becomes incompatible after a major upgrade, making you unable to execute any commands.
 ```bash

--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -239,12 +239,13 @@ DESCRIPTION
 To reset a node:
 ```bash
 $ dashmate reset
-=======
-#### Hard reset
-$ dashmate reset --hard
 ```
 
+#### Hard reset
 With the hard reset mode enabled, the corresponding config will be reset in addition to the platform data. After a hard reset, it is necessary to run the node [setup](#setup-node) to proceed.
+```bash
+$ dashmate reset --hard
+```
 
 #### Manual reset
 Manual reset is used when local setup corrupts and hard reset does not fix it. This could happen, when dashmate configuration becomes incompatible after a major upgrade, making you unable to execute any commands.

--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -31,7 +31,7 @@ Distribution package for Dash Masternode installation
 ### Dependencies
 
 * [Docker](https://docs.docker.com/engine/installation/) (v20.10+)
-* [Node.js](https://nodejs.org/en/download/) (v16.0+, NPM v8.0+)
+* [Node.js](https://nodejs.org/en/download/) (v16, NPM v8.0+)
 
 For Linux installations you may optionally wish to follow the [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) to manage Docker as a non-root user, otherwise you will have to run CLI and Docker commands with `sudo`.
 

--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -244,23 +244,6 @@ To reset a node:
 
 ```bash
 $ dashmate reset
-=======
-#### Hard reset
-
-``dashmate reset --hard``
-
-With the hard reset mode enabled, the corresponding config will be reset as well. This command cleans up all related containers and volumes. To proceed, running the node [setup](#setup-node) is required.
-
-#### Manual reset
-
-Manual reset is used when local setup corrupts and hard reset does not fix it. This could happen, when dashmate configuration becomes incompatible after a major upgrade, making you unable to execute any commands.
-
-```bash
-docker stop $(docker ps -q)
-docker system prune
-docker volume prune
-rm -rf ~/.dashmate/
-```
 
 ### Reindex dashcore chain data
 

--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -241,6 +241,7 @@ DESCRIPTION
 With the hard reset mode enabled, the corresponding config will be reset in addition to the platform data. After a hard reset, it is necessary to run the node [setup](#setup-node) to proceed.
 
 To reset a node:
+
 ```bash
 $ dashmate reset
 =======

--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -238,9 +238,27 @@ DESCRIPTION
   Reset node data
 ```
 
+With the hard reset mode enabled, the corresponding config will be reset as well. To proceed, running the node [setup](#setup-node) is required.
+
 To reset a node:
 ```bash
 $ dashmate reset
+=======
+#### Hard reset
+
+``dashmate reset --hard``
+
+With the hard reset mode enabled, the corresponding config will be reset as well. This command cleans up all related containers and volumes. To proceed, running the node [setup](#setup-node) is required.
+
+#### Manual reset
+
+Manual reset is used when local setup corrupts and hard reset does not fix it. This could happen, when dashmate configuration becomes incompatible after a major upgrade, making you unable to execute any commands.
+
+```bash
+docker stop $(docker ps -q)
+docker system prune
+docker volume prune
+rm -rf ~/.dashmate/
 ```
 
 ### Reindex dashcore chain data
@@ -267,29 +285,6 @@ DESCRIPTION
   Reindex Core
 
   Reindex Core data
-```
-
-With the hard reset mode enabled, the corresponding config will be reset as well. To proceed, running the node [setup](#setup-node) is required.
-
-To reset a node:
-```bash
-$ dashmate reset
-=======
-#### Hard reset
-
-``dashmate reset --hard``
-
-With the hard reset mode enabled, the corresponding config will be reset as well. This command cleans up all related containers and volumes. To proceed, running the node [setup](#setup-node) is required.
-
-#### Manual reset
-
-Manual reset is used when local setup corrupts and hard reset does not fix it. This could happen, when dashmate configuration becomes incompatible after a major upgrade, making you unable to execute any commands.
-
-```bash
-docker stop $(docker ps -q)
-docker system prune
-docker volume prune
-rm -rf ~/.dashmate/
 ```
 
 ### Full node

--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -238,7 +238,7 @@ DESCRIPTION
   Reset node data
 ```
 
-With the hard reset mode enabled, the corresponding config will be reset as well. To proceed, running the node [setup](#setup-node) is required.
+With the hard reset mode enabled, the corresponding config will be reset in addition to the platform data. After a hard reset, it is necessary to run the node [setup](#setup-node) to proceed.
 
 To reset a node:
 ```bash

--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -226,24 +226,33 @@ The `reset` command removes all data corresponding to the specified config and a
 ```
 USAGE
   $ dashmate reset [--config <value>] [-v] [-h] [-f] [-p]
-
 FLAGS
   -f, --force          skip running services check
   -h, --hard           reset config as well as data
   -p, --platform-only  reset platform data only
   -v, --verbose        use verbose mode for output
   --config=<value>     configuration name to use
-
 DESCRIPTION
   Reset node data
 ```
 
-With the hard reset mode enabled, the corresponding config will be reset in addition to the platform data. After a hard reset, it is necessary to run the node [setup](#setup-node) to proceed.
-
 To reset a node:
-
 ```bash
 $ dashmate reset
+=======
+#### Hard reset
+$ dashmate reset --hard
+```
+With the hard reset mode enabled, the corresponding config will be reset in addition to the platform data. After a hard reset, it is necessary to run the node [setup](#setup-node) to proceed.
+#### Manual reset
+Manual reset is used when local setup corrupts and hard reset does not fix it. This could happen, when dashmate configuration becomes incompatible after a major upgrade, making you unable to execute any commands.
+```bash
+docker stop $(docker ps -q)
+docker system prune
+docker volume prune
+rm -rf ~/.dashmate/
+```
+
 
 ### Reindex dashcore chain data
 
@@ -257,27 +266,18 @@ The `reindex` command works for regular and local configurations.
 
 ```
 Reindex Core
-
 USAGE
   $ dashmate core reindex [-v] [--config <value>]
-
 FLAGS
   -v, --verbose     use verbose mode for output
   --config=<value>  configuration name to use
-
 DESCRIPTION
   Reindex Core
-
   Reindex Core data
 ```
 
-### Full node
 
-It is also possible to start a full node instead of a masternode. Modify the config setting as follows:
 
-```bash
-dashmate config set core.masternode.enable false
-```
 
 ### Node groups
 

--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -243,6 +243,7 @@ $ dashmate reset
 #### Hard reset
 $ dashmate reset --hard
 ```
+
 With the hard reset mode enabled, the corresponding config will be reset in addition to the platform data. After a hard reset, it is necessary to run the node [setup](#setup-node) to proceed.
 #### Manual reset
 Manual reset is used when local setup corrupts and hard reset does not fix it. This could happen, when dashmate configuration becomes incompatible after a major upgrade, making you unable to execute any commands.

--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -276,7 +276,11 @@ DESCRIPTION
   Reindex Core data
 ```
 
-
+### Full node
+It is also possible to start a full node instead of a masternode. Modify the config setting as follows:
+```bash
+dashmate config set core.masternode.enable false
+```
 
 
 ### Node groups


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
As we are not supporting higher than 16 version of nodeJS, the documentation for platform is misleading. 
Dashmate reset command description is also wrongly placed and mixed with reindex command.


## What was done?
Update platform, DAPI and dashmate docs about currently supported nodeJS version (from v16+ to v16).
Fix incorrect description for dashmate `reset` command which was partly pasted into reindex command description.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
