### PR TITLE
rfc: interface between wallet and sdk

### DIFF
--- a/packages/rs-drive-proof-verifier/src/provider.rs
+++ b/packages/rs-drive-proof-verifier/src/provider.rs
@@ -1,13 +1,20 @@
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
+use crate::error::ContextProviderError;
 use dpp::prelude::{DataContract, Identifier};
 use hex::ToHex;
 
-/// `ContextProvider` trait provides an interface to fetch information about context of proof verification, like
-/// quorum information, data contracts present in the platform, etc.
+/// Interface between the Sdk and state of the application.
 ///
-/// Developers should implement this trait to provide required information to [FromProof](crate::FromProof)
-/// implementations.
+/// ContextProvider is called by the [FromProof](crate::FromProof) trait (and similar) to get information about
+/// the application and/or network state, including data contracts that might be cached by the application or
+/// quorum public keys.
+///
+/// Developers using the Dash Platform SDK should implement this trait to provide required information
+/// to the Sdk, especially implementation of [FromProof](crate::FromProof) trait.
+///
+/// A ContextProvider should be thread-safe and manage timeouts and other concurrency-related issues internally,
+/// as the [FromProof](crate::FromProof) implementations can block on ContextProvider calls.
 pub trait ContextProvider: Send + Sync {
     /// Fetches the public key for a specified quorum.
     ///
@@ -26,7 +33,7 @@ pub trait ContextProvider: Send + Sync {
         quorum_type: u32,
         quorum_hash: [u8; 32], // quorum hash is 32 bytes
         core_chain_locked_height: u32,
-    ) -> Result<[u8; 48], crate::Error>; // public key is 48 bytes
+    ) -> Result<[u8; 48], ContextProviderError>; // public key is 48 bytes
 
     /// Fetches the data contract for a specified data contract ID.
     /// This method is used by [FromProof](crate::FromProof) implementations to fetch data contracts
@@ -41,14 +48,58 @@ pub trait ContextProvider: Send + Sync {
     /// * `Ok(Option<Arc<DataContract>>)`: On success, returns the data contract if it exists, or `None` if it does not.
     /// We use Arc to avoid copying the data contract.
     /// * `Err(Error)`: On failure, returns an error indicating why the operation failed.
-    fn get_data_contract(&self, id: &Identifier)
-        -> Result<Option<Arc<DataContract>>, crate::Error>;
+    fn get_data_contract(
+        &self,
+        id: &Identifier,
+    ) -> Result<Option<Arc<DataContract>>, ContextProviderError>;
+}
+
+impl<C: AsRef<dyn ContextProvider> + Send + Sync> ContextProvider for C {
+    fn get_quorum_public_key(
+        &self,
+        quorum_type: u32,
+        quorum_hash: [u8; 32],
+        core_chain_locked_height: u32,
+    ) -> Result<[u8; 48], ContextProviderError> {
+        self.as_ref()
+            .get_quorum_public_key(quorum_type, quorum_hash, core_chain_locked_height)
+    }
+
+    fn get_data_contract(
+        &self,
+        id: &Identifier,
+    ) -> Result<Option<Arc<DataContract>>, ContextProviderError> {
+        self.as_ref().get_data_contract(id)
+    }
+}
+
+impl<'a, T: ContextProvider + 'a> ContextProvider for std::sync::Mutex<T>
+where
+    Self: Sync + Send,
+{
+    fn get_data_contract(
+        &self,
+        id: &Identifier,
+    ) -> Result<Option<Arc<DataContract>>, ContextProviderError> {
+        let lock = self.lock().expect("lock poisoned");
+        lock.get_data_contract(id)
+    }
+    fn get_quorum_public_key(
+        &self,
+        quorum_type: u32,
+        quorum_hash: [u8; 32], // quorum hash is 32 bytes
+        core_chain_locked_height: u32,
+    ) -> Result<[u8; 48], ContextProviderError> {
+        let lock = self.lock().expect("lock poisoned");
+        lock.get_quorum_public_key(quorum_type, quorum_hash, core_chain_locked_height)
+    }
 }
 
 /// Mock ContextProvider that can read quorum keys from files.
 ///
-/// Use `dash_sdk::SdkBuilder::with_dump_dir()` to generate quorum keys files.
+/// Use `dash_platform_sdk::SdkBuilder::with_dump_dir()` to generate quorum keys files.
 #[cfg(feature = "mocks")]
+#[derive(Debug)]
 pub struct MockContextProvider {
     quorum_keys_dir: Option<std::path::PathBuf>,
 }
@@ -71,7 +122,7 @@ impl MockContextProvider {
 
     /// Set the directory where quorum keys are stored.
     ///
-    /// This directory should contain quorum keys files generated using `dash_sdk::SdkBuilder::with_dump_dir()`.
+    /// This directory should contain quorum keys files generated using `dash_platform_sdk::SdkBuilder::with_dump_dir()`.
     pub fn quorum_keys_dir(&mut self, quorum_keys_dir: Option<std::path::PathBuf>) {
         self.quorum_keys_dir = quorum_keys_dir;
     }
@@ -87,20 +138,16 @@ impl Default for MockContextProvider {
 impl ContextProvider for MockContextProvider {
     /// Mock implementation of [ContextProvider] that returns keys from files saved on disk.
     ///
-    /// Use `dash_sdk::SdkBuilder::with_dump_dir()` to generate quorum keys files.
+    /// Use `dash_platform_sdk::SdkBuilder::with_dump_dir()` to generate quorum keys files.   
     fn get_quorum_public_key(
         &self,
         quorum_type: u32,
         quorum_hash: [u8; 32],
         _core_chain_locked_height: u32,
-    ) -> Result<[u8; 48], crate::Error> {
+    ) -> Result<[u8; 48], ContextProviderError> {
         let path = match &self.quorum_keys_dir {
             Some(p) => p,
-            None => {
-                return Err(crate::Error::InvalidQuorum {
-                    error: "dump dir not set".to_string(),
-                })
-            }
+            None => return Err(ContextProviderError::Config("dump dir not set".to_string())),
         };
 
         let file = path.join(format!(
@@ -112,13 +159,11 @@ impl ContextProvider for MockContextProvider {
         let f = match std::fs::File::open(&file) {
             Ok(f) => f,
             Err(e) => {
-                return Err(crate::Error::InvalidQuorum {
-                    error: format!(
-                        "cannot load quorum key file {}: {}",
-                        file.to_string_lossy(),
-                        e
-                    ),
-                })
+                return Err(ContextProviderError::InvalidQuorum(format!(
+                    "cannot load quorum key file {}: {}",
+                    file.to_string_lossy(),
+                    e
+                )))
             }
         };
 
@@ -130,7 +175,43 @@ impl ContextProvider for MockContextProvider {
     fn get_data_contract(
         &self,
         _data_contract_id: &Identifier,
-    ) -> Result<Option<Arc<DataContract>>, crate::Error> {
+    ) -> Result<Option<Arc<DataContract>>, ContextProviderError> {
         todo!("not implemented yet");
     }
 }
+// the trait `std::convert::AsRef<(dyn drive_proof_verifier::ContextProvider + 'static)>`
+// is not implemented for `std::sync::Arc<mock::provider::GrpcContextProvider<'_>>`
+impl<'a, T: ContextProvider + 'a> AsRef<dyn ContextProvider + 'a> for Arc<T> {
+    fn as_ref(&self) -> &(dyn ContextProvider + 'a) {
+        self.deref()
+    }
+}
+
+// // the trait `std::convert::AsRef<(dyn drive_proof_verifier::ContextProvider + 'static)>`
+// // is not implemented for `tokio::sync::Mutex<mock::provider::GrpcContextProvider<'_>>`
+// impl<'a, T: ContextProvider + 'a> AsRef<dyn ContextProvider + 'a> for std::sync::Mutex<T> {
+//     fn as_ref(&self) -> &(dyn ContextProvider + 'a) {
+//         let lock: &std::sync::MutexGuard<'_, T> = &self.lock().expect("lock poisoned");
+//         lock.deref()
+//     }
+// }
+
+// impl<P: ContextProvider> ContextProvider for Arc<&P> {
+//     fn get_data_contract(
+//         &self,
+//         id: &Identifier,
+//     ) -> Result<Option<Arc<DataContract>>, crate::Error> {
+//         let provider = self.as_ref();
+//         provider.get_data_contract(id)
+//     }
+
+//     fn get_quorum_public_key(
+//         &self,
+//         quorum_type: u32,
+//         quorum_hash: [u8; 32], // quorum hash is 32 bytes
+//         core_chain_locked_height: u32,
+//     ) -> Result<[u8; 48], crate::Error> {
+//         let provider = self.as_ref();
+//         provider.get_quorum_public_key(quorum_type, quorum_hash, core_chain_locked_height)
+//     }
+// }

--- a/packages/rs-sdk/README.md
+++ b/packages/rs-sdk/README.md
@@ -4,21 +4,51 @@ This is the official Rust SDK for the Dash Platform. Dash Platform is a Layer 2 
 
 See Rust documentation of this crate for more details.
 
-## Usage
+## Quick start
+
+### Cargo.toml
 
 To use this crate, define it as a dependency in your `Cargo.toml`:
 
 ```toml
 [dependencies]
 
-dash-sdk = { git="https://github.com/dashpay/platform"0 }
+dash-platform-sdk = { git="https://github.com/dashpay/platform"0 }
 ```
+
+### Implementing Dash Platform SDK application
+
+In order to build application that uses Dash Platform SDK, you need to:
+
+1. Implement a [Wallet](src/wallet.rs) that will store, manage and use your keys to sign transactions and state transitions.
+   An example implementation of wallet can be found in [src/mock/wallet.rs](src/mock/wallet.rs).
+2. Implement Dash SPV client that will sync your application with Dash Core state, including quorum public keys.
+
+   TODO: Add more details here.
+
+   For testing and development purposes, while you don't have your SPV client implementation ready, you can setup local Dash Core node and access it using RPC interface (see below).
+
+3. Implement  `ContextProvider` gives Dash Platform SDK access to state of your application, like:
+   * quorum public keys retrieved using SPV,
+   * data contracts configured and/or fetched from the server.
+
+   See [GrpcContextProvider](../rs-sdk/src/mock/provider.rs) for an example implementation.
+
+### Mocking
+
+Dash Platform SDK supports mocking with `mocks` feature which provides a
+convenient way to define mock expectations and use the SDK without actual
+connection to the Platform.
+
+You can see examples of mocking in [mock_fetch.rs](tests/fetch/mock_fetch.rs) and  [mock_fetch_many.rs](tests/fetch/mock_fetch_many.rs).
 
 ## Examples
 
 You can find quick start example in `examples/` folder. Examples must be configured by setting constants.
 
 You can also inspect tests in `tests/` folder for more detailed examples.
+
+Also refer to [Platform Explorer](https://github.com/dashpay/rs-platform-explorer/) which uses the SDK to execute various state transitions.
 
 ## Tests
 
@@ -64,7 +94,7 @@ To generate test vectors:
 Run the offline test using the following command:
 
 ```bash
-cargo test -p dash-sdk
+cargo test -p dash-platform-sdk
 ```
 
 ## Implementing Fetch and FetchAny on new objects

--- a/packages/rs-sdk/examples/read_contract.rs
+++ b/packages/rs-sdk/examples/read_contract.rs
@@ -1,33 +1,53 @@
-use std::str::FromStr;
+use std::{num::NonZeroUsize, str::FromStr, sync::Arc};
 
-use dash_sdk::platform::Fetch;
+use clap::Parser;
+use dash_platform_sdk::{
+    mock::{provider::GrpcContextProvider, wallet::MockWallet},
+    platform::Fetch,
+    Sdk, SdkBuilder,
+};
 use dpp::prelude::{DataContract, Identifier};
 use rs_dapi_client::AddressList;
 
-pub const PLATFORM_IP: &str = "127.0.0.1";
-pub const CORE_PORT: u16 = 20002;
-pub const CORE_USER: &str = "someuser";
-pub const CORE_PASSWORD: &str = "verysecretpassword";
-pub const PLATFORM_PORT: u16 = 2443;
+#[derive(clap::Parser, Debug)]
+#[command(version)]
+pub struct Config {
+    /// Dash Platform server hostname or IPv4 address
+    #[arg(short = 'i', long = "address")]
+    pub server_address: String,
+
+    /// Dash Core IP port
+    #[arg(short = 'c', long)]
+    pub core_port: u16,
+
+    // Dash Core RPC user
+    #[arg(short = 'u', long)]
+    pub core_user: String,
+
+    // Dash Core RPC password
+    #[arg(short = 'p', long)]
+    pub core_password: String,
+
+    /// Dash Platform DAPI port
+    #[arg(short = 'd', long)]
+    pub platform_port: u16,
+}
 
 /// Read data contract.
 ///
-/// This example demonstrates how to connect to running platform and try to read
-/// a data contract.
+/// This example demonstrates how to connect to running platform and try to read a data contract.
+/// TODO: add wallet, context provider, etc.
 #[tokio::main(flavor = "multi_thread", worker_threads = 1)]
 async fn main() {
     // Replace const below with data contract identifier of data contract, 32 bytes
     const DATA_CONTRACT_ID_BYTES: [u8; 32] = [1; 32];
 
-    // Configure the SDK to connect to the Platform.
-    // Note that in future versions of the SDK, core user and password will not be
-    // needed.
-    let uri = http::Uri::from_str(&format!("http://{}:{}", PLATFORM_IP, PLATFORM_PORT))
-        .expect("platform address uri");
-    let sdk = dash_sdk::SdkBuilder::new(AddressList::from_iter([uri]))
-        .with_core(PLATFORM_IP, CORE_PORT, CORE_USER, CORE_PASSWORD)
-        .build()
-        .expect("cannot initialize api");
+    // Read configuration
+    let config = Config::parse();
+    // Configure the Sdk
+    let sdk = setup_sdk(&config);
+
+    // read data contract
 
     // Convert bytes to identifier object that can be used as a Query
     let id = Identifier::from_bytes(&DATA_CONTRACT_ID_BYTES).expect("parse data contract id");
@@ -36,7 +56,68 @@ async fn main() {
     let contract: Option<DataContract> =
         DataContract::fetch(&sdk, id).await.expect("fetch identity");
 
-    // Check the result; note that in our case, we expect to not find the data
-    // contract, as the identifier is not valid.
+    // Check the result; note that in our case, we expect to not find the data contract, as the
+    // identifier is not valid.
     assert!(contract.is_none(), "result: {:?}", contract);
+}
+
+/// Setup Rust SDK
+fn setup_sdk(config: &Config) -> Arc<Sdk> {
+    // First, we need to implement a Wallet. In our case, we'll just use GRPC wallet
+    // implementation from the SDK mocking module, which in turn uses separate Platform and
+    // Core wallet.
+    //
+    // Note that this logic is executed automatically when you [build](SdkBuilder::build()) SDK without providing a
+    // wallet nor context provider. We do it manually here to show how it works, and how
+    // you should use it with your own implementation of wallet and context provider.
+    // Now, let's create the wallet
+    let wallet = MockWallet::new_mock(
+        &config.server_address,
+        config.core_port,
+        &config.core_user,
+        &config.core_password,
+    )
+    .expect("mock wallet creation");
+
+    // We also need to implement a ContextProvider.
+    // Here, we will just use a mock implementation.
+    // Tricky thing here is that this implementation requires SDK, so we have a
+    // circular dependency between SDK and ContextProvider.
+    // We'll first provide `None` Sdk, and then update it later.
+    //
+    // To modify context provider, we need locks and Arc to overcome ownership rules.
+    let context_provider = GrpcContextProvider::new(
+        None,
+        &config.server_address,
+        config.core_port,
+        &config.core_user,
+        &config.core_password,
+        NonZeroUsize::new(100).expect("data contracts cache size"),
+        NonZeroUsize::new(100).expect("quorum public keys cache size"),
+    )
+    .expect("context provider");
+    let context_provider = Arc::new(std::sync::Mutex::new(context_provider));
+
+    // Let's build the Sdk.
+    // First, we need an URI of some Dash Platform DAPI host to connect to and use as seed.
+    let uri = http::Uri::from_str(&format!(
+        "http://{}:{}",
+        config.server_address, config.platform_port
+    ))
+    .expect("parse uri");
+
+    // Now, we create the Sdk with the wallet and context provider.
+    let sdk = SdkBuilder::new(AddressList::from_iter([uri]))
+        .with_wallet(wallet)
+        .with_context_provider(Arc::clone(&context_provider))
+        .build()
+        .expect("cannot build sdk");
+
+    // Reconfigure context provider with Sdk
+    let mut guard = context_provider.lock().expect("lock context provider");
+    guard.set_sdk(Some(Arc::clone(&sdk)));
+    drop(guard);
+
+    // Return the SDK we created
+    sdk
 }

--- a/packages/rs-sdk/src/wallet.rs
+++ b/packages/rs-sdk/src/wallet.rs
@@ -1,0 +1,207 @@
+//! Wallet for managing keys assets in Dash Core and Platform.
+
+use async_trait::async_trait;
+pub use dashcore_rpc::dashcore_rpc_json::ListUnspentResultEntry;
+use dpp::bls_signatures::PrivateKey;
+use dpp::identity::{signer::Signer, IdentityPublicKey, Purpose};
+use dpp::platform_value::BinaryData;
+use dpp::prelude::AssetLockProof;
+use dpp::ProtocolError;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+
+use crate::Error;
+
+/// Wallet used by Dash Platform SDK.
+///
+/// Wallet is used to manage keys and addresses, and sign transactions.
+/// It must provide access to operations utilizing private keys, without
+/// exposing them to the Sdk.
+///
+/// It should also add additional level of validation and security on top of
+/// Sdk, to verify that security-related operations are executed as intended by the user.
+/// It can, for example, notify the user if they are about to sign a transaction
+/// that will spend all their funds.
+///
+/// Sdk calls wallet methods whenever operations utilizing private keys are required.
+///
+/// Wallet should be thread-safe, as it can be used from multiple threads.
+/// It should manage timeouts and other concurrency-related issues internally, as the Sdk
+/// will block on wallet calls.
+#[async_trait]
+pub trait Wallet: Send + Sync {
+    // PLATFORM WALLET FUNCTIONS
+
+    /// Sign message using private key associated with provided public key
+    async fn platform_sign(
+        &self,
+        pubkey: &IdentityPublicKey,
+        message: &[u8],
+    ) -> Result<BinaryData, Error>;
+
+    /// Return default identity public key for the provided purpose.
+    async fn identity_public_key(&self, purpose: &Purpose) -> Option<IdentityPublicKey>;
+
+    // CORE WALLET FUNCTIONS
+
+    /// Create new asset lock transaction that locks some amount of Dash to be used in Platform.
+    ///
+    /// # Arguments
+    ///
+    /// * `amount` - Amount of Dash to lock.
+    ///
+    /// # Returns
+    ///
+    /// * `AssetLockProof` - Asset lock proof.
+    /// * `PrivateKey` - One-time private key used to use locked Dash in Platform.
+    /// This key should be used to sign Platform transactions.
+    async fn lock_assets(&self, amount: u64) -> Result<(AssetLockProof, PrivateKey), Error>;
+
+    /// Return balance of the wallet, in satoshis.
+    async fn core_balance(&self) -> Result<u64, Error>;
+
+    /// Return list of unspent transactions with summarized balance at least `sum`
+    async fn core_utxos(&self, sum: Option<u64>) -> Result<Vec<ListUnspentResultEntry>, Error>;
+}
+
+// struct WalletSigner<W>(W);
+// impl<W: Wallet> From<W> for WalletSigner<W> {
+//     fn from(wallet: W) -> Self {
+//         Self(wallet)
+//     }
+// }
+// impl AsRef<dyn Signer> for dyn Wallet
+// where
+//     Self: Send + Sync + Wallet,
+// {
+//     fn as_ref(&self) -> &'static dyn Signer {
+//         &WalletSigner(self)
+//     }
+// }
+
+impl Signer for Box<dyn Wallet> {
+    fn sign(
+        &self,
+        identity_public_key: &IdentityPublicKey,
+        data: &[u8],
+    ) -> Result<BinaryData, ProtocolError> {
+        let wallet = self.as_ref();
+        tokio::task::block_in_place(|| {
+            Handle::current().block_on(wallet.platform_sign(identity_public_key, data))
+        })
+        .map_err(|e| ProtocolError::Generic(e.to_string()))
+    }
+}
+
+// impl Signer for WalletSigner<&dyn Wallet>
+// where
+//     Self: Send + Sync,
+// {
+//     fn sign(
+//         &self,
+//         pubkey: &IdentityPublicKey,
+//         message: &[u8],
+//     ) -> Result<BinaryData, ProtocolError> {
+//         let wallet = self.0;
+//         // TODO: check if this tokio construct works
+//         tokio::task::block_in_place(|| {
+//             Handle::current().block_on(wallet.platform_sign(pubkey, message))
+//         })
+//         .map_err(|e| ProtocolError::Generic(e.to_string()))
+//     }
+// }
+// impl<W: AsRef<dyn Wallet>> Signer for WalletSigner<W>
+// where
+//     W: Send + Sync,
+// {
+//     fn sign(
+//         &self,
+//         pubkey: &IdentityPublicKey,
+//         message: &[u8],
+//     ) -> Result<BinaryData, ProtocolError> {
+//         let wallet = self.0.as_ref();
+//         // TODO: check if this tokio construct works
+//         tokio::task::block_in_place(|| {
+//             Handle::current().block_on(wallet.platform_sign(pubkey, message))
+//         })
+//         .map_err(|e| ProtocolError::Generic(e.to_string()))
+//     }
+// }
+
+#[async_trait]
+//impl<W: AsRef<dyn Wallet>> Wallet for W
+impl Wallet for &'static dyn Wallet
+where
+    Self: Send + Sync,
+{
+    async fn platform_sign(
+        &self,
+        pubkey: &IdentityPublicKey,
+        message: &[u8],
+    ) -> Result<BinaryData, Error> {
+        (*self).platform_sign(pubkey, message).await
+    }
+
+    async fn identity_public_key(&self, purpose: &Purpose) -> Option<IdentityPublicKey> {
+        (*self).identity_public_key(purpose).await
+    }
+
+    async fn lock_assets(&self, amount: u64) -> Result<(AssetLockProof, PrivateKey), Error> {
+        (*self).lock_assets(amount).await
+    }
+
+    async fn core_balance(&self) -> Result<u64, Error> {
+        (*self).core_balance().await
+    }
+
+    async fn core_utxos(&self, sum: Option<u64>) -> Result<Vec<ListUnspentResultEntry>, Error> {
+        (*self).core_utxos(sum).await
+    }
+}
+
+// #[async_trait]
+// impl Wallet for Box<dyn Wallet> {
+//     async fn identity_public_key(&self, purpose: &Purpose) -> Option<IdentityPublicKey> {
+//         self.as_ref().identity_public_key(purpose).await
+//     }
+
+//     async fn lock_assets(&self, amount: u64) -> Result<(AssetLockProof, PrivateKey), Error> {
+//         self.as_ref().lock_assets(amount).await
+//     }
+
+//     async fn core_balance(&self) -> Result<u64, Error> {
+//         self.as_ref().core_balance().await
+//     }
+
+//     async fn core_utxos(&self, sum: Option<u64>) -> Result<Vec<ListUnspentResultEntry>, Error> {
+//         self.as_ref().core_utxos(sum).await
+//     }
+// }
+
+#[async_trait]
+impl<W: Wallet> Wallet for Arc<W> {
+    /// Sign message using private key associated with provided public key
+    async fn platform_sign(
+        &self,
+        pubkey: &IdentityPublicKey,
+        message: &[u8],
+    ) -> Result<BinaryData, Error> {
+        self.as_ref().platform_sign(pubkey, message).await
+    }
+
+    async fn identity_public_key(&self, purpose: &Purpose) -> Option<IdentityPublicKey> {
+        self.as_ref().identity_public_key(purpose).await
+    }
+
+    async fn lock_assets(&self, amount: u64) -> Result<(AssetLockProof, PrivateKey), Error> {
+        self.as_ref().lock_assets(amount).await
+    }
+
+    async fn core_balance(&self) -> Result<u64, Error> {
+        self.as_ref().core_balance().await
+    }
+
+    async fn core_utxos(&self, sum: Option<u64>) -> Result<Vec<ListUnspentResultEntry>, Error> {
+        self.as_ref().core_utxos(sum).await
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For the rs-sdk testing, we assume that each feature must have relevant test implemented.
Current rs-sdk test framework doesn't support testing of Puts (what includes state transitions).

For example, for testing of Put Identity, rs-sdk MUST be able to execute the following operations:

1. Create new identity - OK
2. Create state and sign state transition - not possible
3. Send state transition to DAPI - OK
4. Retrieve state transition result from the DAPI - OK
5. Verify state transition on the server side - OK

In order to create state and sign state transition, the Sdk needs code that is currently part of wallet in rs-platform-explorer, expecially `fn registration_transaction()`. Suggested change is as follows:

* main logic of registration_transaction() shall be moved to rs-sdk, and included inside the put_* methods
* rs-platform-explorer shall implement the Wallet trait that implements access to wallet as a set of atomic (eg. doing only one thing) functions
* wallet shall NOT provide access to private key - it should provide respective sign method instead, with enough details to ensure the Wallet can verify tx and is not blindly signing data - I assume separate sign function might be needed for different types of transitions. **These sign methods are not part of this PR**.

### Rationale

In rs-sdk we have the following architecture:

* simple services layer - layer providing "atomic" features, eg. doing only one thing at a time; for example, FromProof trait or rs-dapi-client
* composite services layer - layer connecting these simple services together, to do more complex stuff; this is the role of rs-sdk

Now, I see the wallet as a member of simple services layer, managing addresses and keys - that is, more-or-less CRUD-type operations ("read that address balance", "create new address", etc.). IMO it should have a sub-component that will be a "secure cryptographic device" (ledger/smartcard/trusted chip in phone/...)., but this is out of scope of what we do now.

In this architecture, the role of rs-sdk shall be to compose complex services from simple services - in this particular case, a composite service is implemented in registration_transaction , and IMO it should be part of composite services layer == rs-sdk.

The reason "why" comes from my belief that in most cases, the typical app developer doesn't care about selecting utxo's, determining change addresses, outputs, etc. In essence, the developer doesn't care about all these wallet internals. His goal is to create an identity, and he wants to do it in 2-3 lines, instead of having to understand state transitions, asset locks, utxos, fees, signatures, etc. To me, it all looks confusing when I try to do that, after years of exp in Dash. For newcomers, it's a show-stopper.

However, if a developer wants more control, he should reach out to "simple services" layer and do implementation himself. That's why we designed sdk this way.

So, the goal is to make developer's life as easy as one-two screens of code to create an identity.

## What was done?

Draft wallet and example of use in an application - not building yet.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
