### PR TITLE
feat(dashmate): hint to setup a node on start failure

### DIFF
--- a/packages/dashmate/src/config/systemConfigs/createSystemConfigsFactory.js
+++ b/packages/dashmate/src/config/systemConfigs/createSystemConfigsFactory.js
@@ -21,7 +21,7 @@ function createSystemConfigsFactory(systemConfigs) {
     return new ConfigFile(
       configs,
       packageJson.version,
-      'base',
+      null,
       null,
     );
   }

--- a/packages/dashmate/src/oclif/command/ConfigBaseCommand.js
+++ b/packages/dashmate/src/oclif/command/ConfigBaseCommand.js
@@ -23,7 +23,11 @@ class ConfigBaseCommand extends BaseCommand {
       const defaultConfigName = configFile.getDefaultConfigName();
 
       if (defaultConfigName === null) {
-        throw new Error('Default config is not set. Please use \'--config\' option or set default config');
+        throw new Error(`Default config is not set.
+        
+You probably need to setup a node with the 'dashmate setup' command first.
+
+You also can use the '--config' option or set the default config with 'dashmate config default'`);
       }
 
       if (!configFile.isConfigExists(defaultConfigName)) {

--- a/packages/dashmate/src/oclif/command/ConfigBaseCommand.js
+++ b/packages/dashmate/src/oclif/command/ConfigBaseCommand.js
@@ -25,7 +25,7 @@ class ConfigBaseCommand extends BaseCommand {
       if (defaultConfigName === null) {
         throw new Error(`Default config is not set.
         
-You probably need to setup a node with the 'dashmate setup' command first.
+You probably need to set up a node with the 'dashmate setup' command first.
 
 You also can use the '--config' option or set the default config with 'dashmate config default'`);
       }

--- a/packages/dashmate/src/oclif/command/ConfigBaseCommand.js
+++ b/packages/dashmate/src/oclif/command/ConfigBaseCommand.js
@@ -27,7 +27,7 @@ class ConfigBaseCommand extends BaseCommand {
         
 You probably need to set up a node with the 'dashmate setup' command first.
 
-You also can use the '--config' option or set the default config with 'dashmate config default'`);
+You can also use the '--config' option, or set the default config with 'dashmate config default'`);
       }
 
       if (!configFile.isConfigExists(defaultConfigName)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes people run `dashmate start` without knowing that the node configuration is required.

## What was done?
<!--- Describe your changes in detail -->
- Remove base config as default
- Show a hint to run `dashmate setup` if default config is empty

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
