### PR TITLE
fix(dashmate): dashmate logic doesn't recognize it's ran from helper

### DIFF
--- a/packages/dashmate/Dockerfile
+++ b/packages/dashmate/Dockerfile
@@ -52,7 +52,6 @@ FROM node:16-alpine3.16
 
 ARG NODE_ENV=production
 ENV NODE_ENV ${NODE_ENV}
-ENV DASHMATE_HELPER=1
 
 RUN apk update && \
     apk --no-cache upgrade && \

--- a/packages/dashmate/docker/entrypoint.sh
+++ b/packages/dashmate/docker/entrypoint.sh
@@ -31,4 +31,4 @@ fi
 
 echo "Starting with: USERNAME: $USERNAME, UID: $USER_ID, GID: $GROUP_ID, USER: $USERNAME, GROUP: $GROUP"
 
-exec su - $USERNAME -c "cd /platform;$*"
+exec su - $USERNAME -c "cd /platform;DASHMATE_HELPER=1 $*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ENV DASHMATE_HELPER=1 defined in the Dockerfile is created at root user environment, and it gets erased after we switch it to dashmate in entrypoint.sh

## What was done?
<!--- Describe your changes in detail -->
Moved DASHMATE_HELPER=1 from Dockerfile to entrypoint.sh

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On devnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
