### PR TITLE
style(dpp): remove unused cbor import

### DIFF
--- a/packages/rs-dpp/src/identity/identity_public_key/contract_bounds/mod.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/contract_bounds/mod.rs
@@ -2,7 +2,6 @@ use crate::identifier::Identifier;
 use crate::identity::identity_public_key::contract_bounds::ContractBounds::{
     SingleContract, SingleContractDocumentType,
 };
-use crate::util::cbor_value::{CborCanonicalMap, CborMapExtension};
 use crate::ProtocolError;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
CborCanonicalMap is not used anymore in the contract bounds, but still being imported in the file, making applications fail to build rs-dpp when used externally.

```
warning: `platform-serialization-derive` (lib) generated 2 warnings
   Compiling dpp v0.1.0 (/Users/pshenmic/WebstormProjects/platform/packages/rs-dpp)
error[E0432]: unresolved import `crate::util::cbor_value`
 --> /Users/pshenmic/WebstormProjects/platform/packages/rs-dpp/src/identity/identity_public_key/contract_bounds/mod.rs:5:18
  |
5 | use crate::util::cbor_value::{CborCanonicalMap, CborMapExtension};
  |                  ^^^^^^^^^^ could not find `cbor_value` in `util`
```

## What was done?
<!--- Describe your changes in detail -->
Removed the crashing import line

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Removing this line makes rs-dpp to succesfully compile when used in external Rust project

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
