### PR TITLE
fix(dapi): internal errors if broadcasting failed

### DIFF
--- a/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -4,6 +4,7 @@ const {
       InvalidArgumentGrpcError,
       AlreadyExistsGrpcError,
       ResourceExhaustedGrpcError,
+      UnavailableGrpcError,
     },
   },
 } = require('@dashevo/grpc-common');
@@ -44,7 +45,11 @@ function broadcastStateTransitionHandlerFactory(rpcClient, createGrpcErrorFromDr
     try {
       response = await rpcClient.request('broadcast_tx_sync', { tx });
     } catch (e) {
-      logger.error(e, 'Failed broadcasting state transition');
+      if (e.message === 'socket hang up') {
+        throw new UnavailableGrpcError('Tenderdash is not available');
+      }
+
+      logger.error(`Failed broadcasting state transition: ${e}`);
 
       throw e;
     }

--- a/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -70,6 +70,10 @@ function broadcastStateTransitionHandlerFactory(rpcClient, createGrpcErrorFromDr
         if (jsonRpcError.data.startsWith('mempool is full')) {
           throw new ResourceExhaustedGrpcError(jsonRpcError.data);
         }
+
+        if (jsonRpcError.data.startsWith('broadcast confirmation not received:')) {
+          throw new UnavailableGrpcError(jsonRpcError.data);
+        }
       }
 
       const error = new Error();

--- a/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -45,11 +45,11 @@ function broadcastStateTransitionHandlerFactory(rpcClient, createGrpcErrorFromDr
     try {
       response = await rpcClient.request('broadcast_tx_sync', { tx });
     } catch (e) {
+      logger.error(`Failed broadcasting state transition: ${e}`);
+
       if (e.message === 'socket hang up') {
         throw new UnavailableGrpcError('Tenderdash is not available');
       }
-
-      logger.error(`Failed broadcasting state transition: ${e}`);
 
       throw e;
     }
@@ -72,6 +72,8 @@ function broadcastStateTransitionHandlerFactory(rpcClient, createGrpcErrorFromDr
         }
 
         if (jsonRpcError.data.startsWith('broadcast confirmation not received:')) {
+          logger.error(`Failed broadcasting state transition: ${jsonRpcError.data}`);
+
           throw new UnavailableGrpcError(jsonRpcError.data);
         }
       }
@@ -79,7 +81,7 @@ function broadcastStateTransitionHandlerFactory(rpcClient, createGrpcErrorFromDr
       const error = new Error();
       Object.assign(error, jsonRpcError);
 
-      logger.error(error, 'Unexpected JSON RPC error during broadcasting state transition');
+      logger.error(error, `Unexpected JSON RPC error during broadcasting state transition: ${JSON.stringify(jsonRpcError)}`);
 
       throw error;
     }

--- a/packages/dapi/test/unit/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.spec.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.spec.js
@@ -3,6 +3,7 @@ const {
     error: {
       InvalidArgumentGrpcError,
       AlreadyExistsGrpcError,
+      UnavailableGrpcError,
     },
   },
 } = require('@dashevo/grpc-common');
@@ -113,6 +114,20 @@ describe('broadcastStateTransitionHandlerFactory', () => {
 
     expect(result).to.be.an.instanceOf(BroadcastStateTransitionResponse);
     expect(rpcClientMock.request).to.be.calledOnceWith('broadcast_tx_sync', { tx });
+  });
+
+  it('should throw a unavailable error if tenderdash hands up', async () => {
+    const error = new Error('socket hang up');
+    rpcClientMock.request.throws(error);
+
+    try {
+      await broadcastStateTransitionHandler(call);
+
+      expect.fail('should throw UnavailableGrpcError');
+    } catch (e) {
+      expect(e).to.be.an.instanceOf(UnavailableGrpcError);
+      expect(e.getMessage()).to.equal('Tenderdash is not available');
+    }
   });
 
   it('should throw an error if transaction broadcast returns error', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When Tenderdash under heavy load DAPI fails to connect to it to broadcast a state transition and fails with the `socket hang up` error. We also need to handle a new check tx timeout introduced in tenderdash.

## What was done?
<!--- Describe your changes in detail -->
- handle the `socket hang up` error and return the unavailable error code.
- handle `broadcast confirmation not received` error
- update tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
