### PR TITLE
build: fix race condition in cargo cache download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,10 +115,10 @@ ENV NODE_ENV ${NODE_ENV}
 # better build caching
 WORKDIR /platform
 RUN --mount=type=cache,sharing=shared,target=/root/.cache/sccache \
-    --mount=type=cache,sharing=shared,target=${CARGO_HOME}/registry/index \
-    --mount=type=cache,sharing=shared,target=${CARGO_HOME}/registry/cache \
-    --mount=type=cache,sharing=shared,target=${CARGO_HOME}/git/db \
-    --mount=type=cache,sharing=shared,target=/platform/target \
+    --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/index \
+    --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/cache \
+    --mount=type=cache,sharing=private,target=${CARGO_HOME}/git/db \
+    --mount=type=cache,sharing=private,target=/platform/target \
     export SCCACHE_SERVER_PORT=$((RANDOM+1025)) && \
     if [[ -z "${SCCACHE_MEMCACHED}" ]] ; then unset SCCACHE_MEMCACHED ; fi ; \
     CARGO_TARGET_DIR=/platform/target cargo install --profile "$CARGO_BUILD_PROFILE" wasm-bindgen-cli@0.2.84
@@ -145,10 +145,10 @@ FROM sources AS build-drive-abci
 RUN mkdir /artifacts
 
 RUN --mount=type=cache,sharing=shared,target=/root/.cache/sccache \
-    --mount=type=cache,sharing=shared,target=${CARGO_HOME}/registry/index \
-    --mount=type=cache,sharing=shared,target=${CARGO_HOME}/registry/cache \
-    --mount=type=cache,sharing=shared,target=${CARGO_HOME}/git/db \
-    --mount=type=cache,sharing=shared,target=/platform/target \
+    --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/index \
+    --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/cache \
+    --mount=type=cache,sharing=private,target=${CARGO_HOME}/git/db \
+    --mount=type=cache,sharing=private,target=/platform/target \
     export SCCACHE_SERVER_PORT=$((RANDOM+1025)) && \
     if [[ -z "${SCCACHE_MEMCACHED}" ]] ; then unset SCCACHE_MEMCACHED ; fi ; \
     cargo build \
@@ -166,9 +166,9 @@ FROM sources AS build-js
 RUN mkdir /artifacts
 
 RUN --mount=type=cache,sharing=shared,target=/root/.cache/sccache \
-    --mount=type=cache,sharing=shared,target=${CARGO_HOME}/registry/index \
-    --mount=type=cache,sharing=shared,target=${CARGO_HOME}/registry/cache \
-    --mount=type=cache,sharing=shared,target=${CARGO_HOME}/git/db \
+    --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/index \
+    --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/cache \
+    --mount=type=cache,sharing=private,target=${CARGO_HOME}/git/db \
     --mount=type=cache,sharing=shared,id=wasm_dpp_target,target=/platform/target \
     --mount=type=cache,target=/tmp/unplugged \
     cp -R /tmp/unplugged /platform/.yarn/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN --mount=type=cache,sharing=shared,target=/root/.cache/sccache \
     --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/index \
     --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/cache \
     --mount=type=cache,sharing=private,target=${CARGO_HOME}/git/db \
-    --mount=type=cache,sharing=private,target=/platform/target \
+    --mount=type=cache,sharing=private,id=target_${TARGETARCH},target=/platform/target \
     export SCCACHE_SERVER_PORT=$((RANDOM+1025)) && \
     if [[ -z "${SCCACHE_MEMCACHED}" ]] ; then unset SCCACHE_MEMCACHED ; fi ; \
     CARGO_TARGET_DIR=/platform/target cargo install --profile "$CARGO_BUILD_PROFILE" wasm-bindgen-cli@0.2.84
@@ -148,7 +148,7 @@ RUN --mount=type=cache,sharing=shared,target=/root/.cache/sccache \
     --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/index \
     --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/cache \
     --mount=type=cache,sharing=private,target=${CARGO_HOME}/git/db \
-    --mount=type=cache,sharing=private,target=/platform/target \
+    --mount=type=cache,sharing=private,id=target_${TARGETARCH},target=/platform/target \
     export SCCACHE_SERVER_PORT=$((RANDOM+1025)) && \
     if [[ -z "${SCCACHE_MEMCACHED}" ]] ; then unset SCCACHE_MEMCACHED ; fi ; \
     cargo build \
@@ -169,7 +169,7 @@ RUN --mount=type=cache,sharing=shared,target=/root/.cache/sccache \
     --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/index \
     --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/cache \
     --mount=type=cache,sharing=private,target=${CARGO_HOME}/git/db \
-    --mount=type=cache,sharing=shared,id=wasm_dpp_target,target=/platform/target \
+    --mount=type=cache,sharing=shared,id=target_wasm_${TARGETARCH},target=/platform/target \
     --mount=type=cache,target=/tmp/unplugged \
     cp -R /tmp/unplugged /platform/.yarn/ && \
     export SCCACHE_SERVER_PORT=$((RANDOM+1025)) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,7 +170,7 @@ RUN --mount=type=cache,sharing=shared,target=/root/.cache/sccache \
     --mount=type=cache,sharing=private,target=${CARGO_HOME}/registry/cache \
     --mount=type=cache,sharing=private,target=${CARGO_HOME}/git/db \
     --mount=type=cache,sharing=shared,id=target_wasm_${TARGETARCH},target=/platform/target \
-    --mount=type=cache,target=/tmp/unplugged \
+    --mount=type=cache,id=target_unplugged_${TARGETARCH},target=/tmp/unplugged \
     cp -R /tmp/unplugged /platform/.yarn/ && \
     export SCCACHE_SERVER_PORT=$((RANDOM+1025)) && \
     if [[ -z "${SCCACHE_MEMCACHED}" ]] ; then unset SCCACHE_MEMCACHED ; fi ; \
@@ -229,7 +229,7 @@ FROM build-js AS build-dashmate-helper
 
 # Install Test Suite specific dependencies using previous
 # node_modules directory to reuse built binaries
-RUN --mount=type=cache,target=/tmp/unplugged \
+RUN --mount=type=cache,id=target_unplugged_${TARGETARCH},target=/tmp/unplugged \
     cp -R /tmp/unplugged /platform/.yarn/ && \
     yarn workspaces focus --production dashmate && \
     cp -R /platform/.yarn/unplugged /tmp/
@@ -276,7 +276,7 @@ FROM build-js AS build-test-suite
 
 # Install Test Suite specific dependencies using previous
 # node_modules directory to reuse built binaries
-RUN --mount=type=cache,target=/tmp/unplugged \
+RUN --mount=type=cache,id=target_unplugged_${TARGETARCH},target=/tmp/unplugged \
     cp -R /tmp/unplugged /platform/.yarn/ && \
     yarn workspaces focus --production @dashevo/platform-test-suite && \
     cp -R /platform/.yarn/unplugged /tmp/
@@ -337,7 +337,7 @@ FROM build-js AS build-dapi
 
 # Install Test Suite specific dependencies using previous
 # node_modules directory to reuse built binaries
-RUN --mount=type=cache,target=/tmp/unplugged \
+RUN --mount=type=cache,id=target_unplugged_${TARGETARCH},target=/tmp/unplugged \
     cp -R /tmp/unplugged /platform/.yarn/ && \
     yarn workspaces focus --production @dashevo/dapi && \
     cp -R /platform/.yarn/unplugged /tmp/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

We have race condition here: https://github.com/dashpay/platform/actions/runs/5015722236/jobs/9002775136
Scenario I see:

```
ARM: Fri, 19 May 2023 04:47:15 GMT#35 0.508 Updating [crates.io](http://crates.io/) index
AMD: Fri, 19 May 2023 04:47:35 GMT#30 81.26 error: could not find `wasm-bindgen-cli` in registry `crates-io` with version `=0.2.84`
```

So, we try to install wasm-bindgen-cli during crates-io sync. As we share cached mounts, crates index gets broken.



## What was done?

Cache mounts mode changed to "private".

## How Has This Been Tested?

To be tested during release.

## Breaking Changes

None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
