### PR TITLE
fix(wallet-lib): instant locks not arriving to HD wallets

### DIFF
--- a/packages/wallet-lib/src/plugins/Workers/TransactionsSyncWorker/TransactionsSyncWorker.js
+++ b/packages/wallet-lib/src/plugins/Workers/TransactionsSyncWorker/TransactionsSyncWorker.js
@@ -625,6 +625,7 @@ class TransactionsSyncWorker extends Worker {
    * @param {InstantLock[]} instantLocks
    */
   instantLocksHandler(instantLocks) {
+    // TODO: perform IS locks verification
     instantLocks.forEach((instantLock) => {
       this.importInstantLock(instantLock);
     });

--- a/packages/wallet-lib/src/test/mocks/dashcore/instantlock.js
+++ b/packages/wallet-lib/src/test/mocks/dashcore/instantlock.js
@@ -1,0 +1,20 @@
+const { InstantLock } = require('@dashevo/dashcore-lib');
+
+function mockInstantLock(transactionHash) {
+  return new InstantLock({
+    version: 1,
+    txid: transactionHash,
+    signature: Buffer.alloc(96).toString('hex'),
+    cyclehash: '0dc8d0df62b076a7757ab5ca07dde0f1e2bfaf83f94299fd9a77577e6cc7022e',
+    inputs: [
+      {
+        outpointHash: '6e200d059fb567ba19e92f5c2dcd3dde522fd4e0a50af223752db16158dabb1d',
+        outpointIndex: 0,
+      },
+    ],
+  });
+}
+
+module.exports = {
+  mockInstantLock,
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
HD wallets were never receiving instant locks because every incoming TX fills addresses gap, and TX stream restarts. Instant locks are ready to be dispatched from DAPI, but because wallet restarts stream, it was never happening.

## What was done?
<!--- Describe your changes in detail -->
- Expand bloom filter and restart stream after instant locks arrival.
- In case instant locks were delayed, restart stream when next set of transactions is arrived

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Platform test suite on testnet 

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
