### PR TITLE
refactor: format source code using nightly rustfmt

### DIFF
--- a/.github/workflows/tests-rs-package.yml
+++ b/.github/workflows/tests-rs-package.yml
@@ -62,10 +62,11 @@ jobs:
         uses: ./.github/actions/rust
         with:
           components: rustfmt
+          toolchain: nightly
           cache: false
 
       - name: Check formatting
-        run: exit `cargo fmt --check --package=${{ inputs.package }} | wc -l`
+        run: exit `cargo +nightly fmt --check --package=${{ inputs.package }} | wc -l`
 
   unused_deps:
     name: Unused dependencies

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,17 @@
+unstable_features = true
+
+blank_lines_lower_bound = 0
+condense_wildcard_suffixes = true
+error_on_line_overflow = false
+error_on_unformatted = false
+format_code_in_doc_comments = true
+format_macro_matchers = true
+format_strings = true
+imports_granularity = "Crate"
+normalize_comments = true
+normalize_doc_attributes = true
+reorder_impl_items = true
+group_imports = "StdExternalCrate"
+use_field_init_shorthand = true
+use_try_shorthand = true
+wrap_comments = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,6 @@ welcome to contribute towards development in the form of peer review, testing
 and patches. This document explains the practical process and guidelines for
 contributing.
 
-
 Branches, Bugfixes and New Features
 -----------------------------------
 
@@ -24,7 +23,6 @@ mailing list discussions).
 
 If a pull request is not (yet) ready to be considered for merging, please set
 its status to "Draft" on GitHub.
-
 
 Conventional Commits
 --------------------
@@ -46,7 +44,6 @@ atomic](https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention)
 and diffs should be easy to read. For this reason, do not mix any formatting
 fixes or code movement with actual code changes.
 
-
 Code Conventions
 ----------------
 
@@ -54,6 +51,12 @@ Please ensure that the code you write adheres to the code style adopted in the
 project, and that all linting checks are passing. We use [AirBnB
 style](https://github.com/airbnb/javascript) for JS code.
 
+For Rust, please format your code using nightly version of rustfmt
+and configuration in `.rustfmt.toml`:
+
+```bash
+cargo +nightly fmt
+```
 
 Testing
 -------
@@ -70,7 +73,6 @@ Code should generally be covered by unit and integration tests, and functional
 or e2e tests should be written for larger chunks of functionality (when
 appropriate). Unit and integration tests should not make any network calls, and
 unit tests should mock all dependencies.
-
 
 Squashing Commits
 -----------------
@@ -99,7 +101,6 @@ respective change set.
 The length of time required for peer review is unpredictable and will vary from
 pull request to pull request.
 
-
 Pull Request Philosophy
 -----------------------
 
@@ -107,7 +108,6 @@ Patchsets should always be focused. For example, a pull request could add a
 feature, fix a bug, or refactor code; but not a mixture. Please also avoid super
 pull requests which attempt to do too much, are overly large, or overly complex
 as this makes review difficult.
-
 
 "Decision Making" Process
 -------------------------
@@ -127,7 +127,6 @@ In general, all pull requests must:
 - Not break the existing test suite;
 - Where bugs are fixed, where possible, there should be unit tests demonstrating
   the bug and also proving the fix. This helps prevent regression.
-
 
 Release process
 ---------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

We need to unify code formatting.

## What was done?

This PR adds `.rustfmt.toml` file to the repo that defines formatting of Rust code.

1. Created .rustfmt.toml that defines code formatting policy
2. Configured github actions to run using +nightly
3. Run `cargo +nightly fmt`
4. Updated docs


## How Has This Been Tested?

```
cargo +nightly fmt
```


## Breaking Changes

Will cause tons of conflicts.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
