### PR TITLE
perf(drive): clear instead of delete for previous masternode version voting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "0.1.0"
+version = "0.25.0-dev.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "0.24.0-dev.1"
+version = "0.25.0-dev.30"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "drive-abci"
-version = "0.1.0"
+version = "0.25.0-dev.30"
 dependencies = [
  "anyhow",
  "atty",
@@ -1753,7 +1753,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "grovedb"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=eade3e078a4ba93398d94aade9144f8305632a9b#eade3e078a4ba93398d94aade9144f8305632a9b"
+source = "git+https://github.com/dashpay/grovedb?rev=63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d#63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d"
 dependencies = [
  "bincode 1.3.3",
  "grovedb-costs",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=eade3e078a4ba93398d94aade9144f8305632a9b#eade3e078a4ba93398d94aade9144f8305632a9b"
+source = "git+https://github.com/dashpay/grovedb?rev=63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d#63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=eade3e078a4ba93398d94aade9144f8305632a9b#eade3e078a4ba93398d94aade9144f8305632a9b"
+source = "git+https://github.com/dashpay/grovedb?rev=63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d#63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d"
 dependencies = [
  "blake3",
  "byteorder",
@@ -1809,12 +1809,12 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=eade3e078a4ba93398d94aade9144f8305632a9b#eade3e078a4ba93398d94aade9144f8305632a9b"
+source = "git+https://github.com/dashpay/grovedb?rev=63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d#63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d"
 
 [[package]]
 name = "grovedb-storage"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=eade3e078a4ba93398d94aade9144f8305632a9b#eade3e078a4ba93398d94aade9144f8305632a9b"
+source = "git+https://github.com/dashpay/grovedb?rev=63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d#63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=eade3e078a4ba93398d94aade9144f8305632a9b#eade3e078a4ba93398d94aade9144f8305632a9b"
+source = "git+https://github.com/dashpay/grovedb?rev=63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d#63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d"
 dependencies = [
  "hex",
  "itertools",

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -43,10 +43,10 @@ rust_decimal = { version = "1.2.5", optional = true }
 rust_decimal_macros = { version = "1.25.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 mockall = { version = "0.11", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "eade3e078a4ba93398d94aade9144f8305632a9b", optional = true }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "eade3e078a4ba93398d94aade9144f8305632a9b", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "eade3e078a4ba93398d94aade9144f8305632a9b" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "eade3e078a4ba93398d94aade9144f8305632a9b", optional = true }
+grovedb = { git = "https://github.com/dashpay/grovedb", rev = "63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d", optional = true }
+grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d", optional = true }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "63b4ff1df767cabd92c4ad13a6f2ef87a1299a7d", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/packages/rs-drive/src/drive/grove_operations/grove_clear/mod.rs
+++ b/packages/rs-drive/src/drive/grove_operations/grove_clear/mod.rs
@@ -1,0 +1,40 @@
+mod v0;
+
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use crate::fee::op::LowLevelDriveOperation;
+use dpp::version::drive_versions::DriveVersion;
+
+use grovedb::TransactionArg;
+use grovedb_path::SubtreePath;
+
+impl Drive {
+    /// Handles the deletion of an element in GroveDB at the specified path and key.
+    /// The operation cost is added to `drive_operations` for later processing.
+    ///
+    /// # Parameters
+    /// * `path`: The groveDB hierarchical authenticated structure path where the subtree is to be cleared.
+    /// * `transaction`: The groveDB transaction associated with this operation.
+    /// * `drive_operations`: A vector to collect the costs of operations for later computation.
+    /// * `platform_version`: The platform version to select the correct function version to run.
+    ///
+    /// # Returns
+    /// * `Ok(())` if the operation was successful.
+    /// * `Err(DriveError::UnknownVersionMismatch)` if the platform version does not match known versions.
+    pub fn grove_clear<B: AsRef<[u8]>>(
+        &self,
+        path: SubtreePath<'_, B>,
+        transaction: TransactionArg,
+        drive_version: &DriveVersion,
+    ) -> Result<(), Error> {
+        match drive_version.grove_methods.basic.grove_clear {
+            0 => self.grove_clear_v0(path, transaction),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "grove_clear".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/grove_operations/grove_clear/v0/mod.rs
+++ b/packages/rs-drive/src/drive/grove_operations/grove_clear/v0/mod.rs
@@ -1,0 +1,25 @@
+use crate::drive::Drive;
+use crate::error::Error;
+use grovedb::operations::delete::ClearOptions;
+use grovedb::TransactionArg;
+use grovedb_path::SubtreePath;
+
+impl Drive {
+    /// Pushes the `OperationCost` of deleting an element in groveDB to `drive_operations`.
+    pub(super) fn grove_clear_v0<B: AsRef<[u8]>>(
+        &self,
+        path: SubtreePath<'_, B>,
+        transaction: TransactionArg,
+    ) -> Result<(), Error> {
+        let options = ClearOptions {
+            check_for_subtrees: false,
+            allow_deleting_subtrees: false,
+            trying_to_clear_with_subtrees_returns_error: false,
+        };
+        // we will always return true if there is no error when we don't check for subtrees
+        self.grove
+            .clear_subtree(path, Some(options), transaction)
+            .map_err(Error::GroveDB)
+            .map(|_| ())
+    }
+}

--- a/packages/rs-drive/src/drive/grove_operations/mod.rs
+++ b/packages/rs-drive/src/drive/grove_operations/mod.rs
@@ -131,6 +131,9 @@ pub mod grove_apply_partial_batch_with_add_costs;
 /// Get cost of grove batch operations
 pub mod grove_batch_operations_costs;
 
+/// Clear a subtree in grovedb
+pub mod grove_clear;
+
 use grovedb_costs::CostContext;
 
 use grovedb::EstimatedLayerInformation;

--- a/packages/rs-drive/src/drive/protocol_upgrade/change_to_new_version_and_clear_version_information/v0/mod.rs
+++ b/packages/rs-drive/src/drive/protocol_upgrade/change_to_new_version_and_clear_version_information/v0/mod.rs
@@ -24,11 +24,7 @@ impl Drive {
         let platform_version =
             PlatformVersion::get(current_version).map_err(ProtocolError::PlatformVersionError)?;
         let mut batch_operations: Vec<LowLevelDriveOperation> = vec![];
-        self.clear_version_information_operations_v0(
-            transaction,
-            &mut batch_operations,
-            &platform_version.drive,
-        )?;
+
         self.set_current_protocol_version_operations(
             current_version,
             transaction,
@@ -52,6 +48,9 @@ impl Drive {
                 &platform_version.drive,
             )?;
         }
+
+        self.clear_version_information(transaction, &platform_version.drive)?;
+
         Ok(())
     }
 }

--- a/packages/rs-drive/src/drive/protocol_upgrade/clear_version_information/v0/mod.rs
+++ b/packages/rs-drive/src/drive/protocol_upgrade/clear_version_information/v0/mod.rs
@@ -1,22 +1,10 @@
-use crate::drive::grove_operations::BatchDeleteApplyType::StatefulBatchDelete;
-
-use crate::drive::batch::grovedb_op_batch::GroveDbOpBatchV0Methods;
-use crate::drive::protocol_upgrade::{
-    desired_version_for_validators_path, desired_version_for_validators_path_vec,
-    versions_counter_path, versions_counter_path_vec,
-};
+use crate::drive::protocol_upgrade::{desired_version_for_validators_path, versions_counter_path};
 use crate::drive::Drive;
 
 use crate::error::Error;
 
-use crate::fee::op::LowLevelDriveOperation;
-use crate::query::QueryItem;
-
 use dpp::version::drive_versions::DriveVersion;
-use grovedb::query_result_type::QueryResultType;
-use grovedb::{PathQuery, Query, TransactionArg};
-
-use std::ops::RangeFull;
+use grovedb::TransactionArg;
 
 impl Drive {
     /// Clear all version information from the backing store, this is done on epoch change in
@@ -26,83 +14,17 @@ impl Drive {
         transaction: TransactionArg,
         drive_version: &DriveVersion,
     ) -> Result<(), Error> {
-        let mut batch_operations: Vec<LowLevelDriveOperation> = vec![];
-        self.clear_version_information_operations_v0(
+        self.grove_clear(
+            (&versions_counter_path()).into(),
             transaction,
-            &mut batch_operations,
             drive_version,
         )?;
-        let grove_db_operations =
-            LowLevelDriveOperation::grovedb_operations_batch(&batch_operations);
-        if !grove_db_operations.is_empty() {
-            self.apply_batch_grovedb_operations(
-                None,
-                transaction,
-                grove_db_operations,
-                &mut vec![],
-                drive_version,
-            )?;
-        }
-        Ok(())
-    }
-
-    /// Clear all version information from the backing store, this is done on epoch change in
-    /// execution logic
-    pub(in crate::drive::protocol_upgrade) fn clear_version_information_operations_v0(
-        &self,
-        transaction: TransactionArg,
-        drive_operations: &mut Vec<LowLevelDriveOperation>,
-        drive_version: &DriveVersion,
-    ) -> Result<(), Error> {
-        let path_query = PathQuery::new_unsized(
-            versions_counter_path_vec(),
-            Query::new_single_query_item(QueryItem::RangeFull(RangeFull)),
-        );
-        let results = self
-            .grove_get_path_query(
-                &path_query,
-                transaction,
-                QueryResultType::QueryKeyElementPairResultType,
-                &mut vec![],
-                drive_version,
-            )?
-            .0;
-        for key in results.to_keys() {
-            self.batch_delete(
-                (&versions_counter_path()).into(),
-                key.as_slice(),
-                StatefulBatchDelete {
-                    is_known_to_be_subtree_with_sum: (Some((false, false))),
-                },
-                transaction,
-                drive_operations,
-                drive_version,
-            )?;
-        }
-
-        let path_query = PathQuery::new_unsized(
-            desired_version_for_validators_path_vec(),
-            Query::new_single_query_item(QueryItem::RangeFull(RangeFull)),
-        );
-        let (results, _) = self.grove_get_path_query(
-            &path_query,
+        self.grove_clear(
+            (&desired_version_for_validators_path()).into(),
             transaction,
-            QueryResultType::QueryKeyElementPairResultType,
-            &mut vec![],
             drive_version,
         )?;
-        for (key, _) in results.to_key_elements() {
-            self.batch_delete(
-                (&desired_version_for_validators_path()).into(),
-                key.as_slice(),
-                StatefulBatchDelete {
-                    is_known_to_be_subtree_with_sum: (Some((false, false))),
-                },
-                transaction,
-                drive_operations,
-                drive_version,
-            )?;
-        }
+
         Ok(())
     }
 }

--- a/packages/rs-platform-version/src/version/drive_versions.rs
+++ b/packages/rs-platform-version/src/version/drive_versions.rs
@@ -270,6 +270,7 @@ pub struct DriveGroveBasicMethodVersions {
     pub grove_insert_empty_tree: FeatureVersion,
     pub grove_insert_empty_sum_tree: FeatureVersion,
     pub grove_insert_if_not_exists: FeatureVersion,
+    pub grove_clear: FeatureVersion,
     pub grove_delete: FeatureVersion,
     pub grove_get_raw: FeatureVersion,
     pub grove_get_raw_optional: FeatureVersion,

--- a/packages/rs-platform-version/src/version/mocks/v2_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v2_test.rs
@@ -374,6 +374,7 @@ pub(crate) const TEST_PLATFORM_V2: PlatformVersion = PlatformVersion {
                 grove_insert_empty_tree: 0,
                 grove_insert_empty_sum_tree: 0,
                 grove_insert_if_not_exists: 0,
+                grove_clear: 0,
                 grove_delete: 0,
                 grove_get_raw: 0,
                 grove_get_raw_optional: 0,

--- a/packages/rs-platform-version/src/version/mocks/v3_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v3_test.rs
@@ -374,6 +374,7 @@ pub(crate) const TEST_PLATFORM_V3: PlatformVersion = PlatformVersion {
                 grove_insert_empty_tree: 0,
                 grove_insert_empty_sum_tree: 0,
                 grove_insert_if_not_exists: 0,
+                grove_clear: 0,
                 grove_delete: 0,
                 grove_get_raw: 0,
                 grove_get_raw_optional: 0,

--- a/packages/rs-platform-version/src/version/v1.rs
+++ b/packages/rs-platform-version/src/version/v1.rs
@@ -371,6 +371,7 @@ pub(super) const PLATFORM_V1: PlatformVersion = PlatformVersion {
                 grove_insert_empty_tree: 0,
                 grove_insert_empty_sum_tree: 0,
                 grove_insert_if_not_exists: 0,
+                grove_clear: 0,
                 grove_delete: 0,
                 grove_get_raw: 0,
                 grove_get_raw_optional: 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Previously we were querying all version votes and deleting them individually, this was very much not efficient. Now after this change the tree holding this information is just cleared.


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
Not a breaking change.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
