### PR TITLE
fix(drive)!: updating a masternode identity with invalid entry from SML

### DIFF
--- a/packages/js-drive/lib/identity/masternode/synchronizeMasternodeIdentitiesFactory.js
+++ b/packages/js-drive/lib/identity/masternode/synchronizeMasternodeIdentitiesFactory.js
@@ -96,6 +96,8 @@ function synchronizeMasternodeIdentitiesFactory(
       .getSMLbyHeight(coreHeight)
       .mnList;
 
+    const currentValidMNList = currentMNList.filter((entry) => entry.isValid);
+
     const dataContractResult = await dataContractRepository.fetch(
       masternodeRewardSharesContractId,
       {
@@ -107,7 +109,7 @@ function synchronizeMasternodeIdentitiesFactory(
 
     if (lastSyncedCoreHeight === 0) {
       // Create identities for all masternodes on the first sync
-      newMasternodes = currentMNList;
+      newMasternodes = currentValidMNList;
     } else {
       // simplifiedMasternodeList contains sml only for the last `smlMaxListsLimit` number of blocks
       if (coreHeight - lastSyncedCoreHeight >= smlMaxListsLimit) {
@@ -120,14 +122,14 @@ function synchronizeMasternodeIdentitiesFactory(
       }
 
       // Get the difference between last sync and requested core height
-      newMasternodes = currentMNList.filter((currentMnListEntry) => (
+      newMasternodes = currentValidMNList.filter((currentMnListEntry) => (
         !previousMNList.find((previousMnListEntry) => (
           previousMnListEntry.proRegTxHash === currentMnListEntry.proRegTxHash
         ))
       ));
 
       // Update operator identities (PubKeyOperator is changed)
-      for (const mnEntry of currentMNList) {
+      for (const mnEntry of currentValidMNList) {
         const previousMnEntry = previousMNList.find((previousMnListEntry) => (
           previousMnListEntry.proRegTxHash === mnEntry.proRegTxHash
           && previousMnListEntry.pubKeyOperator !== mnEntry.pubKeyOperator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
During masternode identities sync we trying to update identities for invalid SML entries

## What was done?
<!--- Describe your changes in detail -->
- Create and update masternode identities only for valid entries from SML 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Previous state might be invalid since to new sync mn identities logic

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
