### PR TITLE
fix: check tx should return validation result instead of panic

### DIFF
--- a/packages/data-contracts/src/lib.rs
+++ b/packages/data-contracts/src/lib.rs
@@ -1,5 +1,11 @@
 use serde_json::{Error, Value};
 
+pub use dashpay_contract;
+pub use dpns_contract;
+pub use feature_flags_contract;
+pub use masternode_reward_shares_contract;
+pub use withdrawals_contract;
+
 #[repr(u8)]
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Ord, PartialOrd)]
 pub enum SystemDataContract {

--- a/packages/rs-dpp/src/lib.rs
+++ b/packages/rs-dpp/src/lib.rs
@@ -68,6 +68,7 @@ pub mod prelude {
 
 pub use bincode;
 pub use bls_signatures;
+pub use data_contracts;
 pub use ed25519_dalek;
 pub use jsonschema;
 pub use platform_serialization;

--- a/packages/rs-drive-abci/src/abci/handlers.rs
+++ b/packages/rs-drive-abci/src/abci/handlers.rs
@@ -528,7 +528,7 @@ where
         let _timer = crate::metrics::abci_request_duration("check_tx");
 
         let RequestCheckTx { tx, .. } = request;
-        let validation_result = self.platform.check_tx(tx)?;
+        let validation_result = self.platform.check_tx(tx.as_slice())?;
 
         let validation_error = validation_result.errors.first();
 

--- a/packages/rs-drive-abci/src/execution/check_tx.rs
+++ b/packages/rs-drive-abci/src/execution/check_tx.rs
@@ -104,6 +104,9 @@ mod tests {
     use crate::platform::Platform;
     use crate::test::helpers::setup::TestPlatformBuilder;
     use dpp::block::block_info::BlockInfo;
+    use dpp::consensus::basic::BasicError;
+    use dpp::consensus::state::state_error::StateError;
+    use dpp::consensus::ConsensusError;
     use dpp::dashcore::secp256k1::{Secp256k1, SecretKey};
     use dpp::dashcore::{signer, KeyPair, PrivateKey};
     use dpp::data_contracts::dpns_contract;
@@ -274,7 +277,7 @@ mod tests {
             .expect("expected to commit transaction");
 
         let validation_result = platform
-            .check_tx(identity_top_up.clone())
+            .check_tx(identity_top_up.as_slice())
             .expect("expected to check tx");
 
         assert!(matches!(
@@ -315,10 +318,8 @@ mod tests {
             .expect("expected to commit transaction");
 
         let validation_result = platform
-            .check_tx(identity_create.clone())
+            .check_tx(identity_create.as_slice())
             .expect("expected to check tx");
-
-        dbg!(&validation_result);
 
         assert!(matches!(
             validation_result.errors.first().expect("expected an error"),

--- a/packages/rs-drive-abci/src/state/genesis.rs
+++ b/packages/rs-drive-abci/src/state/genesis.rs
@@ -117,33 +117,37 @@ impl<C> Platform<C> {
         ]);
 
         for (_, (data_contract, identity_public_keys_set)) in system_data_contract_types {
-            let public_keys = BTreeSet::from_iter([
-                IdentityPublicKey {
-                    id: 0,
-                    purpose: Purpose::AUTHENTICATION,
-                    security_level: SecurityLevel::MASTER,
-                    key_type: KeyType::ECDSA_SECP256K1,
-                    read_only: false,
-                    data: identity_public_keys_set.master.into(),
-                    disabled_at: None,
-                },
-                IdentityPublicKey {
-                    id: 1,
-                    purpose: Purpose::AUTHENTICATION,
-                    security_level: SecurityLevel::HIGH,
-                    key_type: KeyType::ECDSA_SECP256K1,
-                    read_only: false,
-                    data: identity_public_keys_set.high.into(),
-                    disabled_at: None,
-                },
-            ]);
+            let public_keys = [
+                (
+                    0,
+                    IdentityPublicKey {
+                        id: 0,
+                        purpose: Purpose::AUTHENTICATION,
+                        security_level: SecurityLevel::MASTER,
+                        key_type: KeyType::ECDSA_SECP256K1,
+                        read_only: false,
+                        data: identity_public_keys_set.master.into(),
+                        disabled_at: None,
+                    },
+                ),
+                (
+                    1,
+                    IdentityPublicKey {
+                        id: 1,
+                        purpose: Purpose::AUTHENTICATION,
+                        security_level: SecurityLevel::HIGH,
+                        key_type: KeyType::ECDSA_SECP256K1,
+                        read_only: false,
+                        data: identity_public_keys_set.high.into(),
+                        disabled_at: None,
+                    },
+                ),
+            ];
 
             let identity = Identity {
                 protocol_version: PROTOCOL_VERSION,
                 id: data_contract.owner_id,
-                // TODO: It super inconvenient to have this boilerplate everywhere and there is no
-                //  way to control consistency. BTreeMap must be internal structure of IdentityPublicKey
-                public_keys: public_keys.into_iter().map(|pk| (pk.id, pk)).collect(),
+                public_keys: BTreeMap::from(public_keys),
                 balance: 0,
                 revision: 0,
                 asset_lock_proof: None,

--- a/packages/rs-drive-abci/src/validation/state_transition/identity_create.rs
+++ b/packages/rs-drive-abci/src/validation/state_transition/identity_create.rs
@@ -194,7 +194,7 @@ impl StateTransitionValidation for IdentityCreateTransition {
         let tx_out_validation = self
             .asset_lock_proof
             .fetch_asset_lock_transaction_output_sync(platform.core_rpc)?;
-        if !tx_out_validation.is_valid_with_data() {
+        if !tx_out_validation.is_valid() {
             return Ok(ConsensusValidationResult::new_with_errors(
                 tx_out_validation.errors,
             ));

--- a/packages/rs-drive-abci/src/validation/state_transition/identity_top_up.rs
+++ b/packages/rs-drive-abci/src/validation/state_transition/identity_top_up.rs
@@ -117,7 +117,7 @@ impl StateTransitionValidation for IdentityTopUpTransition {
         let tx_out_validation = self
             .asset_lock_proof
             .fetch_asset_lock_transaction_output_sync(platform.core_rpc)?;
-        if !tx_out_validation.is_valid_with_data() {
+        if !tx_out_validation.is_valid() {
             return Ok(ConsensusValidationResult::new_with_errors(
                 tx_out_validation.errors,
             ));

--- a/packages/rs-drive-abci/src/validation/state_transition/identity_update.rs
+++ b/packages/rs-drive-abci/src/validation/state_transition/identity_update.rs
@@ -66,7 +66,7 @@ impl StateTransitionValidation for IdentityUpdateTransition {
         let validation_result =
             validate_state_transition_identity_signature(drive, self, true, transaction)?;
 
-        if !result.is_valid() {
+        if !validation_result.is_valid() {
             result.merge(validation_result);
             return Ok(result);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
We were panicking instead of giving back a validation result, this should now be fixed.

In one case we were also not testing the validation result to be errorless and instead testing a previous validation result (as they shared similar names).

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
