### PR TITLE
fix(dashmate): already configured preset is ignored

### DIFF
--- a/packages/dashmate/src/commands/setup.js
+++ b/packages/dashmate/src/commands/setup.js
@@ -69,32 +69,32 @@ class SetupCommand extends BaseCommand {
                 initial: PRESET_MAINNET,
               },
             ]);
+          }
 
-            let isAlreadyConfigured;
-            if (ctx.preset === PRESET_LOCAL) {
-              isAlreadyConfigured = configFile.isGroupExists(ctx.preset);
-            } else {
-              const systemConfig = new Config(ctx.preset, systemConfigs[ctx.preset]);
+          let isAlreadyConfigured;
+          if (ctx.preset === PRESET_LOCAL) {
+            isAlreadyConfigured = configFile.isGroupExists(ctx.preset);
+          } else {
+            const systemConfig = new Config(ctx.preset, systemConfigs[ctx.preset]);
 
-              isAlreadyConfigured = !configFile.getConfig(ctx.preset).isEqual(systemConfig);
-            }
+            isAlreadyConfigured = !configFile.getConfig(ctx.preset).isEqual(systemConfig);
+          }
 
-            if (isAlreadyConfigured) {
-              // eslint-disable-next-line no-param-reassign
-              task.output = chalk`Preset {bold ${ctx.preset}} already configured.
+          if (isAlreadyConfigured) {
+            // eslint-disable-next-line no-param-reassign
+            task.output = chalk`Preset {bold ${ctx.preset}} already configured.
 
   To set up a node with this preset from scratch use {bold.cyanBright dashmate reset --config ${ctx.preset} --hard}.
   Previous data and configuration for this preset will be lost.
 
   If you want to keep the existing data and configuration, please use the {bold.cyanBright dashmate config create}
   command to create a new configuration for this preset.`;
-              throw new Error(`Preset ${ctx.preset} already configured`);
-            } else {
-              // eslint-disable-next-line no-param-reassign
+            throw new Error(`Preset ${ctx.preset} already configured`);
+          } else {
+            // eslint-disable-next-line no-param-reassign
 
-              // eslint-disable-next-line no-param-reassign
-              task.output = ctx.preset;
-            }
+            // eslint-disable-next-line no-param-reassign
+            task.output = ctx.preset;
           }
         },
         options: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If `dashmate setup` command is called with the preset argument then there is no check is this preset already configured

## What was done?
<!--- Describe your changes in detail -->
- Check for preconfigured preset if preset is predefined as well

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
