### PR TITLE
fix(wasm-dpp): invalid js object pointer

### DIFF
--- a/packages/wasm-dpp/src/utils.rs
+++ b/packages/wasm-dpp/src/utils.rs
@@ -193,7 +193,7 @@ pub fn generic_of_js_val<T: RefFromWasmAbi<Abi = u32>>(
         .name();
 
     if ctor_name == class_name {
-        let ptr = js_sys::Reflect::get(js_value, &JsValue::from_str("ptr"))?;
+        let ptr = js_sys::Reflect::get(js_value, &JsValue::from_str("__wbg_ptr"))?;
         let ptr_u32: u32 = ptr
             .as_f64()
             .ok_or_else(|| JsValue::from(JsError::new("Invalid JS object pointer")))?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixed a bug with extraction of wasm object pointer from inside the JS object.
The issue appeared after the upgrade to wasm-bindgen-cli v0.2.85

## What was done?
<!--- Describe your changes in detail -->
Changed `ptr` to `__wbg-ptr`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
This change won't work with the wasm-bindgen-cli v0.2.84 anymore

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
