### PR TITLE
feat(drive): reopen log file on HUP signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,6 +1299,7 @@ dependencies = [
  "prost",
  "rand",
  "regex",
+ "reopen",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
@@ -2231,7 +2232,7 @@ source = "git+https://github.com/fominok/jsonschema-rs?branch=feat-unevaluated-p
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.3",
  "bytecount",
  "fancy-regex",
  "fraction",
@@ -3313,6 +3314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reopen"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff42cec3acf85845f5b18b3cbb7fec619ccbd4a349f6ecbe1c62ab46d4d98293"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -39,7 +39,7 @@ prost = { version = "0.11.6", default-features = false }
 tracing = { version = "0.1.37", default-features = false, features = [] }
 clap = { version = "4.1.8", optional = true, features = ["derive"] }
 envy = { version = "0.4.2" }
-dotenvy = { version = "0.15.6", optional = true }
+dotenvy = { version = "0.15.7", optional = true }
 dapi-grpc = { path = "../dapi-grpc" }
 platform-serialization = { path = "../rs-platform-serialization" }
 platform-serialization-derive = { path = "../rs-platform-serialization-derive" }
@@ -59,6 +59,7 @@ anyhow = { version = "1.0.70" }
 lazy_static = "1.4.0"
 itertools = { version = "0.10.5" }
 file-rotate = { version = "0.7.3" }
+reopen = { version = "1.0.3" }
 delegate = { version = "0.9.0" }
 regex = { version = "1.8.1" }
 metrics = { version = "0.21" }

--- a/packages/rs-drive-abci/src/config.rs
+++ b/packages/rs-drive-abci/src/config.rs
@@ -280,9 +280,16 @@ mod tests {
     fn test_config_from_env() {
         // ABCI log configs are parsed manually, so they deserve separate handling
         // Notat that STDOUT is also defined in .env.example, but env var should overwrite it.
-        let log_ids = &["STDOUT", "UPPERCASE", "lowercase", "miXedC4s3", "123"];
-        for id in log_ids {
-            env::set_var(format!("ABCI_LOG_{}_DESTINATION", id), "bytes");
+        let vectors = &[
+            ("STDOUT", "pretty"),
+            ("UPPERCASE", "json"),
+            ("lowercase", "pretty"),
+            ("miXedC4s3", "full"),
+            ("123", "compact"),
+        ];
+        for vector in vectors {
+            env::set_var(format!("ABCI_LOG_{}_DESTINATION", vector.0), "bytes");
+            env::set_var(format!("ABCI_LOG_{}_FORMAT", vector.0), vector.1);
         }
 
         let envfile = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".env.example");
@@ -293,8 +300,8 @@ mod tests {
         let config = super::PlatformConfig::from_env().unwrap();
         assert!(config.verify_sum_trees);
         assert_ne!(config.quorum_type(), QuorumType::UNKNOWN);
-        for id in log_ids {
-            assert_eq!(config.abci.log[*id].destination.as_str(), "bytes");
+        for id in vectors {
+            assert_eq!(config.abci.log[id.0].destination.as_str(), "bytes");
         }
     }
 }

--- a/packages/rs-drive-abci/src/logging.rs
+++ b/packages/rs-drive-abci/src/logging.rs
@@ -919,7 +919,7 @@ mod tests {
         let tempdir = TempDir::new().unwrap();
         let config = LogConfig {
             destination: tempdir.path().to_string_lossy().to_string(),
-            verbosity: 4,
+            level: LogLevelPreset::Trace,
             format: LogFormat::Pretty,
             max_files: 3,
             ..Default::default()
@@ -965,7 +965,7 @@ mod tests {
         let filepath = tempdir.path().join("drive-abci.log");
         let config = LogConfig {
             destination: tempdir.path().to_string_lossy().to_string(),
-            verbosity: 4,
+            level: LogLevelPreset::Trace,
             format: LogFormat::Pretty,
             max_files: 0,
             ..Default::default()

--- a/packages/rs-drive-abci/src/logging.rs
+++ b/packages/rs-drive-abci/src/logging.rs
@@ -464,9 +464,7 @@ impl Loggers {
                             .and_then(|_| Ok(inner.handle().reopen()));
                     }
                 }
-                d => {
-                    tracing::trace!("log destination {} does not support rotation", d.name())
-                }
+                _ => {}
             }
         }
         result

--- a/packages/rs-drive-abci/src/logging.rs
+++ b/packages/rs-drive-abci/src/logging.rs
@@ -66,7 +66,7 @@ pub struct LogConfig {
     /// detailed description.
     #[serde(default)]
     pub format: LogFormat,
-    /// Max number of daily files to store; only used when storing logs in file; defaults to 0 - rotation disabled
+    /// Max number of daily files to store, excluding active one; only used when storing logs in file; defaults to 0 - rotation disabled
     #[serde(default)]
     pub max_files: usize,
 }
@@ -454,15 +454,11 @@ impl Loggers {
                     };
                 }
                 LogDestination::File(ref f) => {
-                    {
-                        let mut inner = f.0.lock().expect("logging lock poisoned");
+                    let mut inner = f.0.lock().expect("logging lock poisoned");
 
-                        // let inner = guard.get_mut();
-                        result = inner
-                            .flush()
-                            .map_err(|e| Error::FileRotate(e))
-                            .and_then(|_| Ok(inner.handle().reopen()));
-                    }
+                    result = inner.flush().map_err(Error::FileRotate).map(|_| {
+                        inner.handle().reopen();
+                    })
                 }
                 _ => {}
             }
@@ -791,7 +787,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use std::str::from_utf8;
+    use std::{fs, str::from_utf8};
 
     /// Reads data written to provided destination.
     ///
@@ -911,5 +907,131 @@ mod tests {
         assert!(!result_dir_verb_0.contains(TEST_STRING_DEBUG));
         assert!(result_verb_4.contains(TEST_STRING_DEBUG));
         assert!(result_file_verb_4.contains(TEST_STRING_DEBUG));
+    }
+
+    /// Test rotation of RotationWriter destination.
+    ///
+    /// Given that the RotationWriter is rotated 3 times, we expect to see 4 files:
+    /// - 1 file with the original name
+    /// - 3 files with the original name and timestamp suffix
+    #[test]
+    fn test_rotation_writer_rotate() {
+        let tempdir = TempDir::new().unwrap();
+        let config = LogConfig {
+            destination: tempdir.path().to_string_lossy().to_string(),
+            verbosity: 4,
+            format: LogFormat::Pretty,
+            max_files: 3,
+            ..Default::default()
+        };
+
+        let loggers = LogBuilder::new()
+            .with_config("rotate", &config)
+            .expect("configure log builder")
+            .build();
+        let logger = loggers.0.get("rotate").expect("get logger");
+
+        for i in 0..config.max_files + 2 {
+            logger
+                .destination
+                .lock()
+                .unwrap()
+                .write_all(format!("file {}\n", i).as_bytes())
+                .unwrap();
+
+            loggers.rotate().expect("rotate logs");
+            std::thread::sleep(std::time::Duration::from_millis(1100));
+        }
+        let mut counter = 0;
+        tempdir.path().read_dir().unwrap().for_each(|entry| {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            let path = path.to_string_lossy();
+            println!("{}", path);
+            assert!(path.contains("drive-abci.log"));
+            counter = counter + 1;
+        });
+        assert_eq!(counter, config.max_files + 1);
+    }
+
+    /// Test rotation of File destination.
+    ///
+    /// Given that we move the File and then Rotate it, we expect the file to be recreated in new location.
+    #[test]
+    fn test_file_rotate() {
+        const ITERATIONS: usize = 4;
+
+        let tempdir = TempDir::new().unwrap();
+        let filepath = tempdir.path().join("drive-abci.log");
+        let config = LogConfig {
+            destination: tempdir.path().to_string_lossy().to_string(),
+            verbosity: 4,
+            format: LogFormat::Pretty,
+            max_files: 0,
+            ..Default::default()
+        };
+
+        let loggers = LogBuilder::new()
+            .with_config("rotate", &config)
+            .expect("configure log builder")
+            .build();
+        let logger = loggers.0.get("rotate").expect("get logger");
+
+        for i in 0..ITERATIONS {
+            let mut guard = logger.destination.lock().unwrap();
+            guard
+                .write_all(format!("file {}, before rotate\n", i).as_bytes())
+                .unwrap();
+
+            fs::rename(
+                &filepath,
+                tempdir.path().join(format!("drive-abci.log.{}", i)),
+            )
+            .unwrap();
+            // rotate() locks, so we need to drop guard here
+            drop(guard);
+
+            loggers.rotate().expect("rotate logs");
+            let mut guard = logger.destination.lock().unwrap();
+            guard
+                .write_all(format!("file {}, after rotate\n", i + 1).as_bytes())
+                .unwrap();
+            guard.flush().unwrap();
+
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        // Close all files, so that we can read them
+        drop(loggers);
+
+        let mut counter = 0;
+        tempdir.path().read_dir().unwrap().for_each(|entry| {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            let path_str = path.to_string_lossy();
+            let read = fs::read_to_string(&path).unwrap();
+            println!("{}: {}", path_str, read);
+            assert!(path_str.contains("drive-abci.log"));
+
+            if counter < ITERATIONS - 1 {
+                assert!(
+                    read.contains(format!("file {}, before rotate\n", counter).as_str()),
+                    "expect: file {}, before rotate, read: {}",
+                    counter,
+                    read
+                )
+            };
+            if counter > 0 {
+                assert!(
+                    read.contains(format!("file {}, after rotate\n", counter).as_str()),
+                    "expect: file {}, after rotate, read: {}",
+                    counter,
+                    read
+                )
+            }
+
+            counter = counter + 1;
+        });
+        assert_eq!(counter, ITERATIONS + 1);
     }
 }

--- a/packages/rs-drive-abci/src/logging.rs
+++ b/packages/rs-drive-abci/src/logging.rs
@@ -917,8 +917,9 @@ mod tests {
     #[test]
     fn test_rotation_writer_rotate() {
         let tempdir = TempDir::new().unwrap();
+        let filepath = tempdir.path().join("drive-abci.log");
         let config = LogConfig {
-            destination: tempdir.path().to_string_lossy().to_string(),
+            destination: filepath.to_string_lossy().to_string(),
             level: LogLevelPreset::Trace,
             format: LogFormat::Pretty,
             max_files: 3,
@@ -964,7 +965,7 @@ mod tests {
         let tempdir = TempDir::new().unwrap();
         let filepath = tempdir.path().join("drive-abci.log");
         let config = LogConfig {
-            destination: tempdir.path().to_string_lossy().to_string(),
+            destination: filepath.to_string_lossy().to_string(),
             level: LogLevelPreset::Trace,
             format: LogFormat::Pretty,
             max_files: 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Logrotate should send HUP signal to a service after rotating logs.
Service is expected to close the log file and reopen (recreate) it.

## What was done?

Implemented rotate() for LogDestination::File. 

## How Has This Been Tested?

Local devnet

## Breaking Changes

None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
