### PR TITLE
feat(sdk): fetch with metadata

### DIFF
--- a/packages/rs-drive-proof-verifier/src/proof.rs
+++ b/packages/rs-drive-proof-verifier/src/proof.rs
@@ -10,7 +10,7 @@ use dapi_grpc::platform::v0::{
     get_identity_contract_nonce_request, get_identity_keys_request, get_identity_nonce_request,
     get_identity_request, GetProtocolVersionUpgradeStateRequest,
     GetProtocolVersionUpgradeStateResponse, GetProtocolVersionUpgradeVoteStatusRequest,
-    GetProtocolVersionUpgradeVoteStatusResponse,
+    GetProtocolVersionUpgradeVoteStatusResponse, ResponseMetadata,
 };
 use dapi_grpc::platform::{
     v0::{self as platform, key_request_type, KeyRequestType as GrpcKeyType},
@@ -58,6 +58,7 @@ pub trait FromProof<Req> {
     type Request;
     /// Response type for which this trait is implemented.
     type Response;
+
     /// Parse and verify the received proof and retrieve the requested object, if any.
     ///
     /// # Arguments
@@ -68,7 +69,7 @@ pub trait FromProof<Req> {
     ///
     /// # Returns
     ///
-    /// * `Ok(Some(object))` when the requested object was found in the proof.
+    /// * `Ok(Some(object, metadata))` when the requested object was found in the proof.
     /// * `Ok(None)` when the requested object was not found in the proof; this can be interpreted as proof of non-existence.
     /// For collections, returns Ok(None) if none of the requested objects were found.
     /// * `Err(Error)` when either the provided data is invalid or proof validation failed.
@@ -78,6 +79,33 @@ pub trait FromProof<Req> {
         platform_version: &PlatformVersion,
         provider: &'a dyn ContextProvider,
     ) -> Result<Option<Self>, Error>
+    where
+        Self: Sized + 'a,
+    {
+        Self::maybe_from_proof_with_metadata(request, response, platform_version, provider)
+            .map(|maybe_result| maybe_result.0)
+    }
+
+    /// Parse and verify the received proof and retrieve the requested object, if any.
+    ///
+    /// # Arguments
+    ///
+    /// * `request`: The request sent to the server.
+    /// * `response`: The response received from the server.
+    /// * `provider`: A callback implementing [ContextProvider] that provides quorum details required to verify the proof.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some((object, metadata)))` when the requested object was found in the proof.
+    /// * `Ok(None)` when the requested object was not found in the proof; this can be interpreted as proof of non-existence.
+    /// For collections, returns Ok(None) if none of the requested objects were found.
+    /// * `Err(Error)` when either the provided data is invalid or proof validation failed.
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+        request: I,
+        response: O,
+        platform_version: &PlatformVersion,
+        provider: &'a dyn ContextProvider,
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         Self: Sized + 'a;
 
@@ -117,12 +145,12 @@ impl FromProof<platform::GetIdentityRequest> for Identity {
     type Request = platform::GetIdentityRequest;
     type Response = platform::GetIdentityResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         Identity: Sized + 'a,
     {
@@ -155,7 +183,7 @@ impl FromProof<platform::GetIdentityRequest> for Identity {
 
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
-        Ok(maybe_identity)
+        Ok((maybe_identity, mtd.clone()))
     }
 }
 
@@ -164,13 +192,13 @@ impl FromProof<platform::GetIdentityByPublicKeyHashRequest> for Identity {
     type Request = platform::GetIdentityByPublicKeyHashRequest;
     type Response = platform::GetIdentityByPublicKeyHashResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
 
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         Identity: 'a,
     {
@@ -205,7 +233,7 @@ impl FromProof<platform::GetIdentityByPublicKeyHashRequest> for Identity {
 
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
-        Ok(maybe_identity)
+        Ok((maybe_identity, mtd.clone()))
     }
 }
 
@@ -213,13 +241,13 @@ impl FromProof<platform::GetIdentityKeysRequest> for IdentityPublicKeys {
     type Request = platform::GetIdentityKeysRequest;
     type Response = platform::GetIdentityKeysResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
 
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         IdentityPublicKeys: 'a,
     {
@@ -316,7 +344,7 @@ impl FromProof<platform::GetIdentityKeysRequest> for IdentityPublicKeys {
 
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
-        Ok(maybe_keys)
+        Ok((maybe_keys, mtd.clone()))
     }
 }
 
@@ -380,13 +408,13 @@ impl FromProof<platform::GetIdentityNonceRequest> for IdentityNonceFetcher {
     type Request = platform::GetIdentityNonceRequest;
     type Response = platform::GetIdentityNonceResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
 
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         IdentityNonceFetcher: 'a,
     {
@@ -421,7 +449,7 @@ impl FromProof<platform::GetIdentityNonceRequest> for IdentityNonceFetcher {
 
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
-        Ok(maybe_nonce.map(types::IdentityNonceFetcher))
+        Ok((maybe_nonce.map(types::IdentityNonceFetcher), mtd.clone()))
     }
 }
 
@@ -429,13 +457,13 @@ impl FromProof<platform::GetIdentityContractNonceRequest> for IdentityContractNo
     type Request = platform::GetIdentityContractNonceRequest;
     type Response = platform::GetIdentityContractNonceResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
 
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         IdentityContractNonceFetcher: 'a,
     {
@@ -474,7 +502,10 @@ impl FromProof<platform::GetIdentityContractNonceRequest> for IdentityContractNo
 
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
-        Ok(maybe_identity.map(types::IdentityContractNonceFetcher))
+        Ok((
+            maybe_identity.map(types::IdentityContractNonceFetcher),
+            mtd.clone(),
+        ))
     }
 }
 
@@ -482,13 +513,13 @@ impl FromProof<platform::GetIdentityBalanceRequest> for IdentityBalance {
     type Request = platform::GetIdentityBalanceRequest;
     type Response = platform::GetIdentityBalanceResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
 
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         IdentityBalance: 'a,
     {
@@ -520,7 +551,7 @@ impl FromProof<platform::GetIdentityBalanceRequest> for IdentityBalance {
 
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
-        Ok(maybe_identity)
+        Ok((maybe_identity, mtd.clone()))
     }
 }
 
@@ -528,13 +559,13 @@ impl FromProof<platform::GetIdentityBalanceAndRevisionRequest> for IdentityBalan
     type Request = platform::GetIdentityBalanceAndRevisionRequest;
     type Response = platform::GetIdentityBalanceAndRevisionResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         _platform_version: &PlatformVersion,
 
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         IdentityBalanceAndRevision: 'a,
     {
@@ -567,7 +598,7 @@ impl FromProof<platform::GetIdentityBalanceAndRevisionRequest> for IdentityBalan
 
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
-        Ok(maybe_identity)
+        Ok((maybe_identity, mtd.clone()))
     }
 }
 
@@ -575,13 +606,13 @@ impl FromProof<platform::GetDataContractRequest> for DataContract {
     type Request = platform::GetDataContractRequest;
     type Response = platform::GetDataContractResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
 
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         DataContract: 'a,
     {
@@ -616,7 +647,7 @@ impl FromProof<platform::GetDataContractRequest> for DataContract {
 
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
-        Ok(maybe_contract)
+        Ok((maybe_contract, mtd.clone()))
     }
 }
 
@@ -624,13 +655,13 @@ impl FromProof<platform::GetDataContractsRequest> for DataContracts {
     type Request = platform::GetDataContractsRequest;
     type Response = platform::GetDataContractsResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
 
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         DataContracts: 'a,
     {
@@ -689,7 +720,7 @@ impl FromProof<platform::GetDataContractsRequest> for DataContracts {
                 None
             };
 
-        Ok(maybe_contracts)
+        Ok((maybe_contracts, mtd.clone()))
     }
 }
 
@@ -697,13 +728,13 @@ impl FromProof<platform::GetDataContractHistoryRequest> for DataContractHistory 
     type Request = platform::GetDataContractHistoryRequest;
     type Response = platform::GetDataContractHistoryResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
 
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         Self: Sized + 'a,
     {
@@ -742,7 +773,7 @@ impl FromProof<platform::GetDataContractHistoryRequest> for DataContractHistory 
 
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
-        Ok(maybe_history)
+        Ok((maybe_history, mtd.clone()))
     }
 }
 
@@ -750,12 +781,12 @@ impl FromProof<platform::BroadcastStateTransitionRequest> for StateTransitionPro
     type Request = platform::BroadcastStateTransitionRequest;
     type Response = platform::WaitForStateTransitionResultResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         Self: Sized + 'a,
     {
@@ -791,7 +822,7 @@ impl FromProof<platform::BroadcastStateTransitionRequest> for StateTransitionPro
 
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
-        Ok(Some(result))
+        Ok((Some(result), mtd.clone()))
     }
 }
 
@@ -799,28 +830,32 @@ impl FromProof<platform::GetEpochsInfoRequest> for ExtendedEpochInfo {
     type Request = platform::GetEpochsInfoRequest;
     type Response = platform::GetEpochsInfoResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         Self: Sized + 'a,
     {
-        let epochs =
-            ExtendedEpochInfos::maybe_from_proof(request, response, platform_version, provider)?;
+        let epochs = ExtendedEpochInfos::maybe_from_proof_with_metadata(
+            request,
+            response,
+            platform_version,
+            provider,
+        )?;
 
-        if let Some(mut e) = epochs {
+        if let Some(mut e) = epochs.0 {
             if e.len() != 1 {
                 return Err(Error::RequestDecodeError {
                     error: format!("expected 1 epoch, got {}", e.len()),
                 });
             }
             let epoch = e.pop_first().and_then(|v| v.1);
-            Ok(epoch)
+            Ok((epoch, epochs.1))
         } else {
-            Ok(None)
+            Ok((None, epochs.1))
         }
     }
 }
@@ -829,12 +864,12 @@ impl FromProof<platform::GetEpochsInfoRequest> for ExtendedEpochInfos {
     type Request = platform::GetEpochsInfoRequest;
     type Response = platform::GetEpochsInfoResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         Self: Sized + 'a,
     {
@@ -889,7 +924,7 @@ impl FromProof<platform::GetEpochsInfoRequest> for ExtendedEpochInfos {
             None
         };
 
-        Ok(maybe_epoch_info)
+        Ok((maybe_epoch_info, mtd.clone()))
     }
 }
 
@@ -904,12 +939,12 @@ impl FromProof<GetProtocolVersionUpgradeStateRequest> for ProtocolVersionUpgrade
     type Request = GetProtocolVersionUpgradeStateRequest;
     type Response = GetProtocolVersionUpgradeStateResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         _request: I,
         response: O,
         platform_version: &PlatformVersion,
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         Self: Sized + 'a,
     {
@@ -924,11 +959,12 @@ impl FromProof<GetProtocolVersionUpgradeStateRequest> for ProtocolVersionUpgrade
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
         if object.is_empty() {
-            return Ok(None);
+            return Ok((None, mtd.clone()));
         }
 
-        Ok(Some(
-            object.into_iter().map(|(k, v)| (k, Some(v))).collect(),
+        Ok((
+            Some(object.into_iter().map(|(k, v)| (k, Some(v))).collect()),
+            mtd.clone(),
         ))
     }
 }
@@ -937,12 +973,12 @@ impl FromProof<GetProtocolVersionUpgradeVoteStatusRequest> for MasternodeProtoco
     type Request = GetProtocolVersionUpgradeVoteStatusRequest;
     type Response = GetProtocolVersionUpgradeVoteStatusResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         Self: Sized + 'a,
     {
@@ -978,7 +1014,7 @@ impl FromProof<GetProtocolVersionUpgradeVoteStatusRequest> for MasternodeProtoco
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
         if objects.is_empty() {
-            return Ok(None);
+            return Ok((None, mtd.clone()));
         }
         let votes: MasternodeProtocolVotes = objects
             .into_iter()
@@ -999,7 +1035,7 @@ impl FromProof<GetProtocolVersionUpgradeVoteStatusRequest> for MasternodeProtoco
             })
             .collect::<Result<MasternodeProtocolVotes, Error>>()?;
 
-        Ok(Some(votes))
+        Ok((Some(votes), mtd.clone()))
     }
 }
 // #[cfg_attr(feature = "mocks", mockall::automock)]
@@ -1011,13 +1047,13 @@ where
     type Request = Q;
     type Response = platform::GetDocumentsResponse;
 
-    fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
         request: I,
         response: O,
         platform_version: &PlatformVersion,
 
         provider: &'a dyn ContextProvider,
-    ) -> Result<Option<Self>, Error>
+    ) -> Result<(Option<Self>, ResponseMetadata), Error>
     where
         Self: 'a,
     {
@@ -1050,9 +1086,9 @@ where
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
         if documents.is_empty() {
-            Ok(None)
+            Ok((None, mtd.clone()))
         } else {
-            Ok(Some(documents))
+            Ok((Some(documents), mtd.clone()))
         }
     }
 }

--- a/packages/rs-sdk/src/platform/delegate.rs
+++ b/packages/rs-sdk/src/platform/delegate.rs
@@ -78,12 +78,12 @@ macro_rules! delegate_from_proof_variant {
             type Request = $request;
             type Response = $response;
 
-            fn maybe_from_proof<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+            fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
                 request: I,
                 response: O,
                 version: &dpp::version::PlatformVersion,
                 provider: &'a dyn drive_proof_verifier::ContextProvider,
-            ) -> Result<Option<Self>, drive_proof_verifier::Error>
+            ) -> Result<(Option<Self>, ResponseMetadata), drive_proof_verifier::Error>
             where
                 Self: Sized + 'a,
             {
@@ -96,7 +96,7 @@ macro_rules! delegate_from_proof_variant {
                 match request {$(
                     req::$variant(request) => {
                         if let resp::$variant(response) = response {
-                            <Self as drive_proof_verifier::FromProof<$req>>::maybe_from_proof(
+                            <Self as drive_proof_verifier::FromProof<$req>>::maybe_from_proof_with_metadata(
                                 request, response, version, provider,
                             )
                         } else {
@@ -115,6 +115,7 @@ macro_rules! delegate_from_proof_variant {
         }
     };
 }
+
 #[macro_export]
 /// Define enums that will wrap multiple requests/responses for one object.
 ///

--- a/packages/rs-sdk/src/platform/fetch.rs
+++ b/packages/rs-sdk/src/platform/fetch.rs
@@ -9,8 +9,9 @@
 //!   traits. The associated [Fetch::Request]` type needs to implement [TransportRequest].
 
 use crate::mock::MockResponse;
+use crate::platform::query;
 use crate::{error::Error, platform::query::Query, Sdk};
-use dapi_grpc::platform::v0::{self as platform_proto};
+use dapi_grpc::platform::v0::{self as platform_proto, ResponseMetadata};
 use dpp::block::extended_epoch_info::ExtendedEpochInfo;
 use dpp::platform_value::Identifier;
 use dpp::{document::Document, prelude::Identity};
@@ -85,21 +86,50 @@ where
         sdk: &Sdk,
         query: Q,
     ) -> Result<Option<Self>, Error> {
+        Self::fetch_with_settings(sdk, query, RequestSettings::default()).await
+    }
+
+    /// Fetch single object from the Platfom.
+    ///
+    /// Fetch object from the platform that satisfies provided [Query].
+    /// Most often, the Query is an [Identifier] of the object to be fetched.
+    ///
+    /// ## Parameters
+    ///
+    /// - `sdk`: An instance of [Sdk].
+    /// - `query`: A query parameter implementing [`crate::platform::query::Query`] to specify the data to be fetched.
+    ///
+    /// ## Returns
+    ///
+    /// Returns:
+    /// * `Ok(Some(Self))` when object is found
+    /// * `Ok(None)` when object is not found
+    /// * [`Err(Error)`](Error) when an error occurs
+    ///
+    /// ## Error Handling
+    ///
+    /// Any errors encountered during the execution are returned as [Error] instances.
+    async fn fetch_with_metadata<Q: Query<<Self as Fetch>::Request>>(
+        sdk: &Sdk,
+        query: Q,
+        settings: Option<RequestSettings>,
+    ) -> Result<(Option<Self>, ResponseMetadata), Error> {
         let request = query.query(sdk.prove())?;
 
         let response = request
             .clone()
-            .execute(sdk, RequestSettings::default())
+            .execute(sdk, settings.unwrap_or_default())
             .await?;
 
         let object_type = std::any::type_name::<Self>().to_string();
         tracing::trace!(request = ?request, response = ?response, object_type, "fetched object from platform");
 
-        let object: Option<Self> = sdk.parse_proof(request, response)?;
+        let (object, response_metadata): (Option<Self>, ResponseMetadata) =
+            sdk.parse_proof_with_metadata(request, response)?;
 
         match object {
-            Some(item) => Ok(item.into()),
-            None => Ok(None),
+            Some(item) => Ok((item.into(), response_metadata)),
+            None => Ok((None, response_metadata)),
         }
     }
 

--- a/packages/rs-sdk/src/platform/types/identity.rs
+++ b/packages/rs-sdk/src/platform/types/identity.rs
@@ -11,7 +11,7 @@ use dapi_grpc::platform::v0::{
     get_identity_by_public_key_hash_request, get_identity_contract_nonce_request,
     get_identity_nonce_request, get_identity_request, GetIdentityBalanceAndRevisionRequest,
     GetIdentityBalanceRequest, GetIdentityByPublicKeyHashRequest, GetIdentityContractNonceRequest,
-    GetIdentityNonceRequest, GetIdentityRequest,
+    GetIdentityNonceRequest, GetIdentityRequest, ResponseMetadata,
 };
 use dpp::prelude::Identity;
 

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -16,7 +16,7 @@ use dapi_grpc::mock::Mockable;
 use dapi_grpc::platform::v0::get_identity_contract_nonce_request::GetIdentityContractNonceRequestV0;
 use dapi_grpc::platform::v0::get_identity_contract_nonce_response::Version;
 use dapi_grpc::platform::v0::{
-    GetIdentityContractNonceRequest, GetIdentityContractNonceResponse, Proof,
+    GetIdentityContractNonceRequest, GetIdentityContractNonceResponse, Proof, ResponseMetadata,
 };
 use dpp::identity::identity_nonce::IDENTITY_NONCE_VALUE_FILTER;
 use dpp::prelude;
@@ -174,6 +174,26 @@ impl Sdk {
     where
         O::Request: Mockable,
     {
+        self.parse_proof_with_metadata(request, response)
+            .map(|result| result.0)
+    }
+
+    /// Retrieve object `O` from proof contained in `request` (of type `R`) and `response`.
+    ///
+    /// This method is used to retrieve objects from proofs returned by Dash Platform.
+    ///
+    /// ## Generic Parameters
+    ///
+    /// - `R`: Type of the request that was used to fetch the proof.
+    /// - `O`: Type of the object to be retrieved from the proof.
+    pub(crate) fn parse_proof_with_metadata<R, O: FromProof<R> + MockResponse>(
+        &self,
+        request: O::Request,
+        response: O::Response,
+    ) -> Result<(Option<O>, ResponseMetadata), drive_proof_verifier::Error>
+    where
+        O::Request: Mockable,
+    {
         let guard = self
             .context_provider
             .lock()
@@ -184,10 +204,10 @@ impl Sdk {
 
         match self.inner {
             SdkInstance::Dapi { .. } => {
-                O::maybe_from_proof(request, response, self.version(), &provider)
+                O::maybe_from_proof_with_metadata(request, response, self.version(), &provider)
             }
             #[cfg(feature = "mocks")]
-            SdkInstance::Mock { .. } => self.mock().parse_proof(request, response),
+            SdkInstance::Mock { .. } => self.mock().parse_proof_with_metadata(request, response),
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
When fetching through the SDK there was no way to get information about platform that exists in the response metadata such as block height.

## What was done?
Added a method fetch_with_metadata that also returns response metadata.

## How Has This Been Tested?
Ran tests


## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [X] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
