### PR TITLE
chore(dashmate)!: adjust consensus params and enable re-check

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -230,16 +230,33 @@ export default function getBaseConfigFactory(homeDir) {
             genesis: {
               consensus_params: {
                 block: {
-                  max_bytes: '22020096', max_gas: '-1', time_iota_ms: '5000',
+                  max_bytes: '2097152', max_gas: '57631392000', time_iota_ms: '5000',
                 },
                 evidence: {
-                  max_age: '100000', max_age_num_blocks: '100000', max_age_duration: '172800000000000',
+                  max_age: '100000',
+                  max_age_num_blocks: '100000',
+                  max_age_duration: '172800000000000',
                 },
                 validator: {
                   pub_key_types: ['bls12381'],
                 },
                 version: {
                   app_version: '1',
+                },
+                timeout: {
+                  propose: '30000000000',
+                  propose_delta: '1000000000',
+                  vote: '2000000000',
+                  vote_delta: '500000000',
+                  commit: '1000000000',
+                  bypass_commit_timeout: false,
+                },
+                synchrony: {
+                  message_delay: '32000000000',
+                  precision: '500000000',
+                },
+                abci: {
+                  recheck_tx: true,
                 },
               },
             },

--- a/packages/dashmate/configs/defaults/getTestnetConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getTestnetConfigFactory.js
@@ -82,35 +82,6 @@ export default function getTestnetConfigFactory(homeDir, getBaseConfig) {
             genesis: {
               genesis_time: '2023-11-02T10:18:00.000Z',
               chain_id: 'dash-testnet-37',
-              initial_core_chain_locked_height: 918609,
-              consensus_params: {
-                timeout: {
-                  propose: '50000000000',
-                  propose_delta: '10000000000',
-                  vote: '500000000',
-                  vote_delta: '100000000',
-                  commit: '1000000000',
-                  bypass_commit_timeout: false,
-                },
-                block: {
-                  max_bytes: '22020096',
-                  max_gas: '-1',
-                  time_iota_ms: '5000',
-                },
-                evidence: {
-                  max_age: '100000',
-                  max_age_num_blocks: '100000',
-                  max_age_duration: '172800000000000',
-                },
-                validator: {
-                  pub_key_types: [
-                    'bls12381',
-                  ],
-                },
-                version: {
-                  app_version: '1',
-                },
-              },
               validator_quorum_type: 6,
             },
           },

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -406,6 +406,16 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
 
         return configFile;
       },
+      '1.0.0-dev.2': (configFile) => {
+        Object.entries(configFile.configs)
+          .forEach(([name, options]) => {
+            if (defaultConfigs.has(name)) {
+              options.platform.drive.tenderdash.genesis = defaultConfigs.get(name).get('options.platform.drive.tenderdash.genesis');
+            }
+          });
+
+        return configFile;
+      },
     };
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We use default consensus timeouts for local and 0.24-based values for testnet. Re-check is not set so it's initializing as false. We have already more or less tested values and we need re-check to clean up mempool from unpaid invalid txs

## What was done?
<!--- Describe your changes in detail -->
- set consensus timeouts
- adjust some other values
- enable re-check

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On devnet and locally by @lklimek 

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
It will be a breaking change for any network since genesis params are changed

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
