### PR TITLE
fix(dashmate): check core is started checks everytime

### DIFF
--- a/packages/dashmate/src/commands/restart.js
+++ b/packages/dashmate/src/commands/restart.js
@@ -28,7 +28,7 @@ class RestartCommand extends ConfigBaseCommand {
       [
         {
           title: `Restarting ${config.getName()} node`,
-          task: () => restartNodeTask(config, { platformOnly }),
+          task: () => restartNodeTask(config),
         },
       ],
       {
@@ -45,6 +45,7 @@ class RestartCommand extends ConfigBaseCommand {
     try {
       await tasks.run({
         isVerbose,
+        platformOnly: platformOnly === true,
       });
     } catch (e) {
       throw new MuteOneLineError(e);

--- a/packages/dashmate/src/commands/start.js
+++ b/packages/dashmate/src/commands/start.js
@@ -32,7 +32,7 @@ class StartCommand extends ConfigBaseCommand {
       [
         {
           title: `Start ${config.getName()} node`,
-          task: () => startNodeTask(config, { platformOnly }),
+          task: () => startNodeTask(config),
         },
         {
           title: 'Wait for nodes to be ready',
@@ -54,6 +54,7 @@ class StartCommand extends ConfigBaseCommand {
     try {
       await tasks.run({
         isVerbose,
+        platformOnly: platformOnly === true,
       });
     } catch (e) {
       throw new MuteOneLineError(e);

--- a/packages/dashmate/src/commands/stop.js
+++ b/packages/dashmate/src/commands/stop.js
@@ -26,7 +26,7 @@ class StopCommand extends ConfigBaseCommand {
   ) {
     const tasks = new Listr([
       {
-        task: async () => stopNodeTask(config, { platformOnly }),
+        task: async () => stopNodeTask(config),
       },
     ],
     {
@@ -43,6 +43,7 @@ class StopCommand extends ConfigBaseCommand {
       await tasks.run({
         isForce,
         isVerbose,
+        platformOnly: platformOnly === true,
       });
     } catch (e) {
       throw new MuteOneLineError(e);

--- a/packages/dashmate/src/listr/tasks/restartNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/restartNodeTaskFactory.js
@@ -12,12 +12,10 @@ function restartNodeTaskFactory(startNodeTask, stopNodeTask, buildServicesTask) 
    * @typedef {restartNodeTask}
    *
    * @param {Config} config
-   * @param {Object} [options={}]
-   * @param {boolean} [options.platformOnly=false]
    *
    * @return {Listr}
    */
-  function restartNodeTask(config, options = {}) {
+  function restartNodeTask(config) {
     return new Listr([
       {
         enabled: () => config.get('platform.enable') && config.get('platform.sourcePath') !== null,
@@ -28,10 +26,10 @@ function restartNodeTaskFactory(startNodeTask, stopNodeTask, buildServicesTask) 
         },
       },
       {
-        task: () => stopNodeTask(config, options),
+        task: () => stopNodeTask(config),
       },
       {
-        task: () => startNodeTask(config, options),
+        task: () => startNodeTask(config),
       },
     ]);
   }

--- a/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
@@ -26,11 +26,9 @@ function startNodeTaskFactory(
   /**
    * @typedef {startNodeTask}
    * @param {Config} config
-   * @param {Object} [options={}]
-   * @param {boolean} [options.platformOnly=false]
    * @return {Object}
    */
-  function startNodeTask(config, options = {}) {
+  function startNodeTask(config) {
     // check core is not reindexing
     if (config.get('core.reindex.enable', true)) {
       throw new Error(`Your dashcore node in config [${config.name}] is reindexing, please allow the process to complete first`);
@@ -62,15 +60,17 @@ function startNodeTaskFactory(
     return new Listr([
       {
         title: 'Check node is not started',
-        task: async () => {
-          if (await dockerCompose.isServiceRunning(config.toEnvs(options))) {
+        task: async (ctx) => {
+          if (await dockerCompose.isServiceRunning(
+            config.toEnvs({ platformOnly: ctx.platformOnly }),
+          )) {
             throw new Error('Running services detected. Please ensure all services are stopped for this config before starting');
           }
         },
       },
       {
         title: 'Check core is started',
-        enabled: options.platformOnly === true,
+        enabled: (ctx) => ctx.platformOnly === true,
         task: async () => {
           if (!await dockerCompose.isServiceRunning(config.toEnvs(), 'core')) {
             throw new Error('Platform services depend on Core and can\'t be started without it. Please run "dashmate start" without "--platform" flag');
@@ -85,14 +85,14 @@ function startNodeTaskFactory(
       },
       {
         title: 'Start services',
-        task: async () => {
+        task: async (ctx) => {
           const isMasternode = config.get('core.masternode.enable');
           if (isMasternode) {
             // Check operatorPrivateKey is set
             config.get('core.masternode.operator.privateKey', true);
           }
 
-          const envs = config.toEnvs(options);
+          const envs = config.toEnvs({ platformOnly: ctx.platformOnly });
 
           await dockerCompose.up(envs);
         },

--- a/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
@@ -70,7 +70,7 @@ function startNodeTaskFactory(
       },
       {
         title: 'Check core is started',
-        enabled: options.platformOnly,
+        enabled: options.platformOnly === true,
         task: async () => {
           if (!await dockerCompose.isServiceRunning(config.toEnvs(), 'core')) {
             throw new Error('Core service is not running. Please ensure core service is running before starting');

--- a/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
@@ -73,7 +73,7 @@ function startNodeTaskFactory(
         enabled: options.platformOnly === true,
         task: async () => {
           if (!await dockerCompose.isServiceRunning(config.toEnvs(), 'core')) {
-            throw new Error('Core service is not running. Please ensure core service is running before starting');
+            throw new Error('Platform services depend on Core and can\'t be started without it. Please run "dashmate start" without "--platform" flag');
           }
         },
       },

--- a/packages/dashmate/src/listr/tasks/stopNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/stopNodeTaskFactory.js
@@ -15,18 +15,18 @@ function stopNodeTaskFactory(
    * Stop node
    * @typedef stopNodeTask
    * @param {Config} config
-   * @param {Object} [options={}]
-   * @param {boolean} [options.platformOnly=false]
    *
    * @return {Listr}
    */
-  function stopNodeTask(config, options = {}) {
+  function stopNodeTask(config) {
     return new Listr([
       {
         title: 'Check node is running',
         skip: (ctx) => ctx.isForce,
-        task: async () => {
-          if (!await dockerCompose.isServiceRunning(config.toEnvs(options))) {
+        task: async (ctx) => {
+          if (!await dockerCompose.isServiceRunning(
+            config.toEnvs({ platformOnly: ctx.platformOnly }),
+          )) {
             throw new Error('Node is not running');
           }
         },
@@ -50,7 +50,7 @@ function stopNodeTaskFactory(
       },
       {
         title: `Stopping ${config.getName()} node`,
-        task: async () => dockerCompose.stop(config.toEnvs(options)),
+        task: async (ctx) => dockerCompose.stop(config.toEnvs({ platformOnly: ctx.platformOnly })),
       },
     ]);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to check if core service started or not only when we pass `--platform` flag. Now it check every time

## What was done?
<!--- Describe your changes in detail -->
Fixed condition for `Check core is started` task

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
