### PR TITLE
refactor: reduce cargo clippy warnings

### DIFF
--- a/packages/rs-drive/src/drive/batch/transitions/mod.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/mod.rs
@@ -8,7 +8,6 @@ mod document;
 mod identity;
 mod system;
 
-use crate::drive::batch::transitions::document::DriveHighLevelDocumentOperationConverter;
 use crate::drive::batch::DriveOperation;
 use crate::error::Error;
 use crate::state_transition_action::StateTransitionAction;

--- a/packages/rs-drive/src/drive/contract/contract_fetch_info.rs
+++ b/packages/rs-drive/src/drive/contract/contract_fetch_info.rs
@@ -2,7 +2,6 @@ use crate::drive::flags::StorageFlags;
 use dpp::data_contract::DataContract;
 use dpp::data_contracts;
 use dpp::fee::fee_result::FeeResult;
-use dpp::prelude::IdentityNonce;
 use dpp::system_data_contracts::load_system_data_contract;
 #[cfg(feature = "fixtures-and-mocks")]
 use dpp::tests::fixtures::get_dashpay_contract_fixture;

--- a/packages/rs-drive/src/drive/contract/prove/prove_contract/v0/mod.rs
+++ b/packages/rs-drive/src/drive/contract/prove/prove_contract/v0/mod.rs
@@ -1,7 +1,7 @@
 use crate::drive::Drive;
 use crate::error::Error;
 
-use crate::drive::contract::paths::{contract_root_path, contract_root_path_vec};
+use crate::drive::contract::paths::contract_root_path;
 use dpp::version::PlatformVersion;
 use grovedb::TransactionArg;
 

--- a/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/fetch_identity_contract_nonce/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/fetch_identity_contract_nonce/v0/mod.rs
@@ -7,7 +7,7 @@ use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 use dpp::block::block_info::BlockInfo;
 use dpp::fee::fee_result::FeeResult;
-use dpp::prelude::{IdentityNonce, Revision};
+use dpp::prelude::{IdentityNonce};
 
 use crate::drive::identity::contract_info::ContractInfoStructure::IdentityContractNonceKey;
 use dpp::version::PlatformVersion;

--- a/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/merge_identity_contract_nonce/mod.rs
+++ b/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/merge_identity_contract_nonce/mod.rs
@@ -1,6 +1,6 @@
 use crate::drive::Drive;
 use crate::error::drive::DriveError;
-use crate::error::identity::IdentityError;
+
 use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 use dpp::block::block_info::BlockInfo;

--- a/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/merge_identity_contract_nonce/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/merge_identity_contract_nonce/v0/mod.rs
@@ -6,7 +6,7 @@ use crate::drive::object_size_info::{PathKeyElementInfo, PathKeyInfo};
 use crate::drive::Drive;
 use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
-use dpp::data_contract::accessors::v0::DataContractV0Getters;
+
 use dpp::version::PlatformVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{Element, EstimatedLayerInformation, TransactionArg};
@@ -17,7 +17,7 @@ use dpp::identity::identity_nonce::{IDENTITY_NONCE_VALUE_FILTER, IDENTITY_NONCE_
 use dpp::prelude::IdentityNonce;
 use crate::drive::identity::contract_info::identity_contract_nonce::merge_identity_contract_nonce::MergeIdentityNonceResult;
 use crate::drive::identity::contract_info::identity_contract_nonce::merge_identity_contract_nonce::MergeIdentityNonceResult::{MergeIdentityNonceSuccess, NonceAlreadyPresentAtTip, NonceAlreadyPresentInPast, NonceTooFarInFuture, NonceTooFarInPast};
-use crate::error::identity::IdentityError;
+
 
 impl Drive {
     pub(in crate::drive::identity::contract_info) fn merge_identity_contract_nonce_v0(
@@ -157,7 +157,7 @@ impl Drive {
             )?;
         }
 
-        let (existing_nonce, fees) = if previous_nonce_is_sure_to_not_exist {
+        let (existing_nonce, _fees) = if previous_nonce_is_sure_to_not_exist {
             (None, FeeResult::default())
         } else {
             self.fetch_identity_contract_nonce_with_fees(

--- a/packages/rs-drive/src/drive/identity/estimation_costs/for_identity_contract_info_group/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/estimation_costs/for_identity_contract_info_group/v0/mod.rs
@@ -3,7 +3,7 @@ use crate::drive::Drive;
 use grovedb::batch::KeyInfoPath;
 use grovedb::EstimatedLayerCount::ApproximateElements;
 use grovedb::EstimatedLayerInformation;
-use grovedb::EstimatedLayerSizes::{AllSubtrees, Mix};
+use grovedb::EstimatedLayerSizes::Mix;
 use grovedb::EstimatedSumTrees::NoSumTrees;
 use std::collections::HashMap;
 

--- a/packages/rs-drive/src/drive/identity/estimation_costs/for_identity_contract_info_group_keys/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/estimation_costs/for_identity_contract_info_group_keys/v0/mod.rs
@@ -1,6 +1,4 @@
-use crate::drive::identity::{
-    identity_contract_info_group_keys_path_vec, identity_contract_info_group_path_vec,
-};
+use crate::drive::identity::identity_contract_info_group_keys_path_vec;
 use crate::drive::Drive;
 use grovedb::batch::KeyInfoPath;
 use grovedb::EstimatedLayerCount::ApproximateElements;

--- a/packages/rs-drive/src/drive/identity/fetch/nonce/prove_identity_nonce/mod.rs
+++ b/packages/rs-drive/src/drive/identity/fetch/nonce/prove_identity_nonce/mod.rs
@@ -2,10 +2,6 @@ mod v0;
 
 use crate::drive::Drive;
 use crate::error::{drive::DriveError, Error};
-use crate::fee::op::LowLevelDriveOperation;
-use dpp::block::block_info::BlockInfo;
-use dpp::fee::fee_result::FeeResult;
-use dpp::prelude::IdentityNonce;
 
 use dpp::version::PlatformVersion;
 use grovedb::TransactionArg;

--- a/packages/rs-drive/src/drive/identity/fetch/queries/mod.rs
+++ b/packages/rs-drive/src/drive/identity/fetch/queries/mod.rs
@@ -7,7 +7,7 @@ use crate::error::Error;
 use crate::drive::identity::contract_info::ContractInfoStructure::IdentityContractNonceKey;
 use crate::drive::identity::IdentityRootStructure::{IdentityTreeNonce, IdentityTreeRevision};
 use crate::drive::identity::{
-    identity_contract_info_group_path, identity_contract_info_group_path_vec, identity_path_vec,
+    identity_contract_info_group_path_vec, identity_path_vec,
 };
 use crate::error::query::QuerySyntaxError;
 use grovedb::{PathQuery, Query, SizedQuery};

--- a/packages/rs-drive/src/drive/identity/update/methods/merge_identity_nonce/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/methods/merge_identity_nonce/v0/mod.rs
@@ -13,7 +13,6 @@ use dpp::prelude::IdentityNonce;
 use dpp::version::PlatformVersion;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
 
-use crate::drive::identity::update::methods::merge_identity_nonce::MergeIdentityContractNonceResultToResult;
 use dpp::identity::identity_nonce::MergeIdentityNonceResult;
 use std::collections::HashMap;
 

--- a/packages/rs-drive/src/drive/identity/update/operations/initialize_identity_nonce_operation/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/operations/initialize_identity_nonce_operation/v0/mod.rs
@@ -1,7 +1,7 @@
 use crate::drive::identity::{identity_path_vec, IdentityRootStructure};
 use crate::drive::Drive;
 use crate::fee::op::LowLevelDriveOperation;
-use dpp::prelude::{IdentityNonce, Revision};
+use dpp::prelude::IdentityNonce;
 use grovedb::Element;
 
 impl Drive {

--- a/packages/rs-drive/src/drive/identity/update/operations/merge_identity_nonce_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/operations/merge_identity_nonce_operations/v0/mod.rs
@@ -1,4 +1,4 @@
-use crate::drive::identity::{identity_path, identity_path_vec, IdentityRootStructure};
+use crate::drive::identity::identity_path;
 use crate::drive::Drive;
 
 use crate::error::Error;
@@ -13,7 +13,6 @@ use grovedb::{Element, EstimatedLayerInformation, TransactionArg};
 
 use crate::drive::identity::IdentityRootStructure::IdentityTreeNonce;
 use crate::drive::object_size_info::PathKeyElementInfo;
-use crate::error::identity::IdentityError;
 use dpp::block::block_info::BlockInfo;
 use dpp::identity::identity_nonce::MergeIdentityNonceResult::{
     MergeIdentityNonceSuccess, NonceAlreadyPresentAtTip, NonceAlreadyPresentInPast,
@@ -21,8 +20,7 @@ use dpp::identity::identity_nonce::MergeIdentityNonceResult::{
 };
 use dpp::identity::identity_nonce::{
     MergeIdentityNonceResult, IDENTITY_NONCE_VALUE_FILTER, IDENTITY_NONCE_VALUE_FILTER_MAX_BYTES,
-    MAX_MISSING_IDENTITY_REVISIONS, MISSING_IDENTITY_REVISIONS_FILTER,
-    MISSING_IDENTITY_REVISIONS_MAX_BYTES,
+    MISSING_IDENTITY_REVISIONS_FILTER, MISSING_IDENTITY_REVISIONS_MAX_BYTES,
 };
 use std::collections::HashMap;
 

--- a/packages/rs-drive/src/drive/verify/identity/verify_identity_keys_by_identity_id/v0/mod.rs
+++ b/packages/rs-drive/src/drive/verify/identity/verify_identity_keys_by_identity_id/v0/mod.rs
@@ -1,4 +1,4 @@
-use crate::drive::balances::{balance_path, balance_path_vec};
+use crate::drive::balances::balance_path;
 use crate::drive::identity::{identity_key_tree_path, identity_path_vec, IdentityRootStructure};
 use crate::drive::Drive;
 

--- a/packages/rs-drive/src/state_transition_action/document/documents_batch/document_transition/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/document/documents_batch/document_transition/mod.rs
@@ -42,7 +42,7 @@ impl DocumentTransitionAction {
             DocumentTransitionAction::CreateAction(d) => Some(d.base()),
             DocumentTransitionAction::DeleteAction(d) => Some(d.base()),
             DocumentTransitionAction::ReplaceAction(d) => Some(d.base()),
-            DocumentTransitionAction::BumpIdentityDataContractNonce(d) => None,
+            DocumentTransitionAction::BumpIdentityDataContractNonce(_) => None,
         }
     }
 
@@ -52,7 +52,7 @@ impl DocumentTransitionAction {
             DocumentTransitionAction::CreateAction(d) => Some(d.base_owned()),
             DocumentTransitionAction::DeleteAction(d) => Some(d.base_owned()),
             DocumentTransitionAction::ReplaceAction(d) => Some(d.base_owned()),
-            DocumentTransitionAction::BumpIdentityDataContractNonce(d) => None,
+            DocumentTransitionAction::BumpIdentityDataContractNonce(_) => None,
         }
     }
 }

--- a/packages/rs-drive/src/state_transition_action/identity/identity_credit_transfer/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_credit_transfer/mod.rs
@@ -7,7 +7,7 @@ use crate::state_transition_action::identity::identity_credit_transfer::v0::Iden
 use derive_more::From;
 use dpp::fee::Credits;
 use dpp::platform_value::Identifier;
-use dpp::prelude::{IdentityNonce, Revision};
+use dpp::prelude::IdentityNonce;
 
 /// action
 #[derive(Debug, Clone, From)]

--- a/packages/rs-drive/src/state_transition_action/identity/identity_credit_transfer/v0/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_credit_transfer/v0/mod.rs
@@ -2,7 +2,7 @@ mod transformer;
 
 use dpp::fee::Credits;
 use dpp::platform_value::Identifier;
-use dpp::prelude::{IdentityNonce, Revision};
+use dpp::prelude::IdentityNonce;
 use serde::{Deserialize, Serialize};
 
 /// action v0

--- a/packages/rs-drive/src/state_transition_action/identity/identity_credit_withdrawal/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_credit_withdrawal/mod.rs
@@ -8,7 +8,7 @@ use derive_more::From;
 use dpp::document::Document;
 
 use dpp::platform_value::Identifier;
-use dpp::prelude::{IdentityNonce, Revision};
+use dpp::prelude::IdentityNonce;
 
 /// action
 #[derive(Debug, Clone, From)]

--- a/packages/rs-drive/src/state_transition_action/identity/identity_credit_withdrawal/v0/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_credit_withdrawal/v0/mod.rs
@@ -2,7 +2,7 @@ mod transformer;
 
 use dpp::document::Document;
 use dpp::identifier::Identifier;
-use dpp::prelude::{IdentityNonce, Revision};
+use dpp::prelude::IdentityNonce;
 
 use serde::{Deserialize, Serialize};
 

--- a/packages/rs-drive/src/state_transition_action/system/bump_identity_data_contract_nonce_action/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/system/bump_identity_data_contract_nonce_action/mod.rs
@@ -1,5 +1,4 @@
 use derive_more::From;
-use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::platform_value::Identifier;
 
 use dpp::prelude::IdentityNonce;

--- a/packages/rs-drive/src/state_transition_action/system/bump_identity_data_contract_nonce_action/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/system/bump_identity_data_contract_nonce_action/transformer.rs
@@ -4,7 +4,7 @@ use dpp::ProtocolError;
 use dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
 use dpp::state_transition::documents_batch_transition::document_base_transition::DocumentBaseTransition;
 use crate::state_transition_action::contract::data_contract_update::DataContractUpdateTransitionAction;
-use crate::state_transition_action::document::documents_batch::document_transition::document_base_transition_action::{DocumentBaseTransitionAction, DocumentBaseTransitionActionV0};
+use crate::state_transition_action::document::documents_batch::document_transition::document_base_transition_action::DocumentBaseTransitionAction;
 use crate::state_transition_action::system::bump_identity_data_contract_nonce_action::{BumpIdentityDataContractNonceAction, BumpIdentityDataContractNonceActionV0};
 
 impl BumpIdentityDataContractNonceAction {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Reduce cargo clips warnings in rs-platform

## What was done?
372 - 342 = 30 warnings resolved

```
Before
> $ cargo clippy 2>&1 | grep -i "warning" | wc -l

     372

After
> $ cargo clippy 2>&1 | grep -i "warning" | wc -l

     342
```

## How Has This Been Tested?
cargo b and cargo t in rs-drive

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
