### PR TITLE
fix(dashmate): a testnet node fails to sync

### DIFF
--- a/packages/dashmate/configs/defaults/getTestnetConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getTestnetConfigFactory.js
@@ -61,6 +61,7 @@ function getTestnetConfigFactory(homeDir, getBaseConfig) {
                 path: homeDir.joinPath('logs', 'testnet', 'drive-json.log'),
               },
             },
+            epochTime: 3600,
             validatorSet: {
               llmqType: 6,
             },

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -226,6 +226,8 @@ function getConfigFileMigrationsFactory(homeDir, defaultConfigs) {
             if (options.network === NETWORK_TESTNET) {
               options.platform.drive.abci.epochTime = testnet.get('platform.drive.abci.epochTime');
             }
+            options.platform.drive.abci.docker.image = base.get('platform.drive.abci.docker.image');
+            options.platform.dapi.api.docker.image = base.get('platform.drive.abci.docker.image');
           });
 
         return configFile;

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -220,6 +220,16 @@ function getConfigFileMigrationsFactory(homeDir, defaultConfigs) {
 
         return configFile;
       },
+      '0.25.3': (configFile) => {
+        Object.entries(configFile.configs)
+          .forEach(([, options]) => {
+            if (options.network === NETWORK_TESTNET) {
+              options.platform.drive.abci.epochTime = testnet.get('platform.drive.abci.epochTime');
+            }
+          });
+
+        return configFile;
+      },
     };
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Testnet the epoch time length is currently set to 3600 seconds (1 hour). Default value in dashmate is  788400 seconds (9.5 days). This setting affects consensus logic and must be equal otherwise, a dashmate testnet node will fail with wrong app hash result.
Anther issue that platform images weren't updated with migration in existing configs.

## What was done?
<!--- Describe your changes in detail -->
- Update the epoch time length in dashmate's testnet config
- Update platform images in existing configs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
