### PR TITLE
fix(dashmate): config commands output

### DIFF
--- a/packages/dashmate/src/commands/config/get.js
+++ b/packages/dashmate/src/commands/config/get.js
@@ -1,4 +1,9 @@
+const { Flags } = require('@oclif/core');
+const lodash = require('lodash');
+const chalk = require('chalk');
+const { inspect } = require('util');
 const ConfigBaseCommand = require('../../oclif/command/ConfigBaseCommand');
+const { OUTPUT_FORMATS } = require('../../constants');
 
 class ConfigGetCommand extends ConfigBaseCommand {
   /**
@@ -11,14 +16,25 @@ class ConfigGetCommand extends ConfigBaseCommand {
     {
       option: optionPath,
     },
-    flags,
+    {
+      format,
+    },
     config,
   ) {
+    const value = config.get(optionPath);
+
+    let output = value;
+
+    if (format === OUTPUT_FORMATS.JSON) {
+      output = JSON.stringify(value, null, 2);
+    } else if (Array.isArray(value) || lodash.isPlainObject(value)) {
+      output = inspect(value, { depth: Infinity, colors: chalk.supportsColor });
+    }
+
     // eslint-disable-next-line no-console
-    console.dir(
-      config.get(optionPath),
-      { depth: Infinity },
-    );
+    console.log(output);
+
+    return value;
   }
 }
 
@@ -34,6 +50,11 @@ ConfigGetCommand.args = [{
 }];
 
 ConfigGetCommand.flags = {
+  format: Flags.string({
+    description: 'display output format',
+    default: OUTPUT_FORMATS.PLAIN,
+    options: Object.values(OUTPUT_FORMATS),
+  }),
   ...ConfigBaseCommand.flags,
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Recently, there was a change in the config get command to print entire objects and arrays. This change has a side effect: strings are returning with quotes.

## What was done?
<!--- Describe your changes in detail -->
- Use colorized pretty print only for arrays and objects
- Added the format option to `config` and `config get` commands to output valid JSON. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
