### PR TITLE
fix: dpp and drive-abci fail to build without default-features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3925,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "tenderdash-abci"
 version = "0.13.0-dev.2"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?branch=master#00454dbc5d1e452e62ea0c4af7192404467a7655"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci#00454dbc5d1e452e62ea0c4af7192404467a7655"
 dependencies = [
  "bytes",
  "futures",
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "tenderdash-proto"
 version = "0.13.0-dev.2"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?branch=master#00454dbc5d1e452e62ea0c4af7192404467a7655"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci#00454dbc5d1e452e62ea0c4af7192404467a7655"
 dependencies = [
  "bytes",
  "chrono",
@@ -3963,7 +3963,7 @@ dependencies = [
 [[package]]
 name = "tenderdash-proto-compiler"
 version = "0.1.0"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?branch=master#00454dbc5d1e452e62ea0c4af7192404467a7655"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci#00454dbc5d1e452e62ea0c4af7192404467a7655"
 dependencies = [
  "fs_extra",
  "prost-build",

--- a/packages/rs-dpp/src/identity/identity.rs
+++ b/packages/rs-dpp/src/identity/identity.rs
@@ -31,13 +31,7 @@ use std::collections::{BTreeMap, BTreeSet};
     platform_serialize(limit = 15000, unversioned)
 )]
 pub enum Identity {
-    #[cfg_attr(
-        all(
-            feature = "identity-serialization",
-            feature = "identity-serde-conversion"
-        ),
-        serde(rename = "0")
-    )]
+    #[cfg_attr(feature = "identity-serde-conversion", serde(rename = "0"))]
     V0(IdentityV0),
 }
 

--- a/packages/rs-dpp/src/identity/identity.rs
+++ b/packages/rs-dpp/src/identity/identity.rs
@@ -31,7 +31,13 @@ use std::collections::{BTreeMap, BTreeSet};
     platform_serialize(limit = 15000, unversioned)
 )]
 pub enum Identity {
-    #[cfg_attr(feature = "identity-serialization", serde(rename = "0"))]
+    #[cfg_attr(
+        all(
+            feature = "identity-serialization",
+            feature = "identity-serde-conversion"
+        ),
+        serde(rename = "0")
+    )]
     V0(IdentityV0),
 }
 

--- a/packages/rs-dpp/src/identity/identity_factory.rs
+++ b/packages/rs-dpp/src/identity/identity_factory.rs
@@ -20,7 +20,7 @@ use crate::consensus::ConsensusError;
 #[cfg(all(feature = "state-transitions", feature = "client"))]
 use crate::identity::accessors::IdentityGettersV0;
 
-#[cfg(feature = "validation")]
+#[cfg(all(feature = "validation", feature = "identity-value-conversion"))]
 use crate::identity::conversion::platform_value::IdentityPlatformValueConversionMethodsV0;
 #[cfg(all(feature = "identity-serialization", feature = "client"))]
 use crate::serialization::PlatformDeserializable;
@@ -113,7 +113,7 @@ impl IdentityFactory {
     }
 
     //todo: this should be changed into identity.validate()
-    #[cfg(feature = "validation")]
+    #[cfg(all(feature = "validation", feature = "identity-value-conversion"))]
     pub fn validate_identity(&self, _raw_identity: &Value) -> Result<(), ProtocolError> {
         //todo: reenable
         // let result = self

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -29,8 +29,8 @@ bs58 = "0.4.0"
 hex = "0.4.3"
 indexmap = { version = "1.9.3", features = ["serde"] }
 sha2 = "0.10.6"
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", rev="408bef25fd229dbb6b9f1b3d380e2afbc77d812c" }
-dpp = { path = "../rs-dpp" , features = ["abci"] }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", rev = "408bef25fd229dbb6b9f1b3d380e2afbc77d812c" }
+dpp = { path = "../rs-dpp", features = ["abci"] }
 rust_decimal = "1.2.5"
 rust_decimal_macros = "1.25.0"
 mockall = { version = "0.11", optional = true }
@@ -51,9 +51,9 @@ tracing-subscriber = { version = "0.3.16", default-features = false, features = 
     "std",
     "registry",
     "tracing-log",
-], optional = true }
-atty = { version = "0.2.14", optional = true }
-tenderdash-abci = { git = "https://github.com/dashpay/rs-tenderdash-abci", branch = "master" }
+], optional = false }
+atty = { version = "0.2.14", optional = false }
+tenderdash-abci = { git = "https://github.com/dashpay/rs-tenderdash-abci" }
 # tenderdash-abci = { path = "../../../rs-tenderdash-abci/abci" }
 anyhow = { version = "1.0.70" }
 lazy_static = "1.4.0"
@@ -76,15 +76,28 @@ derive_more = "0.99.17"
 
 [dev-dependencies]
 base64 = "0.20.0"
-platform-version = { path = "../rs-platform-version", features = ["mock-versions"]}
-dpp = { path = "../rs-dpp" , features = ["abci", "random-documents", "state-transition-signing", "random-identities",
-  "random-public-keys", "random-document-types", "fixtures-and-mocks", "identity-value-conversion",
-  "data-contract-json-conversion", "data-contract-cbor-conversion"] }
-drive = { path = "../rs-drive", features = ["fixtures-and-mocks"] }
+platform-version = { path = "../rs-platform-version", features = [
+    "mock-versions",
+] }
+dpp = { path = "../rs-dpp", features = [
+    "abci",
+    "random-documents",
+    "state-transition-signing",
+    "random-identities",
+    "random-public-keys",
+    "random-document-types",
+    "fixtures-and-mocks",
+    "identity-value-conversion",
+    "data-contract-json-conversion",
+    "data-contract-cbor-conversion",
+] }
+drive = { path = "../rs-drive" }
 
 [features]
-default = ["server"]
-server = ["clap", "dotenvy", "tracing-subscriber", "atty", "mockall"]
+default = ["server", "mocks"]
+server = ["clap", "dotenvy"]
+mocks = ["mockall", "drive/fixtures-and-mocks"]
+
 
 [[bin]]
 name = "drive-abci"

--- a/packages/rs-drive-abci/src/abci/error.rs
+++ b/packages/rs-drive-abci/src/abci/error.rs
@@ -46,7 +46,6 @@ pub enum AbciError {
     BadCommitSignature(String),
 
     /// Error returned by Tenderdash-abci library
-    #[cfg(feature = "server")]
     #[error("tenderdash: {0}")]
     Tenderdash(#[from] tenderdash_abci::Error),
 

--- a/packages/rs-drive-abci/src/abci/mod.rs
+++ b/packages/rs-drive-abci/src/abci/mod.rs
@@ -1,10 +1,10 @@
 mod error;
 
 /// The handlers of abci messages
+#[cfg(any(feature = "server", test))]
 pub mod handlers;
 
-// new code - config,
-#[cfg(feature = "server")]
+// server configuration
 pub mod config;
 #[cfg(any(feature = "server", test))]
 pub(crate) mod server;
@@ -12,4 +12,5 @@ pub(crate) mod server;
 pub use error::AbciError;
 #[cfg(feature = "server")]
 pub use server::start;
+#[cfg(any(feature = "server", test))]
 pub use server::AbciApplication;

--- a/packages/rs-drive-abci/src/lib.rs
+++ b/packages/rs-drive-abci/src/lib.rs
@@ -33,10 +33,11 @@ pub mod core;
 /// Metrics subsystem
 pub mod metrics;
 /// Test helpers and fixtures
-// #[cfg(test)]
+#[cfg(any(feature = "mocks", test))]
 pub mod test;
 
 /// Mimic of block execution for tests
+#[cfg(any(feature = "mocks", test))]
 pub mod mimic;
 /// Platform module
 pub mod platform_types;

--- a/packages/rs-drive-abci/src/platform_types/platform/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mod.rs
@@ -5,12 +5,12 @@ use crate::rpc::core::{CoreRPCLike, DefaultCoreRPC};
 use drive::drive::Drive;
 use std::fmt::{Debug, Formatter};
 
+#[cfg(any(feature = "mocks", test))]
+use crate::rpc::core::MockCoreRPCLike;
+use dashcore_rpc::dashcore::hashes::hex::FromHex;
 use drive::drive::defaults::PROTOCOL_VERSION;
 use std::path::Path;
 use std::sync::RwLock;
-
-use crate::rpc::core::MockCoreRPCLike;
-use dashcore_rpc::dashcore::hashes::hex::FromHex;
 
 use dashcore_rpc::dashcore::BlockHash;
 
@@ -117,6 +117,7 @@ impl Platform<DefaultCoreRPC> {
     }
 }
 
+#[cfg(any(feature = "mocks", test))]
 impl Platform<MockCoreRPCLike> {
     /// Open Platform with Drive and block execution context and mock core rpc.
     pub fn open<P: AsRef<Path>>(
@@ -142,11 +143,13 @@ impl Platform<MockCoreRPCLike> {
 
     /// Recreate the state from the backing store
     pub fn recreate_state(&self, _platform_version: &PlatformVersion) -> Result<bool, Error> {
-        let Some(serialized_platform_state) = self.drive
+        let Some(serialized_platform_state) = self
+            .drive
             .grove
             .get_aux(b"saved_state", None)
             .unwrap()
-            .map_err(|e| Error::Drive(GroveDB(e)))? else {
+            .map_err(|e| Error::Drive(GroveDB(e)))?
+        else {
             return Ok(false);
         };
 

--- a/packages/rs-drive-abci/src/rpc/core.rs
+++ b/packages/rs-drive-abci/src/rpc/core.rs
@@ -8,7 +8,6 @@ use dashcore_rpc::dashcore_rpc_json::{
 use dashcore_rpc::json::GetTransactionResult;
 use dashcore_rpc::{Auth, Client, Error, RpcApi};
 use dpp::dashcore::InstantLock;
-use mockall::{automock, predicate::*};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -20,7 +19,7 @@ pub type QuorumListExtendedInfo = HashMap<QuorumHash, ExtendedQuorumDetails>;
 /// Core height must be of type u32 (Platform heights are u64)
 pub type CoreHeight = u32;
 /// Core RPC interface
-#[automock]
+#[cfg_attr(any(feature = "mocks", test), mockall::automock)]
 pub trait CoreRPCLike {
     /// Get block hash by height
     fn get_block_hash(&self, height: CoreHeight) -> Result<BlockHash, Error>;

--- a/packages/rs-drive-abci/src/test/helpers/setup.rs
+++ b/packages/rs-drive-abci/src/test/helpers/setup.rs
@@ -35,6 +35,7 @@
 use std::ops::{Deref, DerefMut};
 
 use crate::platform_types::platform::Platform;
+#[cfg(any(feature = "mocks", test))]
 use crate::rpc::core::MockCoreRPCLike;
 use crate::test::fixture::abci::static_system_identity_public_keys_v0;
 use crate::{config::PlatformConfig, rpc::core::DefaultCoreRPC};

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -3,10 +3,10 @@ name = "drive"
 description = "Dash drive built on top of GroveDB"
 version = "0.24.0-dev.1"
 authors = [
-    "Samuel Westrich <sam@dash.org>",
-    "Ivan Shumkov <ivan@shumkov.ru>",
-    "Djavid Gabibiyan <djavid@dash.org>",
-    "Wisdom Ogwu <wisdom@dash.org",
+  "Samuel Westrich <sam@dash.org>",
+  "Ivan Shumkov <ivan@shumkov.ru>",
+  "Djavid Gabibiyan <djavid@dash.org>",
+  "Wisdom Ogwu <wisdom@dash.org",
 ]
 edition = "2021"
 license = "MIT"
@@ -24,7 +24,7 @@ sqlparser = { version = "0.13.0" }
 thiserror = { version = "1.0.30" }
 moka = { version = "0.11.1", features = ["future", "futures-util"] }
 nohash-hasher = { version = "0.2.0" }
-dpp = { path = "../rs-dpp", features = ["drive", "cbor"]}
+dpp = { path = "../rs-dpp", features = ["drive", "cbor"] }
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
 derive_more = "0.99.17"
 
@@ -42,16 +42,27 @@ rust_decimal = { version = "1.2.5", optional = true }
 rust_decimal_macros = { version = "1.25.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 mockall = { version = "0.11", optional = true }
-grovedb = { version = "1.0.0-rc.1", optional = true}
-grovedb-costs = { version = "1.0.0-rc.1", optional = true}
-grovedb-path = { version = "1.0.0-rc.1"}
-grovedb-storage = { version = "1.0.0-rc.1", optional = true}
+grovedb = { version = "1.0.0-rc.1", optional = true }
+grovedb-costs = { version = "1.0.0-rc.1", optional = true }
+grovedb-path = { version = "1.0.0-rc.1" }
+grovedb-storage = { version = "1.0.0-rc.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.5"
-platform-version = { path = "../rs-platform-version", features = ["mock-versions"]}
-dpp = { path = "../rs-dpp", features = ["drive", "document-cbor-conversion", "random-documents", "random-identities",
-  "random-public-keys", "fixtures-and-mocks", "system_contracts", "factories", "data-contract-json-conversion"]}
+platform-version = { path = "../rs-platform-version", features = [
+  "mock-versions",
+] }
+dpp = { path = "../rs-dpp", features = [
+  "drive",
+  "document-cbor-conversion",
+  "random-documents",
+  "random-identities",
+  "random-public-keys",
+  "fixtures-and-mocks",
+  "system_contracts",
+  "factories",
+  "data-contract-json-conversion",
+] }
 
 [[bench]]
 name = "benchmarks"
@@ -59,23 +70,23 @@ harness = false
 
 [features]
 default = ["full"]
-fixtures-and-mocks = ["mockall"]
+fixtures-and-mocks = ["mockall", "dpp/fixtures-and-mocks"]
 full = [
-    "fixtures-and-mocks",
-    "grovedb/estimated_costs",
-    "grovedb-storage",
-    "grovedb-costs",
-    "bs58",
-    "base64",
-    "hex",
-    "tempfile",
-    "serde_json",
-    "enum-map",
-    "intmap",
-    "chrono",
-    "itertools",
-    "rust_decimal",
-    "rust_decimal_macros",
-    "lazy_static",
+  "fixtures-and-mocks",
+  "grovedb/estimated_costs",
+  "grovedb-storage",
+  "grovedb-costs",
+  "bs58",
+  "base64",
+  "hex",
+  "tempfile",
+  "serde_json",
+  "enum-map",
+  "intmap",
+  "chrono",
+  "itertools",
+  "rust_decimal",
+  "rust_decimal_macros",
+  "lazy_static",
 ]
 verify = ["grovedb/verify", "grovedb-costs"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

1. Importing dpp with default features disabled and only  "identity-serialization" enabled as follows fails:

```
dpp = { path = "../platform/packages/rs-dpp", default-features = false, features = [ "identity-serialization" ] }
```

2. Importing drive-abci without default features and without server feature fails.


## What was done?

* Fixed `identity-serialization` feature in dpp
* Introduced `mocks` feature in drive-abci
* Fixed features in drive-abci


## How Has This Been Tested?

Created and built a test project with the following Cargo.toml:

```
[package]
name = "t123"
version = "0.1.0"
edition = "2021"

[dependencies]
dpp = { path = "../platform/packages/rs-dpp", default-features = false, features = [ "identity-serialization" ] }
drive-abci = { path = "../platform/packages/rs-drive-abci", default-features = false }
```

## Breaking Changes

Mocks in drive-abci are now hidden under `mocks` feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
