### PR TITLE
fix(dashmate): BLS private key validate accepts whitespaces

### DIFF
--- a/packages/dashmate/src/listr/prompts/validators/validateBLSPrivateKeyFactory.js
+++ b/packages/dashmate/src/listr/prompts/validators/validateBLSPrivateKeyFactory.js
@@ -1,3 +1,5 @@
+const validateHex = require('./validateHex');
+
 /**
  * @param blsSignatures
  * @returns {validateBLSPrivateKey}
@@ -11,6 +13,10 @@ function validateBLSPrivateKeyFactory(blsSignatures) {
   function validateBLSPrivateKey(value) {
     if (value.length === 0) {
       return 'should not be empty';
+    }
+
+    if (!validateHex(value)) {
+      return 'invalid key';
     }
 
     const operatorPrivateKeyBuffer = Buffer.from(value, 'hex');

--- a/packages/dashmate/src/listr/prompts/validators/validateBLSPrivateKeyFactory.js
+++ b/packages/dashmate/src/listr/prompts/validators/validateBLSPrivateKeyFactory.js
@@ -16,7 +16,7 @@ function validateBLSPrivateKeyFactory(blsSignatures) {
     }
 
     if (!validateHex(value)) {
-      return 'invalid key';
+      return 'invalid key format';
     }
 
     const operatorPrivateKeyBuffer = Buffer.from(value, 'hex');

--- a/packages/dashmate/src/listr/prompts/validators/validateHex.js
+++ b/packages/dashmate/src/listr/prompts/validators/validateHex.js
@@ -1,0 +1,10 @@
+/**
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+function validateHex(value) {
+  return Boolean(value.match(/^[0-9a-fA-F]+$/));
+}
+
+module.exports = validateHex;

--- a/packages/dashmate/src/listr/prompts/validators/validateTxHex.js
+++ b/packages/dashmate/src/listr/prompts/validators/validateTxHex.js
@@ -1,5 +1,12 @@
+const validateHex = require('./validateHex');
+
+/**
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
 function validateTxHex(value) {
-  return Boolean(value.match(/^[0-9A-Fa-f]{64}$/));
+  return validateHex(value) && value.length === 64;
 }
 
 module.exports = validateTxHex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is possible to add an arbitrary text after valid BLS key into the form, e.g. `2f0f410a2ad8f5e1e0eff678d5b56df2440b1792c55c7a3d71714e6f6e146e82 random text`

## What was done?
<!--- Describe your changes in detail -->
`validateBLSPrivateKey` function now checks that value is a valid HEX string

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
