### PR TITLE
fix: bug with parsing of mn operator reward

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc"
 version = "0.15.0"
-source = "git+https://github.com/dashpay/rust-dashcore-rpc?rev=7840fe65fbdf4f083ff8632f6e7afac11a31ca63#7840fe65fbdf4f083ff8632f6e7afac11a31ca63"
+source = "git+https://github.com/dashpay/rust-dashcore-rpc?rev=b9cc4327afb11c2a6d68888af6a5afe6a26ab4df#b9cc4327afb11c2a6d68888af6a5afe6a26ab4df"
 dependencies = [
  "dashcore-rpc-json",
  "env_logger 0.10.0",
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.15.0"
-source = "git+https://github.com/dashpay/rust-dashcore-rpc?rev=7840fe65fbdf4f083ff8632f6e7afac11a31ca63#7840fe65fbdf4f083ff8632f6e7afac11a31ca63"
+source = "git+https://github.com/dashpay/rust-dashcore-rpc?rev=b9cc4327afb11c2a6d68888af6a5afe6a26ab4df#b9cc4327afb11c2a6d68888af6a5afe6a26ab4df"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "dashcore",

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -29,7 +29,7 @@ bs58 = "0.4.0"
 hex = "0.4.3"
 indexmap = { version = "1.9.3", features = ["serde"] }
 sha2 = "0.10.6"
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", rev="7840fe65fbdf4f083ff8632f6e7afac11a31ca63" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", rev="b9cc4327afb11c2a6d68888af6a5afe6a26ab4df" }
 dpp = { path = "../rs-dpp", features = ["abci"] }
 rust_decimal = "1.2.5"
 rust_decimal_macros = "1.25.0"

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/triggers/reward_share/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/triggers/reward_share/v0/mod.rs
@@ -246,7 +246,7 @@ mod test {
             collateral_hash: Txid::from_str("4eb56228c535db3b234907113fd41d57bcc7cdcb8e0e00e57590af27ee88c119").expect("expected to decode collateral hash"),
             collateral_index: 0,
             collateral_address: [0;20],
-            operator_reward: 0,
+            operator_reward: 0.0,
             state: DMNState {
                 service: SocketAddr::from_str("1.2.3.4:1234").unwrap(),
                 registered_height: 0,
@@ -277,7 +277,7 @@ mod test {
             collateral_hash: Txid::from_str("4eb56228c535db3b234907113fd41d57bcc7cdcb8e0e00e57590af27ee88c119").expect("expected to decode collateral hash"),
             collateral_index: 0,
             collateral_address: [0;20],
-            operator_reward: 0,
+            operator_reward: 0.0,
             state: DMNState {
                 service: SocketAddr::from_str("1.2.3.5:1234").unwrap(),
                 registered_height: 0,

--- a/packages/rs-drive-abci/src/platform_types/masternode/accessors.rs
+++ b/packages/rs-drive-abci/src/platform_types/masternode/accessors.rs
@@ -34,7 +34,7 @@ impl MasternodeAccessorsV0 for Masternode {
         }
     }
 
-    fn operator_reward(&self) -> u32 {
+    fn operator_reward(&self) -> f32 {
         match self {
             Masternode::V0(v0) => v0.operator_reward,
         }

--- a/packages/rs-drive-abci/src/platform_types/masternode/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/masternode/mod.rs
@@ -10,7 +10,7 @@ mod accessors;
 pub mod v0;
 
 /// `Masternode` represents a masternode on the network.
-#[derive(Clone, PartialEq, Eq, Debug, Encode, Decode)]
+#[derive(Clone, PartialEq, Debug, Encode, Decode)]
 pub enum Masternode {
     /// Version 0
     V0(MasternodeV0),

--- a/packages/rs-drive-abci/src/platform_types/masternode/v0/accessors.rs
+++ b/packages/rs-drive-abci/src/platform_types/masternode/v0/accessors.rs
@@ -14,5 +14,5 @@ pub trait MasternodeAccessorsV0 {
     /// The address where the collateral is stored.
     fn collateral_address(&self) -> [u8; 20];
     /// The amount of the operator's reward for running the masternode.
-    fn operator_reward(&self) -> u32;
+    fn operator_reward(&self) -> f32;
 }

--- a/packages/rs-drive-abci/src/platform_types/masternode/v0/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/masternode/v0/mod.rs
@@ -10,7 +10,7 @@ use dpp::dashcore::{ProTxHash, Txid};
 use std::net::SocketAddr;
 
 /// `Masternode` represents a masternode on the network.
-#[derive(Clone, PartialEq, Eq, Debug, Encode, Decode)]
+#[derive(Clone, PartialEq, Debug, Encode, Decode)]
 pub struct MasternodeV0 {
     /// The type of masternode (e.g., full, partial).
     pub node_type: MasternodeType,
@@ -25,7 +25,7 @@ pub struct MasternodeV0 {
     /// The address where the collateral is stored.
     pub collateral_address: [u8; 20],
     /// The amount of the operator's reward for running the masternode.
-    pub operator_reward: u32,
+    pub operator_reward: f32,
     /// The current state of the masternode (e.g., enabled, pre-enabled, banned).
     pub state: MasternodeStateV0,
 }

--- a/packages/rs-drive-abci/tests/strategy_tests/masternode_list_item_helpers.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/masternode_list_item_helpers.rs
@@ -96,7 +96,7 @@ mod tests {
             collateral_hash: Txid::from_inner(rng.gen::<[u8; 32]>()),
             collateral_index: 0,
             collateral_address: [0; 20],
-            operator_reward: 0,
+            operator_reward: 0.0,
             state: DMNState {
                 service: SocketAddr::from_str(format!("1.0.{}.{}:1234", i / 256, i % 256).as_str())
                     .unwrap(),

--- a/packages/rs-drive-abci/tests/strategy_tests/masternodes.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/masternodes.rs
@@ -203,7 +203,7 @@ pub fn generate_test_masternodes(
             collateral_hash: Txid::from_inner(rng.gen::<[u8; 32]>()),
             collateral_index: 0,
             collateral_address: [0; 20],
-            operator_reward: 0,
+            operator_reward: 0.0,
             state: DMNState {
                 service: SocketAddr::from_str(format!("1.0.{}.{}:1234", i / 256, i % 256).as_str())
                     .unwrap(),
@@ -338,7 +338,7 @@ pub fn generate_test_masternodes(
             collateral_hash: Txid::from_inner(rng.gen::<[u8; 32]>()),
             collateral_index: 0,
             collateral_address: [0; 20],
-            operator_reward: 0,
+            operator_reward: 0.0,
             state: DMNState {
                 service: SocketAddr::from_str(format!("1.1.{}.{}:1234", i / 256, i % 256).as_str())
                     .unwrap(),
@@ -549,7 +549,7 @@ where
         .collect()
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct MasternodeListItemWithUpdates {
     pub masternode: MasternodeListItem,
     pub updates: BTreeMap<u32, MasternodeListItem>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Core returns operator reward as float number. Because of that drive was crashing on startup

## What was done?
<!--- Describe your changes in detail -->
Updates dashcore-rpc and replaces operator reward with f32 instead of u32

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
