### PR TITLE
feat: spent asset lock verification

### DIFF
--- a/packages/rs-dpp/src/identity/state_transition/asset_lock_proof/mod.rs
+++ b/packages/rs-dpp/src/identity/state_transition/asset_lock_proof/mod.rs
@@ -194,6 +194,20 @@ impl AssetLockProof {
         }
     }
 
+    pub fn instant_lock_output(&self) -> Option<&TxOut> {
+        match self {
+            AssetLockProof::Instant(proof) => proof.output(),
+            AssetLockProof::Chain(_) => None,
+        }
+    }
+
+    pub fn instant_lock_output_index(&self) -> Option<usize> {
+        match self {
+            AssetLockProof::Instant(proof) => Some(proof.output_index()),
+            AssetLockProof::Chain(_) => None,
+        }
+    }
+
     pub fn out_point(&self) -> Option<[u8; 36]> {
         match self {
             AssetLockProof::Instant(proof) => proof.out_point(),

--- a/packages/rs-dpp/src/identity/state_transition/identity_topup_transition/action.rs
+++ b/packages/rs-dpp/src/identity/state_transition/identity_topup_transition/action.rs
@@ -1,5 +1,9 @@
+use crate::consensus::basic::identity::IdentityAssetLockTransactionOutputNotFoundError;
+use crate::consensus::basic::BasicError;
+use crate::consensus::ConsensusError;
 use crate::identifier::Identifier;
 use crate::identity::state_transition::identity_topup_transition::IdentityTopUpTransition;
+use platform_value::Bytes36;
 use serde::{Deserialize, Serialize};
 
 pub const IDENTITY_TOP_UP_TRANSITION_ACTION_VERSION: u32 = 0;
@@ -10,24 +14,62 @@ pub struct IdentityTopUpTransitionAction {
     pub version: u32,
     pub top_up_balance_amount: u64,
     pub identity_id: Identifier,
+    pub asset_lock_outpoint: Bytes36,
 }
 
 impl IdentityTopUpTransitionAction {
-    pub fn from(value: IdentityTopUpTransition, top_up_balance_amount: u64) -> Self {
-        let IdentityTopUpTransition { identity_id, .. } = value;
-        IdentityTopUpTransitionAction {
+    pub fn from(
+        value: IdentityTopUpTransition,
+        top_up_balance_amount: u64,
+    ) -> Result<Self, ConsensusError> {
+        let IdentityTopUpTransition {
+            identity_id,
+            asset_lock_proof,
+            ..
+        } = value;
+        let asset_lock_outpoint = asset_lock_proof
+            .out_point()
+            .ok_or(ConsensusError::BasicError(
+                BasicError::IdentityAssetLockTransactionOutputNotFoundError(
+                    IdentityAssetLockTransactionOutputNotFoundError::new(
+                        asset_lock_proof.instant_lock_output_index().unwrap(),
+                    ),
+                ),
+            ))?
+            .into();
+        Ok(IdentityTopUpTransitionAction {
             version: IDENTITY_TOP_UP_TRANSITION_ACTION_VERSION,
             top_up_balance_amount,
             identity_id,
-        }
+            asset_lock_outpoint,
+        })
     }
 
-    pub fn from_borrowed(value: &IdentityTopUpTransition, top_up_balance_amount: u64) -> Self {
-        let IdentityTopUpTransition { identity_id, .. } = value;
-        IdentityTopUpTransitionAction {
+    pub fn from_borrowed(
+        value: &IdentityTopUpTransition,
+        top_up_balance_amount: u64,
+    ) -> Result<Self, ConsensusError> {
+        let IdentityTopUpTransition {
+            identity_id,
+            asset_lock_proof,
+            ..
+        } = value;
+        let asset_lock_outpoint = asset_lock_proof
+            .out_point()
+            .ok_or(ConsensusError::BasicError(
+                BasicError::IdentityAssetLockTransactionOutputNotFoundError(
+                    IdentityAssetLockTransactionOutputNotFoundError::new(
+                        asset_lock_proof.instant_lock_output_index().unwrap(),
+                    ),
+                ),
+            ))?
+            .into();
+
+        Ok(IdentityTopUpTransitionAction {
             version: IDENTITY_TOP_UP_TRANSITION_ACTION_VERSION,
             top_up_balance_amount,
             identity_id: *identity_id,
-        }
+            asset_lock_outpoint,
+        })
     }
 }

--- a/packages/rs-drive-abci/src/execution/check_tx.rs
+++ b/packages/rs-drive-abci/src/execution/check_tx.rs
@@ -105,6 +105,11 @@ mod tests {
     use crate::platform::Platform;
     use crate::test::helpers::setup::TestPlatformBuilder;
     use dpp::block::block_info::BlockInfo;
+    use dpp::consensus::basic::identity::IdentityAssetLockTransactionOutPointAlreadyExistsError;
+    use dpp::consensus::basic::BasicError;
+    use dpp::consensus::ConsensusError;
+    use dpp::dashcore::hashes::Hash;
+    use dpp::dashcore::Txid;
     use dpp::identity::Identity;
     use dpp::prelude::{Identifier, IdentityPublicKey};
     use dpp::serialization_traits::{PlatformDeserializable, Signable};
@@ -233,6 +238,46 @@ mod tests {
             .commit_transaction(transaction)
             .unwrap()
             .expect("expected to commit transaction");
+    }
+
+    #[test]
+    fn identity_cant_double_top_up() {
+        let identity_top_up = hex::decode("04030000c601018c047719bb8b287e33b788671131b16b1f355d1b3ba6c4917396d0d7bf41e681000000007f1df760772c7ab48c042c01319bd553b7a635936e9a06fa382eb5037638e6ba077a524aa82c6b20e7b8dcadafa46f8ecc59b2dea8c3d6269a24cd5cad74b712ae5a460d11242bd345e168028b3e8442439a63847aa736057a6cd587ae9f7bca1f59f3045566233566142cbca5a7b525085bf96c621ba39f838d6c5c31b116e756753177aa303a8ea712e17ad1ff5dfb0b1504c03d5c225c5cbdb1ee8f6636f0df03000000018c047719bb8b287e33b788671131b16b1f355d1b3ba6c4917396d0d7bf41e681000000006b483045022100d71b565e319a0b85725d1eca250da27d846c6b015e601254e3f8aeb11c0feab60220381c92a46467d6c5270d424b666b989e444e72955f3d5b77d8be9965335b43bd01210222150e3b66410341308b646234bff9c203172c6720b2ecc838c71d94f670066affffffff02e093040000000000166a144cf5fee3ebdce0f51540a3504091c0dccb0f7d343832963b000000001976a914f3b05a1dda565b0013cb9857e708d840bcd47bef88ac00000000003012c19b98ec0033addb36cd64b7f510670f2a351a4304b5f6994144286efdac014120d56826c39c07eaea7157b8b717fdcef73fbc99cc680e34f695e0c763d79531691d8ea117cd4623e96a25cbf673e5b1da6e43a96d5bb2a65fe82c2efd4dc2c6dc").expect("expected to decode");
+
+        let platform = TestPlatformBuilder::new()
+            .with_config(PlatformConfig::default())
+            .build_with_mock_rpc();
+
+        let genesis_time = 0;
+
+        platform
+            .create_genesis_state(genesis_time, platform.config.abci.keys.clone().into(), None)
+            .expect("expected to create genesis state");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let validation_result = platform
+            .execute_tx(identity_top_up.clone(), &BlockInfo::default(), &transaction)
+            .expect("expected to execute identity top up tx");
+        assert!(matches!(validation_result, SuccessfulPaidExecution(..)));
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        let validation_result = platform
+            .check_tx(identity_top_up.clone())
+            .expect("expected to check tx");
+
+        assert!(matches!(
+            validation_result.errors.first().expect("expected an error"),
+            ConsensusError::BasicError(
+                BasicError::IdentityAssetLockTransactionOutPointAlreadyExistsError(_)
+            )
+        ));
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/validation/state_transition/identity_top_up.rs
+++ b/packages/rs-drive-abci/src/validation/state_transition/identity_top_up.rs
@@ -1,8 +1,16 @@
 use crate::asset_lock::fetch_tx_out::FetchAssetLockProofTxOut;
+use dpp::consensus::basic::identity::{
+    IdentityAssetLockTransactionOutPointAlreadyExistsError,
+    IdentityAssetLockTransactionOutputNotFoundError,
+};
+use dpp::consensus::basic::BasicError;
 use dpp::consensus::signature::{IdentityNotFoundError, SignatureError};
+use dpp::consensus::ConsensusError;
+use dpp::dashcore::OutPoint;
 use dpp::identity::state_transition::identity_topup_transition::validation::basic::IDENTITY_TOP_UP_TRANSITION_SCHEMA_VALIDATOR;
 use dpp::identity::state_transition::identity_topup_transition::IdentityTopUpTransitionAction;
 use dpp::identity::PartialIdentity;
+use dpp::platform_value::Bytes36;
 use dpp::{
     identity::state_transition::identity_topup_transition::IdentityTopUpTransition,
     state_transition::StateTransitionAction,
@@ -62,6 +70,40 @@ impl StateTransitionValidation for IdentityTopUpTransition {
         platform: &PlatformRef<C>,
         tx: TransactionArg,
     ) -> Result<ConsensusValidationResult<StateTransitionAction>, Error> {
+        let outpoint = match self.asset_lock_proof.out_point() {
+            None => {
+                return Ok(ConsensusValidationResult::new_with_error(
+                    ConsensusError::BasicError(
+                        BasicError::IdentityAssetLockTransactionOutputNotFoundError(
+                            IdentityAssetLockTransactionOutputNotFoundError::new(
+                                self.asset_lock_proof.instant_lock_output_index().unwrap(),
+                            ),
+                        ),
+                    ),
+                ));
+            }
+            Some(outpoint) => outpoint,
+        };
+
+        // Now we should check that we aren't using an asset lock again
+        let asset_lock_already_found = platform
+            .drive
+            .has_asset_lock_outpoint(&Bytes36(outpoint), tx)?;
+
+        if asset_lock_already_found {
+            let outpoint = OutPoint::from(outpoint);
+            return Ok(ConsensusValidationResult::new_with_error(
+                ConsensusError::BasicError(
+                    BasicError::IdentityAssetLockTransactionOutPointAlreadyExistsError(
+                        IdentityAssetLockTransactionOutPointAlreadyExistsError::new(
+                            outpoint.txid,
+                            outpoint.vout as usize,
+                        ),
+                    ),
+                ),
+            ));
+        }
+
         self.transform_into_action(platform, tx)
     }
 
@@ -82,9 +124,15 @@ impl StateTransitionValidation for IdentityTopUpTransition {
         }
 
         let tx_out = tx_out_validation.into_data()?;
-        validation_result.set_data(
-            IdentityTopUpTransitionAction::from_borrowed(self, tx_out.value * 1000).into(),
-        );
+        match IdentityTopUpTransitionAction::from_borrowed(self, tx_out.value * 1000) {
+            Ok(action) => {
+                validation_result.set_data(action.into());
+            }
+            Err(error) => {
+                validation_result.add_error(error);
+            }
+        }
+
         Ok(validation_result)
     }
 }

--- a/packages/rs-drive-abci/tests/strategy_tests/main.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/main.rs
@@ -374,7 +374,7 @@ mod tests {
             .expect("expected to fetch balances")
             .expect("expected to have an identity to get balance from");
 
-        assert_eq!(balance, 99870453070)
+        assert_eq!(balance, 99864467880)
     }
 
     #[test]
@@ -842,7 +842,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
             ),
-            "894c403bc33c60ae03341a7a286588d7a6d5aec88c0d01b154b4595f83b0961b".to_string()
+            "00e215e827e562b98024c7737b33afd27f0c110327ce20eb372767238cad57b3".to_string()
         )
     }
 
@@ -1366,7 +1366,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
             ),
-            "4a0620fcec40b35447b575562ef51359babd2714f3f79dfee7943760b98578fe".to_string()
+            "9a5917416dcf3dc6e125c347b6d0be8bff8d56eb3f09b05a3cab68026911569c".to_string()
         )
     }
 

--- a/packages/rs-drive/src/drive/asset_lock/estimation_costs.rs
+++ b/packages/rs-drive/src/drive/asset_lock/estimation_costs.rs
@@ -1,0 +1,108 @@
+// MIT LICENSE
+//
+// Copyright (c) 2022 Dash Core Group
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+// MIT LICENSE
+//
+// Copyright (c) 2022 Dash Core Group
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+use crate::drive::Drive;
+
+use grovedb::batch::KeyInfoPath;
+use grovedb::EstimatedLayerCount::{ApproximateElements, EstimatedLevel, PotentiallyAtMaxElements};
+use grovedb::EstimatedLayerInformation;
+use grovedb::EstimatedLayerSizes::{AllItems, AllSubtrees};
+
+use crate::drive::system::misc_path_vec;
+
+use crate::drive::asset_lock::asset_lock_storage_path;
+use grovedb::EstimatedSumTrees::SomeSumTrees;
+use std::collections::HashMap;
+
+impl Drive {
+    pub(crate) fn add_estimation_costs_for_adding_asset_lock(
+        estimated_costs_only_with_layer_info: &mut HashMap<KeyInfoPath, EstimatedLayerInformation>,
+    ) {
+        //todo: verify (this is wrong)
+        // we have constructed the top layer so contract/documents tree are at the top
+        // since balance will be on layer 2, updating will mean we will update 1 sum tree
+        // and 1 normal tree, hence we should give an equal weight to both
+        estimated_costs_only_with_layer_info.insert(
+            KeyInfoPath::from_known_path([]),
+            EstimatedLayerInformation {
+                is_sum_tree: false,
+                estimated_layer_count: EstimatedLevel(1, false),
+                estimated_layer_sizes: AllSubtrees(
+                    1,
+                    SomeSumTrees {
+                        sum_trees_weight: 1,
+                        non_sum_trees_weight: 1,
+                    },
+                    None,
+                ),
+            },
+        );
+
+        estimated_costs_only_with_layer_info.insert(
+            KeyInfoPath::from_known_path(asset_lock_storage_path()),
+            EstimatedLayerInformation {
+                is_sum_tree: false,
+                estimated_layer_count: PotentiallyAtMaxElements,
+                estimated_layer_sizes: AllItems(
+                    36, //The size of an outpoint
+                    0, None,
+                ),
+            },
+        );
+    }
+}

--- a/packages/rs-drive/src/drive/asset_lock/mod.rs
+++ b/packages/rs-drive/src/drive/asset_lock/mod.rs
@@ -1,0 +1,111 @@
+mod estimation_costs;
+
+use crate::drive::grove_operations::DirectQueryType::{StatefulDirectQuery, StatelessDirectQuery};
+use crate::drive::grove_operations::QueryTarget::QueryTargetValue;
+use crate::drive::object_size_info::PathKeyElementInfo::PathFixedSizeKeyRefElement;
+use crate::drive::{Drive, RootTree};
+use crate::error::Error;
+use crate::fee::op::LowLevelDriveOperation;
+use dpp::dashcore::{OutPoint, TxOut};
+use dpp::platform_value::Bytes36;
+use grovedb::batch::KeyInfoPath;
+use grovedb::Element::Item;
+use grovedb::{EstimatedLayerInformation, TransactionArg};
+use std::collections::HashMap;
+
+/// The asset lock root storage path
+pub(crate) fn asset_lock_storage_path() -> [&'static [u8]; 1] {
+    [Into::<&[u8; 1]>::into(RootTree::SpentAssetLockTransactions)]
+}
+
+impl Drive {
+    /// Checks if a given `outpoint` is present as an asset lock in the transaction.
+    ///
+    /// # Arguments
+    ///
+    /// * `&self` - A reference to the current object.
+    /// * `outpoint` - An `OutPoint` reference to be checked in the transaction.
+    /// * `transaction` - The `TransactionArg` in which to check for the `outpoint`.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` which is `Ok` if the outpoint exists in the transaction or an `Error` otherwise.
+    pub fn has_asset_lock_outpoint(
+        &self,
+        outpoint: &Bytes36,
+        transaction: TransactionArg,
+    ) -> Result<bool, Error> {
+        self.has_asset_lock_outpoint_add_operations(true, &mut vec![], outpoint, transaction)
+    }
+
+    /// Checks if a given `outpoint` is present as an asset lock in the transaction and potentially applies operations to it.
+    ///
+    /// # Arguments
+    ///
+    /// * `&self` - A reference to the current object.
+    /// * `apply` - A boolean which when true applies the operations to the asset lock.
+    /// * `drive_operations` - A mutable reference to a vector of `LowLevelDriveOperation` to be possibly executed.
+    /// * `outpoint` - An `OutPoint` reference to be checked in the transaction.
+    /// * `transaction` - The `TransactionArg` in which to check for the `outpoint`.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` which is `Ok` if the outpoint exists in the transaction or an `Error` otherwise.
+    pub fn has_asset_lock_outpoint_add_operations(
+        &self,
+        apply: bool,
+        drive_operations: &mut Vec<LowLevelDriveOperation>,
+        outpoint: &Bytes36,
+        transaction: TransactionArg,
+    ) -> Result<bool, Error> {
+        let asset_lock_storage_path = asset_lock_storage_path();
+        let query_type = if apply {
+            StatefulDirectQuery
+        } else {
+            StatelessDirectQuery {
+                in_tree_using_sums: false,
+                query_target: QueryTargetValue(36),
+            }
+        };
+        self.grove_has_raw(
+            asset_lock_storage_path,
+            outpoint.as_slice(),
+            query_type,
+            transaction,
+            drive_operations,
+        )
+    }
+
+    /// Adds operations to a given `outpoint` if it is present in the estimated costs.
+    ///
+    /// # Arguments
+    ///
+    /// * `&self` - A reference to the current object.
+    /// * `outpoint` - An `OutPoint` reference to be potentially modified.
+    /// * `estimated_costs_only_with_layer_info` - A mutable reference to an optional `HashMap` that contains layer information.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing a vector of `LowLevelDriveOperation` if successful, or an `Error` otherwise.
+    pub fn add_asset_lock_outpoint_operations(
+        &self,
+        outpoint: &Bytes36,
+        estimated_costs_only_with_layer_info: &mut Option<
+            HashMap<KeyInfoPath, EstimatedLayerInformation>,
+        >,
+    ) -> Result<Vec<LowLevelDriveOperation>, Error> {
+        let mut drive_operations = vec![];
+        if let Some(estimated_costs_only_with_layer_info) = estimated_costs_only_with_layer_info {
+            Self::add_estimation_costs_for_adding_asset_lock(estimated_costs_only_with_layer_info);
+        }
+        self.batch_insert(
+            PathFixedSizeKeyRefElement((
+                asset_lock_storage_path(),
+                outpoint.as_slice(),
+                Item(vec![], None),
+            )),
+            &mut drive_operations,
+        )?;
+        Ok(drive_operations)
+    }
+}

--- a/packages/rs-drive/src/drive/balances/mod.rs
+++ b/packages/rs-drive/src/drive/balances/mod.rs
@@ -164,7 +164,7 @@ impl Drive {
     ) -> Result<(), Error> {
         let mut drive_operations = vec![];
         let batch_operations =
-            self.add_to_system_credits_operation(amount, &mut None, transaction)?;
+            self.add_to_system_credits_operations(amount, &mut None, transaction)?;
         let grove_db_operations =
             LowLevelDriveOperation::grovedb_operations_batch(&batch_operations);
         self.grove_apply_batch_with_add_costs(
@@ -176,7 +176,7 @@ impl Drive {
     }
 
     /// The operations to add to system credits
-    pub(crate) fn add_to_system_credits_operation(
+    pub(crate) fn add_to_system_credits_operations(
         &self,
         amount: u64,
         estimated_costs_only_with_layer_info: &mut Option<

--- a/packages/rs-drive/src/drive/batch/drive_op_batch/system.rs
+++ b/packages/rs-drive/src/drive/batch/drive_op_batch/system.rs
@@ -4,7 +4,10 @@ use crate::error::Error;
 use crate::fee::credits::Credits;
 use crate::fee::op::LowLevelDriveOperation;
 use dpp::block::block_info::BlockInfo;
+use std::borrow::Cow;
 
+use dpp::dashcore::OutPoint;
+use dpp::platform_value::Bytes36;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
 use std::collections::HashMap;
@@ -22,6 +25,11 @@ pub enum SystemOperationType {
         /// The amount of credits we are seeking to remove
         amount: Credits,
     },
+    /// Adding a used asset lock
+    AddUsedAssetLock {
+        /// The asset lock outpoint that should be added
+        asset_lock_outpoint: Bytes36,
+    },
 }
 
 impl DriveLowLevelOperationConverter for SystemOperationType {
@@ -36,7 +44,7 @@ impl DriveLowLevelOperationConverter for SystemOperationType {
     ) -> Result<Vec<LowLevelDriveOperation>, Error> {
         match self {
             SystemOperationType::AddToSystemCredits { amount } => drive
-                .add_to_system_credits_operation(
+                .add_to_system_credits_operations(
                     amount,
                     estimated_costs_only_with_layer_info,
                     transaction,
@@ -47,6 +55,12 @@ impl DriveLowLevelOperationConverter for SystemOperationType {
                     estimated_costs_only_with_layer_info,
                     transaction,
                 ),
+            SystemOperationType::AddUsedAssetLock {
+                asset_lock_outpoint,
+            } => drive.add_asset_lock_outpoint_operations(
+                &asset_lock_outpoint,
+                estimated_costs_only_with_layer_info,
+            ),
         }
     }
 }

--- a/packages/rs-drive/src/drive/batch/transitions/identity/identity_create_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/identity/identity_create_transition.rs
@@ -2,6 +2,7 @@ use crate::drive::batch::transitions::DriveHighLevelOperationConverter;
 use crate::drive::batch::DriveOperation::{IdentityOperation, SystemOperation};
 use crate::drive::batch::{DriveOperation, IdentityOperationType, SystemOperationType};
 use crate::drive::defaults::PROTOCOL_VERSION;
+use std::borrow::Cow;
 
 use crate::error::Error;
 use dpp::block::epoch::Epoch;
@@ -18,6 +19,7 @@ impl DriveHighLevelOperationConverter for IdentityCreateTransitionAction {
             public_keys,
             initial_balance_amount,
             identity_id,
+            asset_lock_outpoint,
             ..
         } = self;
 
@@ -36,6 +38,9 @@ impl DriveHighLevelOperationConverter for IdentityCreateTransitionAction {
             }),
             SystemOperation(SystemOperationType::AddToSystemCredits {
                 amount: initial_balance_amount,
+            }),
+            SystemOperation(SystemOperationType::AddUsedAssetLock {
+                asset_lock_outpoint,
             }),
         ];
         Ok(drive_operations)

--- a/packages/rs-drive/src/drive/batch/transitions/identity/identity_top_up_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/identity/identity_top_up_transition.rs
@@ -14,6 +14,7 @@ impl DriveHighLevelOperationConverter for IdentityTopUpTransitionAction {
         let IdentityTopUpTransitionAction {
             top_up_balance_amount,
             identity_id,
+            asset_lock_outpoint,
             ..
         } = self;
 
@@ -24,6 +25,9 @@ impl DriveHighLevelOperationConverter for IdentityTopUpTransitionAction {
             }),
             SystemOperation(SystemOperationType::AddToSystemCredits {
                 amount: top_up_balance_amount,
+            }),
+            SystemOperation(SystemOperationType::AddUsedAssetLock {
+                asset_lock_outpoint,
             }),
         ];
         Ok(drive_operations)

--- a/packages/rs-drive/src/drive/mod.rs
+++ b/packages/rs-drive/src/drive/mod.rs
@@ -110,6 +110,8 @@ mod system;
 mod test_utils;
 
 #[cfg(feature = "full")]
+mod asset_lock;
+#[cfg(feature = "full")]
 mod prove;
 #[cfg(feature = "full")]
 mod system_contracts_cache;

--- a/packages/rs-platform-value/src/types/bytes_36.rs
+++ b/packages/rs-platform-value/src/types/bytes_36.rs
@@ -164,6 +164,18 @@ impl From<&Bytes36> for Value {
     }
 }
 
+impl From<[u8; 36]> for Bytes36 {
+    fn from(value: [u8; 36]) -> Self {
+        Bytes36(value)
+    }
+}
+
+impl From<&[u8; 36]> for Bytes36 {
+    fn from(value: &[u8; 36]) -> Self {
+        Bytes36(*value)
+    }
+}
+
 impl TryFrom<String> for Bytes36 {
     type Error = Error;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Spent asset locks were not being verified, this meant you could top of forever with the same asset lock. This was not actually a bug, just something that was pushed off till now.


## What was done?
Built the system for an identity create and identity top up. It will now verify that the asset lock was never used before.

## How Has This Been Tested?
Wrote a unit test.


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
