### PR TITLE
fix(drive): non-deterministic run of mn identities sync

### DIFF
--- a/packages/js-drive/lib/abci/handlers/proposal/beginBlockFactory.js
+++ b/packages/js-drive/lib/abci/handlers/proposal/beginBlockFactory.js
@@ -106,7 +106,7 @@ function beginBlockFactory(
     proposalBlockExecutionContext.setLastCommitInfo(lastCommitInfo);
 
     // Update SML
-    const isSimplifiedMasternodeListUpdated = await updateSimplifiedMasternodeList(
+    await updateSimplifiedMasternodeList(
       coreChainLockedHeight,
       {
         logger: contextLogger,
@@ -142,8 +142,7 @@ function beginBlockFactory(
       validatorSetQuorumHash: quorumHash,
       coreChainLockedHeight,
       lastSyncedCoreHeight,
-      // TODO: Since we don't have HPMNs now and every masternode can be a validator,
-      //  we pass the whole list
+      // TODO: We should pass only HPMNs
       totalHpmns: simplifiedMasternodeList.getStore()
         .getCurrentSML()
         .getValidMasternodesList()
@@ -188,19 +187,18 @@ function beginBlockFactory(
     }
 
     // Synchronize masternode identities
+    const blockInfo = BlockInfo.createFromBlockExecutionContext(proposalBlockExecutionContext);
 
-    if (isSimplifiedMasternodeListUpdated) {
-      const blockInfo = BlockInfo.createFromBlockExecutionContext(proposalBlockExecutionContext);
+    const synchronizeMasternodeIdentitiesResult = await synchronizeMasternodeIdentities(
+      coreChainLockedHeight,
+      blockInfo,
+    );
 
-      const synchronizeMasternodeIdentitiesResult = await synchronizeMasternodeIdentities(
-        coreChainLockedHeight,
-        blockInfo,
-      );
+    const {
+      createdEntities, updatedEntities, removedEntities, fromHeight, toHeight,
+    } = synchronizeMasternodeIdentitiesResult;
 
-      const {
-        createdEntities, updatedEntities, removedEntities, fromHeight, toHeight,
-      } = synchronizeMasternodeIdentitiesResult;
-
+    if (fromHeight !== toHeight) {
       contextLogger.info(
         `Masternode identities are synced for heights from ${fromHeight} to ${toHeight}: ${createdEntities.length} created, ${updatedEntities.length} updated, ${removedEntities.length} removed`,
       );

--- a/packages/js-drive/lib/identity/masternode/synchronizeMasternodeIdentitiesFactory.js
+++ b/packages/js-drive/lib/identity/masternode/synchronizeMasternodeIdentitiesFactory.js
@@ -58,8 +58,6 @@ function synchronizeMasternodeIdentitiesFactory(
   lastSyncedCoreHeightRepository,
   fetchSimplifiedMNList,
 ) {
-  let lastSyncedCoreHeight = 0;
-
   /**
    * @typedef synchronizeMasternodeIdentities
    * @param {number} coreHeight
@@ -73,18 +71,23 @@ function synchronizeMasternodeIdentitiesFactory(
    * }>}
    */
   async function synchronizeMasternodeIdentities(coreHeight, blockInfo) {
+    // TODO: Must be moved outside of this function
+    const lastSyncedHeightResult = await lastSyncedCoreHeightRepository.fetch({
+      useTransaction: true,
+    });
+
+    const lastSyncedCoreHeight = lastSyncedHeightResult.getValue() || 0;
+
     let result = {
       createdEntities: [],
       updatedEntities: [],
       removedEntities: [],
+      fromHeight: lastSyncedCoreHeight,
+      toHeight: coreHeight,
     };
 
-    if (!lastSyncedCoreHeight) {
-      const lastSyncedHeightResult = await lastSyncedCoreHeightRepository.fetch({
-        useTransaction: true,
-      });
-
-      lastSyncedCoreHeight = lastSyncedHeightResult.getValue() || 0;
+    if (lastSyncedCoreHeight === coreHeight) {
+      return result;
     }
 
     let newMasternodes;
@@ -242,9 +245,7 @@ function synchronizeMasternodeIdentitiesFactory(
       result = mergeEntities(result, affectedEntities);
     }
 
-    result.fromHeight = lastSyncedCoreHeight;
-    result.toHeight = coreHeight;
-
+    // TODO: Must be moved outside of this function
     await lastSyncedCoreHeightRepository.store(coreHeight, {
       useTransaction: true,
     });

--- a/packages/js-drive/test/integration/identity/masternode/synchronizeMasternodeIdentitiesFactory.spec.js
+++ b/packages/js-drive/test/integration/identity/masternode/synchronizeMasternodeIdentitiesFactory.spec.js
@@ -520,6 +520,8 @@ describe.skip('synchronizeMasternodeIdentitiesFactory', function main() {
     }
   });
 
+  it('should do nothing if last synced height is equal to the current height');
+
   it('should create identities for all masternodes on the first sync', async () => {
     const result = await synchronizeMasternodeIdentities(coreHeight, blockInfo);
 

--- a/packages/js-drive/test/unit/abci/handlers/proposal/beginBlockFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/proposal/beginBlockFactory.spec.js
@@ -191,7 +191,10 @@ describe('beginBlockFactory', () => {
       coreChainLockedHeight, { logger: loggerMock },
     );
 
-    expect(synchronizeMasternodeIdentitiesMock).to.not.been.called();
+    expect(synchronizeMasternodeIdentitiesMock).to.be.calledWithExactly(
+      coreChainLockedHeight,
+      blockInfo,
+    );
 
     expect(executionTimerMock.clearTimer).to.be.calledTwice();
     expect(executionTimerMock.clearTimer.getCall(1)).to.be.calledWithExactly('roundExecution');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If some nodes were restarted or missed some rounds during consensus polka, masternode identities synchronization can be called in non-deterministic manner due to in-memory state.

## What was done?
<!--- Describe your changes in detail -->
- Remove in-memory state for synchronize masternode identities logic

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
