### PR TITLE
fix(sdk): identifier expects buffer with "in" operator in where query

### DIFF
--- a/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.spec.ts
+++ b/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.spec.ts
@@ -73,6 +73,25 @@ describe('Client - Platform - Documents - .get()', () => {
     ]);
   });
 
+  it('should convert identifier properties inside where condition with "in" operator', async () => {
+    const id = await generateRandomIdentifier();
+    await get.call(platform, 'app.withByteArrays', {
+      where: [
+        ['identifierField', 'in', [id.toString()]],
+      ],
+    });
+
+    expect(getDocumentsMock.getCall(0).args).to.have.deep.members([
+      appDefinition.contractId,
+      'withByteArrays',
+      {
+        where: [
+          ['identifierField', 'in', [id]],
+        ],
+      },
+    ]);
+  });
+
   it('should convert $id and $ownerId to identifiers inside where condition', async () => {
     const id = await generateRandomIdentifier();
     const ownerId = await generateRandomIdentifier();
@@ -91,6 +110,29 @@ describe('Client - Platform - Documents - .get()', () => {
         where: [
           ['$id', '==', id],
           ['$ownerId', '==', ownerId],
+        ],
+      },
+    ]);
+  });
+
+  it('should convert $id and $ownerId to identifiers inside where condition with "in" operator', async () => {
+    const id = await generateRandomIdentifier();
+    const ownerId = await generateRandomIdentifier();
+
+    await get.call(platform, 'app.withByteArrays', {
+      where: [
+        ['$id', 'in', [id.toString()]],
+        ['$ownerId', 'in', [ownerId.toString()]],
+      ],
+    });
+
+    expect(getDocumentsMock.getCall(0).args).to.have.deep.members([
+      appDefinition.contractId,
+      'withByteArrays',
+      {
+        where: [
+          ['$id', 'in', [id]],
+          ['$ownerId', 'in', [ownerId]],
         ],
       },
     ]);

--- a/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.ts
+++ b/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.ts
@@ -80,8 +80,12 @@ function convertIdentifierProperties(
   const isPropertyIdentifier = property && property.contentMediaType === Identifier.MEDIA_TYPE;
   const isSystemIdentifier = ['$id', '$ownerId'].includes(propertyName);
 
-  if (isSystemIdentifier || (isPropertyIdentifier && typeof propertyValue === 'string')) {
-    convertedPropertyValue = Identifier.from(propertyValue);
+  if (isSystemIdentifier || isPropertyIdentifier) {
+    if (Array.isArray(propertyValue)) {
+      convertedPropertyValue = propertyValue.map((id) => Identifier.from(id));
+    } else if (typeof propertyValue === 'string') {
+      convertedPropertyValue = Identifier.from(propertyValue);
+    }
   }
 
   return [propertyName, operator, convertedPropertyValue];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes bug with identifiers conversion for `in` query condition.
[Bug reported in Discord](https://discord.com/channels/670271785974890526/670540408593448980/1118221370220884088)


## What was done?
<!--- Describe your changes in detail -->
- Checked if identifier propery is an array in `where` query

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Added unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
