### PR TITLE
ci: select workflow_id to cancel based on head_ref

### DIFF
--- a/.github/workflows/manage-runs.yml
+++ b/.github/workflows/manage-runs.yml
@@ -23,17 +23,22 @@ jobs:
         run: |
           current_branch=${GITHUB_REF##*/}
 
+          echo $current_branch
+
           # loop thru the workflows found & filter out ones that are not on PRs pointing to this branch
           workflow_ids=$(echo '${{ steps.get_active_workflows.outputs.data }}' | \
             jq '.workflow_runs | map({id, head_branch})' | \
             jq 'map(select(.head_branch == "'$current_branch'")) | map(.id)' | \
             jq 'join(",")')
 
+          echo $workflow_ids
+
           # strip the wrapping quote marks before passing to next step
           echo 'WORKFLOW_IDS='$(echo $workflow_ids | tr -d '"') >> $GITHUB_ENV
 
       - name: Cancel active workflow runs
         run: |
+          echo $WORKFLOW_IDS
           for id in ${WORKFLOW_IDS//,/ }
           do
             echo "Cancelling workflow with id: $id"

--- a/.github/workflows/manage-runs.yml
+++ b/.github/workflows/manage-runs.yml
@@ -29,8 +29,6 @@ jobs:
             jq 'map(select(.head_branch == "'$current_branch'")) | map(.id)' | \
             jq 'join(",")')
 
-          echo workflow_ids is $workflow_ids
-
           # strip the wrapping quote marks before passing to next step
           echo 'WORKFLOW_IDS='$(echo $workflow_ids | tr -d '"') >> $GITHUB_ENV
 

--- a/.github/workflows/manage-runs.yml
+++ b/.github/workflows/manage-runs.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Extract running workflow ids
         id: extract_workflow_ids
         run: |
-          echo ${GITHUB_REF}
-          echo ${GITHUB_REF_NAME}
-          echo ${GITHUB_REF##*/}
+          echo GITHUB_REF is ${GITHUB_REF}
+          echo GITHUB_REF_NAME is ${GITHUB_REF_NAME}
+          echo GITHUB_HEAD_REF is ${GITHUB_HEAD_REF}
 
           current_branch=${GITHUB_REF##*/}
 
-          echo $current_branch
+          echo current_branch is $current_branch
 
           # loop thru the workflows found & filter out ones that are not on PRs pointing to this branch
           workflow_ids=$(echo '${{ steps.get_active_workflows.outputs.data }}' | \

--- a/.github/workflows/manage-runs.yml
+++ b/.github/workflows/manage-runs.yml
@@ -21,11 +21,7 @@ jobs:
       - name: Extract running workflow ids
         id: extract_workflow_ids
         run: |
-          echo GITHUB_HEAD_REF is ${GITHUB_HEAD_REF}
-
           current_branch=${GITHUB_HEAD_REF}
-
-          echo current_branch is $current_branch
 
           # loop thru the workflows found & filter out ones that are not on PRs pointing to this branch
           workflow_ids=$(echo '${{ steps.get_active_workflows.outputs.data }}' | \
@@ -38,11 +34,8 @@ jobs:
           # strip the wrapping quote marks before passing to next step
           echo 'WORKFLOW_IDS='$(echo $workflow_ids | tr -d '"') >> $GITHUB_ENV
 
-          echo 'WORKFLOW_IDS='$(echo $workflow_ids | tr -d '"')
-
       - name: Cancel active workflow runs
         run: |
-          echo $WORKFLOW_IDS
           for id in ${WORKFLOW_IDS//,/ }
           do
             echo "Cancelling workflow with id: $id"

--- a/.github/workflows/manage-runs.yml
+++ b/.github/workflows/manage-runs.yml
@@ -22,6 +22,7 @@ jobs:
         id: extract_workflow_ids
         run: |
           echo ${GITHUB_REF}
+          echo ${GITHUB_REF_NAME}
           echo ${GITHUB_REF##*/}
 
           current_branch=${GITHUB_REF##*/}

--- a/.github/workflows/manage-runs.yml
+++ b/.github/workflows/manage-runs.yml
@@ -25,7 +25,7 @@ jobs:
           echo GITHUB_REF_NAME is ${GITHUB_REF_NAME}
           echo GITHUB_HEAD_REF is ${GITHUB_HEAD_REF}
 
-          current_branch=${GITHUB_REF##*/}
+          current_branch=${GITHUB_HEAD_REF}
 
           echo current_branch is $current_branch
 
@@ -39,6 +39,8 @@ jobs:
 
           # strip the wrapping quote marks before passing to next step
           echo 'WORKFLOW_IDS='$(echo $workflow_ids | tr -d '"') >> $GITHUB_ENV
+
+          echo $workflow_ids | tr -d '"'
 
       - name: Cancel active workflow runs
         run: |

--- a/.github/workflows/manage-runs.yml
+++ b/.github/workflows/manage-runs.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Extract running workflow ids
         id: extract_workflow_ids
         run: |
+          echo ${GITHUB_REF}
+          echo ${GITHUB_REF##*/}
+
           current_branch=${GITHUB_REF##*/}
 
           echo $current_branch

--- a/.github/workflows/manage-runs.yml
+++ b/.github/workflows/manage-runs.yml
@@ -21,8 +21,6 @@ jobs:
       - name: Extract running workflow ids
         id: extract_workflow_ids
         run: |
-          echo GITHUB_REF is ${GITHUB_REF}
-          echo GITHUB_REF_NAME is ${GITHUB_REF_NAME}
           echo GITHUB_HEAD_REF is ${GITHUB_HEAD_REF}
 
           current_branch=${GITHUB_HEAD_REF}
@@ -35,12 +33,12 @@ jobs:
             jq 'map(select(.head_branch == "'$current_branch'")) | map(.id)' | \
             jq 'join(",")')
 
-          echo $workflow_ids
+          echo workflow_ids is $workflow_ids
 
           # strip the wrapping quote marks before passing to next step
           echo 'WORKFLOW_IDS='$(echo $workflow_ids | tr -d '"') >> $GITHUB_ENV
 
-          echo $workflow_ids | tr -d '"'
+          echo 'WORKFLOW_IDS='$(echo $workflow_ids | tr -d '"')
 
       - name: Cancel active workflow runs
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Workflows were still not getting cancelled properly when the PR was closed. Adding debug output showed the change in trigger to the "Manage runs" action meant that `$GITHUB_REF` was set to the PR merge branch, i.e. `refs/pull/1247/merge`. 

## What was done?
<!--- Describe your changes in detail -->
Setting the `$current_branch` variable to `$GITHUB_HEAD_REF` seems to return the expected result.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In CI, see successful cancel here: https://github.com/dashpay/platform/actions/runs/5641805311/job/15280481158

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
