### PR TITLE
fix(dashmate): config is not persisted after migration

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -177,7 +177,7 @@ function getBaseConfigFactory(homeDir) {
           tenderdash: {
             mode: 'full',
             docker: {
-              image: 'dashpay/tenderdash:0.13.2',
+              image: 'dashpay/tenderdash:0.13.3',
             },
             p2p: {
               port: 26656,

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -299,6 +299,8 @@ function getConfigFileMigrationsFactory(homeDir, defaultConfigs) {
       '0.25.12': (configFile) => {
         Object.entries(configFile.configs)
           .forEach(([name, options]) => {
+            options.platform.drive.tenderdash.docker.image = base.get('platform.drive.tenderdash.docker.image');
+
             if (options.network === NETWORK_TESTNET) {
               options.core.docker.image = base.get('core.docker.image');
 

--- a/packages/dashmate/scripts/helper.js
+++ b/packages/dashmate/scripts/helper.js
@@ -28,8 +28,21 @@ const createDIContainer = require('../src/createDIContainer');
    * @type {ConfigFileJsonRepository}
    */
   const configFileRepository = container.resolve('configFileRepository');
+  /**
+   * @type {writeConfigTemplates}
+   */
+  const writeConfigTemplates = container.resolve('writeConfigTemplates');
 
   const configFile = await configFileRepository.read();
+
+  // Persist config if it was migrated
+  if (configFile.isChanged()) {
+    await configFileRepository.write(configFile);
+
+    configFile.getAllConfigs()
+      .filter((config) => config.isChanged())
+      .forEach(writeConfigTemplates);
+  }
 
   const config = configFile.getConfig(configName);
 

--- a/packages/dashmate/src/commands/config/create.js
+++ b/packages/dashmate/src/commands/config/create.js
@@ -4,9 +4,6 @@ class ConfigCreateCommand extends BaseCommand {
   /**
    * @param {Object} args
    * @param {Object} flags
-   * @param {renderServiceTemplates} renderServiceTemplates
-   * @param {writeServiceConfigs} writeServiceConfigs
-   * @param {ConfigFileJsonRepository} configFileRepository
    * @param {ConfigFile} configFile
    * @return {Promise<void>}
    */
@@ -16,17 +13,9 @@ class ConfigCreateCommand extends BaseCommand {
       from: fromConfigName,
     },
     flags,
-    renderServiceTemplates,
-    writeServiceConfigs,
-    configFileRepository,
     configFile,
   ) {
     configFile.createConfig(configName, fromConfigName);
-
-    configFileRepository.write(configFile);
-
-    const serviceConfigs = renderServiceTemplates(configFile.getConfig(configName));
-    writeServiceConfigs(configName, serviceConfigs);
 
     // eslint-disable-next-line no-console
     console.log(`${configName} created`);

--- a/packages/dashmate/src/commands/config/index.js
+++ b/packages/dashmate/src/commands/config/index.js
@@ -9,8 +9,6 @@ class ConfigCommand extends ConfigBaseCommand {
    * @param {Object} args
    * @param {Object} flags
    * @param {Config} config
-   * @param {renderServiceTemplates} renderServiceTemplates
-   * @param {writeServiceConfigs} writeServiceConfigs
    * @return {Promise<void>}
    */
   async runWithDependencies(
@@ -19,8 +17,6 @@ class ConfigCommand extends ConfigBaseCommand {
       format,
     },
     config,
-    renderServiceTemplates,
-    writeServiceConfigs,
   ) {
     let configOptions;
     if (format === OUTPUT_FORMATS.JSON) {
@@ -33,9 +29,6 @@ class ConfigCommand extends ConfigBaseCommand {
     }
 
     const output = `${config.getName()} config:\n\n${configOptions}`;
-
-    const serviceConfigs = renderServiceTemplates(config);
-    writeServiceConfigs(config.getName(), serviceConfigs);
 
     // eslint-disable-next-line no-console
     console.log(output);

--- a/packages/dashmate/src/commands/config/remove.js
+++ b/packages/dashmate/src/commands/config/remove.js
@@ -1,3 +1,4 @@
+const fs = require('node:fs');
 const BaseCommand = require('../../oclif/command/BaseCommand');
 
 class ConfigRemoveCommand extends BaseCommand {
@@ -6,9 +7,7 @@ class ConfigRemoveCommand extends BaseCommand {
    * @param {Object} flags
    * @param {ConfigFile} configFile
    * @param {DefaultConfigs} defaultConfigs
-   * @param {renderServiceTemplates} renderServiceTemplates
-   * @param {writeServiceConfigs} writeServiceConfigs
-   * @param {ConfigFileJsonRepository} configFileRepository
+   * @param {HomeDir} homeDir
    * @return {Promise<void>}
    */
   async runWithDependencies(
@@ -18,9 +17,7 @@ class ConfigRemoveCommand extends BaseCommand {
     flags,
     configFile,
     defaultConfigs,
-    renderServiceTemplates,
-    writeServiceConfigs,
-    configFileRepository,
+    homeDir,
   ) {
     if (defaultConfigs.has(configName)) {
       throw new Error(`system config ${configName} can't be removed.\nPlease use 'dashmate reset --hard --config=${configName}' command to reset the configuration`);
@@ -28,10 +25,12 @@ class ConfigRemoveCommand extends BaseCommand {
 
     configFile.removeConfig(configName);
 
-    configFileRepository.write(configFile);
+    const serviceConfigsPath = homeDir.joinPath(configName);
 
-    const serviceConfigs = renderServiceTemplates(configFile.getConfig(configName));
-    writeServiceConfigs(configName, serviceConfigs);
+    fs.rmSync(serviceConfigsPath, {
+      recursive: true,
+      force: true,
+    });
 
     // eslint-disable-next-line no-console
     console.log(`${configName} removed`);

--- a/packages/dashmate/src/commands/config/set.js
+++ b/packages/dashmate/src/commands/config/set.js
@@ -5,7 +5,6 @@ class ConfigSetCommand extends ConfigBaseCommand {
    * @param args
    * @param flags
    * @param {Config} config
-   * @param {ConfigFile} configFile
    * @return {Promise<void>}
    */
   async runWithDependencies(
@@ -15,7 +14,6 @@ class ConfigSetCommand extends ConfigBaseCommand {
     },
     flags,
     config,
-    configFile,
   ) {
     // check for existence
     config.get(optionPath);
@@ -29,7 +27,6 @@ class ConfigSetCommand extends ConfigBaseCommand {
     }
 
     config.set(optionPath, value);
-    configFile.markAsChanged();
 
     // eslint-disable-next-line no-console
     console.log(`${optionPath} set to ${optionValue}`);

--- a/packages/dashmate/src/commands/config/set.js
+++ b/packages/dashmate/src/commands/config/set.js
@@ -5,9 +5,6 @@ class ConfigSetCommand extends ConfigBaseCommand {
    * @param args
    * @param flags
    * @param {Config} config
-   * @param {renderServiceTemplates} renderServiceTemplates
-   * @param {writeServiceConfigs} writeServiceConfigs
-   * @param {ConfigFileJsonRepository} configFileRepository
    * @param {ConfigFile} configFile
    * @return {Promise<void>}
    */
@@ -18,9 +15,6 @@ class ConfigSetCommand extends ConfigBaseCommand {
     },
     flags,
     config,
-    renderServiceTemplates,
-    writeServiceConfigs,
-    configFileRepository,
     configFile,
   ) {
     // check for existence
@@ -35,11 +29,7 @@ class ConfigSetCommand extends ConfigBaseCommand {
     }
 
     config.set(optionPath, value);
-
-    configFileRepository.write(configFile);
-
-    const serviceConfigs = renderServiceTemplates(config);
-    writeServiceConfigs(config.getName(), serviceConfigs);
+    configFile.markAsChanged();
 
     // eslint-disable-next-line no-console
     console.log(`${optionPath} set to ${optionValue}`);

--- a/packages/dashmate/src/config/Config.js
+++ b/packages/dashmate/src/config/Config.js
@@ -20,6 +20,7 @@ class Config {
    */
   constructor(name, options = {}) {
     this.name = name;
+    this.changed = false;
 
     this.setOptions(options);
   }
@@ -103,6 +104,8 @@ class Config {
 
     this.options = clonedOptions;
 
+    this.changed = true;
+
     return this;
   }
 
@@ -139,6 +142,8 @@ class Config {
 
     this.options = clonedOptions;
 
+    this.changed = true;
+
     return this;
   }
 
@@ -150,6 +155,29 @@ class Config {
    */
   isEqual(config) {
     return lodashIsEqual(this.getOptions(), config.getOptions());
+  }
+
+  /**
+   * Is config changed
+   *
+   * @return {boolean}
+   */
+  isChanged() {
+    return this.changed;
+  }
+
+  /**
+   * Mark config as changed
+   */
+  markAsChanged() {
+    this.changed = true;
+  }
+
+  /**
+   * Mark config as saved
+   */
+  markAsSaved() {
+    this.changed = false;
   }
 }
 

--- a/packages/dashmate/src/config/configFile/ConfigFile.js
+++ b/packages/dashmate/src/config/configFile/ConfigFile.js
@@ -12,12 +12,19 @@ class ConfigFile {
    * @param {string|null} defaultConfigName
    * @param {string|null} defaultGroupName
    */
-  constructor(configs, configFormatVersion, projectId, defaultConfigName, defaultGroupName) {
+  constructor(
+    configs,
+    configFormatVersion,
+    projectId,
+    defaultConfigName,
+    defaultGroupName,
+  ) {
     this.setConfigs(configs);
     this.configFormatVersion = configFormatVersion;
     this.defaultConfigName = defaultConfigName;
     this.defaultGroupName = defaultGroupName;
     this.projectId = projectId || null;
+    this.changed = false;
   }
 
   /**
@@ -41,6 +48,8 @@ class ConfigFile {
     }
 
     this.defaultConfigName = name;
+
+    this.changed = true;
 
     return this;
   }
@@ -111,6 +120,8 @@ class ConfigFile {
       throw new GroupIsNotPresentError(defaultGroupName);
     }
 
+    this.changed = true;
+
     this.defaultGroupName = defaultGroupName;
   }
 
@@ -177,6 +188,9 @@ class ConfigFile {
     const fromConfig = this.getConfig(fromConfigName);
 
     this.configsMap[name] = new Config(name, fromConfig.getOptions());
+    this.configsMap[name].markAsChanged();
+
+    this.changed = true;
 
     return this.configsMap[name];
   }
@@ -198,6 +212,8 @@ class ConfigFile {
 
     delete this.configsMap[name];
 
+    this.changed = true;
+
     return this;
   }
 
@@ -208,6 +224,8 @@ class ConfigFile {
    */
   setConfig(config) {
     this.configsMap[config.getName()] = config;
+
+    this.changed = true;
   }
 
   /**
@@ -221,6 +239,8 @@ class ConfigFile {
 
       return configsMap;
     }, {});
+
+    this.changed = true;
   }
 
   /**
@@ -232,6 +252,8 @@ class ConfigFile {
   setProjectId(projectId) {
     this.projectId = projectId;
 
+    this.changed = true;
+
     return this;
   }
 
@@ -242,6 +264,31 @@ class ConfigFile {
    */
   getProjectId() {
     return this.projectId;
+  }
+
+  /**
+   * Is config file changed
+   *
+   * @return {boolean}
+   */
+  isChanged() {
+    return this.changed
+      || Object.values(this.configsMap)
+        .find((config) => config.isChanged()) !== undefined;
+  }
+
+  /**
+   * Mark config file as changed
+   */
+  markAsChanged() {
+    this.changed = true;
+  }
+
+  /**
+   * Mark config file as saved
+   */
+  markAsSaved() {
+    this.changed = false;
   }
 
   /**

--- a/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
+++ b/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
@@ -64,13 +64,20 @@ class ConfigFileJsonRepository {
       throw new InvalidConfigFileFormatError(this.configFilePath, e);
     }
 
-    return new ConfigFile(
+    const configFile = new ConfigFile(
       configs,
-      packageJson.version,
+      migratedConfigFileData.configFormatVersion,
       migratedConfigFileData.projectId,
       migratedConfigFileData.defaultConfigName,
       migratedConfigFileData.defaultGroupName,
     );
+
+    // Persist config if it was actually migrated
+    if (migratedConfigFileData.configFormatVersion !== configFile.configFormatVersion) {
+      this.write(configFile);
+    }
+
+    return configFile;
   }
 
   /**

--- a/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
+++ b/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
@@ -73,7 +73,7 @@ class ConfigFileJsonRepository {
     );
 
     // Persist config if it was actually migrated
-    if (migratedConfigFileData.configFormatVersion !== configFile.configFormatVersion) {
+    if (migratedConfigFileData.configFormatVersion !== configFileData.configFormatVersion) {
       this.write(configFile);
     }
 

--- a/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
+++ b/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
@@ -42,6 +42,8 @@ class ConfigFileJsonRepository {
       throw new InvalidConfigFileFormatError(this.configFilePath, e);
     }
 
+    const currentConfigVersion = configFileData.configFormatVersion
+
     const migratedConfigFileData = this.migrateConfigFile(
       configFileData,
       configFileData.configFormatVersion,
@@ -73,7 +75,7 @@ class ConfigFileJsonRepository {
     );
 
     // Persist config if it was actually migrated
-    if (migratedConfigFileData.configFormatVersion !== configFileData.configFormatVersion) {
+    if (migratedConfigFileData.configFormatVersion !== currentConfigVersion) {
       this.write(configFile);
     }
 

--- a/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
+++ b/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
@@ -42,7 +42,7 @@ class ConfigFileJsonRepository {
       throw new InvalidConfigFileFormatError(this.configFilePath, e);
     }
 
-    const currentConfigVersion = configFileData.configFormatVersion
+    const originConfigVersion = configFileData.configFormatVersion;
 
     const migratedConfigFileData = this.migrateConfigFile(
       configFileData,
@@ -74,9 +74,10 @@ class ConfigFileJsonRepository {
       migratedConfigFileData.defaultGroupName,
     );
 
-    // Persist config if it was actually migrated
-    if (migratedConfigFileData.configFormatVersion !== currentConfigVersion) {
-      this.write(configFile);
+    // Mark configs as changed if they were migrated
+    if (migratedConfigFileData.configFormatVersion !== originConfigVersion) {
+      configFile.markAsChanged();
+      configFile.getAllConfigs().forEach((config) => config.markAsChanged());
     }
 
     return configFile;
@@ -90,6 +91,8 @@ class ConfigFileJsonRepository {
    */
   write(configFile) {
     const configFileJSON = JSON.stringify(configFile.toObject(), undefined, 2);
+
+    configFile.markAsSaved();
 
     fs.writeFileSync(this.configFilePath, `${configFileJSON}\n`, 'utf8');
   }

--- a/packages/dashmate/src/config/configFile/createConfigFileFactory.js
+++ b/packages/dashmate/src/config/configFile/createConfigFileFactory.js
@@ -16,13 +16,16 @@ function createConfigFileFactory(defaultConfigs, homeDir) {
   function createConfigFile() {
     const projectId = getShortHash(homeDir.getPath());
 
-    return new ConfigFile(
+    const configFile = new ConfigFile(
       defaultConfigs.getAll(),
       packageJson.version,
       projectId,
       null,
       null,
     );
+
+    configFile.markAsChanged();
+    configFile.getAllConfigs().forEach((config) => config.markAsChanged());
   }
 
   return createConfigFile;

--- a/packages/dashmate/src/config/configFile/createConfigFileFactory.js
+++ b/packages/dashmate/src/config/configFile/createConfigFileFactory.js
@@ -26,6 +26,8 @@ function createConfigFileFactory(defaultConfigs, homeDir) {
 
     configFile.markAsChanged();
     configFile.getAllConfigs().forEach((config) => config.markAsChanged());
+
+    return configFile;
   }
 
   return createConfigFile;

--- a/packages/dashmate/src/createDIContainer.js
+++ b/packages/dashmate/src/createDIContainer.js
@@ -109,6 +109,7 @@ const getConfigProfilesFactory = require('./config/getConfigProfilesFactory');
 const createIpAndPortsFormFactory = require('./listr/prompts/createIpAndPortsForm');
 const registerMasternodeWithCoreWalletFactory = require('./listr/tasks/setup/regular/registerMasternode/registerMasternodeWithCoreWallet');
 const registerMasternodeWithDMTFactory = require('./listr/tasks/setup/regular/registerMasternode/registerMasternodeWithDMT');
+const writeConfigTemplatesFactory = require('./templates/writeConfigTemplatesFactory');
 
 /**
  * @param {Object} [options]
@@ -176,6 +177,7 @@ async function createDIContainer(options = {}) {
     renderTemplate: asFunction(renderTemplateFactory).singleton(),
     renderServiceTemplates: asFunction(renderServiceTemplatesFactory).singleton(),
     writeServiceConfigs: asFunction(writeServiceConfigsFactory).singleton(),
+    writeConfigTemplates: asFunction(writeConfigTemplatesFactory).singleton(),
   });
 
   /**

--- a/packages/dashmate/src/helper/scheduleRenewZeroSslCertificateFactory.js
+++ b/packages/dashmate/src/helper/scheduleRenewZeroSslCertificateFactory.js
@@ -8,8 +8,7 @@ const { EXPIRATION_LIMIT_DAYS } = require('../ssl/zerossl/Certificate');
  * @param {DockerCompose} dockerCompose
  * @param {ConfigFileJsonRepository} configFileRepository
  * @param {ConfigFile} configFile
- * @param {renderServiceTemplates} renderServiceTemplates
- * @param {writeServiceConfigs} writeServiceConfigs
+ * @param {writeConfigTemplates} writeConfigTemplates
  * @return {scheduleRenewZeroSslCertificate}
  */
 function scheduleRenewZeroSslCertificateFactory(
@@ -18,8 +17,7 @@ function scheduleRenewZeroSslCertificateFactory(
   dockerCompose,
   configFileRepository,
   configFile,
-  renderServiceTemplates,
-  writeServiceConfigs,
+  writeConfigTemplates,
 ) {
   /**
    * @typedef scheduleRenewZeroSslCertificate
@@ -62,9 +60,7 @@ function scheduleRenewZeroSslCertificateFactory(
 
         // Write config files
         configFileRepository.write(configFile);
-
-        const serviceConfigs = renderServiceTemplates(config);
-        writeServiceConfigs(config.getName(), serviceConfigs);
+        writeConfigTemplates(config);
 
         // Restart Envoy to catch up new SSL certificates
         await dockerCompose.execCommand(config, 'dapi_envoy', 'kill -SIGHUP 1');

--- a/packages/dashmate/src/listr/tasks/resetNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/resetNodeTaskFactory.js
@@ -12,9 +12,6 @@ const wait = require('../../util/wait');
  * @param {ConfigFile} configFile
  * @param {HomeDir} homeDir
  * @param {generateEnvs} generateEnvs
- * @param {ConfigFileJsonRepository} configFileRepository
- * @param {renderServiceTemplates} renderServiceTemplates
- * @param {writeServiceConfigs} writeServiceConfigs
  * @return {resetNodeTask}
  */
 function resetNodeTaskFactory(
@@ -26,9 +23,6 @@ function resetNodeTaskFactory(
   configFile,
   homeDir,
   generateEnvs,
-  configFileRepository,
-  renderServiceTemplates,
-  writeServiceConfigs,
 ) {
   /**
    * @typedef {resetNodeTask}
@@ -115,12 +109,7 @@ function resetNodeTaskFactory(
         task: () => {
           // TODO: We should remove it from config
           config.set('core.miner.mediantime', null);
-
-          configFileRepository.write(configFile);
-
-          // Render updated service configs
-          const serviceConfigs = renderServiceTemplates(config);
-          writeServiceConfigs(config.getName(), serviceConfigs);
+          configFile.markAsChanged();
         },
       },
       {
@@ -128,7 +117,6 @@ function resetNodeTaskFactory(
         enabled: (ctx) => ctx.removeConfig,
         task: () => {
           configFile.removeConfig(config.getName());
-          configFileRepository.write(configFile);
 
           const serviceConfigsPath = homeDir.joinPath(config.getName());
 
@@ -157,6 +145,7 @@ function resetNodeTaskFactory(
             }
 
             config.set('group', groupName);
+            configFile.markAsChanged();
 
             // Remove service configs
             let serviceConfigsPath = homeDir.joinPath(defaultConfigName);
@@ -169,10 +158,6 @@ function resetNodeTaskFactory(
               recursive: true,
               force: true,
             });
-
-            // Render updated service configs
-            const serviceConfigs = renderServiceTemplates(config);
-            writeServiceConfigs(config.getName(), serviceConfigs);
           } else {
             // Delete config if no base config
             configFile.removeConfig(config.getName());
@@ -185,8 +170,6 @@ function resetNodeTaskFactory(
               force: true,
             });
           }
-
-          configFileRepository.write(configFile);
         },
       },
     ]);

--- a/packages/dashmate/src/listr/tasks/resetNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/resetNodeTaskFactory.js
@@ -109,7 +109,6 @@ function resetNodeTaskFactory(
         task: () => {
           // TODO: We should remove it from config
           config.set('core.miner.mediantime', null);
-          configFile.markAsChanged();
         },
       },
       {
@@ -145,7 +144,6 @@ function resetNodeTaskFactory(
             }
 
             config.set('group', groupName);
-            configFile.markAsChanged();
 
             // Remove service configs
             let serviceConfigsPath = homeDir.joinPath(defaultConfigName);

--- a/packages/dashmate/src/listr/tasks/setup/local/configureCoreTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/local/configureCoreTaskFactory.js
@@ -11,8 +11,7 @@ const waitForNodesToHaveTheSameHeight = require('../../../../core/waitForNodesTo
 const { NETWORK_LOCAL, HPMN_COLLATERAL_AMOUNT } = require('../../../../constants');
 
 /**
- * @param {renderServiceTemplates} renderServiceTemplates
- * @param {writeServiceConfigs} writeServiceConfigs
+ * @param {writeConfigTemplates} writeConfigTemplates
  * @param {startCore} startCore
  * @param {generateBlocks} generateBlocks
  * @param {waitForCoreSync} waitForCoreSync
@@ -22,11 +21,11 @@ const { NETWORK_LOCAL, HPMN_COLLATERAL_AMOUNT } = require('../../../../constants
  * @param {generateBlsKeys} generateBlsKeys
  * @param {enableCoreQuorumsTask} enableCoreQuorumsTask
  * @param {waitForMasternodesSync} waitForMasternodesSync
+ * @param {ConfigFile} configFile
  * @return {configureCoreTask}
  */
 function configureCoreTaskFactory(
-  renderServiceTemplates,
-  writeServiceConfigs,
+  writeConfigTemplates,
   startCore,
   generateBlocks,
   waitForCoreSync,
@@ -36,6 +35,7 @@ function configureCoreTaskFactory(
   generateBlsKeys,
   enableCoreQuorumsTask,
   waitForMasternodesSync,
+  configFile,
 ) {
   const WAIT_FOR_NODES_TIMEOUT = 60 * 5 * 1000;
 
@@ -78,9 +78,10 @@ function configureCoreTaskFactory(
               sporkPrivKey.toWIF(),
             );
 
+            configFile.markAsChanged();
+
             // Write configs
-            const configFiles = renderServiceTemplates(config);
-            writeServiceConfigs(config.getName(), configFiles);
+            writeConfigTemplates(config);
           });
 
           return new Listr([
@@ -173,9 +174,10 @@ function configureCoreTaskFactory(
 
                         config.set('core.masternode.operator.privateKey', ctx.operator.privateKey);
 
+                        configFile.markAsChanged();
+
                         // Write configs
-                        const configFiles = renderServiceTemplates(config);
-                        writeServiceConfigs(config.getName(), configFiles);
+                        writeConfigTemplates(config);
 
                         // eslint-disable-next-line no-param-reassign
                         task.output = `Public key: ${ctx.operator.publicKey}\nPrivate key: ${ctx.operator.privateKey}`;

--- a/packages/dashmate/src/listr/tasks/setup/local/configureCoreTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/local/configureCoreTaskFactory.js
@@ -78,8 +78,6 @@ function configureCoreTaskFactory(
               sporkPrivKey.toWIF(),
             );
 
-            configFile.markAsChanged();
-
             // Write configs
             writeConfigTemplates(config);
           });

--- a/packages/dashmate/src/listr/tasks/setup/local/configureTenderdashTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/local/configureTenderdashTaskFactory.js
@@ -2,12 +2,9 @@ const { Listr } = require('listr2');
 const { getLatestProtocolVersion } = require('@dashevo/wasm-dpp');
 
 /**
- * @param {ConfigFile} configFile
  * @return {configureTenderdashTask}
  */
-function configureTenderdashTaskFactory(
-  configFile,
-) {
+function configureTenderdashTaskFactory() {
   /**
    * @typedef {configureTenderdashTask}
    * @param {Config[]} configGroup
@@ -28,8 +25,6 @@ function configureTenderdashTaskFactory(
               const chainId = `dashmate_local_${randomChainIdPart}`;
 
               const genesisTime = new Date().toISOString();
-
-              configFile.markAsChanged();
 
               platformConfigs.forEach((config, index) => {
                 config.set('platform.drive.tenderdash.genesis.genesis_time', genesisTime);

--- a/packages/dashmate/src/listr/tasks/setup/local/configureTenderdashTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/local/configureTenderdashTaskFactory.js
@@ -2,13 +2,11 @@ const { Listr } = require('listr2');
 const { getLatestProtocolVersion } = require('@dashevo/wasm-dpp');
 
 /**
- * @param {renderServiceTemplates} renderServiceTemplates
- * @param {writeServiceConfigs} writeServiceConfigs
+ * @param {ConfigFile} configFile
  * @return {configureTenderdashTask}
  */
 function configureTenderdashTaskFactory(
-  renderServiceTemplates,
-  writeServiceConfigs,
+  configFile,
 ) {
   /**
    * @typedef {configureTenderdashTask}
@@ -30,6 +28,8 @@ function configureTenderdashTaskFactory(
               const chainId = `dashmate_local_${randomChainIdPart}`;
 
               const genesisTime = new Date().toISOString();
+
+              configFile.markAsChanged();
 
               platformConfigs.forEach((config, index) => {
                 config.set('platform.drive.tenderdash.genesis.genesis_time', genesisTime);
@@ -63,9 +63,6 @@ function configureTenderdashTaskFactory(
                   'platform.drive.tenderdash.genesis.consensus_params.version.app_version',
                   getLatestProtocolVersion().toString(),
                 );
-
-                const configFiles = renderServiceTemplates(config);
-                writeServiceConfigs(config.getName(), configFiles);
               });
             },
           });

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -17,8 +17,7 @@ const generateRandomString = require('../../../util/generateRandomString');
  * @param {configFileRepository} configFileRepository
  * @param {generateHDPrivateKeys} generateHDPrivateKeys
  * @param {HomeDir} homeDir
- * @param {writeServiceConfigs} writeServiceConfigs
- * @param {renderServiceTemplates} renderServiceTemplates
+ * @param {writeConfigTemplates} writeConfigTemplates
  */
 function setupLocalPresetTaskFactory(
   configFile,
@@ -29,8 +28,7 @@ function setupLocalPresetTaskFactory(
   configFileRepository,
   generateHDPrivateKeys,
   homeDir,
-  writeServiceConfigs,
-  renderServiceTemplates,
+  writeConfigTemplates,
 ) {
   /**
    * @typedef {setupLocalPresetTask}
@@ -87,7 +85,7 @@ function setupLocalPresetTaskFactory(
             message: 'Enter the interval between core blocks',
             initial: configFile.getConfig('base').get('core.miner.interval'),
             validate: (state) => {
-              if (state.match(/\d+(\.\d+)?(m|s)/)) {
+              if (state.match(/\d+(\.\d+)?([ms])/)) {
                 return true;
               }
 
@@ -291,10 +289,7 @@ function setupLocalPresetTaskFactory(
         task: (ctx) => {
           configFile.setDefaultGroupName(PRESET_LOCAL);
 
-          for (const config of ctx.configGroup) {
-            const serviceConfigFiles = renderServiceTemplates(config);
-            writeServiceConfigs(config.getName(), serviceConfigFiles);
-          }
+          ctx.configGroup.forEach(writeConfigTemplates);
 
           configFileRepository.write(configFile);
         },

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -104,7 +104,7 @@ function setupLocalPresetTaskFactory(
                 : configFile.createConfig(configName, PRESET_LOCAL)
             ));
 
-          configFile.setDefaultGroupName(PRESET_LOCAL);
+          // configFile.setDefaultGroupName(PRESET_LOCAL); disable for test
 
           const hostDockerInternalIp = await resolveDockerHostIp();
 

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -102,9 +102,9 @@ function setupLocalPresetTaskFactory(
               configFile.isConfigExists(configName)
                 ? configFile.getConfig(configName)
                 : configFile.createConfig(configName, PRESET_LOCAL)
-            ))
+            ));
 
-          ctx.configGroup.forEach((config)=> config.set('group', 'local'));
+          ctx.configGroup.forEach((config) => config.set('group', 'local'));
 
           configFile.setDefaultGroupName(PRESET_LOCAL);
 

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -14,10 +14,8 @@ const generateRandomString = require('../../../util/generateRandomString');
  * @param {configureTenderdashTask} configureTenderdashTask
  * @param {obtainSelfSignedCertificateTask} obtainSelfSignedCertificateTask
  * @param {resolveDockerHostIp} resolveDockerHostIp
- * @param {configFileRepository} configFileRepository
  * @param {generateHDPrivateKeys} generateHDPrivateKeys
  * @param {HomeDir} homeDir
- * @param {writeConfigTemplates} writeConfigTemplates
  */
 function setupLocalPresetTaskFactory(
   configFile,
@@ -25,10 +23,8 @@ function setupLocalPresetTaskFactory(
   obtainSelfSignedCertificateTask,
   configureTenderdashTask,
   resolveDockerHostIp,
-  configFileRepository,
   generateHDPrivateKeys,
   homeDir,
-  writeConfigTemplates,
 ) {
   /**
    * @typedef {setupLocalPresetTask}
@@ -107,6 +103,8 @@ function setupLocalPresetTaskFactory(
                 ? configFile.getConfig(configName)
                 : configFile.createConfig(configName, PRESET_LOCAL)
             ));
+
+          configFile.setDefaultGroupName(PRESET_LOCAL);
 
           const hostDockerInternalIp = await resolveDockerHostIp();
 
@@ -283,16 +281,6 @@ function setupLocalPresetTaskFactory(
       {
         title: 'Configure Tenderdash nodes',
         task: (ctx) => configureTenderdashTask(ctx.configGroup),
-      },
-      {
-        title: 'Persist configs',
-        task: (ctx) => {
-          configFile.setDefaultGroupName(PRESET_LOCAL);
-
-          ctx.configGroup.forEach(writeConfigTemplates);
-
-          configFileRepository.write(configFile);
-        },
       },
       {
         title: 'Configure SSL certificates',

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -102,9 +102,11 @@ function setupLocalPresetTaskFactory(
               configFile.isConfigExists(configName)
                 ? configFile.getConfig(configName)
                 : configFile.createConfig(configName, PRESET_LOCAL)
-            ));
+            ))
 
-          // configFile.setDefaultGroupName(PRESET_LOCAL); disable for test
+          ctx.configGroup.forEach((config)=> config.set('group', 'local'));
+
+          configFile.setDefaultGroupName(PRESET_LOCAL);
 
           const hostDockerInternalIp = await resolveDockerHostIp();
 

--- a/packages/dashmate/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
@@ -22,9 +22,6 @@ const generateRandomString = require('../../../util/generateRandomString');
  * @param {ConfigFile} configFile
  * @param {generateBlsKeys} generateBlsKeys
  * @param {registerMasternodeTask} registerMasternodeTask
- * @param {ConfigFileJsonRepository} configFileRepository
- * @param {renderServiceTemplates} renderServiceTemplates
- * @param {writeServiceConfigs} writeServiceConfigs
  * @param {obtainZeroSSLCertificateTask} obtainZeroSSLCertificateTask
  * @param {registerMasternodeGuideTask} registerMasternodeGuideTask
  * @param {configureNodeTask} configureNodeTask
@@ -35,9 +32,6 @@ function setupRegularPresetTaskFactory(
   configFile,
   generateBlsKeys,
   registerMasternodeTask,
-  configFileRepository,
-  renderServiceTemplates,
-  writeServiceConfigs,
   obtainZeroSSLCertificateTask,
   registerMasternodeGuideTask,
   configureNodeTask,
@@ -151,11 +145,6 @@ function setupRegularPresetTaskFactory(
         task: (ctx, task) => {
           configFile.setConfig(ctx.config);
           configFile.setDefaultConfigName(ctx.preset);
-
-          configFileRepository.write(configFile);
-
-          const serviceConfigFiles = renderServiceTemplates(ctx.config);
-          writeServiceConfigs(ctx.config.getName(), serviceConfigFiles);
 
           // eslint-disable-next-line no-param-reassign
           task.output = chalk`Node configuration completed successfully!

--- a/packages/dashmate/src/oclif/command/BaseCommand.js
+++ b/packages/dashmate/src/oclif/command/BaseCommand.js
@@ -96,6 +96,31 @@ class BaseCommand extends Command {
   async finally(err) {
     // Save configs collection
     if (this.container) {
+      /**
+       * @var {ConfigFileJsonRepository} configFileRepository
+       */
+      const configFileRepository = this.container.resolve('configFileRepository');
+
+      if (this.container.has('configFile')) {
+        /**
+         * @var {ConfigFile} configFile
+         */
+        const configFile = this.container.resolve('configFile');
+
+        if (configFile.isChanged()) {
+          configFileRepository.write(configFile);
+
+          /**
+           * @var {writeConfigTemplates} writeConfigTemplates
+           */
+          const writeConfigTemplates = this.container.resolve('writeConfigTemplates');
+
+          configFile.getAllConfigs()
+            .filter((config) => config.isChanged())
+            .forEach(writeConfigTemplates);
+        }
+      }
+
       // Stop all running containers
       const stopAllContainers = this.container.resolve('stopAllContainers');
       const startedContainers = this.container.resolve('startedContainers');

--- a/packages/dashmate/src/oclif/command/BaseCommand.js
+++ b/packages/dashmate/src/oclif/command/BaseCommand.js
@@ -101,7 +101,7 @@ class BaseCommand extends Command {
        */
       const configFileRepository = this.container.resolve('configFileRepository');
 
-      if (this.container.has('configFile')) {
+      if (this.container.has('configFile') && err === undefined) {
         /**
          * @var {ConfigFile} configFile
          */

--- a/packages/dashmate/src/templates/writeConfigTemplatesFactory.js
+++ b/packages/dashmate/src/templates/writeConfigTemplatesFactory.js
@@ -1,0 +1,19 @@
+/**
+ * @return {writeConfigTemplates}
+ */
+function writeConfigTemplatesFactory(renderServiceTemplates, writeServiceConfigs) {
+  /**
+   * @typedef {writeConfigTemplates}
+   * @param {Config} config
+   */
+  function writeConfigTemplates(config) {
+    const serviceConfigs = renderServiceTemplates(config);
+    writeServiceConfigs(config.getName(), serviceConfigs);
+
+    config.markAsSaved();
+  }
+
+  return writeConfigTemplates;
+}
+
+module.exports = writeConfigTemplatesFactory;

--- a/packages/dashmate/test/e2e/localNetwork.js
+++ b/packages/dashmate/test/e2e/localNetwork.js
@@ -93,13 +93,9 @@ describe('Local Network', function main() {
       // Write configs
       await configFileRepository.write(configFile);
 
-      const renderServiceTemplates = container.resolve('renderServiceTemplates');
+      const writeConfigTemplates = container.resolve('writeConfigTemplates');
 
-      const writeServiceConfigs = container.resolve('writeServiceConfigs');
-      for (const config of configGroup) {
-        const serviceConfigFiles = renderServiceTemplates(config);
-        writeServiceConfigs(config.getName(), serviceConfigFiles);
-      }
+      configGroup.forEach(writeConfigTemplates);
     });
   });
 

--- a/packages/dashmate/test/e2e/testnetFullnode.spec.js
+++ b/packages/dashmate/test/e2e/testnetFullnode.spec.js
@@ -109,11 +109,8 @@ describe('Testnet Fullnode', function main() {
       // Write configs
       await configFileRepository.write(configFile);
 
-      const renderServiceTemplates = container.resolve('renderServiceTemplates');
-      const writeServiceConfigs = container.resolve('writeServiceConfigs');
-
-      const serviceConfigFiles = renderServiceTemplates(config);
-      writeServiceConfigs(config.getName(), serviceConfigFiles);
+      const writeConfigTemplates = container.resolve('writeConfigTemplates');
+      writeConfigTemplates(config);
     });
   });
 

--- a/packages/dashmate/test/e2e/testnetHPFullnode.spec.js
+++ b/packages/dashmate/test/e2e/testnetHPFullnode.spec.js
@@ -109,11 +109,9 @@ describe('Testnet HP Fullnode', function main() {
       // Write configs
       await configFileRepository.write(configFile);
 
-      const renderServiceTemplates = container.resolve('renderServiceTemplates');
-      const writeServiceConfigs = container.resolve('writeServiceConfigs');
+      const writeConfigTemplates = container.resolve('writeConfigTemplates');
 
-      const serviceConfigFiles = renderServiceTemplates(config);
-      writeServiceConfigs(config.getName(), serviceConfigFiles);
+      writeConfigTemplates(config);
     });
   });
 

--- a/packages/dashmate/test/unit/commands/config/set.spec.js
+++ b/packages/dashmate/test/unit/commands/config/set.spec.js
@@ -6,18 +6,13 @@ describe('Config set command', () => {
   const flags = {};
 
   let config;
-  let mockRenderServiceTemplates;
-  let mockWriteServiceConfigs;
-  let mockConfigFileRepository;
+  let mockConfigFile;
 
   beforeEach(async () => {
     const getBaseConfig = getBaseConfigFactory(HomeDir.createTemp());
 
     config = getBaseConfig();
-
-    mockRenderServiceTemplates = () => {};
-    mockWriteServiceConfigs = () => {};
-    mockConfigFileRepository = { write: () => {} };
+    mockConfigFile = { markAsChanged: () => {} };
   });
 
   describe('#platform', () => {
@@ -26,9 +21,7 @@ describe('Config set command', () => {
 
       await command.runWithDependencies({
         option: 'core.docker.image', value: 'fake_image',
-      }, flags, config,
-      mockRenderServiceTemplates, mockWriteServiceConfigs,
-      mockConfigFileRepository);
+      }, flags, config, mockConfigFile);
     });
 
     it('should allow setting null', async () => {
@@ -36,17 +29,13 @@ describe('Config set command', () => {
 
       await command.runWithDependencies({
         option: 'description', value: null,
-      }, flags, config,
-      mockRenderServiceTemplates, mockWriteServiceConfigs,
-      mockConfigFileRepository);
+      }, flags, config, mockConfigFile);
 
       expect(config.get('description')).to.equal(null);
 
       await command.runWithDependencies({
         option: 'description', value: 'null',
-      }, flags, config,
-      mockRenderServiceTemplates, mockWriteServiceConfigs,
-      mockConfigFileRepository);
+      }, flags, config, mockConfigFile);
 
       expect(config.get('description')).to.equal(null);
     });
@@ -57,18 +46,14 @@ describe('Config set command', () => {
       await command.runWithDependencies({
         option: 'platform.drive.abci.validatorSet.llmqType',
         value: 107,
-      }, flags, config,
-      mockRenderServiceTemplates, mockWriteServiceConfigs,
-      mockConfigFileRepository);
+      }, flags, config, mockConfigFile);
 
       expect(config.get('platform.drive.abci.validatorSet.llmqType')).to.equal(107);
 
       await command.runWithDependencies({
         option: 'platform.drive.abci.validatorSet.llmqType',
         value: '107',
-      }, flags, config,
-      mockRenderServiceTemplates, mockWriteServiceConfigs,
-      mockConfigFileRepository);
+      }, flags, config, mockConfigFile);
 
       expect(config.get('platform.drive.abci.validatorSet.llmqType')).to.equal(107);
     });
@@ -78,17 +63,13 @@ describe('Config set command', () => {
 
       await command.runWithDependencies({
         option: 'dashmate.helper.api.enable', value: 'true',
-      }, flags, config,
-      mockRenderServiceTemplates, mockWriteServiceConfigs,
-      mockConfigFileRepository);
+      }, flags, config, mockConfigFile);
 
       expect(config.get('dashmate.helper.api.enable')).to.equal(true);
 
       await command.runWithDependencies({
         option: 'dashmate.helper.api.enable', value: true,
-      }, flags, config,
-      mockRenderServiceTemplates, mockWriteServiceConfigs,
-      mockConfigFileRepository);
+      }, flags, config, mockConfigFile);
 
       expect(config.get('dashmate.helper.api.enable')).to.equal(true);
     });
@@ -98,9 +79,7 @@ describe('Config set command', () => {
 
       await command.runWithDependencies({
         option: 'core.rpc.allowIps', value: '["1337", "36484"]',
-      }, flags, config,
-      mockRenderServiceTemplates, mockWriteServiceConfigs,
-      mockConfigFileRepository);
+      }, flags, config, mockConfigFile);
 
       expect(config.get('core.rpc.allowIps')).to.deep.equal(['1337', '36484']);
     });
@@ -111,9 +90,7 @@ describe('Config set command', () => {
       await command.runWithDependencies({
         option: 'docker.network',
         value: '{"subnet":"127.0.0.1/24", "bindIp": "0.0.0.0"}',
-      }, flags, config,
-      mockRenderServiceTemplates, mockWriteServiceConfigs,
-      mockConfigFileRepository);
+      }, flags, config, mockConfigFile);
     });
 
     it('should throw on unknown path', async () => {
@@ -123,9 +100,7 @@ describe('Config set command', () => {
       try {
         await command.runWithDependencies({
           option: 'fakePath', value: 'fake',
-        }, flags, config,
-        mockRenderServiceTemplates, mockWriteServiceConfigs,
-        mockConfigFileRepository);
+        }, flags, config, mockConfigFile);
 
         expect.fail('should throw error');
       } catch (e) {
@@ -140,9 +115,7 @@ describe('Config set command', () => {
       try {
         await command.runWithDependencies({
           option: 'core.rpc.allowIps', value: 'fake_image',
-        }, flags, config,
-        mockRenderServiceTemplates, mockWriteServiceConfigs,
-        mockConfigFileRepository);
+        }, flags, config, mockConfigFile);
 
         expect.fail('should throw error');
       } catch (e) {
@@ -157,9 +130,7 @@ describe('Config set command', () => {
       try {
         await command.runWithDependencies({
           option: 'dashmate.helper.api.enable', value: 120,
-        }, flags, config,
-        mockRenderServiceTemplates, mockWriteServiceConfigs,
-        mockConfigFileRepository);
+        }, flags, config, mockConfigFile);
 
         expect.fail('should throw error');
       } catch (e) {

--- a/packages/dashmate/test/unit/commands/config/set.spec.js
+++ b/packages/dashmate/test/unit/commands/config/set.spec.js
@@ -6,13 +6,11 @@ describe('Config set command', () => {
   const flags = {};
 
   let config;
-  let mockConfigFile;
 
   beforeEach(async () => {
     const getBaseConfig = getBaseConfigFactory(HomeDir.createTemp());
 
     config = getBaseConfig();
-    mockConfigFile = { markAsChanged: () => {} };
   });
 
   describe('#platform', () => {
@@ -21,7 +19,7 @@ describe('Config set command', () => {
 
       await command.runWithDependencies({
         option: 'core.docker.image', value: 'fake_image',
-      }, flags, config, mockConfigFile);
+      }, flags, config);
     });
 
     it('should allow setting null', async () => {
@@ -29,13 +27,13 @@ describe('Config set command', () => {
 
       await command.runWithDependencies({
         option: 'description', value: null,
-      }, flags, config, mockConfigFile);
+      }, flags, config);
 
       expect(config.get('description')).to.equal(null);
 
       await command.runWithDependencies({
         option: 'description', value: 'null',
-      }, flags, config, mockConfigFile);
+      }, flags, config);
 
       expect(config.get('description')).to.equal(null);
     });
@@ -46,14 +44,14 @@ describe('Config set command', () => {
       await command.runWithDependencies({
         option: 'platform.drive.abci.validatorSet.llmqType',
         value: 107,
-      }, flags, config, mockConfigFile);
+      }, flags, config);
 
       expect(config.get('platform.drive.abci.validatorSet.llmqType')).to.equal(107);
 
       await command.runWithDependencies({
         option: 'platform.drive.abci.validatorSet.llmqType',
         value: '107',
-      }, flags, config, mockConfigFile);
+      }, flags, config);
 
       expect(config.get('platform.drive.abci.validatorSet.llmqType')).to.equal(107);
     });
@@ -63,13 +61,13 @@ describe('Config set command', () => {
 
       await command.runWithDependencies({
         option: 'dashmate.helper.api.enable', value: 'true',
-      }, flags, config, mockConfigFile);
+      }, flags, config);
 
       expect(config.get('dashmate.helper.api.enable')).to.equal(true);
 
       await command.runWithDependencies({
         option: 'dashmate.helper.api.enable', value: true,
-      }, flags, config, mockConfigFile);
+      }, flags, config);
 
       expect(config.get('dashmate.helper.api.enable')).to.equal(true);
     });
@@ -79,7 +77,7 @@ describe('Config set command', () => {
 
       await command.runWithDependencies({
         option: 'core.rpc.allowIps', value: '["1337", "36484"]',
-      }, flags, config, mockConfigFile);
+      }, flags, config);
 
       expect(config.get('core.rpc.allowIps')).to.deep.equal(['1337', '36484']);
     });
@@ -90,7 +88,7 @@ describe('Config set command', () => {
       await command.runWithDependencies({
         option: 'docker.network',
         value: '{"subnet":"127.0.0.1/24", "bindIp": "0.0.0.0"}',
-      }, flags, config, mockConfigFile);
+      }, flags, config);
     });
 
     it('should throw on unknown path', async () => {
@@ -100,7 +98,7 @@ describe('Config set command', () => {
       try {
         await command.runWithDependencies({
           option: 'fakePath', value: 'fake',
-        }, flags, config, mockConfigFile);
+        }, flags, config);
 
         expect.fail('should throw error');
       } catch (e) {
@@ -115,7 +113,7 @@ describe('Config set command', () => {
       try {
         await command.runWithDependencies({
           option: 'core.rpc.allowIps', value: 'fake_image',
-        }, flags, config, mockConfigFile);
+        }, flags, config);
 
         expect.fail('should throw error');
       } catch (e) {
@@ -130,7 +128,7 @@ describe('Config set command', () => {
       try {
         await command.runWithDependencies({
           option: 'dashmate.helper.api.enable', value: 120,
-        }, flags, config, mockConfigFile);
+        }, flags, config);
 
         expect.fail('should throw error');
       } catch (e) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When dashmate migrate config to the new version, it should be persist back to disk, but it's not. So dashmate migrate config every command call without actual effect of this migration.
There are few commands that mutate config. It should be persisted in this case too.

## What was done?
<!--- Describe your changes in detail -->
- Keep status of changes for configs and config file
- Persist config file if changed
- Render templates for a config if  it was changed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
