### PR TITLE
fix(dapi-client): platform port is ignored from SML

### DIFF
--- a/packages/js-dapi-client/lib/dapiAddressProvider/ListDAPIAddressProvider.js
+++ b/packages/js-dapi-client/lib/dapiAddressProvider/ListDAPIAddressProvider.js
@@ -30,7 +30,7 @@ class ListDAPIAddressProvider {
     }
 
     // This is a temporary fix for a localhost masternode.
-    // On mac os, internal docker IP is used to register masternode, and it's
+    // On macOS, internal docker IP is used to register masternode, and it's
     // not really possible to bind to that address, so that workaround is introduced.
     const network = networks.get(this.options.network);
     if (network && network.regtestEnabled) {

--- a/packages/js-dapi-client/lib/dapiAddressProvider/SimplifiedMasternodeListDAPIAddressProvider.js
+++ b/packages/js-dapi-client/lib/dapiAddressProvider/SimplifiedMasternodeListDAPIAddressProvider.js
@@ -22,7 +22,10 @@ class SimplifiedMasternodeListDAPIAddressProvider {
     const validMasternodeList = sml.getValidMasternodesList();
 
     const addressesByRegProTxHashes = {};
+    let allowSelfSignedCertificate;
     this.listDAPIAddressProvider.getAllAddresses().forEach((address) => {
+      allowSelfSignedCertificate = address.isSelfSignedCertificateAllowed();
+
       if (!address.getProRegTxHash()) {
         return;
       }
@@ -36,6 +39,8 @@ class SimplifiedMasternodeListDAPIAddressProvider {
       if (!address) {
         address = new DAPIAddress({
           host: smlEntry.getIp(),
+          port: smlEntry.platformHTTPPort,
+          allowSelfSignedCertificate,
           proRegTxHash: smlEntry.proRegTxHash,
         });
       } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DAPI Client ignores platform HTTP port for node addresses received with SML

## What was done?
<!--- Describe your changes in detail -->
- Set correct port and certificate options for addresses received from SML

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
