### PR TITLE
fix(dashmate): reward shares can be negative during HP masternode registration

### DIFF
--- a/packages/dashmate/src/listr/prompts/validators/validatePercentage.js
+++ b/packages/dashmate/src/listr/prompts/validators/validatePercentage.js
@@ -5,7 +5,7 @@
 function validatePercentage(value) {
   const reminder = value.split('.')[1];
 
-  return Number(value) <= 100 && (!reminder || reminder.length <= 2);
+  return Number(value) >= 0 && Number(value) <= 100 && (!reminder || reminder.length <= 2);
 }
 
 module.exports = validatePercentage;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reward shares input allows to have negative values

## What was done?
<!--- Describe your changes in detail -->
Fixed reward shares validation

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
