### PR TITLE
fix(dashmate)!: helper default port was bound to Windows print port

### DIFF
--- a/packages/dashmate/configs/migrations.js
+++ b/packages/dashmate/configs/migrations.js
@@ -571,6 +571,10 @@ module.exports = {
 
         config.platform.dapi.envoy.docker.image = systemConfigs.base.platform
           .dapi.envoy.docker.image;
+
+        // Update ports
+        config.platform.dashmate.helper.api.port = systemConfigs.base.platform
+          .dashmate.helper.api.port;
       });
     return configFile;
   },

--- a/packages/dashmate/configs/migrations.js
+++ b/packages/dashmate/configs/migrations.js
@@ -571,7 +571,12 @@ module.exports = {
 
         config.platform.dapi.envoy.docker.image = systemConfigs.base.platform
           .dapi.envoy.docker.image;
-
+      });
+    return configFile;
+  },
+  '0.24.12': (configFile) => {
+    Object.entries(configFile.configs)
+      .forEach(([, config]) => {
         // Update ports
         config.platform.dashmate.helper.api.port = systemConfigs.base.platform
           .dashmate.helper.api.port;

--- a/packages/dashmate/configs/system/base.js
+++ b/packages/dashmate/configs/system/base.js
@@ -249,7 +249,7 @@ module.exports = {
       },
       api: {
         enable: false,
-        port: 9000,
+        port: 9100,
       },
     },
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Changing the basic port of Dashmate Helper to avoid binding to the print port


## What was done?
<!--- Describe your changes in detail -->
- updated base config

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local env

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Default dashmate helper port changed from 9000 to 9100

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
