### PR TITLE
feat(dashmate): `no-retry` flag for ssl obtain command

### DIFF
--- a/packages/dashmate/src/commands/ssl/obtain.js
+++ b/packages/dashmate/src/commands/ssl/obtain.js
@@ -17,6 +17,7 @@ class ObtainCommand extends ConfigBaseCommand {
     args,
     {
       verbose: isVerbose,
+      'no-retry': noRetry,
     },
     config,
     obtainZeroSSLCertificateTask,
@@ -38,7 +39,9 @@ class ObtainCommand extends ConfigBaseCommand {
     });
 
     try {
-      await tasks.run();
+      await tasks.run({
+        noRetry,
+      });
     } catch (e) {
       throw new MuteOneLineError(e);
     }
@@ -53,6 +56,7 @@ Obtain SSL certificate using ZeroSSL API Key
 ObtainCommand.flags = {
   ...ConfigBaseCommand.flags,
   verbose: Flags.boolean({ char: 'v', description: 'use verbose mode for output', default: false }),
+  'no-retry': Flags.boolean({ description: 'do not retry on IP verification failure', default: false }),
 };
 
 module.exports = ObtainCommand;

--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -60,7 +60,6 @@ function obtainZeroSSLCertificateTaskFactory(
         title: 'Start verification server',
         task: async () => verificationServer.start(),
       },
-      // TODO: Duplicate tasks
       {
         title: 'Verify IP',
         task: async (ctx, task) => {
@@ -69,20 +68,22 @@ function obtainZeroSSLCertificateTaskFactory(
             try {
               await verifyDomain(ctx.response.id, config.get('platform.dapi.envoy.ssl.providerConfigs.zerossl.apiKey'));
             } catch (e) {
-              retry = await task.prompt({
-                type: 'toggle',
-                header: chalk`  An error occurred during verification: {red ${e.message}}
-
-  Please ensure that port 80 on your public IP address ${config.get('externalIp')} is open
-  for incoming HTTP connections. You may need to configure your firewall to
-  ensure this port is accessible from the public internet. If you are using
-  Network Address Translation (NAT), please enable port forwarding for port 80
-  and all Dash service ports listed above.`,
-                message: 'Try again?',
-                enabled: 'Yes',
-                disabled: 'No',
-                initial: true,
-              });
+              if (ctx.noRetry !== true) {
+                retry = await task.prompt({
+                  type: 'toggle',
+                  header: chalk`  An error occurred during verification: {red ${e.message}}
+  
+    Please ensure that port 80 on your public IP address ${config.get('externalIp')} is open
+    for incoming HTTP connections. You may need to configure your firewall to
+    ensure this port is accessible from the public internet. If you are using
+    Network Address Translation (NAT), please enable port forwarding for port 80
+    and all Dash service ports listed above.`,
+                  message: 'Try again?',
+                  enabled: 'Yes',
+                  disabled: 'No',
+                  initial: true,
+                });
+              }
 
               if (!retry) {
                 throw e;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In case of using with deployment tool we don't need retry logic on the ssl obtain command

## What was done?
<!--- Describe your changes in detail -->
- Added `no-retry` flag to the ssl obtain command

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
