### PR TITLE
fix(wasm-dpp): fix decoding protocol version varint error to match previous implementation

### DIFF
--- a/packages/rs-dpp/src/decode_protocol_entity_factory.rs
+++ b/packages/rs-dpp/src/decode_protocol_entity_factory.rs
@@ -18,6 +18,7 @@ impl DecodeProtocolEntity {
             main_message_bytes: document_bytes,
             ..
         } = deserializer::split_protocol_version(buffer.as_ref())?;
+
         let cbor_value: CborValue = ciborium::de::from_reader(document_bytes).map_err(|e| {
             ConsensusError::SerializedObjectParsingError {
                 parsing_error: anyhow!("Decode protocol entity: {:#?}", e),

--- a/packages/rs-dpp/src/util/deserializer.rs
+++ b/packages/rs-dpp/src/util/deserializer.rs
@@ -1,3 +1,5 @@
+use crate::consensus::basic::decode::ProtocolVersionParsingError;
+use crate::consensus::ConsensusError;
 use integer_encoding::VarInt;
 use serde_json::{Map, Number, Value as JsonValue};
 
@@ -45,8 +47,10 @@ pub fn split_protocol_version(
     message_bytes: &[u8],
 ) -> Result<SplitProtocolVersionOutcome, ProtocolError> {
     let (protocol_version, protocol_version_size) =
-        u32::decode_var(message_bytes).ok_or(ProtocolError::UnknownProtocolVersionError(
-            "protocol version could not be decoded as a varint".to_string(),
+        u32::decode_var(message_bytes).ok_or(ConsensusError::ProtocolVersionParsingError(
+            ProtocolVersionParsingError::new(ProtocolError::UnknownProtocolVersionError(
+                "protocol version could not be decoded as a varint".to_string(),
+            )),
         ))?;
     let (_, main_message_bytes) = message_bytes.split_at(protocol_version_size);
 

--- a/packages/wasm-dpp/src/decode_protocol_entity.rs
+++ b/packages/wasm-dpp/src/decode_protocol_entity.rs
@@ -1,6 +1,7 @@
 use crate::errors::protocol_error::from_protocol_error;
 use core::iter::FromIterator;
 use dpp::decode_protocol_entity_factory::DecodeProtocolEntity;
+use dpp::ProtocolError;
 use js_sys::Array;
 use serde::Serialize;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -8,13 +9,17 @@ use wasm_bindgen::JsValue;
 
 #[wasm_bindgen(js_name=decodeProtocolEntity)]
 pub fn decode_protocol_entity(buffer: Vec<u8>) -> Result<Array, JsValue> {
-    DecodeProtocolEntity::decode_protocol_entity(buffer)
-        .map(|(protocol_version, json_value)| {
-            let serializer = serde_wasm_bindgen::Serializer::json_compatible();
-            let js_value = json_value
-                .serialize(&serializer)
-                .expect("implements Serialize");
-            Array::from_iter(vec![JsValue::from(protocol_version), js_value])
-        })
-        .map_err(from_protocol_error)
+    let (protocol_version, value) =
+        DecodeProtocolEntity::decode_protocol_entity(buffer).map_err(from_protocol_error)?;
+
+    let serializer = serde_wasm_bindgen::Serializer::json_compatible();
+    let js_value = value
+        .try_to_validating_json()
+        .map_err(|e| from_protocol_error(ProtocolError::ValueError(e)))?
+        .serialize(&serializer)
+        .map_err(|e| from_protocol_error(ProtocolError::NonConsensusError(e.to_string())))?;
+    Ok(Array::from_iter(vec![
+        JsValue::from(protocol_version),
+        js_value,
+    ]))
 }

--- a/packages/wasm-dpp/src/errors/protocol_error.rs
+++ b/packages/wasm-dpp/src/errors/protocol_error.rs
@@ -18,6 +18,10 @@ pub fn from_protocol_error(protocol_error: dpp::ProtocolError) -> JsValue {
         dpp::ProtocolError::Error(anyhow_error) => {
             format!("Non-protocol error: {}", anyhow_error).into()
         }
-        _ => todo!("Implement protocol error conversions"),
+        e => format!(
+            "ProtocolError conversion not implemented: {}",
+            e
+        )
+        .into(),
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
CI being broken because varint parsing error implementation changed

## What was done?
<!--- Describe your changes in detail -->
Brought the old error back

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
