### PR TITLE
feat(dashmate): exit status with 2 if it's not running

### DIFF
--- a/packages/dashmate/src/commands/status/index.js
+++ b/packages/dashmate/src/commands/status/index.js
@@ -24,7 +24,11 @@ class StatusCommand extends ConfigBaseCommand {
     config,
   ) {
     if (!(await dockerCompose.isServiceRunning(config.toEnvs()))) {
-      throw new Error('Node is not running, start it with `dashmate start`');
+      const error = new Error('Node is not running, start it with `dashmate start`');
+
+      error.exitCode = 2;
+
+      throw error;
     }
 
     const scope = await getOverviewScope(config);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The status command returns exit code 1 if nodes are not running and other errors are occurring. It prevents to handle properly  restart/start logic in the deployment tool

## What was done?
<!--- Describe your changes in detail -->
- Exit with code 2 if sevices are not running

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
