### PR TITLE
ci: make actions-cache steps access S3 using the correct region

### DIFF
--- a/.github/actions/nodejs/action.yaml
+++ b/.github/actions/nodejs/action.yaml
@@ -17,6 +17,10 @@ runs:
       shell: bash
       run: npm config set audit false
 
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: eu-west-1
+
     - name: Cache NPM build artifacts
       uses: everpcpc/actions-cache@v1
       with:

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -32,6 +32,10 @@ runs:
         echo "PROTOC=${HOME}/.local/bin/protoc" >> $GITHUB_ENV
         export PATH="${PATH}:${HOME}/.local/bin"
 
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: eu-west-1
+
     - name: Cache Rust build artifacts
       uses: everpcpc/actions-cache@v1
       with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Actions using `everpcpc/actions-cache` were experiencing non-fatal errors when trying to access S3, slowing down actions:

```
Restore s3 cache failed: Error: Unexpected (permanent) at Pager::next, context: { response: Parts { status: 301, version: HTTP/1.1, headers: {"x-amz-bucket-region": "eu-west-1", "x-amz-request-id": "3WEXC0275TW606D3", "x-amz-id-2": "BQW9Imt05kUrseOe7TpuXwChVydDLjFl+/p3tpxbZiTZVJzyp/Mnm06R3hAAXkQBFcU+9nWT008=", "content-type": "application/xml", "transfer-encoding": "chunked", "date": "Tue, 12 Sep 2023 04:32:59 GMT", "server": "AmazonS3"} }, service: s3, path: Linux-yarn-unplugged-eef79a1fefecdfa2e3d63ea004871c480d656559c004f343a5fc34f32c02cd39/ } => S3Error { code: "PermanentRedirect", message: "The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.", resource: "", request_id: "3WEXC0275TW606D3" }
```

## What was done?
<!--- Describe your changes in detail -->
This error occurs when attempting to access a bucket in the wrong region. Unlike our custom caching actions, this action depends on a properly configured AWS environment on the runner now that we are using gateway endpoints to access S3. Running `aws-actions/configure-aws-credentials` first sets up the environment properly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None, but we should merge https://github.com/dcginfra/tf-aws-gh-runner/pull/11 first because the updated action requires Node 20

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
