### PR TITLE
fix(dashmate): incorrect imports 

### DIFF
--- a/packages/bench-suite/README.md
+++ b/packages/bench-suite/README.md
@@ -14,7 +14,7 @@ This benchmark publishes a data contract and documents defined in configuration 
 
 ### Function
 
-Function benchmark allow to call a function or functions and collect metrics using [performance tools](https://nodejs.org/docs/latest-v18.x/api/perf_hooks.html).
+Function benchmark allow to call a function or functions and collect metrics using [performance tools](https://nodejs.org/docs/latest-v20.x/api/perf_hooks.html).
 
 ### Running benchmarks
 

--- a/packages/dapi/README.md
+++ b/packages/dapi/README.md
@@ -23,7 +23,7 @@ npm install
 
 ### Dependencies
 
-DAPI targets the latest v18 release of Node.js.
+DAPI targets the latest v20 release of Node.js.
 
 DAPI requires the latest version of [dashcore](https://github.com/dashevo/dash-evo-branches/tree/evo) with Evolution features (special branch repo).
 

--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -32,7 +32,7 @@ Distribution package for Dash node installation
 ### Dependencies
 
 * [Docker](https://docs.docker.com/engine/installation/) (v20.10+)
-* [Node.js](https://nodejs.org/en/download/) (v18, NPM v8.0+)
+* [Node.js](https://nodejs.org/en/download/) (v20, NPM v8.0+)
 
 For Linux installations you may optionally wish to follow the Docker [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) to manage Docker as a non-root user, otherwise you will have to run CLI and Docker commands with `sudo`.
 

--- a/packages/dashmate/src/constants.js
+++ b/packages/dashmate/src/constants.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import * as url from 'url';
+import url from 'url';
 
 export const NETWORK_LOCAL = 'local';
 export const NETWORK_DEVNET = 'devnet';

--- a/packages/dashmate/src/listr/prompts/formatters/formatPercentage.js
+++ b/packages/dashmate/src/listr/prompts/formatters/formatPercentage.js
@@ -1,4 +1,4 @@
-import * as placeholder from 'enquirer/lib/placeholder.js';
+import placeholder from 'enquirer/lib/placeholder.js';
 
 /**
  * @param {string} input

--- a/packages/dashmate/src/templates/renderServiceTemplatesFactory.js
+++ b/packages/dashmate/src/templates/renderServiceTemplatesFactory.js
@@ -1,5 +1,5 @@
 import dots from 'dot';
-import * as glob from 'glob';
+import glob from 'glob';
 import { TEMPLATES_DIR } from '../constants.js';
 
 /**

--- a/packages/dashmate/src/templates/renderServiceTemplatesFactory.js
+++ b/packages/dashmate/src/templates/renderServiceTemplatesFactory.js
@@ -1,5 +1,5 @@
 import dots from 'dot';
-import glob from 'glob';
+import * as glob from 'glob';
 import { TEMPLATES_DIR } from '../constants.js';
 
 /**

--- a/packages/dashmate/src/update/updateNodeFactory.js
+++ b/packages/dashmate/src/update/updateNodeFactory.js
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import lodash from 'lodash';
 
 /**
  * @param {getServiceList} getServiceList
@@ -18,7 +18,7 @@ export default function updateNodeFactory(getServiceList, docker) {
     const services = getServiceList(config);
 
     return Promise.all(
-      _.uniqBy(services, 'image')
+      lodash.uniqBy(services, 'image')
         .map(async ({ name, image, title }) => new Promise((resolve, reject) => {
           docker.pull(image, (err, stream) => {
             if (err) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dashmate contains import * as imports that are not working quite correctly leading to two errors:

* dashmate setup: `at SelectPrompt.reset (/home/me/.nvm/versions/node/v20.9.0/lib/node_modules/dashmate/node_modules/enquirer/lib/types/array.js:38:13)`
* dashmate update: `TypeError: _.uniqBy is not a function`


## What was done?
<!--- Describe your changes in detail -->
* Replaced `import * as from` in the code where its possible
* Updated few missing node.js 20 mentions in the docs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally + CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
