### PR TITLE
fix(dashmate): wrong volume removal retry logic

### DIFF
--- a/packages/dashmate/src/listr/tasks/resetNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/resetNodeTaskFactory.js
@@ -76,13 +76,18 @@ function resetNodeTaskFactory(
               .map(async (volumeName) => {
                 const volume = await docker.getVolume(volumeName);
 
+                let isRetry;
                 do {
+                  isRetry = false;
+
                   try {
                     await volume.remove({ force: true });
                   } catch (e) {
                     // volume is in use
                     if (e.statusCode === 409) {
                       await wait(1000);
+
+                      isRetry = true;
 
                       continue;
                     }
@@ -94,8 +99,7 @@ function resetNodeTaskFactory(
 
                     throw e;
                   }
-                  // eslint-disable-next-line no-constant-condition
-                } while (false);
+                } while (isRetry);
               }),
           );
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The volume removal logic in reset command has wrong retry condition so if volume is in use it won't be removed 

## What was done?
<!--- Describe your changes in detail -->
- Fixed retry logic

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
