### PR TITLE
release: reference rs-drive-abci instead of js-drive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,7 @@ jobs:
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
-          file: ./packages/js-drive/Dockerfile
+          file: ./packages/rs-drive/Dockerfile
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,7 @@ jobs:
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
-          file: ./packages/rs-drive/Dockerfile
+          file: ./packages/rs-drive-abci/Dockerfile
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
Use rs-drive-abci instead of js-drive when building drive in GH actions