### PR TITLE
fix(drive)!: non-unique masternode voting keys

### DIFF
--- a/packages/js-drive/lib/identity/masternode/handleNewMasternodeFactory.js
+++ b/packages/js-drive/lib/identity/masternode/handleNewMasternodeFactory.js
@@ -2,7 +2,6 @@ const Address = require('@dashevo/dashcore-lib/lib/address');
 const Script = require('@dashevo/dashcore-lib/lib/script');
 const { KeyType, Identifier } = require('@dashevo/wasm-dpp');
 const createOperatorIdentifier = require('./createOperatorIdentifier');
-const createVotingIdentifier = require('./createVotingIdentifier');
 
 /**
  *
@@ -97,22 +96,23 @@ function handleNewMasternodeFactory(
       }
     }
 
-    const votingPubKeyHash = Buffer.from(proRegTxPayload.keyIDVoting, 'hex').reverse();
+    // const votingPubKeyHash = Buffer.from(proRegTxPayload.keyIDVoting, 'hex').reverse();
 
+    // TODO: Disabled until we have uniq keys support in DPP
     // don't need to create a separate Identity in case we don't have
     // voting public key (keyIDVoting === keyIDOwner)
-    if (!votingPubKeyHash.equals(ownerPublicKeyHash)) {
-      const votingIdentifier = createVotingIdentifier(masternodeEntry);
-
-      createdEntities.push(
-        await createMasternodeIdentity(
-          blockInfo,
-          votingIdentifier,
-          votingPubKeyHash,
-          KeyType.ECDSA_HASH160,
-        ),
-      );
-    }
+    // if (!votingPubKeyHash.equals(ownerPublicKeyHash)) {
+    //   const votingIdentifier = createVotingIdentifier(masternodeEntry);
+    //
+    //   createdEntities.push(
+    //     await createMasternodeIdentity(
+    //       blockInfo,
+    //       votingIdentifier,
+    //       votingPubKeyHash,
+    //       KeyType.ECDSA_HASH160,
+    //     ),
+    //   );
+    // }
 
     return {
       createdEntities,

--- a/packages/js-drive/lib/identity/masternode/synchronizeMasternodeIdentitiesFactory.js
+++ b/packages/js-drive/lib/identity/masternode/synchronizeMasternodeIdentitiesFactory.js
@@ -146,19 +146,19 @@ function synchronizeMasternodeIdentitiesFactory(
           result = mergeEntities(result, affectedEntities);
         }
 
-        const previousVotingMnEntry = previousMNList.find((previousMnListEntry) => (
-          previousMnListEntry.proRegTxHash === mnEntry.proRegTxHash
-          && previousMnListEntry.votingAddress !== mnEntry.votingAddress
-        ));
-
-        if (previousVotingMnEntry) {
-          const affectedEntities = await handleUpdatedVotingAddress(
-            mnEntry,
-            blockInfo,
-          );
-
-          result = mergeEntities(result, affectedEntities);
-        }
+        // const previousVotingMnEntry = previousMNList.find((previousMnListEntry) => (
+        //   previousMnListEntry.proRegTxHash === mnEntry.proRegTxHash
+        //   && previousMnListEntry.votingAddress !== mnEntry.votingAddress
+        // ));
+        //
+        // if (previousVotingMnEntry) {
+        //   const affectedEntities = await handleUpdatedVotingAddress(
+        //     mnEntry,
+        //     blockInfo,
+        //   );
+        //
+        //   result = mergeEntities(result, affectedEntities);
+        // }
 
         if (mnEntry.payoutAddress) {
           const mnEntryWithChangedPayoutAddress = previousMNList.find((previousMnListEntry) => (

--- a/packages/js-drive/test/integration/identity/masternode/synchronizeMasternodeIdentitiesFactory.spec.js
+++ b/packages/js-drive/test/integration/identity/masternode/synchronizeMasternodeIdentitiesFactory.spec.js
@@ -333,7 +333,7 @@ function expectDeterministicAppHashFactory(groveDBStore) {
 
     expect(actualAppHashHex).to.deep.equal(appHash);
   }
-
+g
   return expectDeterministicAppHash;
 }
 

--- a/packages/js-drive/test/integration/identity/masternode/synchronizeMasternodeIdentitiesFactory.spec.js
+++ b/packages/js-drive/test/integration/identity/masternode/synchronizeMasternodeIdentitiesFactory.spec.js
@@ -333,7 +333,7 @@ function expectDeterministicAppHashFactory(groveDBStore) {
 
     expect(actualAppHashHex).to.deep.equal(appHash);
   }
-g
+
   return expectDeterministicAppHash;
 }
 

--- a/packages/js-drive/test/unit/identity/masternode/handleNewMasternodeFactory.spec.js
+++ b/packages/js-drive/test/unit/identity/masternode/handleNewMasternodeFactory.spec.js
@@ -9,7 +9,6 @@ const handleNewMasternodeFactory = require('../../../../lib/identity/masternode/
 const getSmlFixture = require('../../../../lib/test/fixtures/getSmlFixture');
 const createOperatorIdentifier = require('../../../../lib/identity/masternode/createOperatorIdentifier');
 const BlockInfo = require('../../../../lib/blockExecution/BlockInfo');
-const createVotingIdentifier = require('../../../../lib/identity/masternode/createVotingIdentifier');
 
 describe('handleNewMasternodeFactory', () => {
   let handleNewMasternode;
@@ -65,12 +64,12 @@ describe('handleNewMasternodeFactory', () => {
 
     const result = await handleNewMasternode(masternodeEntry, dataContract, blockInfo);
 
-    expect(result.createdEntities).to.have.lengthOf(2);
+    expect(result.createdEntities).to.have.lengthOf(1); // TODO: should be 2
     expect(result.updatedEntities).to.have.lengthOf(0);
     expect(result.removedEntities).to.have.lengthOf(0);
 
     expect(result.createdEntities[0].toObject()).to.deep.equal(identityFixture.toObject());
-    expect(result.createdEntities[1].toObject()).to.deep.equal(identityFixture.toObject());
+    // expect(result.createdEntities[1].toObject()).to.deep.equal(identityFixture.toObject());
 
     expect(fetchTransactionMock).to.be.calledOnceWithExactly(masternodeEntry.proRegTxHash);
     expect(createMasternodeIdentityMock.getCall(0)).to.be.calledWithExactly(
@@ -81,12 +80,12 @@ describe('handleNewMasternodeFactory', () => {
       payoutScript,
     );
 
-    expect(createMasternodeIdentityMock.getCall(1)).to.be.calledWithExactly(
-      blockInfo,
-      Identifier.from('GVYoKVDd29gbmHzbVGepFjCbdymCS5Jq26CCiLnWNL6C'),
-      Buffer.from('6262626262626262626262626262626262626262', 'hex'),
-      KeyType.ECDSA_HASH160,
-    );
+    // expect(createMasternodeIdentityMock.getCall(1)).to.be.calledWithExactly(
+    //   blockInfo,
+    //   Identifier.from('GVYoKVDd29gbmHzbVGepFjCbdymCS5Jq26CCiLnWNL6C'),
+    //   Buffer.from('6262626262626262626262626262626262626262', 'hex'),
+    //   KeyType.ECDSA_HASH160,
+    // );
 
     expect(createRewardShareDocumentMock).to.not.be.called();
   });
@@ -126,24 +125,24 @@ describe('handleNewMasternodeFactory', () => {
 
     const result = await handleNewMasternode(masternodeEntry, dataContract, blockInfo);
 
-    expect(result.createdEntities).to.have.lengthOf(3);
+    expect(result.createdEntities).to.have.lengthOf(2); // TODO: Should be 3
     expect(result.updatedEntities).to.have.lengthOf(0);
     expect(result.removedEntities).to.have.lengthOf(0);
 
     expect(result.createdEntities[0].toJSON()).to.deep.equal(identityFixture.toJSON());
     expect(result.createdEntities[1].toJSON()).to.deep.equal(identityFixture.toJSON());
-    expect(result.createdEntities[2].toJSON()).to.deep.equal(identityFixture.toJSON());
+    // expect(result.createdEntities[2].toJSON()).to.deep.equal(identityFixture.toJSON());
 
     const operatorIdentifier = createOperatorIdentifier(masternodeEntry);
     const operatorPayoutAddress = Address.fromString(masternodeEntry.operatorPayoutAddress);
     const operatorPayoutScript = new Script(operatorPayoutAddress);
 
-    const votingIdentifier = createVotingIdentifier(masternodeEntry);
+    // const votingIdentifier = createVotingIdentifier(masternodeEntry);
     const payoutAddress = Address.fromString(masternodeEntry.payoutAddress);
     const payoutScript = new Script(payoutAddress);
 
     expect(fetchTransactionMock).to.be.calledOnceWithExactly(masternodeEntry.proRegTxHash);
-    expect(createMasternodeIdentityMock).to.be.calledThrice();
+    expect(createMasternodeIdentityMock).to.be.calledTwice(); // TODO: Should be calledThrice
     expect(createMasternodeIdentityMock.getCall(0)).to.be.calledWithExactly(
       blockInfo,
       Identifier.from('HYyu6DdUQyiHZwzeWpmahu7AUrsEF9MKkRcrdQnKeNSj'),
@@ -160,12 +159,12 @@ describe('handleNewMasternodeFactory', () => {
       operatorPayoutScript,
     );
 
-    expect(createMasternodeIdentityMock.getCall(2)).to.be.calledWithExactly(
-      blockInfo,
-      votingIdentifier,
-      Buffer.from('6262626262626262626262626262626262626262', 'hex'),
-      KeyType.ECDSA_HASH160,
-    );
+    // expect(createMasternodeIdentityMock.getCall(2)).to.be.calledWithExactly(
+    //   blockInfo,
+    //   votingIdentifier,
+    //   Buffer.from('6262626262626262626262626262626262626262', 'hex'),
+    //   KeyType.ECDSA_HASH160,
+    // );
 
     expect(createRewardShareDocumentMock).to.be.calledOnceWithExactly(
       dataContract,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Testnet uses non unque keys for owners and voting but the current implementation of syncronize masternode identities doesn't suport it 

## What was done?
<!--- Describe your changes in detail -->
- Disable voting keys until we have support for non-unique keys in DPP

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Previous state won't be valid due to changes in the sync identities logic

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
