### PR TITLE
chore(dashmate): temporary disable HPMN registration with mobile wallets

### DIFF
--- a/packages/dashmate/src/listr/tasks/setup/regular/registerMasternodeGuideTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/registerMasternodeGuideTaskFactory.js
@@ -41,8 +41,9 @@ function registerMasternodeGuideTaskFactory() {
 
     const REGISTRARS = {
       CORE: 'dashCore',
-      ANDROID: 'dashAndroid',
-      IOS: 'dashIOS',
+      // TODO: Temporary disabled until this functionality is implemented in mobile wallets
+      // ANDROID: 'dashAndroid',
+      // IOS: 'dashIOS',
       OTHER: 'other',
     };
 
@@ -62,8 +63,8 @@ function registerMasternodeGuideTaskFactory() {
               message: 'Which wallet will you use to store keys for your masternode?',
               choices: [
                 { name: REGISTRARS.CORE, message: 'Dash Core Wallet' },
-                { name: REGISTRARS.ANDROID, message: 'Android Dash Wallet' },
-                { name: REGISTRARS.IOS, message: 'iOS Dash Wallet' },
+                // { name: REGISTRARS.ANDROID, message: 'Android Dash Wallet' },
+                // { name: REGISTRARS.IOS, message: 'iOS Dash Wallet' },
                 { name: REGISTRARS.OTHER, message: 'Other' },
               ],
               initial: REGISTRARS.CORE,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Evonodes registration is not implemented yet in Mobile Wallets

## What was done?
<!--- Describe your changes in detail -->
- Temporary hide options to register masternode with mobile wallets in `dashmate setup` 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
