### PR TITLE
fix(drive): filtering of failed and exceeding limit transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4132,8 +4132,8 @@ dependencies = [
 
 [[package]]
 name = "tenderdash-abci"
-version = "0.13.1"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci#865fd059564c203ae20ae0f9343f1e7f3fe1b200"
+version = "0.14.0-dev.1"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci#b4df6543efb0457a477db30153131495da1b8bbb"
 dependencies = [
  "bytes",
  "futures",
@@ -4153,8 +4153,8 @@ dependencies = [
 
 [[package]]
 name = "tenderdash-proto"
-version = "0.13.2"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci#865fd059564c203ae20ae0f9343f1e7f3fe1b200"
+version = "0.14.0-dev.1"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci#b4df6543efb0457a477db30153131495da1b8bbb"
 dependencies = [
  "bytes",
  "chrono",
@@ -4171,8 +4171,8 @@ dependencies = [
 
 [[package]]
 name = "tenderdash-proto-compiler"
-version = "0.1.0"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci#865fd059564c203ae20ae0f9343f1e7f3fe1b200"
+version = "0.14.0-dev.1"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci#b4df6543efb0457a477db30153131495da1b8bbb"
 dependencies = [
  "fs_extra",
  "prost-build 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
  "clap 2.34.0",
  "criterion-plot",
  "csv",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -839,7 +839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -1195,7 +1195,7 @@ dependencies = [
  "hex",
  "indexmap 2.1.0",
  "integer-encoding 4.0.0",
- "itertools 0.10.5",
+ "itertools",
  "json-patch",
  "jsonptr",
  "jsonschema",
@@ -1244,7 +1244,7 @@ dependencies = [
  "indexmap 1.9.3",
  "integer-encoding 4.0.0",
  "intmap",
- "itertools 0.10.5",
+ "itertools",
  "moka",
  "nohash-hasher",
  "platform-version",
@@ -1281,7 +1281,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "integer-encoding 4.0.0",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
@@ -1767,7 +1767,7 @@ dependencies = [
  "indexmap 1.9.3",
  "integer-encoding 3.0.4",
  "intmap",
- "itertools 0.10.5",
+ "itertools",
  "nohash-hasher",
  "serde",
  "tempfile",
@@ -1838,7 +1838,7 @@ version = "1.0.0-rc.2"
 source = "git+https://github.com/dashpay/grovedb?rev=b40dd1a35f852c81caeda2d3c2910c40fae3a67f#b40dd1a35f852c81caeda2d3c2910c40fae3a67f"
 dependencies = [
  "hex",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -2149,15 +2149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,7 +2233,7 @@ source = "git+https://github.com/fominok/jsonschema-rs?branch=feat-unevaluated-p
 dependencies = [
  "ahash 0.7.7",
  "anyhow",
- "base64 0.21.5",
+ "base64 0.13.1",
  "bytecount",
  "fancy-regex",
  "fraction",
@@ -2986,7 +2977,7 @@ checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools 0.10.5",
+ "itertools",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -3119,7 +3110,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "log",
  "multimap",
@@ -3141,7 +3132,7 @@ checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.11.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
@@ -3162,7 +3153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3175,7 +3166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.40",
@@ -4142,7 +4133,7 @@ dependencies = [
 [[package]]
 name = "tenderdash-abci"
 version = "0.13.1"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci#f413119a5c7f4b519ba3eec5746cd013a73e45db"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci#865fd059564c203ae20ae0f9343f1e7f3fe1b200"
 dependencies = [
  "bytes",
  "futures",
@@ -4163,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "tenderdash-proto"
 version = "0.13.2"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci#f413119a5c7f4b519ba3eec5746cd013a73e45db"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci#865fd059564c203ae20ae0f9343f1e7f3fe1b200"
 dependencies = [
  "bytes",
  "chrono",
@@ -4181,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "tenderdash-proto-compiler"
 version = "0.1.0"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci#f413119a5c7f4b519ba3eec5746cd013a73e45db"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci#865fd059564c203ae20ae0f9343f1e7f3fe1b200"
 dependencies = [
  "fs_extra",
  "prost-build 0.12.3",
@@ -4866,7 +4857,7 @@ dependencies = [
  "async-trait",
  "dpp",
  "hex",
- "itertools 0.10.5",
+ "itertools",
  "js-sys",
  "log",
  "num_enum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "dapi-grpc-macros",
  "platform-version",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc-macros"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "dapi-grpc",
  "heck",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "platform-value",
  "serde_json",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1165,7 +1165,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dpns-contract"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "platform-value",
  "serde_json",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "anyhow",
  "base64 0.21.5",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "drive-abci"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "atty",
  "base64 0.20.0",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "dapi-grpc",
  "dpp",
@@ -1514,7 +1514,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "feature-flags-contract"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "platform-value",
  "serde_json",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "platform-value",
  "serde_json",
@@ -2849,7 +2849,7 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "platform-serialization"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "platform-version",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "base64 0.13.1",
  "bincode 2.0.0-rc.3",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value-convertible"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "quote",
  "syn 2.0.40",
@@ -2896,14 +2896,14 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "platform-versioning"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "backon",
  "chrono",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "rs-sdk"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "async-trait",
  "base64 0.21.5",
@@ -3915,7 +3915,7 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simple-signer"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "anyhow",
  "bincode 2.0.0-rc.3",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "strategy-tests"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "dpp",
@@ -4860,7 +4860,7 @@ checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "wasm-dpp"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5102,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "0.25.17"
+version = "0.25.18"
 dependencies = [
  "num_enum",
  "platform-value",

--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -168,7 +168,7 @@ export default function getBaseConfigFactory(homeDir) {
           tenderdash: {
             mode: 'full',
             docker: {
-              image: 'dashpay/tenderdash:0.13.4',
+              image: 'dashpay/tenderdash:0.14.0-dev.1',
             },
             p2p: {
               host: '0.0.0.0',

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -58,7 +58,7 @@ tracing-subscriber = { version = "0.3.16", default-features = false, features = 
     "tracing-log",
 ], optional = false }
 atty = { version = "0.2.14", optional = false }
-tenderdash-abci = { git = "https://github.com/dashpay/rs-tenderdash-abci", version = "0.13.1" }
+tenderdash-abci = { git = "https://github.com/dashpay/rs-tenderdash-abci", version = "0.14.0-dev.1" }
 lazy_static = "1.4.0"
 itertools = { version = "0.10.5" }
 file-rotate = { version = "0.7.3" }

--- a/packages/rs-drive-abci/src/abci/handler/mod.rs
+++ b/packages/rs-drive-abci/src/abci/handler/mod.rs
@@ -260,7 +260,9 @@ where
                 TxAction::Unmodified
             } as i32;
 
-            tx_results.push(tx_result);
+            if action != TxAction::Removed as i32 {
+                tx_results.push(tx_result);
+            }
             tx_records.push(TxRecord { action, tx });
         }
 

--- a/packages/rs-drive-abci/src/abci/handler/mod.rs
+++ b/packages/rs-drive-abci/src/abci/handler/mod.rs
@@ -291,7 +291,7 @@ where
             transactions_exceeding_max_block_size
                 .into_iter()
                 .map(|tx| TxRecord {
-                    action: TxAction::Removed as i32,
+                    action: TxAction::Delayed as i32,
                     tx,
                 }),
         );

--- a/packages/rs-drive-abci/src/abci/handler/mod.rs
+++ b/packages/rs-drive-abci/src/abci/handler/mod.rs
@@ -170,7 +170,7 @@ where
 
     fn prepare_proposal(
         &self,
-        request: RequestPrepareProposal,
+        mut request: RequestPrepareProposal,
     ) -> Result<ResponsePrepareProposal, proto::ResponseException> {
         let _timer = crate::metrics::abci_request_duration("prepare_proposal");
 
@@ -189,6 +189,26 @@ where
             }
             Err(_) => None,
         };
+
+        // Filter out transactions exceeding max_block_size
+        let mut transactions_exceeding_max_block_size = Vec::new();
+        {
+            let mut total_transactions_size = 0;
+            let mut index_to_remove_at = None;
+            for (i, raw_transaction) in request.txs.iter().enumerate() {
+                total_transactions_size += raw_transaction.len();
+
+                if total_transactions_size as i64 > request.max_tx_bytes {
+                    index_to_remove_at = Some(i);
+                    break;
+                }
+            }
+
+            if let Some(index_to_remove_at) = index_to_remove_at {
+                transactions_exceeding_max_block_size
+                    .extend(request.txs.drain(index_to_remove_at..));
+            }
+        }
 
         let mut block_proposal: BlockProposal = (&request).try_into()?;
 
@@ -265,6 +285,16 @@ where
             }
             tx_records.push(TxRecord { action, tx });
         }
+
+        // Add up exceeding transactions to the response
+        tx_records.extend(
+            transactions_exceeding_max_block_size
+                .into_iter()
+                .map(|tx| TxRecord {
+                    action: TxAction::Removed as i32,
+                    tx,
+                }),
+        );
 
         // TODO: implement all fields, including tx processing; for now, just leaving bare minimum
         let response = ResponsePrepareProposal {

--- a/packages/rs-drive-abci/src/mimic/mod.rs
+++ b/packages/rs-drive-abci/src/mimic/mod.rs
@@ -79,6 +79,7 @@ impl<'a, C: CoreRPCLike> AbciApplication<'a, C> {
         expect_validation_errors: &[u32],
         expect_vote_extension_errors: bool,
         state_transitions: Vec<StateTransition>,
+        max_tx_bytes_per_block: i64,
         options: MimicExecuteBlockOptions,
     ) -> Result<MimicExecuteBlockOutcome, Error> {
         const APP_VERSION: u64 = 0;
@@ -104,7 +105,7 @@ impl<'a, C: CoreRPCLike> AbciApplication<'a, C> {
         // PREPARE (also processes internally)
 
         let request_prepare_proposal = RequestPrepareProposal {
-            max_tx_bytes: 44800,
+            max_tx_bytes: max_tx_bytes_per_block,
             txs: serialized_state_transitions.clone(),
             local_last_commit: None,
             misbehavior: vec![],

--- a/packages/rs-drive-abci/src/mimic/mod.rs
+++ b/packages/rs-drive-abci/src/mimic/mod.rs
@@ -104,7 +104,7 @@ impl<'a, C: CoreRPCLike> AbciApplication<'a, C> {
         // PREPARE (also processes internally)
 
         let request_prepare_proposal = RequestPrepareProposal {
-            max_tx_bytes: 0,
+            max_tx_bytes: 44800,
             txs: serialized_state_transitions.clone(),
             local_last_commit: None,
             misbehavior: vec![],

--- a/packages/rs-drive-abci/tests/strategy_tests/core_update_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/core_update_tests.rs
@@ -55,6 +55,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: false,
+            ..Default::default()
         };
 
         let quorum_size = 100;
@@ -160,6 +161,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: false,
+            ..Default::default()
         };
 
         let quorum_size = 100;
@@ -254,6 +256,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: false,
+            ..Default::default()
         };
 
         let quorum_size = 100;

--- a/packages/rs-drive-abci/tests/strategy_tests/execution.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/execution.rs
@@ -748,6 +748,7 @@ pub(crate) fn continue_chain_for_strategy(
                         expected_validation_errors.as_slice(),
                         false,
                         state_transitions.clone(),
+                        strategy.max_tx_bytes_per_block,
                         MimicExecuteBlockOptions {
                             dont_finalize_block: strategy.dont_finalize_block(),
                             rounds_before_finalization: strategy.failure_testing.as_ref().and_then(

--- a/packages/rs-drive-abci/tests/strategy_tests/failures.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/failures.rs
@@ -397,12 +397,9 @@ mod tests {
             .1;
         assert_eq!(first_document_insert_result.code, 0);
 
-        let second_document_insert_result = &state_transitions_block_2
-            .get(1)
-            .as_ref()
-            .expect("expected a document insert")
-            .1;
+        let second_document_insert_result = &state_transitions_block_2.get(1);
 
-        assert_eq!(second_document_insert_result.code, 4009); // we expect an error
+        // Second document should not be present
+        assert!(second_document_insert_result.is_none());
     }
 }

--- a/packages/rs-drive-abci/tests/strategy_tests/failures.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/failures.rs
@@ -78,6 +78,7 @@ mod tests {
             }),
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -162,6 +163,7 @@ mod tests {
             }),
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -362,6 +364,7 @@ mod tests {
             }),
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
 
         let mut core_block_heights = vec![10, 11];

--- a/packages/rs-drive-abci/tests/strategy_tests/main.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/main.rs
@@ -3066,6 +3066,7 @@ mod tests {
         assert!(last_identity_balance > 100000000000u64);
     }
 
+    // Test should filter out transactions exceeding max tx bytes per block
     #[test]
     fn run_transactions_exceeding_max_block_size() {
         let strategy = NetworkStrategy {

--- a/packages/rs-drive-abci/tests/strategy_tests/main.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/main.rs
@@ -141,6 +141,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: false,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -196,6 +197,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: false,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -251,6 +253,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: false,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -392,6 +395,7 @@ mod tests {
             }),
             query_testing: None,
             verify_state_transition_results: false,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -528,6 +532,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -596,6 +601,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -651,6 +657,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let hour_in_ms = 1000 * 60 * 60;
         let config = PlatformConfig {
@@ -713,6 +720,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let hour_in_s = 60 * 60;
         let three_mins_in_ms = 1000 * 60 * 3;
@@ -780,6 +788,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 10,
@@ -869,6 +878,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 10,
@@ -943,6 +953,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 10,
@@ -1012,6 +1023,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 10,
@@ -1111,6 +1123,7 @@ mod tests {
                 },
             }),
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -1167,6 +1180,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let day_in_ms = 1000 * 60 * 60 * 24;
         let config = PlatformConfig {
@@ -1251,6 +1265,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -1362,6 +1377,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -1468,6 +1484,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -1550,6 +1567,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let day_in_ms = 1000 * 60 * 60 * 24;
         let config = PlatformConfig {
@@ -1660,6 +1678,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let day_in_ms = 1000 * 60 * 60 * 24;
         let config = PlatformConfig {
@@ -1770,6 +1789,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let day_in_ms = 1000 * 60 * 60 * 24;
         let config = PlatformConfig {
@@ -1894,6 +1914,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
 
         let day_in_ms = 1000 * 60 * 60 * 24;
@@ -2024,6 +2045,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
 
         let day_in_ms = 1000 * 60 * 60 * 24;
@@ -2099,6 +2121,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -2182,6 +2205,7 @@ mod tests {
             // because we can add an identity and add keys to it in the same block
             // the result would be different then expected
             verify_state_transition_results: false,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -2270,6 +2294,7 @@ mod tests {
             // because we can add an identity and remove keys to it in the same block
             // the result would be different then expected
             verify_state_transition_results: false,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -2365,6 +2390,7 @@ mod tests {
             // because we can add an identity and withdraw from it in the same block
             // the result would be different then expected
             verify_state_transition_results: false,
+            ..Default::default()
         };
         let config = PlatformConfig {
             quorum_size: 100,
@@ -2423,6 +2449,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: false,
+            ..Default::default()
         };
         let day_in_ms = 1000 * 60 * 60 * 24;
         let config = PlatformConfig {
@@ -2579,6 +2606,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: false,
+            ..Default::default()
         };
         let day_in_ms = 1000 * 60 * 60 * 24;
         let config = PlatformConfig {
@@ -2706,6 +2734,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: false,
+            ..Default::default()
         };
         let day_in_ms = 1000 * 60 * 60 * 24;
         let config = PlatformConfig {
@@ -2833,6 +2862,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: false,
+            ..Default::default()
         };
         let day_in_ms = 1000 * 60 * 60 * 24;
         let config = PlatformConfig {
@@ -2974,6 +3004,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
 
         let config = PlatformConfig {

--- a/packages/rs-drive-abci/tests/strategy_tests/query.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/query.rs
@@ -415,6 +415,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let hour_in_ms = 1000 * 60 * 60;
         let config = PlatformConfig {
@@ -525,6 +526,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let hour_in_ms = 1000 * 60 * 60;
         let config = PlatformConfig {
@@ -636,6 +638,7 @@ mod tests {
             failure_testing: None,
             query_testing: None,
             verify_state_transition_results: true,
+            ..Default::default()
         };
         let hour_in_ms = 1000 * 60 * 60;
         let config = PlatformConfig {

--- a/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
@@ -167,6 +167,29 @@ pub struct NetworkStrategy {
     pub failure_testing: Option<FailureStrategy>,
     pub query_testing: Option<QueryStrategy>,
     pub verify_state_transition_results: bool,
+    pub max_tx_bytes_per_block: i64,
+}
+
+impl Default for NetworkStrategy {
+    fn default() -> Self {
+        NetworkStrategy {
+            strategy: Default::default(),
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            quorum_count: 24,
+            upgrading_info: None,
+            core_height_increase: Frequency {
+                times_per_block_range: Default::default(),
+                chance_per_block: None,
+            },
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: false,
+            max_tx_bytes_per_block: 44800,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/packages/rs-drive-abci/tests/strategy_tests/upgrade_fork_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/upgrade_fork_tests.rs
@@ -58,6 +58,7 @@ mod tests {
                     failure_testing: None,
                     query_testing: None,
                     verify_state_transition_results: false,
+                    ..Default::default()
                 };
                 let twenty_minutes_in_ms = 1000 * 60 * 20;
                 let mut config = PlatformConfig {
@@ -326,6 +327,7 @@ mod tests {
                     failure_testing: None,
                     query_testing: None,
                     verify_state_transition_results: false,
+                    ..Default::default()
                 };
                 let one_hour_in_s = 60 * 60;
                 let thirty_seconds_in_ms = 1000 * 30;
@@ -587,6 +589,7 @@ mod tests {
                     failure_testing: None,
                     query_testing: None,
                     verify_state_transition_results: false,
+                    ..Default::default()
                 };
                 let hour_in_ms = 1000 * 60 * 60;
                 let config = PlatformConfig {
@@ -847,6 +850,7 @@ mod tests {
                     failure_testing: None,
                     query_testing: None,
                     verify_state_transition_results: false,
+                    ..Default::default()
                 };
                 let hour_in_ms = 1000 * 60 * 60;
                 let mut config = PlatformConfig {
@@ -1027,6 +1031,7 @@ mod tests {
                     failure_testing: None,
                     query_testing: None,
                     verify_state_transition_results: false,
+                    ..Default::default()
                 };
 
                 let block_start = platform
@@ -1211,6 +1216,7 @@ mod tests {
                     failure_testing: None,
                     query_testing: None,
                     verify_state_transition_results: false,
+                    ..Default::default()
                 };
                 let hour_in_ms = 1000 * 60 * 60;
                 let config = PlatformConfig {
@@ -1322,6 +1328,7 @@ mod tests {
                     failure_testing: None,
                     query_testing: None,
                     verify_state_transition_results: false,
+                    ..Default::default()
                 };
 
                 // we hit the required threshold to upgrade

--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -97,6 +97,18 @@ pub struct Strategy {
     pub signer: Option<SimpleSigner>,
 }
 
+impl Default for Strategy {
+    fn default() -> Self {
+        Strategy {
+            contracts_with_updates: vec![],
+            operations: vec![],
+            start_identities: vec![],
+            identities_inserts: Frequency::default(),
+            signer: None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Encode, Decode)]
 struct StrategyInSerializationFormat {
     pub contracts_with_updates: Vec<(Vec<u8>, Option<BTreeMap<u64, Vec<u8>>>)>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PR changes `prepare_proposal` logic in `rs-drive-abci` related to transactions related response:
- If amount of transactions exceeded `max_tx_bytes` setting, they never get executed but remain in `tx_records` vector
- If some of the transactions are failed during the execution, they remain in `tx_records`, but not added to `tx_results`

## What was done?
<!--- Describe your changes in detail -->
- Updated `prepare_proposal` logic
- Refactored `NetworkStrategy` and `Strategy` structs in strategy tests to support default value
- Added strategy test to cover max block size excession case
- Updated existing strategy test covering failure scenario for one of the state transitions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
