### PR TITLE
feat(drive): check tx and queries error handling

### DIFF
--- a/packages/dapi/lib/externalApis/drive/DriveClient.js
+++ b/packages/dapi/lib/externalApis/drive/DriveClient.js
@@ -59,7 +59,7 @@ class DriveClient {
    */
   async fetchDataContract(request) {
     return this.request(
-      '/dataContracts',
+      '/dataContract',
       request.serializeBinary(),
     );
   }
@@ -73,7 +73,7 @@ class DriveClient {
    */
   async fetchDocuments(request) {
     return this.request(
-      '/dataContracts/documents',
+      '/dataContract/documents',
       request.serializeBinary(),
     );
   }

--- a/packages/dapi/lib/grpcServer/handlers/createGrpcErrorFromDriveResponse.js
+++ b/packages/dapi/lib/grpcServer/handlers/createGrpcErrorFromDriveResponse.js
@@ -73,6 +73,11 @@ async function createGrpcErrorFromDriveResponse(code, info) {
       );
     }
 
+    // TODO(rs-drive-abci): revisit.
+    //   Rust does not provide stack trace in case of an error.
+    //   It is possible however to use Backtrace crate to report stack.
+    //   Decide whether it worth using Backtrace in rs-drive-abci queries
+    //   and remove if not needed
     // Restore stack for internal error
     if (code === GrpcErrorCodes.INTERNAL) {
       const error = new Error(message);

--- a/packages/dapi/lib/grpcServer/handlers/createGrpcErrorFromDriveResponse.js
+++ b/packages/dapi/lib/grpcServer/handlers/createGrpcErrorFromDriveResponse.js
@@ -111,14 +111,14 @@ async function createGrpcErrorFromDriveResponse(code, info) {
 
   // DPP errors
   if (code >= 1000 && code < 5000) {
-    const serializedConsensusError = Buffer.from(info, 'hex');
-    const consensusError = deserializeConsensusError(serializedConsensusError || []);
+    const serializedError = Buffer.from(info, 'hex');
+    const consensusError = deserializeConsensusError(serializedError || []);
 
     // Basic
     if (code >= 1000 && code < 2000) {
       return new InvalidArgumentGrpcError(
         consensusError.message,
-        { code, ...createRawMetadata({ serializedConsensusError }) },
+        { code, ...createRawMetadata({ serializedError }) },
       );
     }
 
@@ -127,7 +127,7 @@ async function createGrpcErrorFromDriveResponse(code, info) {
       return new GrpcError(
         GrpcErrorCodes.UNAUTHENTICATED,
         consensusError.message,
-        { code, ...createRawMetadata({ serializedConsensusError }) },
+        { code, ...createRawMetadata({ serializedError }) },
       );
     }
 
@@ -135,7 +135,7 @@ async function createGrpcErrorFromDriveResponse(code, info) {
     if (code >= 3000 && code < 4000) {
       return new FailedPreconditionGrpcError(
         consensusError.message,
-        { code, ...createRawMetadata({ serializedConsensusError }) },
+        { code, ...createRawMetadata({ serializedError }) },
       );
     }
 
@@ -143,7 +143,7 @@ async function createGrpcErrorFromDriveResponse(code, info) {
     if (code >= 4000 && code < 5000) {
       return new InvalidArgumentGrpcError(
         consensusError.message,
-        { code, ...createRawMetadata({ serializedConsensusError }) },
+        { code, ...createRawMetadata({ serializedError }) },
       );
     }
   }

--- a/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -51,7 +51,7 @@ function broadcastStateTransitionHandlerFactory(rpcClient, createGrpcErrorFromDr
     }
 
     if (result.code !== 0) {
-      throw await createGrpcErrorFromDriveResponse(result.code, result.info);
+      throw await createGrpcErrorFromDriveResponse(result.code, result.data);
     }
 
     return new BroadcastStateTransitionResponse();

--- a/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -51,7 +51,7 @@ function broadcastStateTransitionHandlerFactory(rpcClient, createGrpcErrorFromDr
     }
 
     if (result.code !== 0) {
-      throw await createGrpcErrorFromDriveResponse(result.code, result.data);
+      throw await createGrpcErrorFromDriveResponse(result.code, result.info);
     }
 
     return new BroadcastStateTransitionResponse();

--- a/packages/dapi/test/unit/externalApis/drive/DriveClient.spec.js
+++ b/packages/dapi/test/unit/externalApis/drive/DriveClient.spec.js
@@ -118,7 +118,7 @@ describe('DriveClient', () => {
       const result = await drive.fetchDataContract(request);
 
       expect(drive.client.request).to.have.been.calledOnceWithExactly('abci_query', {
-        path: '/dataContracts',
+        path: '/dataContract',
         data: Buffer.from(request.serializeBinary()).toString('hex'),
       });
       expect(result).to.be.deep.equal(responseBytes);
@@ -154,7 +154,7 @@ describe('DriveClient', () => {
       const result = await drive.fetchDocuments(request);
 
       expect(drive.client.request).to.have.been.calledOnceWithExactly('abci_query', {
-        path: '/dataContracts/documents',
+        path: '/dataContract/documents',
         data: Buffer.from(request.serializeBinary()).toString('hex'), // cbor encoded empty object
       });
       expect(result).to.be.deep.equal(responseBytes);

--- a/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.ts
+++ b/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.ts
@@ -153,7 +153,9 @@ export async function get(this: Platform, typeLocator: string, opts: FetchOpts):
 
   const result = await Promise.all(
     rawDocuments.map(async (rawDocument) => {
-      const document = await this.dpp.document.createFromBuffer(rawDocument);
+      const document = await this.dpp.document.createExtendedDocumentFromDocumentBuffer(
+        rawDocument, fieldType, appDefinition.contract,
+      );
 
       let metadata;
       const responseMetadata = documentsResponse.getMetadata();

--- a/packages/rs-dpp/src/document/document_facade.rs
+++ b/packages/rs-dpp/src/document/document_facade.rs
@@ -81,6 +81,16 @@ where
         self.factory.create_from_buffer(bytes, options).await
     }
 
+    pub async fn create_extended_from_document_buffer(
+        &self,
+        buffer: &[u8],
+        document_type: &str,
+        data_contract: &DataContract,
+    ) -> Result<ExtendedDocument, ProtocolError> {
+        self.factory
+            .create_extended_from_document_buffer(buffer, document_type, data_contract)
+    }
+
     /// Creates Documents State Transition
     pub fn create_state_transition(
         &self,

--- a/packages/rs-dpp/src/document/document_factory.rs
+++ b/packages/rs-dpp/src/document/document_factory.rs
@@ -270,6 +270,31 @@ where
         DocumentsBatchTransition::from_value_map(raw_batch_transition, data_contracts)
     }
 
+    pub fn create_extended_from_document_buffer(
+        &self,
+        buffer: &[u8],
+        document_type: &str,
+        data_contract: &DataContract,
+    ) -> Result<ExtendedDocument, ProtocolError> {
+        let document_type = data_contract.document_types.get(document_type).ok_or(
+            ProtocolError::DataContractError(DataContractError::DocumentTypeNotFound(
+                "document type was not found in the data contract",
+            )),
+        )?;
+
+        let document = Document::from_bytes(buffer, document_type)?;
+
+        Ok(ExtendedDocument {
+            protocol_version: data_contract.protocol_version,
+            document_type_name: document_type.name.clone(),
+            data_contract_id: data_contract.id,
+            document,
+            data_contract: data_contract.clone(),
+            metadata: None,
+            entropy: Bytes32::default(),
+        })
+    }
+
     pub async fn create_from_buffer(
         &self,
         buffer: impl AsRef<[u8]>,

--- a/packages/rs-drive-abci/src/abci/handlers.rs
+++ b/packages/rs-drive-abci/src/abci/handlers.rs
@@ -513,20 +513,29 @@ where
         let RequestCheckTx { tx, .. } = request;
         let validation_result = self.platform.check_tx(tx)?;
 
-        // If there are no execution errors the code will be 0
-        let code = validation_result
-            .errors
-            .first()
-            .map(|error| error.code())
-            .unwrap_or_default();
+        let validation_error = validation_result.errors.first();
+
+        let (code, serialized_error, info) = if let Some(validation_error) = validation_error {
+            (
+                validation_error.code(),
+                validation_error
+                    .serialize()
+                    .map_err(|e| ResponseException::from(Error::Protocol(e)))?,
+                validation_error.to_string(),
+            )
+        } else {
+            // If there are no execution errors the code will be 0
+            (0, vec![], "".to_string())
+        };
+
         let gas_wanted = validation_result
             .data
             .map(|fee_result| fee_result.total_base_fee())
             .unwrap_or_default();
         Ok(ResponseCheckTx {
             code,
-            data: vec![],
-            info: "".to_string(),
+            data: serialized_error,
+            info,
             gas_wanted: gas_wanted as SignedCredits,
             codespace: "".to_string(),
             sender: "".to_string(),

--- a/packages/wasm-dpp/src/document/document_facade.rs
+++ b/packages/wasm-dpp/src/document/document_facade.rs
@@ -89,6 +89,17 @@ impl DocumentFacadeWasm {
             .await
     }
 
+    #[wasm_bindgen(js_name=createExtendedDocumentFromDocumentBuffer)]
+    pub fn create_extended_from_document_buffer(
+        &self,
+        buffer: Vec<u8>,
+        document_type: &str,
+        data_contract: &DataContractWasm,
+    ) -> Result<ExtendedDocumentWasm, JsValue> {
+        self.factory
+            .create_extended_from_document_buffer(buffer, document_type, data_contract)
+    }
+
     /// Creates Documents State Transition
     #[wasm_bindgen(js_name=createStateTransition)]
     pub fn create_state_transition(

--- a/packages/wasm-dpp/src/document/factory.rs
+++ b/packages/wasm-dpp/src/document/factory.rs
@@ -212,6 +212,23 @@ impl DocumentFactoryWASM {
 
         Ok(document.into())
     }
+
+    #[wasm_bindgen(js_name=createExtendedDocumentFromDocumentBuffer)]
+    pub fn create_extended_from_document_buffer(
+        &self,
+        buffer: Vec<u8>,
+        document_type: &str,
+        data_contract: &DataContractWasm,
+    ) -> Result<ExtendedDocumentWasm, JsValue> {
+        self.0
+            .create_extended_from_document_buffer(
+                buffer.as_slice(),
+                document_type,
+                &data_contract.to_owned().into(),
+            )
+            .map(|document| document.into())
+            .with_js_error()
+    }
 }
 
 fn extract_documents_by_action(

--- a/packages/wasm-dpp/src/state_transition/errors/invalid_state_transition_error.rs
+++ b/packages/wasm-dpp/src/state_transition/errors/invalid_state_transition_error.rs
@@ -1,6 +1,5 @@
 use dpp::consensus::ConsensusError;
 use serde::Serialize;
-
 use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
 
 use crate::{
@@ -53,9 +52,8 @@ impl InvalidStateTransitionErrorWasm {
         let errors = serde_json::to_value(&self.errors)
             .map_err(|_| JsError::new("Can't serialize consensus errors to json"))?;
         let ser = serde_wasm_bindgen::Serializer::json_compatible();
-        let val = errors
+        errors
             .serialize(&ser)
-            .map_err(|_| JsError::new("Can't serialize consensus errors to json"));
-        val
+            .map_err(|_| JsError::new("Can't serialize consensus errors to json"))
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Refactored query and consensus error handling in rs-drive-abci to comply with DAPI

## What was done?
<!--- Describe your changes in detail -->
Drive
- Refactored query error response (Without error codes for now)
- Provided consensus error serialization in check_tx response
- Fixed bug with decoding of empty order_by in /document query

DAPI
- Refactored some endpoint names to match rs-drive-abci handlers

SDK and Wasm-dpp
- Introduced function to create exteneded document from regular document and data contract


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
