### PR TITLE
chore: bump up dashd version for mainnet in dashmate

### DIFF
--- a/packages/dashmate/configs/system/base.js
+++ b/packages/dashmate/configs/system/base.js
@@ -44,7 +44,7 @@ module.exports = {
   },
   core: {
     docker: {
-      image: 'dashpay/dashd:19.0.0',
+      image: 'dashpay/dashd:19.1.0',
     },
     p2p: {
       port: 9999,

--- a/packages/dashmate/configs/system/mainnet.js
+++ b/packages/dashmate/configs/system/mainnet.js
@@ -16,7 +16,7 @@ const mainnetConfig = lodashMerge({}, baseConfig, {
   },
   core: {
     docker: {
-      image: 'dashpay/dashd:19.0.0',
+      image: 'dashpay/dashd:19.1.0',
     },
     indexes: false,
     log: {

--- a/packages/dashmate/configs/system/mainnet.js
+++ b/packages/dashmate/configs/system/mainnet.js
@@ -16,7 +16,7 @@ const mainnetConfig = lodashMerge({}, baseConfig, {
   },
   core: {
     docker: {
-      image: 'dashpay/dashd:18.2.2',
+      image: 'dashpay/dashd:19.0.0',
     },
     indexes: false,
     log: {

--- a/packages/dashmate/configs/system/testnet.js
+++ b/packages/dashmate/configs/system/testnet.js
@@ -17,7 +17,7 @@ module.exports = lodashMerge({}, baseConfig, {
   },
   core: {
     docker: {
-      image: 'dashpay/dashd:19.0.0',
+      image: 'dashpay/dashd:19.1.0',
     },
     p2p: {
       port: 19999,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dashmate has wrong dashd version for mainnet configuration

## What was done?
<!--- Describe your changes in detail -->
Bump up version from 18.2.2 to 19.0.0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
