### PR TITLE
fix: double process proposal from Tenderdash restart

### DIFF
--- a/packages/rs-drive-abci/src/abci/handlers.rs
+++ b/packages/rs-drive-abci/src/abci/handlers.rs
@@ -261,7 +261,9 @@ where
             if block_execution_context.block_state_info.round != (request.round as u32) {
                 // We were not the proposer, and we should process something new
                 drop_block_execution_context = true;
-            } else if let Some(current_block_hash) = block_execution_context.block_state_info.block_hash {
+            } else if let Some(current_block_hash) =
+                block_execution_context.block_state_info.block_hash
+            {
                 // There is also the possibility that this block already came in, but tenderdash crashed
                 // Now tenderdash is sending it again
                 if let Some(proposal_info) = block_execution_context.proposer_results.as_ref() {

--- a/packages/rs-drive-abci/src/abci/handlers.rs
+++ b/packages/rs-drive-abci/src/abci/handlers.rs
@@ -281,13 +281,38 @@ where
         let mut block_execution_context_guard =
             self.platform.block_execution_context.write().unwrap();
 
-        let mut new_round = false;
+        let mut drop_block_execution_context = false;
         if let Some(block_execution_context) = block_execution_context_guard.as_mut() {
             // We are already in a block
             // This only makes sense if we were the proposer unless we are at a future round
             if block_execution_context.block_state_info.round != (request.round as u32) {
                 // We were not the proposer, and we should process something new
-                new_round = true;
+                drop_block_execution_context = true;
+            } else if let Some(current_block_hash) = block_execution_context.block_state_info.block_hash {
+                // There is also the possibility that this block already came in, but tenderdash crashed
+                // Now tenderdash is sending it again
+                if let Some(proposal_info) = block_execution_context.proposer_results.as_ref() {
+                    // We were the proposer as well, so we have the result in cache
+                    return Ok(ResponseProcessProposal {
+                        status: proto::response_process_proposal::ProposalStatus::Accept.into(),
+                        app_hash: proposal_info.app_hash.clone(),
+                        tx_results: proposal_info.tx_results.clone(),
+                        consensus_param_updates: proposal_info.consensus_param_updates.clone(),
+                        validator_set_update: proposal_info.validator_set_update.clone(),
+                    });
+                }
+
+                if current_block_hash.as_slice() == request.hash {
+                    // We were not the proposer, just drop the execution context
+                    // Todo: (maybe) cache previous results
+                    drop_block_execution_context = true;
+                } else {
+                    // We are getting a different block hash for a block of the same round
+                    // This is a terrible issue
+                    return Err(Error::Abci(AbciError::BadRequest(
+                        "received a process proposal request twice with different hash".to_string(),
+                    )))?;
+                }
             } else {
                 let Some(proposal_info) = block_execution_context.proposer_results.as_ref() else {
                     return Err(Error::Abci(AbciError::BadRequest(
@@ -311,7 +336,7 @@ where
             }
         }
 
-        if new_round {
+        if drop_block_execution_context {
             *block_execution_context_guard = None;
         }
         drop(block_execution_context_guard);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
When Tenderdash stops for some reason or another :) . It might come back and request a block proposal that has already been processed. This case is now handled.


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
