### PR TITLE
refactor: unwanted usage of x11-hash-js

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2523,7 +2523,9 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["levelup", "npm:4.4.0"],\
             ["memdown", "npm:5.1.0"],\
             ["mocha", "npm:9.2.2"],\
-            ["should", "npm:13.2.3"]\
+            ["should", "npm:13.2.3"],\
+            ["sinon", "npm:11.1.2"],\
+            ["wasm-x11-hash", "npm:0.0.2"]\
           ],\
           "linkType": "SOFT"\
         }]\

--- a/packages/dash-spv/.mocharc.yml
+++ b/packages/dash-spv/.mocharc.yml
@@ -1,0 +1,4 @@
+exit: true
+timeout: 3000
+file:
+  - ./lib/test/bootstrap.js

--- a/packages/dash-spv/lib/test/.eslintrc
+++ b/packages/dash-spv/lib/test/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "node": true,
+    "mocha": true
+  },
+  "rules": {
+    "import/no-extraneous-dependencies": "off"
+  }
+}

--- a/packages/dash-spv/lib/test/bootstrap.js
+++ b/packages/dash-spv/lib/test/bootstrap.js
@@ -1,0 +1,19 @@
+const sinon = require('sinon');
+
+beforeEach(function beforeEach() {
+  if (!this.sinon) {
+    this.sinon = sinon.createSandbox();
+  } else {
+    this.sinon.restore();
+  }
+});
+
+before(function before() {
+  if (!this.sinon) {
+    this.sinon = sinon.createSandbox();
+  }
+});
+
+afterEach(function afterEach() {
+  this.sinon.restore();
+});

--- a/packages/dash-spv/lib/x11.js
+++ b/packages/dash-spv/lib/x11.js
@@ -1,0 +1,27 @@
+const { configure: configureDashcore } = require('@dashevo/dashcore-lib');
+const X11 = require('wasm-x11-hash');
+
+let x11Promise = null;
+let x11Ready = false;
+
+const load = async () => {
+  if (!x11Promise) {
+    x11Promise = X11().then(
+      (x11Hash) => {
+        configureDashcore({
+          x11hash: x11Hash,
+        });
+        x11Ready = true;
+      },
+    );
+  }
+
+  return x11Promise;
+};
+
+const ready = () => x11Ready;
+
+module.exports = {
+  ready,
+  load,
+};

--- a/packages/dash-spv/package.json
+++ b/packages/dash-spv/package.json
@@ -16,7 +16,8 @@
     "@dashevo/dash-util": "^2.0.3",
     "@dashevo/dashcore-lib": "~0.20.9",
     "levelup": "^4.4.0",
-    "memdown": "^5.1.0"
+    "memdown": "^5.1.0",
+    "wasm-x11-hash": "~0.0.2"
   },
   "devDependencies": {
     "chai": "^4.3.4",
@@ -24,6 +25,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.24.2",
     "mocha": "^9.1.2",
-    "should": "^13.2.3"
+    "should": "^13.2.3",
+    "sinon": "^11.1.2"
   }
 }

--- a/packages/dash-spv/test/index.js
+++ b/packages/dash-spv/test/index.js
@@ -16,8 +16,10 @@ let merkleBlock = null;
 let merkleBlock2 = null;
 
 describe('SPV-DASH (forks & re-orgs) deserialized headers', () => {
-  before(() => {
+  before(async () => {
     chain = new Blockchain('testnet');
+    await Blockchain.wasmX11Ready();
+    chain.initialize();
   });
 
   it('should get 26 testnet headers', () => {
@@ -83,8 +85,9 @@ describe('SPV-DASH (forks & re-orgs) deserialized headers', () => {
 });
 
 describe('SPV-DASH (forks & re-orgs) serialized raw headers for mainnet', () => {
-  before(() => {
-    chain = new Blockchain('mainnet', 10000, utils.normalizeHeader(mainnet[0]));
+  before(async () => {
+    chain = new Blockchain('mainnet', 10000);
+    chain.initialize(utils.normalizeHeader(mainnet[0]), 1);
   });
 
   it('should get 2000 mainnet headers', () => {
@@ -127,8 +130,9 @@ describe('SPV-DASH (forks & re-orgs) serialized raw headers for mainnet', () => 
 });
 
 describe('SPV-DASH (addHeaders) add many headers for testnet', () => {
-  before(() => {
-    chain = new Blockchain('testnet', 10000, utils.normalizeHeader(testnet[0]));
+  before(async () => {
+    chain = new Blockchain('testnet', 10000);
+    chain.initialize(utils.normalizeHeader(testnet[0]), 1);
   });
 
   it('should add the 1st 250 testnet headers', () => {
@@ -146,7 +150,8 @@ describe('SPV-DASH (addHeaders) add many headers for testnet', () => {
   });
 
   it('should add the 1st 250 testnet2 headers', () => {
-    chain = new Blockchain('testnet', 10000, utils.normalizeHeader(testnet2[0]));
+    chain = new Blockchain('testnet', 10000);
+    chain.initialize(utils.normalizeHeader(testnet2[0]), 1);
     chain.addHeaders(testnet2.slice(1, 250));
     chain.getOrphanChunks().length.should.equal(0);
     chain.getAllBranches().length.should.equal(1);
@@ -161,7 +166,8 @@ describe('SPV-DASH (addHeaders) add many headers for testnet', () => {
   });
 
   it('should add the 1st 250 testnet3 headers', () => {
-    chain = new Blockchain('testnet', 10000, utils.normalizeHeader(testnet3[0]));
+    chain = new Blockchain('testnet', 10000);
+    chain.initialize(utils.normalizeHeader(testnet3[0]), 1);
     chain.addHeaders(testnet3.slice(1, 250));
     chain.getOrphanChunks().length.should.equal(0);
     chain.getAllBranches().length.should.equal(1);
@@ -199,7 +205,8 @@ describe('SPV-DASH (addHeaders) add many headers for testnet', () => {
 
 describe('SPV-DASH (addHeaders) add testnet headers out of order', () => {
   before(() => {
-    chain = new Blockchain('testnet', 10000, utils.normalizeHeader(testnet[0]));
+    chain = new Blockchain('testnet', 10000);
+    chain.initialize(utils.normalizeHeader(testnet[0]), 1);
   });
 
   it('should add the 1st 100 testnet headers', () => {
@@ -242,7 +249,8 @@ describe('SPV-DASH (addHeaders) add testnet headers out of order', () => {
 
 describe('SPV-DASH (addHeaders) add many headers for mainnet', () => {
   before(() => {
-    chain = new Blockchain('mainnet', 10000, utils.normalizeHeader(mainnet[0]));
+    chain = new Blockchain('mainnet', 10000);
+    chain.initialize(utils.normalizeHeader(mainnet[0]), 1);
   });
 
   it('should add the 1st 500 mainnet headers', () => {
@@ -290,7 +298,8 @@ describe('SPV-DASH (addHeaders) add many headers for mainnet', () => {
 
 describe('SPV-DASH (addHeaders) add mainnet headers out of order', () => {
   before(() => {
-    chain = new Blockchain('mainnet', 10000, utils.normalizeHeader(mainnet[0]));
+    chain = new Blockchain('mainnet', 10000);
+    chain.initialize(utils.normalizeHeader(mainnet[0]), 1);
   });
 
   it('should add the 1st 100 mainnet headers', () => {
@@ -377,7 +386,8 @@ describe('MerkleProofs', () => {
 
 describe('Transaction validation', () => {
   before(() => {
-    chain = new Blockchain('testnet', 10000, utils.normalizeHeader(testnet[0]));
+    chain = new Blockchain('testnet', 10000);
+    chain.initialize(utils.normalizeHeader(testnet[0]), 1);
     chain.addHeaders(testnet.slice(1, 500));
   });
 

--- a/packages/dash-spv/test/spvchain.js
+++ b/packages/dash-spv/test/spvchain.js
@@ -1,19 +1,65 @@
 const { expect } = require('chai');
+const X11 = require('../lib/x11');
 const { SpvChain } = require('../index');
-
 const { testnet } = require('./data/rawHeaders');
 
 describe('SPVChain', () => {
   let spvChain;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     spvChain = new SpvChain('testnet', 100);
+    await SpvChain.wasmX11Ready();
+  });
+
+  describe('#initialize', () => {
+    it('should throw an error if wasmX11 is not initialized', function it() {
+      this.sinon.stub(X11, 'ready').returns(false);
+      expect(() => spvChain.initialize())
+        .to.throw('X11 wasm not ready, call wasmX11Ready() first');
+    });
+
+    it('should throw an error if chain is already initialized', async () => {
+      spvChain.initialize(testnet[0], 10000);
+      expect(() => spvChain.initialize())
+        .to.throw('Chain already initialized');
+    });
+
+    it('should initialize chain with genesis header', async () => {
+      spvChain.initialize();
+      expect(spvChain.startBlockHeight).to.be.equal(0);
+      expect(spvChain.getLongestChain())
+        .to.be.deep.equal([spvChain.genesis]);
+    });
+
+    it('should not allow initializing from arbitrary block without height', () => {
+      expect(() => spvChain.initialize(testnet[0]))
+        .to.throw('Initialization error, please provide both startBlock and height');
+    });
+
+    it('should initialize from arbitrary block', () => {
+      spvChain.initialize(testnet[0], 10000);
+      expect(spvChain.startBlockHeight).to.be.equal(10000);
+      expect(spvChain.getLongestChain()[0].toBuffer().toString('hex'))
+        .to.be.equal(testnet[0]);
+    });
   });
 
   describe('#addHeaders', () => {
-    it('should assemble headers chain if headers arriving out of order', () => {
+    it('should throw an error if wasmX11 is not initialized', function it() {
+      this.sinon.stub(X11, 'ready').returns(false);
+      expect(() => spvChain.addHeaders(testnet.slice(400)))
+        .to.throw('X11 wasm not ready, call wasmX11Ready() first');
+    });
+
+    it('should throw an error if chain is not initialized', async () => {
+      expect(() => spvChain.addHeaders(testnet.slice(400)))
+        .to.throw('Chain not initialized, either call initialize() or set pendingStartBlockHeight');
+    });
+
+    it('should assemble headers chain if headers arriving out of order', async () => {
       expect(true).to.equal(true);
-      spvChain.reset(10000);
+
+      spvChain.initialize(testnet[0], 10000);
 
       spvChain.addHeaders(testnet.slice(400), 10400);
       expect(spvChain.getOrphanChunks()).to.have.length(1);

--- a/packages/js-dapi-client/test/integration/BlockHeadersProvider/BlockHeadersProvider.spec.js
+++ b/packages/js-dapi-client/test/integration/BlockHeadersProvider/BlockHeadersProvider.spec.js
@@ -11,7 +11,7 @@ describe('BlockHeadersProvider - integration', function describe() {
   let historicalStreams = [];
   let continuousStream;
 
-  const createBlockHeadersProvider = (sinon, opts = {}) => {
+  const createBlockHeadersProvider = async (sinon, opts = {}) => {
     historicalStreams = [];
     continuousStream = null;
 
@@ -39,6 +39,7 @@ describe('BlockHeadersProvider - integration', function describe() {
         count: 0,
       }),
     );
+    await blockHeadersProvider.initializeChainWith([], 0);
   };
 
   // Start from height bigger than the first block
@@ -59,7 +60,7 @@ describe('BlockHeadersProvider - integration', function describe() {
   before(async function () {
     headers = await mockHeadersChain('testnet', numHeaders);
 
-    createBlockHeadersProvider(this.sinon, {
+    await createBlockHeadersProvider(this.sinon, {
       targetBatchSize: historicalBatchSize,
     });
   });

--- a/packages/js-dapi-client/test/unit/BlockHeadersProvider/BlockHeadersProvider.spec.js
+++ b/packages/js-dapi-client/test/unit/BlockHeadersProvider/BlockHeadersProvider.spec.js
@@ -10,15 +10,20 @@ const getHeadersFixture = require('../../../lib/test/fixtures/getHeadersFixture'
 describe('BlockHeadersProvider - unit', () => {
   let blockHeadersProvider;
   let headers;
+  let spvChain;
 
   beforeEach(function () {
     blockHeadersProvider = new BlockHeadersProvider();
-    blockHeadersProvider.setSpvChain({
+    spvChain = {
       addHeaders: this.sinon.stub().callsFake((newHeaders) => newHeaders),
       hashesByHeight: new Map([[0, '0x000000001']]),
       reset: this.sinon.spy(),
       validate: this.sinon.spy(),
-    });
+      wasmX11Ready: this.sinon.stub().returns(true),
+      initialized: this.sinon.stub().returns(true),
+      initialize: this.sinon.stub(),
+    };
+    blockHeadersProvider.setSpvChain(spvChain);
 
     const blockHeadersReader = new EventEmitter();
     blockHeadersReader.readHistorical = this.sinon.spy();
@@ -140,7 +145,9 @@ describe('BlockHeadersProvider - unit', () => {
     it('should reset SPV chain in case header at specified height is missing', async () => {
       blockHeadersProvider.ensureChainRoot(2);
       expect(blockHeadersProvider.spvChain.reset)
-        .to.have.been.calledOnceWith(2);
+        .to.have.been.calledOnce();
+      expect(blockHeadersProvider.spvChain.pendingStartBlockHeight)
+        .to.equal(2);
     });
   });
 

--- a/packages/wallet-lib/src/test/mocks/TransportMock.js
+++ b/packages/wallet-lib/src/test/mocks/TransportMock.js
@@ -31,6 +31,7 @@ class TransportMock extends EventEmitter {
     provider.stop = sinonSandbox.stub().callsFake(() => {
       provider.emit('STOPPED');
     });
+    provider.initializeChainWith = sinonSandbox.spy();
     provider.readHistorical = sinonSandbox.spy();
     provider.startContinuousSync = sinonSandbox.spy();
     provider.spvChain = {

--- a/packages/wallet-lib/src/types/Account/Account.spec.js
+++ b/packages/wallet-lib/src/types/Account/Account.spec.js
@@ -44,6 +44,13 @@ describe('Account - class', function suite() {
       this.accounts = [];
       this.network = Dashcore.Networks.testnet;
       this.storage = new Storage();
+      this.transport = {
+        client: {
+          blockHeadersProvider: {
+            initializeChainWith: () => {}
+          }
+        }
+      }
     })());
     mocks.wallet.storage.application.network = mocks.wallet.network;
     mocks.wallet.storage.currentNetwork = mocks.wallet.network.toString()

--- a/packages/wallet-lib/src/types/Account/_initializeAccount.js
+++ b/packages/wallet-lib/src/types/Account/_initializeAccount.js
@@ -16,9 +16,10 @@ async function _initializeAccount(account, userUnsafePlugins) {
   // Add block headers from storage into the SPV chain if there are any
   const chainStore = self.storage.getDefaultChainStore();
   const { blockHeaders, lastSyncedHeaderHeight } = chainStore.state;
-  if (!self.offlineMode && blockHeaders.length > 0) {
+  if (!self.offlineMode) {
     const { blockHeadersProvider } = self.transport.client;
-    blockHeadersProvider.initializeWith(blockHeaders, lastSyncedHeaderHeight);
+    const firstHeaderHeight = lastSyncedHeaderHeight - blockHeaders.length + 1;
+    await blockHeadersProvider.initializeChainWith(blockHeaders, firstHeaderHeight);
   }
 
   // We run faster in offlineMode to speed up the process when less happens.

--- a/packages/wallet-lib/tests/integration/plugins/Workers/BlockHeadersSyncWorker.spec.js
+++ b/packages/wallet-lib/tests/integration/plugins/Workers/BlockHeadersSyncWorker.spec.js
@@ -51,6 +51,7 @@ describe('BlockHeadersSyncWorker - integration', () => {
       continuousStream,
       TOTAL_HEADERS_PER_STREAM,
     );
+    await blockHeadersProvider.initializeChainWith([], 0);
     const storage = await mockStorage({
       withAdapter,
     });
@@ -86,7 +87,7 @@ describe('BlockHeadersSyncWorker - integration', () => {
       // Only first batch from the first stream that attaches to genesis block gets verified
       // The rest marked as orphaned because some batches are missing
       // and there's no connection yet between them
-      it('should process first batch of from first stream and consider remaining batches as orphaned', async () => {
+      it('should process first batch from first stream and consider remaining batches as orphaned', async () => {
         const chainStore = blockHeadersSyncWorker.storage.getDefaultChainStore();
 
         // Wait for the stream to start
@@ -265,6 +266,7 @@ describe('BlockHeadersSyncWorker - integration', () => {
 
         // Reset spv chain
         blockHeadersProvider.spvChain.reset();
+        await blockHeadersProvider.initializeChainWith([], 0);
         blockHeadersProvider.spvChain
           .addHeaders(storage.getDefaultChainStore().state.blockHeaders);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1506,6 +1506,8 @@ __metadata:
     memdown: ^5.1.0
     mocha: ^9.1.2
     should: ^13.2.3
+    sinon: ^11.1.2
+    wasm-x11-hash: ~0.0.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is expected to use wasm-x11-hash library to calculate hashes of block headers. However, in certain situations, legacy x11-hash-js was still used.

## What was done?
<!--- Describe your changes in detail -->
- Refactored dash-spv initialization to support wasm-x11-hash
- Updated dapi client and block headers provider to support async initialization

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Manual testing on testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
