### PR TITLE
feat(wasm-dpp): provide external entropy generator to document factory

### DIFF
--- a/packages/rs-dpp/src/data_contract/data_contract_factory.rs
+++ b/packages/rs-dpp/src/data_contract/data_contract_factory.rs
@@ -12,30 +12,17 @@ use crate::data_contract::errors::InvalidDataContractError;
 use crate::data_contract::property_names::PROTOCOL_VERSION;
 
 use crate::state_transition::StateTransitionType;
+use crate::util::entropy_generator::{DefaultEntropyGenerator, EntropyGenerator};
 use crate::{
     data_contract::{self, generate_data_contract_id},
     decode_protocol_entity_factory::DecodeProtocolEntity,
     errors::ProtocolError,
     prelude::Identifier,
-    util::entropy_generator,
 };
 
 use super::state_transition::data_contract_create_transition::DataContractCreateTransition;
 use super::state_transition::data_contract_update_transition::DataContractUpdateTransition;
 use super::{validation::data_contract_validator::DataContractValidator, DataContract};
-
-/// A way to provide external entropy generator.
-pub trait EntropyGenerator {
-    fn generate(&self) -> [u8; 32];
-}
-
-struct DefaultEntropyGenerator;
-
-impl EntropyGenerator for DefaultEntropyGenerator {
-    fn generate(&self) -> [u8; 32] {
-        entropy_generator::generate().expect("entropy generation failed")
-    }
-}
 
 pub struct DataContractFactory {
     protocol_version: u32,
@@ -72,7 +59,7 @@ impl DataContractFactory {
         config: Option<ContractConfig>,
         definitions: Option<Value>,
     ) -> Result<DataContract, ProtocolError> {
-        let entropy = Bytes32::new(self.entropy_generator.generate());
+        let entropy = Bytes32::new(self.entropy_generator.generate()?);
 
         let data_contract_id = Identifier::from_bytes(&generate_data_contract_id(
             owner_id.to_buffer(),

--- a/packages/rs-dpp/src/document/document_facade.rs
+++ b/packages/rs-dpp/src/document/document_facade.rs
@@ -39,7 +39,6 @@ where
             protocol_version,
             document_validator.clone(),
             data_contract_fetcher_and_validator.clone(),
-            None,
         );
 
         Self {

--- a/packages/rs-dpp/src/document/document_factory.rs
+++ b/packages/rs-dpp/src/document/document_factory.rs
@@ -5,8 +5,7 @@ use std::collections::BTreeMap;
 use itertools::Itertools;
 
 use platform_value::{Bytes32, Value};
-use rand::rngs::StdRng;
-use rand::SeedableRng;
+
 use serde::{Deserialize, Serialize};
 
 use crate::consensus::basic::document::InvalidDocumentTypeError;
@@ -16,12 +15,12 @@ use crate::data_contract::DriveContractExt;
 use crate::document::document_transition::INITIAL_REVISION;
 use crate::document::Document;
 use crate::identity::TimestampMillis;
+use crate::util::entropy_generator::{DefaultEntropyGenerator, EntropyGenerator};
 use crate::{
     data_contract::{errors::DataContractError, DataContract},
     decode_protocol_entity_factory::DecodeProtocolEntity,
     prelude::Identifier,
     state_repository::StateRepositoryLike,
-    util::entropy_generator,
     ProtocolError,
 };
 
@@ -71,7 +70,7 @@ pub struct DocumentFactory<ST> {
     protocol_version: u32,
     document_validator: DocumentValidator,
     data_contract_fetcher_and_validator: DataContractFetcherAndValidator<ST>,
-    rng: StdRng,
+    entropy_generator: Box<dyn EntropyGenerator>,
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, Default)]
@@ -91,17 +90,26 @@ where
         protocol_version: u32,
         validate_document: DocumentValidator,
         data_contract_fetcher_and_validator: DataContractFetcherAndValidator<ST>,
-        seed: Option<u64>,
     ) -> Self {
-        let rng = match seed {
-            None => StdRng::from_entropy(),
-            Some(seed_value) => StdRng::seed_from_u64(seed_value),
-        };
         DocumentFactory {
             protocol_version,
             document_validator: validate_document,
             data_contract_fetcher_and_validator,
-            rng,
+            entropy_generator: Box::new(DefaultEntropyGenerator),
+        }
+    }
+
+    pub fn new_with_entropy_generator(
+        protocol_version: u32,
+        validate_document: DocumentValidator,
+        data_contract_fetcher_and_validator: DataContractFetcherAndValidator<ST>,
+        entropy_generator: Box<dyn EntropyGenerator>,
+    ) -> Self {
+        DocumentFactory {
+            protocol_version,
+            document_validator: validate_document,
+            data_contract_fetcher_and_validator,
+            entropy_generator,
         }
     }
 
@@ -119,7 +127,7 @@ where
             .into());
         }
 
-        let document_entropy = entropy_generator::generate()?; // TODO use EntropyGenerator
+        let document_entropy = self.entropy_generator.generate()?;
 
         let document_id = generate_document_id(
             &data_contract.id,
@@ -452,7 +460,6 @@ mod test {
             1,
             get_document_validator_fixture(),
             DataContractFetcherAndValidator::new(Arc::new(MockStateRepositoryLike::new())),
-            None,
         );
         let name = "Cutie";
         let contract_id = Identifier::from_string(
@@ -500,7 +507,6 @@ mod test {
             1,
             get_document_validator_fixture(),
             DataContractFetcherAndValidator::new(Arc::new(MockStateRepositoryLike::new())),
-            None,
         );
 
         let result = factory.create_state_transition(vec![]);
@@ -516,7 +522,6 @@ mod test {
             1,
             get_document_validator_fixture(),
             DataContractFetcherAndValidator::new(Arc::new(MockStateRepositoryLike::new())),
-            None,
         );
 
         documents[0].document.owner_id = generate_random_identifier_struct();
@@ -535,7 +540,6 @@ mod test {
             1,
             get_document_validator_fixture(),
             DataContractFetcherAndValidator::new(Arc::new(MockStateRepositoryLike::new())),
-            None,
         );
         let result = factory.create_state_transition(vec![(Action::Create, documents)]);
         assert_error_contains!(result, "Invalid Document initial revision '3'")
@@ -549,7 +553,6 @@ mod test {
             1,
             get_document_validator_fixture(),
             DataContractFetcherAndValidator::new(Arc::new(MockStateRepositoryLike::new())),
-            None,
         );
 
         let new_document = documents[0].clone();

--- a/packages/rs-dpp/src/document/state_transition/documents_batch_transition/mod.rs
+++ b/packages/rs-dpp/src/document/state_transition/documents_batch_transition/mod.rs
@@ -587,7 +587,6 @@ mod test {
             1,
             get_document_validator_fixture(),
             DataContractFetcherAndValidator::new(Arc::new(MockStateRepositoryLike::new())),
-            None,
         );
 
         let batch_transition = document_factory

--- a/packages/rs-dpp/src/identity/state_transition/identity_credit_withdrawal_transition/apply_identity_credit_withdrawal_transition_factory.rs
+++ b/packages/rs-dpp/src/identity/state_transition/identity_credit_withdrawal_transition/apply_identity_credit_withdrawal_transition_factory.rs
@@ -10,11 +10,12 @@ use serde_json::json;
 use crate::contracts::withdrawals_contract::property_names;
 use crate::data_contract::document_type::document_type::PROTOCOL_VERSION;
 use crate::document::ExtendedDocument;
+use crate::util::entropy_generator::DefaultEntropyGenerator;
 use crate::{
     contracts::withdrawals_contract, data_contract::DataContract, document::generate_document_id,
     document::Document, identity::state_transition::identity_credit_withdrawal_transition::Pooling,
     state_repository::StateRepositoryLike, state_transition::StateTransitionLike,
-    util::entropy_generator::generate,
+    util::entropy_generator::EntropyGenerator,
 };
 
 use super::IdentityCreditWithdrawalTransition;
@@ -90,8 +91,9 @@ where
 
         let mut document_id;
 
+        let generator = DefaultEntropyGenerator;
         loop {
-            let document_entropy = generate()?;
+            let document_entropy = generator.generate()?;
 
             document_id = generate_document_id::generate_document_id(
                 data_contract_id,

--- a/packages/rs-dpp/src/tests/fixtures/get_dashpay_document_fixture.rs
+++ b/packages/rs-dpp/src/tests/fixtures/get_dashpay_document_fixture.rs
@@ -30,7 +30,6 @@ pub fn get_contact_request_document_fixture(
         LATEST_VERSION,
         get_document_validator_fixture(),
         data_contract_fetcher_and_validator,
-        None,
     );
 
     let mut data = platform_value! ({

--- a/packages/rs-dpp/src/tests/fixtures/get_document_transitions_fixture.rs
+++ b/packages/rs-dpp/src/tests/fixtures/get_document_transitions_fixture.rs
@@ -20,7 +20,6 @@ pub fn get_document_transitions_fixture(
         LATEST_VERSION,
         get_document_validator_fixture(),
         DataContractFetcherAndValidator::new(Arc::new(MockStateRepositoryLike::new())),
-        None,
     );
 
     let mut documents_collected: HashMap<Action, Vec<ExtendedDocument>> =

--- a/packages/rs-dpp/src/tests/fixtures/get_documents_fixture.rs
+++ b/packages/rs-dpp/src/tests/fixtures/get_documents_fixture.rs
@@ -30,7 +30,6 @@ pub fn get_documents_fixture_with_owner_id_from_contract(
         LATEST_VERSION,
         get_document_validator_fixture(),
         data_contract_fetcher_and_validator,
-        None,
     );
     let owner_id = data_contract.owner_id;
 
@@ -53,7 +52,6 @@ pub fn get_extended_documents_fixture(
         LATEST_VERSION,
         get_document_validator_fixture(),
         data_contract_fetcher_and_validator,
-        None,
     );
     let owner_id = gen_owner_id();
 

--- a/packages/rs-dpp/src/tests/fixtures/get_dpns_document_fixture.rs
+++ b/packages/rs-dpp/src/tests/fixtures/get_dpns_document_fixture.rs
@@ -39,7 +39,6 @@ pub fn get_dpns_parent_document_fixture(options: ParentDocumentOptions) -> Exten
         LATEST_VERSION,
         get_document_validator_fixture(),
         DataContractFetcherAndValidator::new(Arc::new(MockStateRepositoryLike::new())),
-        None,
     );
     let data_contract = get_dpns_data_contract_fixture(Some(options.owner_id));
     let mut pre_order_salt = [0u8; 32];

--- a/packages/rs-dpp/src/tests/fixtures/get_masternode_reward_shares_documents_fixture.rs
+++ b/packages/rs-dpp/src/tests/fixtures/get_masternode_reward_shares_documents_fixture.rs
@@ -29,7 +29,6 @@ pub fn get_masternode_reward_shares_documents_fixture() -> (Vec<ExtendedDocument
         LATEST_VERSION,
         document_validator,
         DataContractFetcherAndValidator::new(Arc::new(MockStateRepositoryLike::new())),
-        None,
     );
 
     (

--- a/packages/rs-dpp/src/util/entropy_generator.rs
+++ b/packages/rs-dpp/src/util/entropy_generator.rs
@@ -1,8 +1,17 @@
 use anyhow::Context;
 use getrandom::getrandom;
 
-pub fn generate() -> Result<[u8; 32], anyhow::Error> {
-    let mut buffer = [0u8; 32];
-    getrandom(&mut buffer).context("generating entropy failed")?;
-    Ok(buffer)
+/// A way to provide external entropy generator.
+pub trait EntropyGenerator {
+    fn generate(&self) -> anyhow::Result<[u8; 32]>;
+}
+
+pub struct DefaultEntropyGenerator;
+
+impl EntropyGenerator for DefaultEntropyGenerator {
+    fn generate(&self) -> anyhow::Result<[u8; 32]> {
+        let mut buffer = [0u8; 32];
+        getrandom(&mut buffer).context("generating entropy failed")?;
+        Ok(buffer)
+    }
 }

--- a/packages/rs-drive/src/drive/document/update.rs
+++ b/packages/rs-drive/src/drive/document/update.rs
@@ -2416,7 +2416,6 @@ mod tests {
             1,
             document_validator,
             DataContractFetcherAndValidator::new(Arc::new(MockStateRepositoryLike::new())),
-            None,
         );
 
         // Create a document

--- a/packages/wasm-dpp/lib/test/fixtures/getDataContractFixture.js
+++ b/packages/wasm-dpp/lib/test/fixtures/getDataContractFixture.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const protocolVersion = require('@dashevo/dpp/lib/version/protocolVersion');
 const JsIdentifier = require('@dashevo/dpp/lib/identifier/Identifier');
 const generateRandomIdentifierAsync = require('../utils/generateRandomIdentifierAsync');
@@ -250,12 +251,20 @@ module.exports = async function getDataContractFixture(ownerId = randomOwnerId) 
   };
 
   const dataContractValidator = new DataContractValidator();
+  const entropyGenerator = {
+    generate() {
+      return crypto.randomBytes(32);
+    },
+  };
   const factory = new DataContractFactory(
     protocolVersion.latestVersion,
     dataContractValidator,
+    entropyGenerator,
   );
 
-  const dataContract = factory.create(ownerId, documents);
+  // TODO: Identifier/buffer issue - hidden Identifier bug.
+  //  Without toBuffer() it results on Identifier filled with zeroes
+  const dataContract = factory.create(ownerId.toBuffer(), documents);
 
   // dataContract.setDefinitions({
   //   lastName: {

--- a/packages/wasm-dpp/lib/test/fixtures/getDocumentsFixture.js
+++ b/packages/wasm-dpp/lib/test/fixtures/getDocumentsFixture.js
@@ -21,7 +21,12 @@ module.exports = async function getDocumentsFixture(
   ({ DocumentFactory, DocumentValidator, ProtocolVersionValidator } = await loadWasmDpp());
 
   const documentValidator = new DocumentValidator(new ProtocolVersionValidator());
-  const factory = new DocumentFactory(1, documentValidator, {});
+  const entropyGenerator = {
+    generate() {
+      return crypto.randomBytes(32);
+    },
+  };
+  const factory = new DocumentFactory(1, documentValidator, {}, entropyGenerator);
 
   const ownerId = await generateRandomIdentifierAsync();
 

--- a/packages/wasm-dpp/src/data_contract_factory/data_contract_factory.rs
+++ b/packages/wasm-dpp/src/data_contract_factory/data_contract_factory.rs
@@ -1,10 +1,8 @@
-use std::convert::TryInto;
 use std::sync::Arc;
 
 use dpp::{
     data_contract::{
         validation::data_contract_validator::DataContractValidator, DataContractFactory,
-        EntropyGenerator,
     },
     platform_value,
     prelude::Identifier,
@@ -13,7 +11,9 @@ use dpp::{
 };
 use wasm_bindgen::prelude::*;
 
+use crate::entropy_generator::ExternalEntropyGenerator;
 use crate::utils::WithJsError;
+
 use crate::{
     data_contract::errors::InvalidDataContractError,
     errors::{from_dpp_err, protocol_error::from_protocol_error},
@@ -79,23 +79,6 @@ impl From<DataContractFactoryWasm> for DataContractFactory {
     }
 }
 
-#[wasm_bindgen]
-extern "C" {
-    pub type ExternalEntropyGenerator;
-
-    #[wasm_bindgen(structural, method)]
-    pub fn generate(this: &ExternalEntropyGenerator) -> Vec<u8>;
-}
-
-impl EntropyGenerator for ExternalEntropyGenerator {
-    fn generate(&self) -> [u8; 32] {
-        // TODO: think about changing API to return an error but does it worth it for JS?
-
-        ExternalEntropyGenerator::generate(self)
-            .try_into()
-            .expect("Bad entropy generator provided: should return 32 bytes")
-    }
-}
 #[wasm_bindgen(js_class=DataContractFactory)]
 impl DataContractFactoryWasm {
     #[wasm_bindgen(constructor)]

--- a/packages/wasm-dpp/src/entropy_generator.rs
+++ b/packages/wasm-dpp/src/entropy_generator.rs
@@ -1,0 +1,34 @@
+use crate::errors::from_js_error;
+use dpp::util::entropy_generator::EntropyGenerator;
+use std::convert::TryInto;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsValue;
+
+#[wasm_bindgen]
+extern "C" {
+    pub type ExternalEntropyGenerator;
+
+    #[wasm_bindgen(catch, structural, method)]
+    pub fn generate(this: &ExternalEntropyGenerator) -> Result<JsValue, JsValue>;
+}
+
+impl EntropyGenerator for ExternalEntropyGenerator {
+    fn generate(&self) -> anyhow::Result<[u8; 32]> {
+        let js_value = ExternalEntropyGenerator::generate(self).map_err(from_js_error)?;
+
+        if !js_value.has_type::<js_sys::Uint8Array>() {
+            anyhow::bail!("Entropy generator should return Buffer");
+        }
+
+        let vec = js_value
+            .dyn_into::<js_sys::Uint8Array>()
+            .map_err(from_js_error)?
+            .to_vec();
+
+        let bytes = vec.try_into().map_err(|_| {
+            anyhow::anyhow!("Bad entropy generator provided: should return 32 bytes")
+        })?;
+
+        Ok(bytes)
+    }
+}

--- a/packages/wasm-dpp/src/lib.rs
+++ b/packages/wasm-dpp/src/lib.rs
@@ -28,5 +28,6 @@ mod utils;
 mod bls_adapter;
 mod buffer;
 mod decode_protocol_entity;
+mod entropy_generator;
 mod lodash;
 mod validation;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PR addresses next issues:
- Need to provide external entropy generator to Document Factory (needed for JS)
- Proper error handling for entropy generator (need to know what's going on in case external generator fails to produce entropy)


## What was done?
<!--- Describe your changes in detail -->
- Return Result instead of panicking in `generate()` function
- Add entropy generator as an argument to DocumentFactory
- Refactor entropy generator file structure
- Update JS fixture


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
