### PR TITLE
fix(drive): -32603 error code on broadcast

### DIFF
--- a/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -41,7 +41,7 @@ function broadcastStateTransitionHandlerFactory(rpcClient, createGrpcErrorFromDr
 
     if (jsonRpcError) {
       if (jsonRpcError.data === 'tx already exists in cache') {
-        throw new AlreadyExistsGrpcError('State transition already in chain', jsonRpcError);
+        throw new AlreadyExistsGrpcError('State transition already in chain');
       }
 
       const error = new Error();

--- a/packages/rs-drive-abci/src/abci/handlers.rs
+++ b/packages/rs-drive-abci/src/abci/handlers.rs
@@ -617,7 +617,7 @@ where
 
                     (
                         consensus_error.code(),
-                        encode(&consensus_error_bytes, Encoding::Base64),
+                        encode(&error_data_buffer, Encoding::Base64),
                     )
                 } else {
                     // If there are no execution errors the code will be 0

--- a/packages/rs-drive-abci/src/abci/handlers.rs
+++ b/packages/rs-drive-abci/src/abci/handlers.rs
@@ -602,7 +602,7 @@ where
 
                     let error_data = cbor!({
                         "data" => {
-                            "serializedError": consensus_error_bytes
+                            "serializedError" => consensus_error_bytes
                         }
                     })
                     .map_err(|err| {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Client DAPI Client getting -32603 instead of proper error code when we broadcast a state transition

## What was done?
<!--- Describe your changes in detail -->
- Send base64-encoded cbor instead of consensus error bincode
- Do not pass json rpc error code in case if state transition is already exists

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with test suite

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
