### PR TITLE
chore(drive): temporary disable unstable withdrawal logic

### DIFF
--- a/packages/rs-drive-abci/src/abci/handlers.rs
+++ b/packages/rs-drive-abci/src/abci/handlers.rs
@@ -138,7 +138,7 @@ impl TenderdashAbci for Platform {
         // If last synced Core block height is not set instead of scanning
         // number of blocks for asset unlock transactions scan only one
         // on Core chain locked height by setting last_synced_core_height to the same value
-        let last_synced_core_height = if request.last_synced_core_height == 0 {
+        let _last_synced_core_height = if request.last_synced_core_height == 0 {
             block_execution_context.block_info.core_chain_locked_height
         } else {
             request.last_synced_core_height
@@ -147,10 +147,12 @@ impl TenderdashAbci for Platform {
         self.block_execution_context
             .replace(Some(block_execution_context));
 
-        self.update_broadcasted_withdrawal_transaction_statuses(
-            last_synced_core_height,
-            transaction,
-        )?;
+        // TODO: This code is not stable and blocking WASM-DPP integration and v0.24 testing
+        //   Must be enabled and accomplished when we come back to withdrawals
+        // self.update_broadcasted_withdrawal_transaction_statuses(
+        //     last_synced_core_height,
+        //     transaction,
+        // )?;
 
         let unsigned_withdrawal_transaction_bytes = self
             .fetch_and_prepare_unsigned_withdrawal_transactions(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Rust Core RPC client fails with:

```
execution: Core PC error: could not get block hash on height: 6251, reason: JSON-RPC error: transport error: HTTP response too short: length 0, needed 12.
```

## What was done?
<!--- Describe your changes in detail -->
- Temporarily disable withdrawal logic which uses RPC client until it's stabilized.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
