### PR TITLE
feat(dashmate): platform flag for start, stop and restart commands

### DIFF
--- a/packages/dashmate/src/commands/restart.js
+++ b/packages/dashmate/src/commands/restart.js
@@ -56,7 +56,7 @@ RestartCommand.description = 'Restart node';
 
 RestartCommand.flags = {
   ...ConfigBaseCommand.flags,
-  platform: Flags.boolean({ char: 'p', description: 'start only platform', default: false }),
+  platform: Flags.boolean({ char: 'p', description: 'restart only platform', default: false }),
 };
 
 module.exports = RestartCommand;

--- a/packages/dashmate/src/commands/restart.js
+++ b/packages/dashmate/src/commands/restart.js
@@ -1,5 +1,6 @@
 const { Listr } = require('listr2');
 
+const { Flags } = require('@oclif/core');
 const ConfigBaseCommand = require('../oclif/command/ConfigBaseCommand');
 
 const MuteOneLineError = require('../oclif/errors/MuteOneLineError');
@@ -17,6 +18,7 @@ class RestartCommand extends ConfigBaseCommand {
     args,
     {
       verbose: isVerbose,
+      platform: platformOnly,
     },
     dockerCompose,
     restartNodeTask,
@@ -26,7 +28,7 @@ class RestartCommand extends ConfigBaseCommand {
       [
         {
           title: `Restarting ${config.getName()} node`,
-          task: () => restartNodeTask(config),
+          task: () => restartNodeTask(config, { platformOnly }),
         },
       ],
       {
@@ -54,6 +56,7 @@ RestartCommand.description = 'Restart node';
 
 RestartCommand.flags = {
   ...ConfigBaseCommand.flags,
+  platform: Flags.boolean({ char: 'p', description: 'start only platform', default: false }),
 };
 
 module.exports = RestartCommand;

--- a/packages/dashmate/src/commands/start.js
+++ b/packages/dashmate/src/commands/start.js
@@ -21,6 +21,7 @@ class StartCommand extends ConfigBaseCommand {
     {
       'wait-for-readiness': waitForReadiness,
       verbose: isVerbose,
+      platform: platformOnly,
     },
     dockerCompose,
     startNodeTask,
@@ -31,7 +32,7 @@ class StartCommand extends ConfigBaseCommand {
       [
         {
           title: `Start ${config.getName()} node`,
-          task: () => startNodeTask(config),
+          task: () => startNodeTask(config, { platformOnly }),
         },
         {
           title: 'Wait for nodes to be ready',
@@ -65,6 +66,7 @@ StartCommand.description = 'Start node';
 StartCommand.flags = {
   ...ConfigBaseCommand.flags,
   'wait-for-readiness': Flags.boolean({ char: 'w', description: 'wait for nodes to be ready', default: false }),
+  platform: Flags.boolean({ char: 'p', description: 'start only platform', default: false }),
 };
 
 module.exports = StartCommand;

--- a/packages/dashmate/src/commands/stop.js
+++ b/packages/dashmate/src/commands/stop.js
@@ -19,13 +19,14 @@ class StopCommand extends ConfigBaseCommand {
     {
       force: isForce,
       verbose: isVerbose,
+      platform: platformOnly,
     },
     stopNodeTask,
     config,
   ) {
     const tasks = new Listr([
       {
-        task: async () => stopNodeTask(config),
+        task: async () => stopNodeTask(config, { platformOnly }),
       },
     ],
     {
@@ -58,6 +59,12 @@ StopCommand.flags = {
     description: 'force stop even if any service is running',
     default: false,
   }),
+  platform: Flags.boolean({
+    char: 'p',
+    description: 'stop only platform',
+    default: false,
+  }),
+
 };
 
 module.exports = StopCommand;

--- a/packages/dashmate/src/listr/tasks/restartNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/restartNodeTaskFactory.js
@@ -12,10 +12,12 @@ function restartNodeTaskFactory(startNodeTask, stopNodeTask, buildServicesTask) 
    * @typedef {restartNodeTask}
    *
    * @param {Config} config
+   * @param {Object} [options={}]
+   * @param {boolean} [options.platformOnly=false]
    *
    * @return {Listr}
    */
-  function restartNodeTask(config) {
+  function restartNodeTask(config, options = {}) {
     return new Listr([
       {
         enabled: () => config.get('platform.enable') && config.get('platform.sourcePath') !== null,
@@ -26,10 +28,10 @@ function restartNodeTaskFactory(startNodeTask, stopNodeTask, buildServicesTask) 
         },
       },
       {
-        task: () => stopNodeTask(config),
+        task: () => stopNodeTask(config, options),
       },
       {
-        task: () => startNodeTask(config),
+        task: () => startNodeTask(config, options),
       },
     ]);
   }

--- a/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
@@ -26,9 +26,11 @@ function startNodeTaskFactory(
   /**
    * @typedef {startNodeTask}
    * @param {Config} config
+   * @param {Object} [options={}]
+   * @param {boolean} [options.platformOnly=false]
    * @return {Object}
    */
-  function startNodeTask(config) {
+  function startNodeTask(config, options = {}) {
     // check core is not reindexing
     if (config.get('core.reindex.enable', true)) {
       throw new Error(`Your dashcore node in config [${config.name}] is reindexing, please allow the process to complete first`);
@@ -61,7 +63,7 @@ function startNodeTaskFactory(
       {
         title: 'Check node is not started',
         task: async () => {
-          if (await dockerCompose.isServiceRunning(config.toEnvs())) {
+          if (await dockerCompose.isServiceRunning(config.toEnvs(options))) {
             throw new Error('Running services detected. Please ensure all services are stopped for this config before starting');
           }
         },
@@ -81,7 +83,7 @@ function startNodeTaskFactory(
             config.get('core.masternode.operator.privateKey', true);
           }
 
-          const envs = config.toEnvs();
+          const envs = config.toEnvs(options);
 
           await dockerCompose.up(envs);
         },

--- a/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
@@ -69,6 +69,15 @@ function startNodeTaskFactory(
         },
       },
       {
+        title: 'Check core is started',
+        enabled: options.platformOnly,
+        task: async () => {
+          if (!await dockerCompose.isServiceRunning(config.toEnvs(), 'core')) {
+            throw new Error('Core service is not running. Please ensure core service is running before starting');
+          }
+        },
+      },
+      {
         enabled: (ctx) => !ctx.skipBuildServices
           && config.get('platform.enable')
           && config.get('platform.sourcePath') !== null,

--- a/packages/dashmate/src/listr/tasks/stopNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/stopNodeTaskFactory.js
@@ -15,16 +15,18 @@ function stopNodeTaskFactory(
    * Stop node
    * @typedef stopNodeTask
    * @param {Config} config
+   * @param {Object} [options={}]
+   * @param {boolean} [options.platformOnly=false]
    *
    * @return {Listr}
    */
-  function stopNodeTask(config) {
+  function stopNodeTask(config, options = {}) {
     return new Listr([
       {
         title: 'Check node is running',
         skip: (ctx) => ctx.isForce,
         task: async () => {
-          if (!await dockerCompose.isServiceRunning(config.toEnvs())) {
+          if (!await dockerCompose.isServiceRunning(config.toEnvs(options))) {
             throw new Error('Node is not running');
           }
         },
@@ -48,7 +50,7 @@ function stopNodeTaskFactory(
       },
       {
         title: `Stopping ${config.getName()} node`,
-        task: async () => dockerCompose.stop(config.toEnvs()),
+        task: async () => dockerCompose.stop(config.toEnvs(options)),
       },
     ]);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add `platform` flag which allows to start, stop or restart only platform

## What was done?
<!--- Describe your changes in detail -->
`platform` flad was added to start, stop and restart commands

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
