### PR TITLE
chore(dashmate): better port labels for mainnet evolution node setup 

### DIFF
--- a/packages/dashmate/src/listr/prompts/createIpAndPortsForm.js
+++ b/packages/dashmate/src/listr/prompts/createIpAndPortsForm.js
@@ -87,7 +87,7 @@ async function createIpAndPortsForm(network, options = {}) {
       message: 'Core P2P port',
       initial: initialCoreP2PPort,
       validate: validateCoreP2PPort,
-      disabled: network === PRESET_MAINNET,
+      disabled: network === PRESET_MAINNET ? '(reserved for mainnet)' : false,
     },
   ];
 
@@ -102,7 +102,7 @@ async function createIpAndPortsForm(network, options = {}) {
       message: 'Platform P2P port',
       initial: initialPlatformP2PPort,
       validate: validatePlatformP2PPort,
-      disabled: network === PRESET_MAINNET,
+      disabled: network === PRESET_MAINNET ? '(reserved for mainnet)' : false,
     });
 
     let initialPlatformHTTPPort;
@@ -115,7 +115,7 @@ async function createIpAndPortsForm(network, options = {}) {
       message: 'Platform HTTP port',
       initial: initialPlatformHTTPPort,
       validate: validatePlatformHTTPPort,
-      disabled: network === PRESET_MAINNET,
+      disabled: network === PRESET_MAINNET ? '(reserved for mainnet)' : false,
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When users setup evolution masternode and follow setup steps, on the step “Enter IP address and ports:” they see form with `disabled` fields, which is confusing

## What was done?
<!--- Describe your changes in detail -->
Changed port labels for mainnet evolution node setup to non confusing ones

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
