### PR TITLE
ci: specify docker mount cache bucket name as variable

### DIFF
--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -76,6 +76,7 @@ runs:
       uses: dcginfra/buildkit-cache-dance/inject@main
       if: ${{ inputs.cache_mounts != '' }}
       with:
+        bucket: platform-runner-cache
         mounts: ${{ inputs.cache_mounts }}
 
     - name: Set suffix
@@ -135,4 +136,5 @@ runs:
       uses: dcginfra/buildkit-cache-dance/extract@main
       if: ${{ inputs.cache_mounts != '' }}
       with:
+        bucket: platform-runner-cache
         mounts: ${{ inputs.cache_mounts }}

--- a/.github/workflows/all-packages.yml
+++ b/.github/workflows/all-packages.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Load Docker mount cache
         uses: dcginfra/buildkit-cache-dance/inject@main
         with:
+          bucket: platform-runner-cache
           mounts: |
             cargo_registry_index
             cargo_registry_cache
@@ -162,6 +163,7 @@ jobs:
       - name: Store Docker mount cache
         uses: dcginfra/buildkit-cache-dance/extract@main
         with:
+          bucket: platform-runner-cache
           mounts: |
             cargo_registry_index
             cargo_registry_cache
@@ -220,6 +222,7 @@ jobs:
       - name: Load Docker mount cache
         uses: dcginfra/buildkit-cache-dance/inject@main
         with:
+          bucket: platform-runner-cache
           mounts: |
             cargo_registry_index
             cargo_registry_cache
@@ -278,6 +281,7 @@ jobs:
       - name: Store Docker mount cache
         uses: dcginfra/buildkit-cache-dance/extract@main
         with:
+          bucket: platform-runner-cache
           mounts: |
             cargo_registry_index
             cargo_registry_cache

--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -117,6 +117,7 @@ jobs:
         if: ${{ inputs.start-local-network }}
         uses: dcginfra/buildkit-cache-dance/inject@main
         with:
+          bucket: platform-runner-cache
           mounts: |
             cargo_registry_index
             cargo_registry_cache
@@ -178,6 +179,7 @@ jobs:
         if: ${{ inputs.start-local-network }}
         uses: dcginfra/buildkit-cache-dance/extract@main
         with:
+          bucket: platform-runner-cache
           mounts: |
             cargo_registry_index
             cargo_registry_cache


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Modifying https://github.com/dcginfra/tf-aws-gh-runner/ to a multi-runner config means different runners should access different buckets to store cache. 

## What was done?
<!--- Describe your changes in detail -->
Add the bucket input as a variable passed to the cache dance action ([corresponding PR](https://github.com/dcginfra/buildkit-cache-dance/pull/2)) to support this use case.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On https://github.com/strophy/platform with a separate runner stack

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
