### PR TITLE
chore(dpp)!: allow only one document transition

### DIFF
--- a/packages/rs-dpp/src/errors/consensus/basic/basic_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/basic_error.rs
@@ -18,12 +18,13 @@ use crate::consensus::basic::decode::{
     ProtocolVersionParsingError, SerializedObjectParsingError, VersionError,
 };
 use crate::consensus::basic::document::{
-    DataContractNotPresentError, DuplicateDocumentTransitionsWithIdsError,
-    DuplicateDocumentTransitionsWithIndicesError, InconsistentCompoundIndexDataError,
-    InvalidDocumentTransitionActionError, InvalidDocumentTransitionIdError,
-    InvalidDocumentTypeError, MaxDocumentsTransitionsExceededError,
-    MissingDataContractIdBasicError, MissingDocumentTransitionActionError,
-    MissingDocumentTransitionTypeError, MissingDocumentTypeError,
+    DataContractNotPresentError, DocumentTransitionsAreAbsentError,
+    DuplicateDocumentTransitionsWithIdsError, DuplicateDocumentTransitionsWithIndicesError,
+    InconsistentCompoundIndexDataError, InvalidDocumentTransitionActionError,
+    InvalidDocumentTransitionIdError, InvalidDocumentTypeError,
+    MaxDocumentsTransitionsExceededError, MissingDataContractIdBasicError,
+    MissingDocumentTransitionActionError, MissingDocumentTransitionTypeError,
+    MissingDocumentTypeError,
 };
 use crate::consensus::basic::identity::{
     DataContractBoundsNotPresentError, DuplicatedIdentityPublicKeyBasicError,
@@ -294,6 +295,9 @@ pub enum BasicError {
 
     #[error(transparent)]
     StateTransitionMaxSizeExceededError(StateTransitionMaxSizeExceededError),
+
+    #[error(transparent)]
+    DocumentTransitionsAreAbsentError(DocumentTransitionsAreAbsentError),
 }
 
 impl From<BasicError> for ConsensusError {

--- a/packages/rs-dpp/src/errors/consensus/basic/document/document_transitions_are_absent_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/document/document_transitions_are_absent_error.rs
@@ -1,0 +1,26 @@
+use crate::consensus::basic::BasicError;
+use crate::consensus::ConsensusError;
+use crate::errors::ProtocolError;
+use bincode::{Decode, Encode};
+
+use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
+use thiserror::Error;
+
+#[derive(
+    Error, Debug, Clone, PartialEq, Eq, Encode, Decode, PlatformSerialize, PlatformDeserialize,
+)]
+#[error("Documents Batch Transition has no document transitions")]
+#[platform_serialize(unversioned)]
+pub struct DocumentTransitionsAreAbsentError {}
+
+impl DocumentTransitionsAreAbsentError {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl From<DocumentTransitionsAreAbsentError> for ConsensusError {
+    fn from(err: DocumentTransitionsAreAbsentError) -> Self {
+        Self::BasicError(BasicError::DocumentTransitionsAreAbsentError(err))
+    }
+}

--- a/packages/rs-dpp/src/errors/consensus/basic/document/mod.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/document/mod.rs
@@ -1,4 +1,5 @@
 mod data_contract_not_present_error;
+mod document_transitions_are_absent_error;
 mod duplicate_document_transitions_with_ids_error;
 mod duplicate_document_transitions_with_indices_error;
 mod inconsistent_compound_index_data_error;
@@ -12,6 +13,7 @@ mod missing_document_transition_type_error;
 mod missing_document_type_error;
 
 pub use data_contract_not_present_error::*;
+pub use document_transitions_are_absent_error::*;
 pub use duplicate_document_transitions_with_ids_error::*;
 pub use duplicate_document_transitions_with_indices_error::*;
 pub use inconsistent_compound_index_data_error::*;

--- a/packages/rs-dpp/src/errors/consensus/codes.rs
+++ b/packages/rs-dpp/src/errors/consensus/codes.rs
@@ -77,6 +77,7 @@ impl ErrorWithCode for BasicError {
             Self::MissingDocumentTransitionTypeError { .. } => 1027,
             Self::MissingDocumentTypeError { .. } => 1028,
             Self::MaxDocumentsTransitionsExceededError { .. } => 1065,
+            Self::DocumentTransitionsAreAbsentError { .. } => 1066,
 
             // Identity
             Self::DuplicatedIdentityPublicKeyBasicError(_) => 1029,

--- a/packages/wasm-dpp/src/errors/consensus/basic/document/document_transitions_are_absent_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/basic/document/document_transitions_are_absent_error.rs
@@ -1,0 +1,29 @@
+use dpp::consensus::codes::ErrorWithCode;
+use dpp::consensus::ConsensusError;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use dpp::consensus::basic::document::DocumentTransitionsAreAbsentError;
+
+#[wasm_bindgen(js_name=DocumentTransitionsAreAbsentError)]
+pub struct DocumentTransitionsAreAbsentErrorWasm {
+    inner: DocumentTransitionsAreAbsentError,
+}
+
+impl From<&DocumentTransitionsAreAbsentError> for DocumentTransitionsAreAbsentErrorWasm {
+    fn from(e: &DocumentTransitionsAreAbsentError) -> Self {
+        Self { inner: e.clone() }
+    }
+}
+
+#[wasm_bindgen(js_class=DocumentTransitionsAreAbsentError)]
+impl DocumentTransitionsAreAbsentErrorWasm {
+    #[wasm_bindgen(js_name=getCode)]
+    pub fn get_code(&self) -> u32 {
+        ConsensusError::from(self.inner.clone()).code()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn message(&self) -> String {
+        self.inner.to_string()
+    }
+}

--- a/packages/wasm-dpp/src/errors/consensus/basic/document/mod.rs
+++ b/packages/wasm-dpp/src/errors/consensus/basic/document/mod.rs
@@ -1,4 +1,5 @@
 mod data_contract_not_present_error;
+mod document_transitions_are_absent_error;
 mod duplicate_document_transitions_with_ids_error;
 mod duplicate_document_transitions_with_indices_error;
 mod inconsistent_compound_index_data_error;
@@ -11,6 +12,7 @@ mod missing_document_transition_type_error;
 mod missing_document_type_error;
 
 pub use data_contract_not_present_error::*;
+pub use document_transitions_are_absent_error::*;
 pub use duplicate_document_transitions_with_ids_error::*;
 pub use duplicate_document_transitions_with_indices_error::*;
 pub use inconsistent_compound_index_data_error::*;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We potentually have an issue, processing multiple document transition in Drive ABCI

## What was done?
<!--- Describe your changes in detail -->
- Allow 1 document max
- Return a consenus error if there are no transitions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Validation rules for DocumentBatchTransition is changed so previous block result is no valid anymore

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
