### PR TITLE
fix: DAPI still expected on normal masternodes

### DIFF
--- a/packages/js-dapi-client/lib/dapiAddressProvider/SimplifiedMasternodeListDAPIAddressProvider.js
+++ b/packages/js-dapi-client/lib/dapiAddressProvider/SimplifiedMasternodeListDAPIAddressProvider.js
@@ -19,7 +19,9 @@ class SimplifiedMasternodeListDAPIAddressProvider {
    */
   async getLiveAddress() {
     const sml = await this.smlProvider.getSimplifiedMNList();
-    const validMasternodeList = sml.getValidMasternodesList();
+    const validMasternodeList = sml.getValidMasternodesList()
+      // Keep only HP masternodes
+      .filter((smlEntry) => smlEntry.nType === 1);
 
     const addressesByRegProTxHashes = {};
     let allowSelfSignedCertificate;

--- a/scripts/configure_test_suite_network.sh
+++ b/scripts/configure_test_suite_network.sh
@@ -56,7 +56,7 @@ FEATURE_FLAGS_OWNER_PRIVATE_KEY=$(yq .feature_flags_hd_private_key "$CONFIG")
 MASTERNODE_NAME=$(grep "$DAPI_SEED" "$INVENTORY" | awk '{print $1;}')
 
 MASTERNODE_OWNER_PRO_REG_TX_HASH=$(grep "$DAPI_SEED" "$INVENTORY" | awk -F "=" '{print $6;}')
-MASTERNODE_OWNER_MASTER_PRIVATE_KEY=$(yq .masternodes."$MASTERNODE_NAME".owner.private_key "$CONFIG")
+MASTERNODE_OWNER_MASTER_PRIVATE_KEY=$(yq .hp_masternodes."$MASTERNODE_NAME".owner.private_key "$CONFIG")
 
 if [[ "$NETWORK_STRING" == "devnet"* ]]; then
   NETWORK=devnet


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
configure_test_suite_network script points wrong mastenode private key list and sml provider returns regular masternodes

## What was done?
<!--- Describe your changes in detail -->
* Fixed configure_test_suite_network.sh script
* Fixed SML provider so that it returns only hpmns

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
platform-test-suite

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
