### PR TITLE
fix(dashmate): invalid mn register command in output of dashmate setup

### DIFF
--- a/packages/dashmate/src/listr/tasks/setup/regular/registerMasternodeGuideTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/registerMasternodeGuideTaskFactory.js
@@ -219,27 +219,27 @@ function registerMasternodeGuideTaskFactory() {
 
             let command;
             if (ctx.isHP) {
-              command = `dash-cli register_hpmn
-                    ${state.collateral.txId}
-                    ${state.collateral.outputIndex}
-                    ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort}
-                    ${state.keys.ownerAddress}
-                    ${operatorPublicKeyHex}
-                    ${state.keys.votingAddress}
-                    ${state.operator.rewardShare}
-                    ${state.keys.payoutAddress}
-                    ${deriveTenderdashNodeId(state.platformNodeKey)}
-                    ${platformP2PPort}
+              command = `dash-cli protx register_hpmn \
+                    ${state.collateral.txId} \
+                    ${state.collateral.outputIndex} \
+                    ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort} \
+                    ${state.keys.ownerAddress} \
+                    ${operatorPublicKeyHex} \
+                    ${state.keys.votingAddress} \
+                    ${state.operator.rewardShare} \
+                    ${state.keys.payoutAddress} \
+                    ${deriveTenderdashNodeId(state.platformNodeKey)} \
+                    ${platformP2PPort} \
                     ${platformHTTPPort}`;
             } else {
-              command = `dash-cli register
-                    ${state.collateral.txId}
-                    ${state.collateral.outputIndex}
-                    ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort}
-                    ${state.keys.ownerAddress}
-                    ${operatorPublicKeyHex}
-                    ${state.keys.votingAddress}
-                    ${state.operator.rewardShare}
+              command = `dash-cli protx register \
+                    ${state.collateral.txId} \
+                    ${state.collateral.outputIndex} \
+                    ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort} \
+                    ${state.keys.ownerAddress} \
+                    ${operatorPublicKeyHex} \
+                    ${state.keys.votingAddress} \
+                    ${state.operator.rewardShare} \
                     ${state.keys.payoutAddress}`;
             }
 

--- a/packages/dashmate/src/listr/tasks/setup/regular/registerMasternodeGuideTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/registerMasternodeGuideTaskFactory.js
@@ -219,27 +219,27 @@ function registerMasternodeGuideTaskFactory() {
 
             let command;
             if (ctx.isHP) {
-              command = `dash-cli protx register_hpmn \
-                    ${state.collateral.txId} \
-                    ${state.collateral.outputIndex} \
-                    ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort} \
-                    ${state.keys.ownerAddress} \
-                    ${operatorPublicKeyHex} \
-                    ${state.keys.votingAddress} \
-                    ${state.operator.rewardShare} \
-                    ${state.keys.payoutAddress} \
-                    ${deriveTenderdashNodeId(state.platformNodeKey)} \
-                    ${platformP2PPort} \
+              command = `dash-cli protx register_hpmn \\
+                    ${state.collateral.txId} \\
+                    ${state.collateral.outputIndex} \\
+                    ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort} \\
+                    ${state.keys.ownerAddress} \\
+                    ${operatorPublicKeyHex} \\
+                    ${state.keys.votingAddress} \\
+                    ${state.operator.rewardShare} \\
+                    ${state.keys.payoutAddress} \\
+                    ${deriveTenderdashNodeId(state.platformNodeKey)} \\
+                    ${platformP2PPort} \\
                     ${platformHTTPPort}`;
             } else {
-              command = `dash-cli protx register \
-                    ${state.collateral.txId} \
-                    ${state.collateral.outputIndex} \
-                    ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort} \
-                    ${state.keys.ownerAddress} \
-                    ${operatorPublicKeyHex} \
-                    ${state.keys.votingAddress} \
-                    ${state.operator.rewardShare} \
+              command = `dash-cli protx register \\
+                    ${state.collateral.txId} \\
+                    ${state.collateral.outputIndex} \\
+                    ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort} \\
+                    ${state.keys.ownerAddress} \\
+                    ${operatorPublicKeyHex} \\
+                    ${state.keys.votingAddress} \\
+                    ${state.operator.rewardShare} \\
                     ${state.keys.payoutAddress}`;
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resulting  hpmn_register multiline command doesn't have "\" at the end of string so you can't paste it the terminal

protx is missing before register_hpmn and register

## What was done?
<!--- Describe your changes in detail -->
Fixed the output

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
