### PR TITLE
feat(dashmate): add cli command for core service

### DIFF
--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -18,6 +18,7 @@ Distribution package for Dash node installation
   - [Stop node](#stop-node)
   - [Restart node](#restart-node)
   - [Show node status](#show-node-status)
+  - [Execute Core CLI command](#execute-core-cli-command)
   - [Reset node data](#reset-node-data)
   - [Full node](#full-node)
   - [Node groups](#node-groups)
@@ -242,6 +243,30 @@ COMMANDS
 To show the host status:
 ```bash
 $ dashmate status host
+```
+
+### Execute Core CLI command
+
+The `core cli` command executes an `dash-cli` command to the core container on the current config.
+
+```
+USAGE
+  $ dashmate core cli [COMMAND] [--config <value>]
+
+ARGUMENTS
+  COMMAND dash-cli command written in the double quotes 
+
+FLAGS
+  --config=<value>  configuration name to use
+
+DESCRIPTION
+  Dash Core CLI
+```
+
+Example:
+```bash
+$ dashmate core cli "getblockcount"
+1337
 ```
 
 ### Reset node data

--- a/packages/dashmate/src/commands/core/cli.js
+++ b/packages/dashmate/src/commands/core/cli.js
@@ -1,6 +1,7 @@
 const ConfigBaseCommand = require('../../oclif/command/ConfigBaseCommand');
+const ServiceIsNotRunningError = require('../../docker/errors/ServiceIsNotRunningError');
 
-class DashCliCommand extends ConfigBaseCommand {
+class CliCommand extends ConfigBaseCommand {
   /**
    * @param {Object} args
    * @param {Object} flags
@@ -17,6 +18,10 @@ class DashCliCommand extends ConfigBaseCommand {
   ) {
     const { command } = args;
 
+    if (!(await dockerCompose.isServiceRunning(config, 'core'))) {
+      throw new ServiceIsNotRunningError(config.name, 'core');
+    }
+
     const { out } = await dockerCompose.execCommand(config, 'core', `dash-cli ${command}`);
 
     // eslint-disable-next-line no-console
@@ -26,16 +31,16 @@ class DashCliCommand extends ConfigBaseCommand {
   }
 }
 
-DashCliCommand.description = 'Dash Core CLI';
+CliCommand.description = 'Dash Core CLI';
 
-DashCliCommand.args = [{
+CliCommand.args = [{
   name: 'command',
   required: true,
   description: 'dash core command written in the double quotes',
 }];
 
-DashCliCommand.flags = {
+CliCommand.flags = {
   ...ConfigBaseCommand.flags,
 };
 
-module.exports = DashCliCommand;
+module.exports = CliCommand;

--- a/packages/dashmate/src/commands/core/cli.js
+++ b/packages/dashmate/src/commands/core/cli.js
@@ -1,0 +1,45 @@
+const { Flags } = require('@oclif/core');
+
+const ConfigBaseCommand = require('../../oclif/command/ConfigBaseCommand');
+
+class DashCliCommand extends ConfigBaseCommand {
+  /**
+   * @param {Object} args
+   * @param {Object} flags
+   * @param {Config} config
+   *
+   * @param dockerCompose
+   * @return {Promise<void>}
+   */
+  async runWithDependencies(
+    args,
+    {
+      verbose: isVerbose,
+    },
+    config,
+    dockerCompose
+  ) {
+    const {command} = args
+    const {exitCode, out} = await dockerCompose.execCommand(config, 'core', `dash-cli ${command}`);
+
+    console.log(out.trim())
+
+    return out
+  }
+}
+
+DashCliCommand.description = 'Dash Core CLI`';
+
+DashCliCommand.args = [{
+  name: 'command',
+  required: true,
+  description: 'Execute a dash-cli command on the core container of the given node config',
+}];
+
+
+DashCliCommand.flags = {
+  ...ConfigBaseCommand.flags,
+  verbose: Flags.boolean({ char: 'v', description: 'use verbose mode for output', default: false }),
+};
+
+module.exports = DashCliCommand;

--- a/packages/dashmate/src/commands/core/cli.js
+++ b/packages/dashmate/src/commands/core/cli.js
@@ -17,14 +17,16 @@ class DashCliCommand extends ConfigBaseCommand {
       verbose: isVerbose,
     },
     config,
-    dockerCompose
+    dockerCompose,
   ) {
-    const {command} = args
-    const {exitCode, out} = await dockerCompose.execCommand(config, 'core', `dash-cli ${command}`);
+    const { command } = args;
 
-    console.log(out.trim())
+    const { out } = await dockerCompose.execCommand(config, 'core', `dash-cli ${command}`);
 
-    return out
+    // eslint-disable-next-line no-console
+    console.log(out.trim());
+
+    return out;
   }
 }
 
@@ -35,7 +37,6 @@ DashCliCommand.args = [{
   required: true,
   description: 'Execute a dash-cli command on the core container of the given node config',
 }];
-
 
 DashCliCommand.flags = {
   ...ConfigBaseCommand.flags,

--- a/packages/dashmate/src/commands/core/cli.js
+++ b/packages/dashmate/src/commands/core/cli.js
@@ -1,5 +1,3 @@
-const { Flags } = require('@oclif/core');
-
 const ConfigBaseCommand = require('../../oclif/command/ConfigBaseCommand');
 
 class DashCliCommand extends ConfigBaseCommand {

--- a/packages/dashmate/src/commands/core/cli.js
+++ b/packages/dashmate/src/commands/core/cli.js
@@ -26,12 +26,12 @@ class DashCliCommand extends ConfigBaseCommand {
   }
 }
 
-DashCliCommand.description = 'Dash Core CLI`';
+DashCliCommand.description = 'Dash Core CLI';
 
 DashCliCommand.args = [{
   name: 'command',
   required: true,
-  description: 'Execute a dash-cli command on the core container of the given node config',
+  description: 'dash core command written in the double quotes',
 }];
 
 DashCliCommand.flags = {

--- a/packages/dashmate/src/commands/core/cli.js
+++ b/packages/dashmate/src/commands/core/cli.js
@@ -13,9 +13,7 @@ class DashCliCommand extends ConfigBaseCommand {
    */
   async runWithDependencies(
     args,
-    {
-      verbose: isVerbose,
-    },
+    flags,
     config,
     dockerCompose,
   ) {
@@ -40,7 +38,6 @@ DashCliCommand.args = [{
 
 DashCliCommand.flags = {
   ...ConfigBaseCommand.flags,
-  verbose: Flags.boolean({ char: 'v', description: 'use verbose mode for output', default: false }),
 };
 
 module.exports = DashCliCommand;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add a dashmate command to execute dash-cli commands in the core container. This is very useful, when you need to do something or check something with the dash-cli of the current node, but you have to use `docker exec -it..` instead.

## What was done?
<!--- Describe your changes in detail -->
* Added a cli command in the core folder

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
