### PR TITLE
fix(dashmate): config format is not conventional

### DIFF
--- a/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
+++ b/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
@@ -82,7 +82,7 @@ class ConfigFileJsonRepository {
   write(configFile) {
     const configFileJSON = JSON.stringify(configFile.toObject(), undefined, 2);
 
-    fs.writeFileSync(this.configFilePath, configFileJSON, 'utf8');
+    fs.writeFileSync(this.configFilePath, `${configFileJSON}\n`, 'utf8');
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Config doesn't have newline at the end so when we render config with deployment tool with template that has newline we getting different file. In turn, this fact trigger restart of the whole dashmate on deploy.

## What was done?
<!--- Describe your changes in detail -->
- Added newline to config

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
