### PR TITLE
fix(dashmate)!: multiple issues in the reset command

### DIFF
--- a/packages/dashmate/docker-compose.platform.yml
+++ b/packages/dashmate/docker-compose.platform.yml
@@ -4,8 +4,6 @@ services:
   drive_abci:
     image: ${PLATFORM_DRIVE_ABCI_DOCKER_IMAGE:?err}
     restart: unless-stopped
-    depends_on:
-      - core
     volumes:
       - drive_abci_data:/platform/packages/js-drive/db
       - ${PLATFORM_DRIVE_ABCI_LOG_PRETTY_DIRECTORY_PATH:?err}:/var/log/pretty
@@ -58,7 +56,6 @@ services:
     restart: unless-stopped
     depends_on:
       - drive_tenderdash
-      - core
     environment:
       - API_JSON_RPC_PORT=3004
       - API_GRPC_PORT=3005
@@ -81,8 +78,6 @@ services:
   dapi_tx_filter_stream:
     image: ${PLATFORM_DAPI_API_DOCKER_IMAGE:?err}
     restart: unless-stopped
-    depends_on:
-      - core
     environment:
       - TX_FILTER_STREAM_GRPC_PORT=3006
       - DASHCORE_RPC_HOST=core

--- a/packages/dashmate/src/commands/group/reset.js
+++ b/packages/dashmate/src/commands/group/reset.js
@@ -72,13 +72,6 @@ class GroupResetCommand extends GroupBaseCommand {
           title: 'Configure Tenderdash nodes',
           task: () => configureTenderdashTask(configGroup),
         },
-        {
-          // in case we don't need to register masternodes
-          title: `Generate ${amount} dash to local wallet`,
-          enabled: (ctx) => !ctx.isHardReset && groupName === PRESET_LOCAL,
-          skip: (ctx) => !!ctx.fundingPrivateKeyString,
-          task: () => generateToAddressTask(configGroup[0], amount),
-        },
       ],
       {
         renderer: isVerbose ? 'verbose' : 'default',

--- a/packages/dashmate/src/commands/group/reset.js
+++ b/packages/dashmate/src/commands/group/reset.js
@@ -37,8 +37,6 @@ class GroupResetCommand extends GroupBaseCommand {
   ) {
     const groupName = configGroup[0].get('group');
 
-    const amount = 100;
-
     const tasks = new Listr(
       [
         {

--- a/packages/dashmate/src/commands/group/reset.js
+++ b/packages/dashmate/src/commands/group/reset.js
@@ -4,6 +4,7 @@ const { Flags } = require('@oclif/core');
 
 const GroupBaseCommand = require('../../oclif/command/GroupBaseCommand');
 const MuteOneLineError = require('../../oclif/errors/MuteOneLineError');
+const { PRESET_LOCAL } = require('../../constants');
 
 class GroupResetCommand extends GroupBaseCommand {
   /**
@@ -16,7 +17,6 @@ class GroupResetCommand extends GroupBaseCommand {
    * @param {configureTenderdashTask} configureTenderdashTask
    * @param {generateToAddressTask} generateToAddressTask
    * @param {ConfigFile} configFile
-   * @param {Object[]} systemConfigs
    * @return {Promise<void>}
    */
   async runWithDependencies(
@@ -25,7 +25,7 @@ class GroupResetCommand extends GroupBaseCommand {
       verbose: isVerbose,
       hard: isHardReset,
       force: isForce,
-      'platform-only': isPlatformOnlyReset,
+      platform: isPlatformOnlyReset,
     },
     isSystemConfig,
     resetNodeTask,
@@ -34,15 +34,8 @@ class GroupResetCommand extends GroupBaseCommand {
     configureTenderdashTask,
     generateToAddressTask,
     configFile,
-    systemConfigs,
   ) {
     const groupName = configGroup[0].get('group');
-
-    if (isHardReset && !isSystemConfig(groupName)) {
-      throw new Error(`Cannot hard reset non-system config group "${configGroup[0].get('group')}"`);
-    }
-
-    const baseConfig = systemConfigs.base;
 
     const amount = 100;
 
@@ -50,50 +43,39 @@ class GroupResetCommand extends GroupBaseCommand {
       [
         {
           title: `Reset ${groupName} nodes`,
-          task: () => new Listr(configGroup.map((config) => ({
-            title: `Reset ${config.getName()} node`,
-            task: (ctx) => {
-              ctx.skipPlatformInitialization = true;
+          task: () => {
+            const resetTasks = configGroup.map((config) => ({
+              title: `Reset ${config.getName()} node`,
+              task: () => resetNodeTask(config),
+            }));
 
-              config.set('platform.dpns', baseConfig.platform.dpns);
-              config.set('platform.dashpay', baseConfig.platform.dashpay);
-              config.set('platform.featureFlags', baseConfig.platform.featureFlags);
-              config.set('platform.masternodeRewardShares', baseConfig.platform.masternodeRewardShares);
-
-              // TODO: Should stay the same
-              config.set('platform.drive.tenderdash.node.id', baseConfig.platform.drive.tenderdash.node.id);
-              config.set('platform.drive.tenderdash.node.key', baseConfig.platform.drive.tenderdash.node.key);
-              config.set('platform.drive.tenderdash.genesis', baseConfig.platform.drive.tenderdash.genesis);
-
-              if (!ctx.isPlatformOnlyReset) {
-                config.set('core.masternode.operator.privateKey', baseConfig.core.masternode.operator.privateKey);
-              }
-
-              return resetNodeTask(config);
-            },
-          }))),
+            return new Listr(resetTasks);
+          },
         },
         {
-          enabled: (ctx) => ctx.isHardReset,
+          enabled: (ctx) => ctx.isHardReset && groupName === PRESET_LOCAL,
           title: 'Delete node configs',
           task: () => (
-            configGroup.forEach((config) => configFile.removeConfig(config.getName()))
+            configGroup
+              .filter((config) => configFile.isConfigExists(config.getName()))
+              .forEach((config) => configFile.removeConfig(config.getName()))
           ),
         },
         {
-          enabled: (ctx) => !ctx.isHardReset,
-          title: 'Configure Tenderdash nodes',
-          task: () => configureTenderdashTask(configGroup),
-        },
-        {
-          enabled: (ctx) => !ctx.isHardReset && !ctx.isPlatformOnlyReset,
+          enabled: (ctx) => !ctx.isHardReset
+            && !ctx.isPlatformOnlyReset && groupName === PRESET_LOCAL,
           title: 'Configure Core nodes',
           task: () => configureCoreTask(configGroup),
         },
         {
+          enabled: (ctx) => !ctx.isHardReset && groupName === PRESET_LOCAL,
+          title: 'Configure Tenderdash nodes',
+          task: () => configureTenderdashTask(configGroup),
+        },
+        {
           // in case we don't need to register masternodes
           title: `Generate ${amount} dash to local wallet`,
-          enabled: (ctx) => !ctx.isHardReset,
+          enabled: (ctx) => !ctx.isHardReset && groupName === PRESET_LOCAL,
           skip: (ctx) => !!ctx.fundingPrivateKeyString,
           task: () => generateToAddressTask(configGroup[0], amount),
         },
@@ -135,9 +117,9 @@ GroupResetCommand.flags = {
     description: 'reset even running node',
     default: false,
   }),
-  'platform-only': Flags.boolean({
+  platform: Flags.boolean({
     char: 'p',
-    description: 'reset platform data only',
+    description: 'reset platform services and data only',
     default: false,
   }),
 };

--- a/packages/dashmate/src/commands/reset.js
+++ b/packages/dashmate/src/commands/reset.js
@@ -22,20 +22,12 @@ class ResetCommand extends ConfigBaseCommand {
       verbose: isVerbose,
       hard: isHardReset,
       force: isForce,
-      'platform-only': isPlatformOnlyReset,
+      platform: isPlatformOnlyReset,
     },
     isSystemConfig,
     config,
     resetNodeTask,
   ) {
-    if (isHardReset && !isSystemConfig(config.getName())) {
-      throw new Error(`Cannot hard reset non-system config "${config.getName()}"`);
-    }
-
-    if (!config.get('platform.enable') && isPlatformOnlyReset) {
-      throw new Error('Cannot reset platform only if platform services are not enabled in config');
-    }
-
     const tasks = new Listr([
       {
         title: `Reset ${config.getName()} node`,
@@ -71,7 +63,7 @@ ResetCommand.flags = {
   ...ConfigBaseCommand.flags,
   hard: Flags.boolean({ char: 'h', description: 'reset config as well as data', default: false }),
   force: Flags.boolean({ char: 'f', description: 'skip running services check', default: false }),
-  'platform-only': Flags.boolean({ char: 'p', description: 'reset platform data only', default: false }),
+  platform: Flags.boolean({ char: 'p', description: 'reset platform services and data only', default: false }),
   verbose: Flags.boolean({ char: 'v', description: 'use verbose mode for output', default: false }),
 };
 

--- a/packages/dashmate/src/config/Config.js
+++ b/packages/dashmate/src/config/Config.js
@@ -151,14 +151,20 @@ class Config {
   }
 
   /**
-   *
+   * @param {Object} [options={}]
+   * @param {boolean} [options.platformOnly=false]
    * @return {{CONFIG_NAME: string, COMPOSE_PROJECT_NAME: string}}
    */
-  toEnvs() {
-    const dockerComposeFiles = ['docker-compose.yml'];
+  toEnvs(options = {}) {
+    const dockerComposeFiles = [];
 
-    if (this.get('core.masternode.enable') === true) {
-      dockerComposeFiles.push('docker-compose.sentinel.yml');
+    if (!options.platformOnly) {
+      // TODO: it should contain only the dashmate helper that must be ran always
+      dockerComposeFiles.push('docker-compose.yml');
+
+      if (this.get('core.masternode.enable') === true) {
+        dockerComposeFiles.push('docker-compose.sentinel.yml');
+      }
     }
 
     if (this.get('platform.enable')) {

--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -235,7 +235,7 @@ class DockerCompose {
    * @param {Object} envs
    * @param {string} [filterServiceNames]
    * @param {boolean} returnServiceNames
-   * @return {string[]}
+   * @return {Promise<string[]>}
    */
   async getContainersList(
     envs,
@@ -324,7 +324,7 @@ class DockerCompose {
     try {
       await dockerCompose.rm({
         ...this.getOptions(envs),
-        commandOptions: ['--stop', '-v'],
+        commandOptions: ['--stop'],
       }, ...serviceNames);
     } catch (e) {
       throw new DockerComposeError(e);

--- a/packages/dashmate/src/listr/tasks/resetNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/resetNodeTaskFactory.js
@@ -73,6 +73,14 @@ function resetNodeTaskFactory(
         },
       },
       {
+        title: 'Reset dashmate\'s ephemeral data',
+        task: (ctx) => {
+          if (!ctx.isPlatformOnlyReset) {
+            config.set('core.miner.mediantime', null);
+          }
+        },
+      },
+      {
         title: `Reset config ${config.getName()}`,
         enabled: (ctx) => ctx.isHardReset,
         task: (ctx) => {

--- a/packages/dashmate/src/listr/tasks/setup/local/configureCoreTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/local/configureCoreTaskFactory.js
@@ -162,13 +162,6 @@ function configureCoreTaskFactory(
 
                 const subTasks = masternodeConfigs.map((config, index) => ({
                   title: `Register ${config.getName()} masternode`,
-                  skip: () => {
-                    if (config.get('core.masternode.operator.privateKey')) {
-                      return `Masternode operator private key ('core.masternode.operator.privateKey') is already set in ${config.getName()} config`;
-                    }
-
-                    return false;
-                  },
                   task: () => new Listr([
                     {
                       title: 'Generate a masternode operator key',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The reset and group reset commands do not work with `--force` flag

## What was done?
<!--- Describe your changes in detail -->
- Remove containers and volumes in two steps since `docker compose rm --stop --volumes` doesn't work properly.
- Fixed group soft reset
- Refactored reset logic
- Renamed the `--platfrom-only` to `--platform` flag follow naming convention with other commands

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
- The `--platfrom-only` flag is renamed to `--platform`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
