### PR TITLE
feat(dashmate): re-use ZeroSSL private key

### DIFF
--- a/packages/dashmate/src/commands/ssl/obtain.js
+++ b/packages/dashmate/src/commands/ssl/obtain.js
@@ -38,6 +38,7 @@ class ObtainCommand extends ConfigBaseCommand {
         clearOutput: false,
         collapse: false,
         showSubtasks: true,
+        removeEmptyLines: false,
       },
     });
 

--- a/packages/dashmate/src/listr/tasks/ssl/saveCertificateTask.js
+++ b/packages/dashmate/src/listr/tasks/ssl/saveCertificateTask.js
@@ -21,11 +21,8 @@ function saveCertificateTask(config) {
 
         fs.writeFileSync(crtFile, ctx.certificateFile, 'utf8');
 
-        if (ctx.privateKeyFile) {
-          const keyFile = path.join(configDir, 'private.key');
-
-          fs.writeFileSync(keyFile, ctx.privateKeyFile, 'utf8');
-        }
+        const keyFile = path.join(configDir, 'private.key');
+        fs.writeFileSync(keyFile, ctx.privateKeyFile, 'utf8');
 
         config.set('platform.dapi.envoy.ssl.enabled', true);
       },

--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -284,7 +284,6 @@ function obtainZeroSSLCertificateTaskFactory(
       },
     ], {
       rendererOptions: {
-        clearOutput: false,
         showErrorMessage: true,
       },
     });

--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -282,7 +282,12 @@ function obtainZeroSSLCertificateTaskFactory(
           await verificationServer.destroy();
         },
       },
-    ]);
+    ], {
+      rendererOptions: {
+        clearOutput: false,
+        showErrorMessage: true,
+      },
+    });
   }
 
   return obtainZeroSSLCertificateTask;

--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -154,7 +154,7 @@ function obtainZeroSSLCertificateTaskFactory(
       },
       {
         title: 'Generate a keypair',
-        enabled: (ctx) => !ctx.csr,
+        enabled: (ctx) => !ctx.isCrtFilePresent,
         task: async (ctx) => {
           ctx.keyPair = await generateKeyPair();
           ctx.privateKeyFile = ctx.keyPair.privateKey;
@@ -162,7 +162,7 @@ function obtainZeroSSLCertificateTaskFactory(
       },
       {
         title: 'Generate CSR',
-        enabled: (ctx) => !ctx.csr,
+        enabled: (ctx) => !ctx.isCrtFilePresent,
         task: async (ctx) => {
           ctx.csr = await generateCsr(
             ctx.keyPair,

--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -55,15 +55,18 @@ function obtainZeroSSLCertificateTaskFactory(
         task: async (ctx, task) => {
           ctx.apiKey = config.get('platform.dapi.envoy.ssl.providerConfigs.zerossl.apiKey');
 
-          // Certificate is already configured
           const certificateId = await config.get('platform.dapi.envoy.ssl.providerConfigs.zerossl.id');
 
           if (!certificateId) {
+            // Certificate is not configured
+
             // eslint-disable-next-line no-param-reassign
             task.output = 'Certificate is configure yet. Create a new one';
 
             return;
           }
+
+          // Certificate is already configured
 
           // This function will throw an error if certificate with specified ID is not present
           const certificate = await getCertificate(ctx.apiKey, certificateId);
@@ -136,7 +139,7 @@ function obtainZeroSSLCertificateTaskFactory(
             // We need to re-download certificate bundle
             ctx.isBundleFilePresent = false;
 
-            if (!ctx.csr) {
+            if (!ctx.isCrtFilePresent) {
               throw new Error(`Certificate request file is not found in ${csrFilePath}.\n`
                 + 'To renew certificate please use the obtain'
                 + ' command with --force flag and revoke previous certificate in ZeroSSL'

--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -82,7 +82,7 @@ function obtainZeroSSLCertificateTaskFactory(
           // In this case we need to regenerate certificate or put back this private key
           if (!ctx.isPrivateKeyFilePresent) {
             throw new Error(`Certificate private key file is not found in ${privateKeyFilePath}.\n`
-              + 'Please regenerate the certificated using the the obtain'
+              + 'Please regenerate the certificate using the the obtain'
               + ' command with --force flag and revoke previous certificate in ZeroSSL'
               + ' dashboard');
           }
@@ -90,7 +90,7 @@ function obtainZeroSSLCertificateTaskFactory(
           // We need to make sure that external IP and certificate IP match
           if (certificate.common_name !== config.get('externalIp')) {
             throw new Error(`Certificate IPe ${certificate.common_name} does not match external IP ${config.get('externalIp')}.\n`
-            + 'Please change external IP or regenerate the certificated using the obtain'
+            + 'Please change external IP or regenerate the certificate using the obtain'
             + ' command with --force flag and revoke previous certificate in ZeroSSL'
             + ' dashboard');
           }

--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -109,7 +109,7 @@ function obtainZeroSSLCertificateTaskFactory(
               // and download certificate file
               ctx.certificate = certificate;
 
-              // We need to re-download certificate bundle
+              // We need to download new certificate bundle
               ctx.isBundleFilePresent = false;
 
               // eslint-disable-next-line no-param-reassign
@@ -118,7 +118,7 @@ function obtainZeroSSLCertificateTaskFactory(
               // Certificate is not valid, so we need to re-create it
               ctx.certificate = null;
 
-              // We need to re-download certificate bundle
+              // We need to download certificate bundle
               ctx.isBundleFilePresent = false;
 
               if (!ctx.isCrtFilePresent) {
@@ -136,7 +136,7 @@ function obtainZeroSSLCertificateTaskFactory(
           } else {
             // Certificate is going to expire soon, we need to obtain a new one
 
-            // We need to re-download certificate bundle
+            // We need to download new certificate bundle
             ctx.isBundleFilePresent = false;
 
             if (!ctx.isCrtFilePresent) {

--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -68,15 +68,15 @@ function obtainZeroSSLCertificateTaskFactory(
 
           // Certificate is already configured
 
-          // This function will throw an error if certificate with specified ID is not present
-          const certificate = await getCertificate(ctx.apiKey, certificateId);
-
           // Check if certificate files are present
           ctx.isCrtFilePresent = fs.existsSync(csrFilePath);
 
           ctx.isPrivateKeyFilePresent = fs.existsSync(privateKeyFilePath);
 
           ctx.isBundleFilePresent = fs.existsSync(bundleFilePath);
+
+          // This function will throw an error if certificate with specified ID is not present
+          const certificate = await getCertificate(ctx.apiKey, certificateId);
 
           // If certificate exists but private key is not, then we can't setup TLS connection
           // In this case we need to regenerate certificate or put back this private key
@@ -161,7 +161,7 @@ function obtainZeroSSLCertificateTaskFactory(
         },
       },
       {
-        title: 'Generate CSR',
+        title: 'Generate certificate request',
         enabled: (ctx) => !ctx.isCrtFilePresent,
         task: async (ctx) => {
           ctx.csr = await generateCsr(

--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -98,13 +98,13 @@ function obtainZeroSSLCertificateTaskFactory(
           if (!certificate.isExpiredInDays(ctx.expirationDays)) {
             // Certificate is not going to expire soon
 
-            if (ctx.certificate.status === 'issued') {
+            if (certificate.status === 'issued') {
               // Certificate is valid, so we might need only to download certificate bundle
               ctx.certificate = certificate;
 
               // eslint-disable-next-line no-param-reassign
-              task.output = `Certificate is valid and expires at ${ctx.certificate.expires}`;
-            } else if (['pending_validation', 'draft'].includes(ctx.certificate.status)) {
+              task.output = `Certificate is valid and expires at ${certificate.expires}`;
+            } else if (['pending_validation', 'draft'].includes(certificate.status)) {
               // Certificate is already created, so we just need to pass validation
               // and download certificate file
               ctx.certificate = certificate;
@@ -116,7 +116,6 @@ function obtainZeroSSLCertificateTaskFactory(
               task.output = 'Certificate is already created, but not validated yet.';
             } else {
               // Certificate is not valid, so we need to re-create it
-              ctx.certificate = null;
 
               // We need to download certificate bundle
               ctx.isBundleFilePresent = false;
@@ -149,7 +148,7 @@ function obtainZeroSSLCertificateTaskFactory(
             ctx.csr = fs.readFileSync(csrFilePath, 'utf8');
 
             // eslint-disable-next-line no-param-reassign
-            task.output = `Certificate exists but expires in less than ${EXPIRATION_LIMIT_DAYS} days at ${ctx.certificate.expires}. Obtain a new one`;
+            task.output = `Certificate exists but expires in less than ${EXPIRATION_LIMIT_DAYS} days at ${certificate.expires}. Obtain a new one`;
           }
         },
       },

--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -155,7 +155,7 @@ function obtainZeroSSLCertificateTaskFactory(
       },
       {
         title: 'Generate a keypair',
-        skip: (ctx) => ctx.csr,
+        enabled: (ctx) => !ctx.csr,
         task: async (ctx) => {
           ctx.keyPair = await generateKeyPair();
           ctx.privateKeyFile = ctx.keyPair.privateKey;
@@ -163,7 +163,7 @@ function obtainZeroSSLCertificateTaskFactory(
       },
       {
         title: 'Generate CSR',
-        skip: (ctx) => ctx.csr,
+        enabled: (ctx) => !ctx.csr,
         task: async (ctx) => {
           ctx.csr = await generateCsr(
             ctx.keyPair,
@@ -247,7 +247,7 @@ function obtainZeroSSLCertificateTaskFactory(
       },
       {
         title: 'Save certificate private key file',
-        skip: (ctx) => ctx.isPrivateKeyFilePresent,
+        enabled: (ctx) => !ctx.isPrivateKeyFilePresent,
         task: async (ctx, task) => {
           fs.writeFileSync(privateKeyFilePath, ctx.privateKeyFile, 'utf8');
 
@@ -257,7 +257,7 @@ function obtainZeroSSLCertificateTaskFactory(
       },
       {
         title: 'Save certificate request file',
-        skip: (ctx) => ctx.isCrtFilePresent,
+        enabled: (ctx) => !ctx.isCrtFilePresent,
         task: async (ctx, task) => {
           fs.writeFileSync(csrFilePath, ctx.csr, 'utf8');
 

--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -188,7 +188,7 @@ function obtainZeroSSLCertificateTaskFactory(
       },
       {
         title: 'Set up verification server',
-        skip: (ctx) => !['pending_validation', 'draft'].includes(ctx.certificate.status),
+        skip: (ctx) => ctx.certificate && !['pending_validation', 'draft'].includes(ctx.certificate.status),
         task: async (ctx) => {
           const validationResponse = ctx.certificate.validation.other_methods[config.get('externalIp')];
           const route = validationResponse.file_validation_url_http.replace(`http://${config.get('externalIp')}`, '');
@@ -199,12 +199,12 @@ function obtainZeroSSLCertificateTaskFactory(
       },
       {
         title: 'Start verification server',
-        skip: (ctx) => !['pending_validation', 'draft'].includes(ctx.certificate.status),
+        skip: (ctx) => ctx.certificate && !['pending_validation', 'draft'].includes(ctx.certificate.status),
         task: async () => verificationServer.start(),
       },
       {
         title: 'Verify certificate IP address',
-        skip: (ctx) => !['pending_validation', 'draft'].includes(ctx.certificate.status),
+        skip: (ctx) => ctx.certificate && !['pending_validation', 'draft'].includes(ctx.certificate.status),
         task: async (ctx, task) => {
           let retry;
           do {
@@ -277,7 +277,7 @@ function obtainZeroSSLCertificateTaskFactory(
       },
       {
         title: 'Stop verification server',
-        skip: (ctx) => !['pending_validation', 'draft'].includes(ctx.certificate.status),
+        skip: (ctx) => ctx.certificate && !['pending_validation', 'draft'].includes(ctx.certificate.status),
         task: async () => {
           await verificationServer.stop();
           await verificationServer.destroy();

--- a/packages/dashmate/src/ssl/zerossl/Certificate.js
+++ b/packages/dashmate/src/ssl/zerossl/Certificate.js
@@ -20,6 +20,12 @@ class Certificate {
    */
   expires;
 
+  /**
+   * @type {string}
+   */
+  // eslint-disable-next-line camelcase
+  common_name;
+
   static EXPIRATION_LIMIT_DAYS = 3;
 
   /**

--- a/packages/dashmate/src/ssl/zerossl/cancelCertificate.js
+++ b/packages/dashmate/src/ssl/zerossl/cancelCertificate.js
@@ -1,5 +1,4 @@
-const fetch = require('node-fetch');
-const errorDescriptions = require('./errors/errorDescriptions');
+const requestApi = require('./requestApi');
 
 /**
  * Get ZeroSSL certificate
@@ -19,15 +18,7 @@ async function cancelCertificate(apiKey, id) {
     },
   };
 
-  const response = await fetch(url, requestOptions);
-
-  const data = await response.json();
-
-  if (data.error) {
-    const errorMessage = errorDescriptions[data.error.code];
-
-    throw new Error(errorMessage || JSON.stringify(data.error));
-  }
+  return requestApi(url, requestOptions);
 }
 
 module.exports = cancelCertificate;

--- a/packages/dashmate/src/ssl/zerossl/createZeroSSLCertificate.js
+++ b/packages/dashmate/src/ssl/zerossl/createZeroSSLCertificate.js
@@ -1,7 +1,6 @@
-const fetch = require('node-fetch');
 const qs = require('qs');
-const errorDescriptions = require('./errors/errorDescriptions');
 const Certificate = require('./Certificate');
+const requestApi = require('./requestApi');
 
 /**
  * Create a ZeroSSL Certificate
@@ -33,15 +32,7 @@ async function createZeroSSLCertificate(
     },
   };
 
-  const response = await fetch(url, requestOptions);
-
-  const data = await response.json();
-
-  if (data.error) {
-    const errorMessage = errorDescriptions[data.error.code];
-
-    throw new Error(errorMessage || JSON.stringify(data.error));
-  }
+  const data = await requestApi(url, requestOptions);
 
   return new Certificate(data);
 }

--- a/packages/dashmate/src/ssl/zerossl/downloadCertificate.js
+++ b/packages/dashmate/src/ssl/zerossl/downloadCertificate.js
@@ -1,5 +1,4 @@
 const fetch = require('node-fetch');
-const wait = require('../../util/wait');
 const errorDescriptions = require('./errors/errorDescriptions');
 
 /**
@@ -11,9 +10,6 @@ const errorDescriptions = require('./errors/errorDescriptions');
  * @returns {Promise<string>}
  */
 async function downloadCertificate(id, apiKey) {
-  const maxTime = 10 * 60 * 1000; // 10 minutes
-  const startedAt = Date.now();
-
   const url = `https://api.zerossl.com/certificates/${id}/download/return?access_key=${apiKey}`;
 
   const requestOptions = {
@@ -21,24 +17,8 @@ async function downloadCertificate(id, apiKey) {
     headers: { },
   };
 
-  let data;
-  let success = false;
-
-  do {
-    try {
-      await wait(2000);
-      const response = await fetch(url, requestOptions);
-      data = await response.json();
-
-      ({ success } = data);
-    } catch (e) {
-      // do nothing
-    }
-  } while (success === false && Date.now() - startedAt < maxTime);
-
-  if (!data) {
-    throw new Error('Can\'t download certificate: max time limit has been reached');
-  }
+  const response = await fetch(url, requestOptions);
+  const data = await response.json();
 
   if (data.error) {
     const errorMessage = errorDescriptions[data.error.code];

--- a/packages/dashmate/src/ssl/zerossl/downloadCertificate.js
+++ b/packages/dashmate/src/ssl/zerossl/downloadCertificate.js
@@ -1,5 +1,4 @@
-const fetch = require('node-fetch');
-const errorDescriptions = require('./errors/errorDescriptions');
+const requestApi = require('./requestApi');
 
 /**
  * Download the certificate specified by id
@@ -17,14 +16,7 @@ async function downloadCertificate(id, apiKey) {
     headers: { },
   };
 
-  const response = await fetch(url, requestOptions);
-  const data = await response.json();
-
-  if (data.error) {
-    const errorMessage = errorDescriptions[data.error.code];
-
-    throw new Error(errorMessage || JSON.stringify(data.error));
-  }
+  const data = await requestApi(url, requestOptions);
 
   return `${data['certificate.crt']}\n${data['ca_bundle.crt']}`;
 }

--- a/packages/dashmate/src/ssl/zerossl/getCertificate.js
+++ b/packages/dashmate/src/ssl/zerossl/getCertificate.js
@@ -1,6 +1,5 @@
-const fetch = require('node-fetch');
-const errorDescriptions = require('./errors/errorDescriptions');
 const Certificate = require('./Certificate');
+const requestApi = require('./requestApi');
 
 /**
  * Get ZeroSSL certificate
@@ -18,15 +17,7 @@ async function getCertificate(apiKey, id) {
     headers: { },
   };
 
-  const response = await fetch(url, requestOptions);
-
-  const data = await response.json();
-
-  if (data.error) {
-    const errorMessage = errorDescriptions[data.error.code];
-
-    throw new Error(errorMessage || JSON.stringify(data.error));
-  }
+  const data = await requestApi(url, requestOptions);
 
   return new Certificate(data);
 }

--- a/packages/dashmate/src/ssl/zerossl/listCertificates.js
+++ b/packages/dashmate/src/ssl/zerossl/listCertificates.js
@@ -1,6 +1,5 @@
-const fetch = require('node-fetch');
-const errorDescriptions = require('./errors/errorDescriptions');
 const Certificate = require('./Certificate');
+const requestApi = require('./requestApi');
 
 /**
  * List ZeroSSL certificates
@@ -28,15 +27,7 @@ async function listCertificates(apiKey, statuses = [], search = undefined) {
     headers: {},
   };
 
-  const response = await fetch(url, requestOptions);
-
-  const data = await response.json();
-
-  if (data.error) {
-    const errorMessage = errorDescriptions[data.error.code];
-
-    throw new Error(errorMessage || JSON.stringify(data.error));
-  }
+  const data = await requestApi(url, requestOptions);
 
   return data.results.map((certificateData) => new Certificate(certificateData));
 }

--- a/packages/dashmate/src/ssl/zerossl/requestApi.js
+++ b/packages/dashmate/src/ssl/zerossl/requestApi.js
@@ -1,0 +1,29 @@
+const fetch = require('node-fetch');
+
+const errorDescriptions = require('./errors/errorDescriptions');
+
+/**
+ * Request the ZeroSSL API
+ *
+ * @param {string} url
+ * @param {Object} options
+ * @returns {Promise<Object>}
+ */
+async function requestApi(url, options) {
+  const response = await fetch(url, options);
+  const data = await response.json();
+
+  if (data.error) {
+    const errorMessage = errorDescriptions[data.error.code];
+
+    const error = new Error(errorMessage || data.error.type);
+
+    Object.assign(error, data.error);
+
+    throw error;
+  }
+
+  return data;
+}
+
+module.exports = requestApi;

--- a/packages/dashmate/src/ssl/zerossl/revokeCertificate.js
+++ b/packages/dashmate/src/ssl/zerossl/revokeCertificate.js
@@ -1,5 +1,4 @@
-const fetch = require('node-fetch');
-const errorDescriptions = require('./errors/errorDescriptions');
+const requestApi = require('./requestApi');
 
 /**
  * Create a ZeroSSL Certificate
@@ -22,15 +21,7 @@ async function revokeCertificate(
     },
   };
 
-  const response = await fetch(url, requestOptions);
-
-  const data = await response.json();
-
-  if (data.error) {
-    const errorMessage = errorDescriptions[data.error.code];
-
-    throw new Error(errorMessage || JSON.stringify(data.error));
-  }
+  return requestApi(url, requestOptions);
 }
 
 module.exports = revokeCertificate;

--- a/packages/dashmate/src/ssl/zerossl/verifyDomain.js
+++ b/packages/dashmate/src/ssl/zerossl/verifyDomain.js
@@ -1,7 +1,5 @@
-const fetch = require('node-fetch');
-
 const qs = require('qs');
-const errorDescriptions = require('./errors/errorDescriptions');
+const requestApi = require('./requestApi');
 
 /**
  * Verify the domain/ip specified by certificate id
@@ -26,17 +24,7 @@ async function verifyDomain(id, apiKey) {
     },
   };
 
-  const response = await fetch(url, requestOptions);
-
-  const data = await response.json();
-
-  if (data.error) {
-    const errorMessage = errorDescriptions[data.error.code];
-
-    throw new Error(errorMessage || JSON.stringify(data.error));
-  }
-
-  return data;
+  return requestApi(url, requestOptions);
 }
 
 module.exports = verifyDomain;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To simplify infrastructure, we want to use the same private key for ZeroSSL certificates for a given node. Current renewal logic creates and new private key and certificate request every time you run it

## What was done?
<!--- Describe your changes in detail -->
- Store and reuse certificate request file for renewals
- Validate ZeroSSL configuration and files
- Download certificate file only if necessary
- Remove unsafe retries from the `downloadCertificate` function

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually running the `dashmate ssl obtain` command
- Running with https://github.com/dashpay/dash-network-deploy/pull/516

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
