### PR TITLE
fix(drive): cannot read properties of undefined (reading 'toString')

### DIFF
--- a/packages/js-drive/lib/abci/errors/VerboseInternalAbciError.js
+++ b/packages/js-drive/lib/abci/errors/VerboseInternalAbciError.js
@@ -7,10 +7,15 @@ class VerboseInternalAbciError extends InternalAbciError {
    */
   constructor(error) {
     const originalError = error.getError();
-    let [, errorPath] = originalError.stack.toString().split(/\r\n|\n/);
 
-    if (!errorPath) {
-      errorPath = originalError.stack;
+    let errorPath = '';
+    if (originalError.stack) {
+      [, errorPath] = originalError.stack.toString()
+        .split(/\r\n|\n/);
+
+      if (!errorPath) {
+        errorPath = originalError.stack;
+      }
     }
 
     const message = `${originalError.message} ${errorPath.trim()}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
[2023-05-08 10:52:39.730 +0000] FATAL (34 on d49e27521be4): Cannot read properties of undefined (reading 'toString')
    driveVersion: "0.24.0-dev.33"
    err: {
      "type": "TypeError",
      "message": "Cannot read properties of undefined (reading 'toString')",
      "stack":
          TypeError: Cannot read properties of undefined (reading 'toString')
              at new VerboseInternalAbciError (/platform/packages/js-drive/lib/abci/errors/VerboseInternalAbciError.js:10:45)
              at Object.methodErrorHandler [as checkTx] (/platform/packages/js-drive/lib/abci/errors/wrapInErrorHandlerFactory.js:49:25)
              at runMicrotasks (<anonymous>)
              at processTicksAndRejections (node:internal/process/task_queues:96:5)
              at async Connection.handleRequest (/platform/.yarn/cache/@dashevo-abci-https-9fb519f2ca-aaf41ab7fa.zip/node_modules/@dashevo/abci/lib/handleRequestFactory.js:55:29)
              at async Connection.readNextRequest (/platform/.yarn/cache/@dashevo-abci-https-9fb519f2ca-aaf41ab7fa.zip/node_modules/@dashevo/abci/lib/Connection.js:176:18)
    }
```

## What was done?
<!--- Describe your changes in detail -->
- Handle empty stack in verbose error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
