### PR TITLE
fix(dashmate): missing fallback fee on testnet with core v20

### DIFF
--- a/packages/dashmate/templates/core/dash.conf.dot
+++ b/packages/dashmate/templates/core/dash.conf.dot
@@ -51,6 +51,7 @@ masternodeblsprivkey={{=it.core.masternode.operator.privateKey}}
 {{?}}
 
 {{? it.network === 'testnet'}}testnet=1
+fallbackfee=1000
 [test]
 {{?? it.network === 'local'}}
 regtest=1

--- a/packages/dashmate/templates/core/dash.conf.dot
+++ b/packages/dashmate/templates/core/dash.conf.dot
@@ -50,8 +50,12 @@ zmqpubrawtxlocksig=tcp://0.0.0.0:29998
 masternodeblsprivkey={{=it.core.masternode.operator.privateKey}}
 {{?}}
 
-{{? it.network === 'testnet'}}testnet=1
+{{? it.network !== 'mainnet'}}
 fallbackfee=0.00001
+{{?}}
+
+{{? it.network === 'testnet'}}testnet=1
+
 [test]
 {{?? it.network === 'local'}}
 regtest=1

--- a/packages/dashmate/templates/core/dash.conf.dot
+++ b/packages/dashmate/templates/core/dash.conf.dot
@@ -51,7 +51,7 @@ masternodeblsprivkey={{=it.core.masternode.operator.privateKey}}
 {{?}}
 
 {{? it.network === 'testnet'}}testnet=1
-fallbackfee=1000
+fallbackfee=0.00001
 [test]
 {{?? it.network === 'local'}}
 regtest=1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dashmate failed to start core v20 with error about missing `fallbackffee` on testnet

## What was done?
<!--- Describe your changes in detail -->
Add `fallbackffee` on testnet

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Untested

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None, this has always been the fallbackfee on testnet I think

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
