### PR TITLE
fix(dashmate)!: runs invalid helper version

### DIFF
--- a/packages/dashmate/configs/migrations.js
+++ b/packages/dashmate/configs/migrations.js
@@ -627,6 +627,8 @@ module.exports = {
 
         config.dashmate.helper.docker.build = systemConfigs.base.dashmate.helper
           .docker.build;
+
+        delete config.dashmate.helper.docker.image;
       });
 
     return configFile;

--- a/packages/dashmate/configs/schema/configJsonSchema.js
+++ b/packages/dashmate/configs/schema/configJsonSchema.js
@@ -18,30 +18,33 @@ module.exports = {
     dockerBuild: {
       type: 'object',
       properties: {
+        enabled: {
+          type: 'boolean',
+        },
+        context: {
+          type: 'string',
+          minLength: 1,
+        },
+        dockerFile: {
+          type: 'string',
+          minLength: 1,
+        },
+        target: {
+          type: 'string',
+        },
+      },
+      required: ['enabled', 'context', 'dockerFile', 'target'],
+      additionalProperties: false,
+    },
+    dockerWithBuild: {
+      type: 'object',
+      properties: {
         image: {
           type: 'string',
           minLength: 1,
         },
         build: {
-          type: 'object',
-          properties: {
-            enabled: {
-              type: 'boolean',
-            },
-            context: {
-              type: 'string',
-              minLength: 1,
-            },
-            dockerFile: {
-              type: 'string',
-              minLength: 1,
-            },
-            target: {
-              type: 'string',
-            },
-          },
-          required: ['enabled', 'context', 'dockerFile', 'target'],
-          additionalProperties: false,
+          $ref: '#/definitions/dockerBuild',
         },
       },
       required: ['image', 'build'],
@@ -324,7 +327,7 @@ module.exports = {
               type: 'object',
               properties: {
                 docker: {
-                  $ref: '#/definitions/dockerBuild',
+                  $ref: '#/definitions/dockerWithBuild',
                 },
                 http: {
                   type: 'object',
@@ -400,7 +403,7 @@ module.exports = {
               type: 'object',
               properties: {
                 docker: {
-                  $ref: '#/definitions/dockerBuild',
+                  $ref: '#/definitions/dockerWithBuild',
                 },
               },
               required: ['docker'],
@@ -417,7 +420,7 @@ module.exports = {
               type: 'object',
               properties: {
                 docker: {
-                  $ref: '#/definitions/dockerBuild',
+                  $ref: '#/definitions/dockerWithBuild',
                 },
                 log: {
                   type: 'object',
@@ -720,7 +723,14 @@ module.exports = {
           type: 'object',
           properties: {
             docker: {
-              $ref: '#/definitions/dockerBuild',
+              type: 'object',
+              properties: {
+                build: {
+                  $ref: '#/definitions/dockerBuild',
+                },
+              },
+              required: ['build'],
+              additionalProperties: false,
             },
             api: {
               type: 'object',

--- a/packages/dashmate/configs/system/base.js
+++ b/packages/dashmate/configs/system/base.js
@@ -268,7 +268,6 @@ module.exports = {
   dashmate: {
     helper: {
       docker: {
-        image: `dashpay/dashmate-helper:${version}`,
         build: {
           enabled: false,
           context: path.join(__dirname, '..', '..', '..', '..'),

--- a/packages/dashmate/src/util/generateEnvs.js
+++ b/packages/dashmate/src/util/generateEnvs.js
@@ -1,5 +1,6 @@
 const nodePath = require('path');
 const convertObjectToEnvs = require('../config/convertObjectToEnvs');
+const { version } = require('../../package.json');
 
 /**
  *
@@ -67,6 +68,7 @@ function generateEnvs(configFile, config, options = {}) {
     CORE_LOG_DIRECTORY_PATH: nodePath.dirname(
       config.get('core.log.file.path'),
     ),
+    DASHMATE_HELPER_DOCKER_IMAGE: `dashpay/dashmate-helper:${version}`,
     PLATFORM_DRIVE_ABCI_LOG_PRETTY_DIRECTORY_PATH: nodePath.dirname(
       config.get('platform.drive.abci.log.prettyFile.path'),
     ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dashmate helper version is persisted in config file and usually outdated or even higher than dashmate version (after `dashmate update`). It leads to different incompatibility issues. The version of helper must be always the same as dashmate code which runs it. We should always use an image with a version that is equal to the package version or build from the source together with dashmate code.

## What was done?
<!--- Describe your changes in detail -->
- Removed `dashmate.helper.docker.image` configuration option
- Hardcoded the helper image with the current package version. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Removed `dashmate.helper.docker.image` configuration option

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
