### PR TITLE
fix(drive): core RPC retry all errors

### DIFF
--- a/packages/rs-drive-abci/src/rpc/core.rs
+++ b/packages/rs-drive-abci/src/rpc/core.rs
@@ -95,9 +95,16 @@ macro_rules! retry {
             match $action {
                 Ok(result) => return Ok(result),
                 Err(e) => {
-                    last_err = Some(e);
-                    let delay = fibonacci(i + 2) * FIB_MULTIPLIER;
-                    std::thread::sleep(Duration::from_secs(delay));
+                    match e {
+                        dashcore_rpc::Error::JsonRpc(
+                            dashcore_rpc::jsonrpc::error::Error::Transport(_),
+                        ) => {
+                            last_err = Some(e);
+                            let delay = fibonacci(i + 2) * FIB_MULTIPLIER;
+                            std::thread::sleep(Duration::from_secs(delay));
+                        }
+                        _ => return Err(e),
+                    };
                 }
             }
         }

--- a/packages/rs-drive-abci/src/rpc/core.rs
+++ b/packages/rs-drive-abci/src/rpc/core.rs
@@ -105,8 +105,10 @@ macro_rules! retry {
                 Err(e) => {
                     match e {
                         dashcore_rpc::Error::JsonRpc(
+                            // Retry on transport connection error
                             dashcore_rpc::jsonrpc::error::Error::Transport(_)
                             | dashcore_rpc::jsonrpc::error::Error::Rpc(
+                                // Retry on Core RPC "not ready" errors
                                 dashcore_rpc::jsonrpc::error::RpcError {
                                     code:
                                         CORE_RPC_ERROR_IN_WARMUP

--- a/packages/rs-drive-abci/src/rpc/core.rs
+++ b/packages/rs-drive-abci/src/rpc/core.rs
@@ -106,11 +106,16 @@ macro_rules! retry {
                     match e {
                         dashcore_rpc::Error::JsonRpc(
                             dashcore_rpc::jsonrpc::error::Error::Transport(_)
-                            | dashcore_rpc::jsonrpc::error::Error::Rpc(ref rpc_error),
-                        ) if code == CORE_RPC_ERROR_IN_WARMUP
-                            || code == CORE_RPC_CLIENT_NOT_CONNECTED
-                            || code == CORE_RPC_CLIENT_IN_INITIAL_DOWNLOAD =>
-                        {
+                            | dashcore_rpc::jsonrpc::error::Error::Rpc(
+                                dashcore_rpc::jsonrpc::error::RpcError {
+                                    code:
+                                        CORE_RPC_ERROR_IN_WARMUP
+                                        | CORE_RPC_CLIENT_NOT_CONNECTED
+                                        | CORE_RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                                    ..
+                                },
+                            ),
+                        ) => {
                             last_err = Some(e);
                             let delay = fibonacci(i + 2) * FIB_MULTIPLIER;
                             std::thread::sleep(Duration::from_secs(delay));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Core RPC retry logic handles all types of errors, even wrong user input, internal library errors or specific errors that needs to be handled manually.

## What was done?
<!--- Describe your changes in detail -->
- Retry only transport errors and Core RPC errors:
   - `RPC_IN_WARMUP`
   - `RPC_CLIENT_NOT_CONNECTED`
   - `RPC_CLIENT_IN_INITIAL_DOWNLOAD`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running existing tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
