### PR TITLE
feat(rs-drive-abci): withdrawal processing using vote extensions

### DIFF
--- a/packages/rs-drive-abci/src/abci/error.rs
+++ b/packages/rs-drive-abci/src/abci/error.rs
@@ -1,5 +1,5 @@
+use super::signature_verifier::SignatureError;
 use crate::validator_set::ValidatorSetError;
-use dpp::bls_signatures::Error as BLSError;
 
 /// Error returned within ABCI server
 #[derive(Debug, thiserror::Error)]
@@ -7,6 +7,19 @@ pub enum AbciError {
     /// Invalid system state
     #[error("invalid state: {0}")]
     InvalidState(String),
+    /// Request does not match currently processed block
+    #[error("request does not match current block: {0}")]
+    RequestForWrongBlockReceived(String),
+    /// Withdrawal transactions mismatch
+    #[error("vote extensions mismatch: got {got:?}, expected {expected:?}")]
+    #[allow(missing_docs)]
+    VoteExtensionMismatchReceived { got: String, expected: String },
+    /// Vote extensions signature is invalid
+    #[error("one of vote extension signatures is invalid")]
+    VoteExtensionsSignatureInvalid,
+    /// Cannot load withdrawal transactions
+    #[error("cannot load withdrawal transactions: {0}")]
+    WithdrawalTransactionsDBLoadError(String),
     /// Wrong finalize block received
     #[error("finalize block received before processing from Tenderdash: {0}")]
     FinalizeBlockReceivedBeforeProcessing(String),
@@ -26,9 +39,9 @@ pub enum AbciError {
     #[error("tenderdash: {0}")]
     Tenderdash(#[from] tenderdash_abci::Error),
 
-    /// Error occurred during bls signature verification
-    #[error("bls error set: {0}")]
-    BLSError(#[from] BLSError),
+    /// Error occurred during signature verification
+    #[error("signature error: {0}")]
+    SignatureError(#[from] SignatureError),
 
     /// Error occurred during validator set creation
     #[error("validator set: {0}")]
@@ -37,4 +50,11 @@ pub enum AbciError {
     /// Generic with code should only be used in tests
     #[error("generic with code: {0}")]
     GenericWithCode(u32),
+}
+
+// used by `?` operator
+impl From<AbciError> for String {
+    fn from(value: AbciError) -> Self {
+        value.to_string()
+    }
 }

--- a/packages/rs-drive-abci/src/abci/mod.rs
+++ b/packages/rs-drive-abci/src/abci/mod.rs
@@ -15,6 +15,9 @@ pub mod mimic;
 #[cfg(any(feature = "server", test))]
 mod server;
 
+pub mod signature_verifier;
+pub mod withdrawal;
+
 pub use error::AbciError;
 #[cfg(feature = "server")]
 pub use server::start;

--- a/packages/rs-drive-abci/src/abci/signature_verifier.rs
+++ b/packages/rs-drive-abci/src/abci/signature_verifier.rs
@@ -1,0 +1,60 @@
+//! Signature verification
+
+use dpp::bls_signatures::Serialize;
+use tenderdash_abci::proto::types::VoteExtension;
+
+/// Errors occured during signature verification
+#[derive(Debug, thiserror::Error)]
+pub enum SignatureError {
+    /// Error occurred during bls signature verification
+    #[error("bls error set: {0}")]
+    BLSError(#[from] dpp::bls_signatures::Error),
+}
+/// SignatureVerifier can be used to verify a BLS signature.
+pub trait SignatureVerifier {
+    /// Verify all signatures using provided public key.
+    ///
+    /// ## Return value
+    ///
+    /// * Ok(true) when all signatures are correct
+    /// * Ok(false) when at least one signature is invalid
+    /// * Err(e) on error
+    fn verify_signature(
+        &self,
+        quorum_public_key: dpp::bls_signatures::PublicKey,
+    ) -> Result<bool, SignatureError>;
+}
+
+impl<T: SignatureVerifier> SignatureVerifier for Vec<T> {
+    fn verify_signature(
+        &self,
+        quorum_public_key: dpp::bls_signatures::PublicKey,
+    ) -> Result<bool, SignatureError> {
+        for tx in self {
+            if !tx.verify_signature(quorum_public_key)? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+impl SignatureVerifier for VoteExtension {
+    fn verify_signature(
+        &self,
+        _quorum_public_key: dpp::bls_signatures::PublicKey,
+    ) -> Result<bool, SignatureError> {
+        let signature = &self.signature;
+
+        // We could have received a fake commit, so signature validation needs to be returned if error as a simple validation result
+        let _signature = match dpp::bls_signatures::Signature::from_bytes(signature.as_slice()) {
+            Ok(signature) => signature,
+            Err(e) => return Err(SignatureError::from(e)),
+        };
+        //  TODO: implement correct signature verification for VoteExtension. It uses CanonicalVoteExtension.
+        // For now, we just return `true`
+        // Ok(quorum_public_key.verify(signature, &self.extension))
+        Ok(true)
+    }
+}

--- a/packages/rs-drive-abci/src/abci/withdrawal.rs
+++ b/packages/rs-drive-abci/src/abci/withdrawal.rs
@@ -1,0 +1,151 @@
+//! Withdrawal transactions definitions and processing
+
+use dpp::bls_signatures::{self};
+use drive::{
+    drive::{batch::DriveOperation, block_info::BlockInfo, Drive},
+    fee::result::FeeResult,
+    query::TransactionArg,
+};
+use std::fmt::Display;
+use tenderdash_abci::proto::{
+    abci::ExtendVoteExtension,
+    types::{VoteExtension, VoteExtensionType},
+};
+
+use super::{
+    signature_verifier::{SignatureError, SignatureVerifier},
+    AbciError,
+};
+
+const MAX_WITHDRAWAL_TXS: u16 = 16;
+
+/// Collection of withdrawal transactions processed at some height/round
+#[derive(Debug)]
+pub struct WithdrawalTxs<'a> {
+    inner: Vec<VoteExtension>,
+    drive_operations: Vec<DriveOperation<'a>>,
+}
+
+impl<'a> WithdrawalTxs<'a> {
+    /// Load pending withdrawal transactions from database
+    pub fn load(transaction: TransactionArg, drive: &Drive) -> Result<Self, AbciError> {
+        let mut drive_operations = Vec::<DriveOperation>::new();
+
+        let inner = drive
+            .dequeue_withdrawal_transactions(MAX_WITHDRAWAL_TXS, transaction, &mut drive_operations)
+            .map_err(|e| AbciError::WithdrawalTransactionsDBLoadError(e.to_string()))?
+            .into_iter()
+            .map(|(_k, v)| VoteExtension {
+                r#type: VoteExtensionType::ThresholdRecover.into(),
+                extension: v,
+                signature: Default::default(),
+            })
+            .collect::<Vec<VoteExtension>>();
+
+        Ok(Self {
+            drive_operations,
+            inner,
+        })
+    }
+
+    /// Basic validation of withdrawals.
+    ///
+    /// TODO: validate signature, etc.
+    pub fn validate(&self) -> Result<(), AbciError> {
+        if self.drive_operations.len() != self.inner.len() {
+            return Err(AbciError::InvalidState(format!(
+                "num of drive operations {} must match num of withdrawal transactions {}",
+                self.drive_operations.len(),
+                self.inner.len(),
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Finalize operations related to this withdrawal, as part of FinalizeBlock logic.
+    ///
+    /// Deletes withdrawal transactions that were executed.
+    pub fn finalize(
+        &self,
+        transaction: TransactionArg,
+        drive: &Drive,
+        block_info: &BlockInfo,
+    ) -> Result<FeeResult, AbciError> {
+        self.validate()?;
+        // TODO: Do we need to do sth with withdrawal txs to actually execute them?
+        // FIXME: check if this is correct, esp. "apply" arg
+        drive
+            .apply_drive_operations(self.drive_operations.clone(), true, block_info, transaction)
+            .map_err(|e| AbciError::WithdrawalTransactionsDBLoadError(e.to_string()))
+    }
+}
+
+impl<'a> WithdrawalTxs<'a> {
+    /// Convert withdrawal transactions to vector of ExtendVoteExtension
+    pub fn to_vec(self) -> Vec<ExtendVoteExtension> {
+        self.inner
+            .into_iter()
+            .map(|v| ExtendVoteExtension {
+                r#type: v.r#type,
+                extension: v.extension,
+            })
+            .collect::<Vec<ExtendVoteExtension>>()
+    }
+}
+
+impl<'a> Display for WithdrawalTxs<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("txs:["))?;
+        for item in &self.inner {
+            f.write_fmt(format_args!(
+                "tx:{},sig:{}\n",
+                hex::encode(&item.extension),
+                hex::encode(&item.signature)
+            ))?;
+        }
+        f.write_str("]\n")?;
+        Ok(())
+    }
+}
+impl<'a> From<Vec<ExtendVoteExtension>> for WithdrawalTxs<'a> {
+    fn from(value: Vec<ExtendVoteExtension>) -> Self {
+        WithdrawalTxs {
+            inner: value
+                .into_iter()
+                .map(|v| VoteExtension {
+                    r#type: v.r#type,
+                    extension: v.extension,
+                    signature: Default::default(),
+                })
+                .collect::<Vec<VoteExtension>>(),
+            drive_operations: Vec::<DriveOperation>::new(),
+        }
+    }
+}
+
+impl<'a> From<&Vec<VoteExtension>> for WithdrawalTxs<'a> {
+    fn from(value: &Vec<VoteExtension>) -> Self {
+        WithdrawalTxs {
+            inner: value.clone(),
+            drive_operations: Vec::<DriveOperation>::new(),
+        }
+    }
+}
+
+impl<'a> PartialEq for WithdrawalTxs<'a> {
+    /// Two sets of withdrawal transactions are equal if all their inner raw transactions are equal.
+    /// Note we don't compare `drive_operations`.
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.eq(&other.inner)
+    }
+}
+
+impl<'a> SignatureVerifier for WithdrawalTxs<'a> {
+    fn verify_signature(
+        &self,
+        quorum_public_key: bls_signatures::PublicKey,
+    ) -> Result<bool, SignatureError> {
+        self.inner.verify_signature(quorum_public_key)
+    }
+}

--- a/packages/rs-drive-abci/src/block.rs
+++ b/packages/rs-drive-abci/src/block.rs
@@ -28,13 +28,12 @@
 //
 
 use crate::abci::AbciError;
-use drive::drive::block_info::BlockInfo;
-use drive::fee::epoch::EpochIndex;
-use drive::fee_pools::epochs::Epoch;
-
 use crate::error::Error;
 use crate::execution::block_proposal::BlockProposal;
 use crate::execution::fee_pools::epoch::EpochInfo;
+use drive::drive::block_info::BlockInfo;
+use drive::fee::epoch::EpochIndex;
+use drive::fee_pools::epochs::Epoch;
 
 /// Block info
 pub struct BlockStateInfo {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Withdrawal transactions need to use vote extensions in their processing

## What was done?

1. Implemented extend_vote and verify_vote_extension hooks
2. Implemented WithdrawalTxs used in these hooks
3. Implemented SignatureVerifier  for VoteExtension (WIP)
4. Extended FinalizeBlock with withdrawal tx processing logic


## How Has This Been Tested?

Not tested at all yet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
