### PR TITLE
fix(dashmate): select number of masternodes during local setup freezes

### DIFF
--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -39,12 +39,18 @@ function setupLocalPresetTaskFactory(
         enabled: (ctx) => ctx.nodeCount === undefined,
         task: async (ctx, task) => {
           ctx.nodeCount = await task.prompt({
-            type: 'Numeral',
+            type: 'input',
             message: 'Enter the number of masternodes',
             initial: 3,
-            float: false,
-            min: 3,
             validate: (state) => {
+              if (Number.isNaN(+state)) {
+                return 'You must set a number of masternodes';
+              }
+
+              if (!Number.isInteger(+state)) {
+                return 'Must be an integer';
+              }
+
               if (+state < 3) {
                 return 'You must set not less than 3';
               }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Select number of masternodes during local setup freezes

## What was done?
<!--- Describe your changes in detail -->
It seems like there is a bug in Listr2 Numeral prompt implementation, which freezes the input. Thats why Numeral prompt was replaced with simple input with additional validations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
