### PR TITLE
fix: broadcasting already invalidated transitions

### DIFF
--- a/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
+++ b/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
@@ -320,7 +320,7 @@ cache-size = 10000
 # Do not remove invalid transactions from the cache (default: false)
 # Set to true if it's not possible for any invalid transaction to become valid
 # again in the future.
-keep-invalid-txs-in-cache = false
+keep-invalid-txs-in-cache = true
 
 # Maximum size of a single transaction.
 # NOTE: the max size of a tx transmitted over the network is {max-tx-bytes}.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are always few transaction that was already included in a bock before and marked as invalid apperaing on other nodes after that block was finaized means they won't be removed. With a big network the number of such ghost invalid transactions in growing and ping ponging between nodes. We shouldn't allow to broadcast already invaidated txs

## What was done?
<!--- Describe your changes in detail -->
- Enable cache for invaid txs to prevent propagain of them

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We had this setting on a month ago and we didn't notice any ghost transactions

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
