### PR TITLE
ci: cancel runs for already merged PRs

### DIFF
--- a/.github/workflows/manage-runs.yml
+++ b/.github/workflows/manage-runs.yml
@@ -1,0 +1,47 @@
+name: Manage runs
+on:
+  push:
+    branches:
+      - master
+      - v[0-9]+\.[0-9]+-dev
+
+jobs:
+  cancel-mergerd-pr-runs:
+    name: Cancel runs for already merged PRs
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: octokit/request-action@v2.x
+        id: get_active_workflows
+        with:
+          route: GET /repos/{repository}/actions/runs?status=in_progress&event=pull_request
+          repository: ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract running workflow ids
+        id: extract_workflow_ids
+        run: |
+          current_branch=${GITHUB_REF##*/}
+
+          # loop thru the workflows found & filter out ones that are not on PRs pointing to this branch
+          workflow_ids=$(echo '${{ steps.get_active_workflows.outputs.data }}' | \
+            jq '.workflow_runs | map({id, name, baseBranch: .pull_requests[0].base.ref})' | \
+            jq 'map(select(.baseBranch == "'$current_branch'")) | map(.id)' | \
+            jq 'join(",")')
+
+          # strip the wrapping quote marks before passing to next step
+          echo 'WORKFLOW_IDS='$(echo $workflow_ids | tr -d '"') >> $GITHUB_ENV
+
+      - name: Cancel active workflow runs
+        run: |
+          for i in ${WORKFLOW_IDS//,/ }
+          do
+            echo "Cancelling workflow with id: $i"
+
+            # use curl here as I have no idea how to use a github action in a loop
+            curl \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/${{ github.repository }}/actions/runs/$i/cancel
+          done

--- a/.github/workflows/manage-runs.yml
+++ b/.github/workflows/manage-runs.yml
@@ -6,7 +6,7 @@ on:
       - v[0-9]+\.[0-9]+-dev
 
 jobs:
-  cancel-mergerd-pr-runs:
+  cancel-merged-pr-runs:
     name: Cancel runs for already merged PRs
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes you merge PR without waiting for all checks passed in case if your RP couldn't affect them (release PR is agood example) but workflow runs still active. We use self-hosted runners and they are very expecive. We need to save any cost we can.

## What was done?
<!--- Describe your changes in detail -->
- Add a workflow to cancel runs for already merged PRs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
