### PR TITLE
fix(dashmate): reset command doesn't reset configs

### DIFF
--- a/packages/dashmate/src/commands/config/get.js
+++ b/packages/dashmate/src/commands/config/get.js
@@ -15,8 +15,9 @@ class ConfigGetCommand extends ConfigBaseCommand {
     config,
   ) {
     // eslint-disable-next-line no-console
-    console.log(
+    console.dir(
       config.get(optionPath),
+      { depth: Infinity },
     );
   }
 }

--- a/packages/dashmate/src/commands/group/reset.js
+++ b/packages/dashmate/src/commands/group/reset.js
@@ -14,8 +14,6 @@ class GroupResetCommand extends GroupBaseCommand {
    * @param {Config[]} configGroup
    * @param {configureCoreTask} configureCoreTask
    * @param {configureTenderdashTask} configureTenderdashTask
-   * @param {generateToAddressTask} generateToAddressTask
-   * @param {ConfigFile} configFile
    * @return {Promise<void>}
    */
   async runWithDependencies(
@@ -30,8 +28,6 @@ class GroupResetCommand extends GroupBaseCommand {
     configGroup,
     configureCoreTask,
     configureTenderdashTask,
-    generateToAddressTask,
-    configFile,
   ) {
     const groupName = configGroup[0].get('group');
 
@@ -39,7 +35,9 @@ class GroupResetCommand extends GroupBaseCommand {
       [
         {
           title: `Reset ${groupName} nodes`,
-          task: () => {
+          task: (ctx) => {
+            ctx.removeConfig = ctx.isHardReset && groupName === PRESET_LOCAL;
+
             const resetTasks = configGroup.map((config) => ({
               title: `Reset ${config.getName()} node`,
               task: () => resetNodeTask(config),
@@ -47,15 +45,6 @@ class GroupResetCommand extends GroupBaseCommand {
 
             return new Listr(resetTasks);
           },
-        },
-        {
-          enabled: (ctx) => ctx.isHardReset && groupName === PRESET_LOCAL,
-          title: 'Delete node configs',
-          task: () => (
-            configGroup
-              .filter((config) => configFile.isConfigExists(config.getName()))
-              .forEach((config) => configFile.removeConfig(config.getName()))
-          ),
         },
         {
           enabled: (ctx) => !ctx.isHardReset


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The reset command with the hard flag doesnt persit configs are resetting

## What was done?
<!--- Describe your changes in detail -->
- Removed duplicated the config removal logic
- Perstit configs after resetting
- Output full config value with the config get command 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
