### PR TITLE
refactor: returns root-hash if an identity is not found

### DIFF
--- a/packages/rs-drive/src/drive/verify/identity.rs
+++ b/packages/rs-drive/src/drive/verify/identity.rs
@@ -342,6 +342,9 @@ impl Drive {
         } else {
             GroveDb::verify_query(proof, &path_query)?
         };
+        if proved_key_values.is_empty() {
+            return Ok((root_hash, None));
+        }
         if proved_key_values.len() == 1 {
             let (path, key, maybe_element) = proved_key_values.remove(0);
             if path != unique_key_hashes_tree_path_vec() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The operation verifying an identity-id must not return an error if the identity doesn't exist

## What was done?
<!--- Describe your changes in detail -->

Added handling edge case when no proof for an identity is found

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit-Test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
