### PR TITLE
refactor: reduce cargo clippy warnings

### DIFF
--- a/packages/rs-drive/src/drive/batch/grovedb_op_batch/mod.rs
+++ b/packages/rs-drive/src/drive/batch/grovedb_op_batch/mod.rs
@@ -245,7 +245,7 @@ impl GroveDbOpBatchV0Methods for GroveDbOpBatch {
         );
 
         self.operations.iter().find_map(|op| {
-            if &op.path == &path && op.key == KeyInfo::KnownKey(key.to_vec()) {
+            if op.path == path && op.key == KeyInfo::KnownKey(key.to_vec()) {
                 Some(&op.op)
             } else {
                 None

--- a/packages/rs-drive/src/drive/batch/transitions/contract/data_contract_create_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/contract/data_contract_create_transition.rs
@@ -14,23 +14,16 @@ impl DriveHighLevelOperationConverter for DataContractCreateTransitionAction {
         _epoch: &Epoch,
         _platform_version: &PlatformVersion,
     ) -> Result<Vec<DriveOperation<'a>>, Error> {
-        let mut drive_operations = vec![];
-
-        drive_operations.push(IdentityOperation(
-            IdentityOperationType::UpdateIdentityNonce {
+        Ok(vec![
+            IdentityOperation(IdentityOperationType::UpdateIdentityNonce {
                 identity_id: self.data_contract_ref().owner_id().into_buffer(),
                 nonce: self.identity_nonce(),
-            },
-        ));
-
-        // We must create the contract
-        drive_operations.push(DataContractOperation(
-            DataContractOperationType::ApplyContract {
+            }),
+            // We must create the contract
+            DataContractOperation(DataContractOperationType::ApplyContract {
                 contract: Cow::Owned(self.data_contract()),
                 storage_flags: None,
-            },
-        ));
-
-        Ok(drive_operations)
+            }),
+        ])
     }
 }

--- a/packages/rs-drive/src/drive/batch/transitions/contract/data_contract_update_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/contract/data_contract_update_transition.rs
@@ -14,22 +14,17 @@ impl DriveHighLevelOperationConverter for DataContractUpdateTransitionAction {
         _epoch: &Epoch,
         _platform_version: &PlatformVersion,
     ) -> Result<Vec<DriveOperation<'a>>, Error> {
-        let mut drive_operations = vec![];
-        // We must create the contract
-        drive_operations.push(IdentityOperation(
-            IdentityOperationType::UpdateIdentityContractNonce {
+        Ok(vec![
+            // We must create the contract
+            IdentityOperation(IdentityOperationType::UpdateIdentityContractNonce {
                 identity_id: self.data_contract_ref().owner_id().into_buffer(),
                 contract_id: self.data_contract_ref().id().into_buffer(),
                 nonce: self.identity_contract_nonce(),
-            },
-        ));
-        drive_operations.push(DataContractOperation(
-            DataContractOperationType::ApplyContract {
+            }),
+            DataContractOperation(DataContractOperationType::ApplyContract {
                 contract: Cow::Owned(self.data_contract()),
                 storage_flags: None,
-            },
-        ));
-
-        Ok(drive_operations)
+            }),
+        ])
     }
 }

--- a/packages/rs-drive/src/drive/batch/transitions/document/document_delete_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/document/document_delete_transition.rs
@@ -26,22 +26,19 @@ impl DriveHighLevelDocumentOperationConverter for DocumentDeleteTransitionAction
 
         let identity_contract_nonce = base.identity_contract_nonce();
 
-        let mut drive_operations = vec![];
-        drive_operations.push(IdentityOperation(
-            IdentityOperationType::UpdateIdentityContractNonce {
+        Ok(vec![
+            IdentityOperation(IdentityOperationType::UpdateIdentityContractNonce {
                 identity_id: owner_id.into_buffer(),
                 contract_id: data_contract_id.into_buffer(),
                 nonce: identity_contract_nonce,
-            },
-        ));
-        drive_operations.push(DocumentOperation(
-            DocumentOperationType::DeleteDocumentOfNamedTypeForContractId {
-                document_id: base.id().to_buffer(),
-                contract_id: base.data_contract_id().to_buffer(),
-                document_type_name: Cow::Owned(base.document_type_name_owned()),
-            },
-        ));
-
-        Ok(drive_operations)
+            }),
+            DocumentOperation(
+                DocumentOperationType::DeleteDocumentOfNamedTypeForContractId {
+                    document_id: base.id().to_buffer(),
+                    contract_id: base.data_contract_id().to_buffer(),
+                    document_type_name: Cow::Owned(base.document_type_name_owned()),
+                },
+            ),
+        ])
     }
 }

--- a/packages/rs-drive/src/drive/batch/transitions/document/document_update_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/document/document_update_transition.rs
@@ -29,23 +29,20 @@ impl DriveHighLevelDocumentOperationConverter for DocumentReplaceTransitionActio
 
         let storage_flags = StorageFlags::new_single_epoch(epoch.index, Some(owner_id.to_buffer()));
 
-        let mut drive_operations = vec![];
-        drive_operations.push(IdentityOperation(
-            IdentityOperationType::UpdateIdentityContractNonce {
+        Ok(vec![
+            IdentityOperation(IdentityOperationType::UpdateIdentityContractNonce {
                 identity_id: owner_id.into_buffer(),
                 contract_id: data_contract_id.into_buffer(),
                 nonce: identity_contract_nonce,
-            },
-        ));
-        drive_operations.push(DocumentOperation(DocumentOperationType::UpdateDocument {
-            owned_document_info: OwnedDocumentInfo {
-                document_info: DocumentOwnedInfo((document, Some(Cow::Owned(storage_flags)))),
-                owner_id: Some(owner_id.into_buffer()),
-            },
-            contract_id: data_contract_id,
-            document_type_name: Cow::Owned(document_type_name),
-        }));
-
-        Ok(drive_operations)
+            }),
+            DocumentOperation(DocumentOperationType::UpdateDocument {
+                owned_document_info: OwnedDocumentInfo {
+                    document_info: DocumentOwnedInfo((document, Some(Cow::Owned(storage_flags)))),
+                    owner_id: Some(owner_id.into_buffer()),
+                },
+                contract_id: data_contract_id,
+                document_type_name: Cow::Owned(document_type_name),
+            }),
+        ])
     }
 }

--- a/packages/rs-drive/src/drive/batch/transitions/mod.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/mod.rs
@@ -24,7 +24,7 @@ pub trait DriveHighLevelOperationConverter {
     ) -> Result<Vec<DriveOperation<'a>>, Error>;
 }
 
-impl<'s> DriveHighLevelOperationConverter for StateTransitionAction {
+impl DriveHighLevelOperationConverter for StateTransitionAction {
     fn into_high_level_drive_operations<'a>(
         self,
         epoch: &Epoch,

--- a/packages/rs-drive/src/drive/cache.rs
+++ b/packages/rs-drive/src/drive/cache.rs
@@ -1,5 +1,4 @@
 use dpp::identity::TimestampMillis;
-use std::sync::RwLock;
 
 mod data_contract;
 mod protocol_version;

--- a/packages/rs-drive/src/drive/cache/system_contracts.rs
+++ b/packages/rs-drive/src/drive/cache/system_contracts.rs
@@ -2,7 +2,6 @@ use crate::error::Error;
 use dpp::data_contract::DataContract;
 use dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
 use platform_version::version::PlatformVersion;
-use std::sync::{RwLock, RwLockReadGuard};
 
 /// System contracts
 pub struct SystemDataContracts {

--- a/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/merge_identity_contract_nonce/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/merge_identity_contract_nonce/v0/mod.rs
@@ -175,53 +175,61 @@ impl Drive {
             revision_nonce
         } else if let Some(existing_nonce) = existing_nonce {
             let actual_existing_revision = existing_nonce & IDENTITY_NONCE_VALUE_FILTER;
-            if actual_existing_revision == revision_nonce {
-                // we were not able to update the revision as it is the same as we already had
-                return Ok((NonceAlreadyPresentAtTip, drive_operations));
-            } else if actual_existing_revision < revision_nonce {
-                if revision_nonce - actual_existing_revision > MISSING_IDENTITY_REVISIONS_MAX_BYTES
-                {
-                    // we are too far away from the actual revision
-                    return Ok((NonceTooFarInFuture, drive_operations));
-                } else {
-                    let missing_amount_of_revisions = revision_nonce - actual_existing_revision - 1;
-                    let new_previous_missing_revisions = (existing_nonce
-                        & MISSING_IDENTITY_REVISIONS_FILTER)
-                        << (missing_amount_of_revisions + 1);
-                    // the missing_revisions_bytes are the amount of bytes to put in the missing area
-                    let missing_revisions_bytes = if missing_amount_of_revisions > 0 {
-                        ((1 << missing_amount_of_revisions) - 1)
-                            << IDENTITY_NONCE_VALUE_FILTER_MAX_BYTES
-                    } else {
-                        0
-                    };
-                    new_previous_missing_revisions | revision_nonce | missing_revisions_bytes
+            match actual_existing_revision.cmp(&revision_nonce) {
+                std::cmp::Ordering::Equal => {
+                    // we were not able to update the revision as it is the same as we already had
+                    return Ok((NonceAlreadyPresentAtTip, drive_operations));
                 }
-            } else {
-                let previous_revision_position_from_top = actual_existing_revision - revision_nonce;
-                if previous_revision_position_from_top >= MISSING_IDENTITY_REVISIONS_MAX_BYTES {
-                    // we are too far away from the actual revision
-                    return Ok((NonceTooFarInPast, drive_operations));
-                } else {
-                    let old_missing_revisions = existing_nonce & MISSING_IDENTITY_REVISIONS_FILTER;
-                    if old_missing_revisions == 0 {
-                        return Ok((
-                            NonceAlreadyPresentInPast(previous_revision_position_from_top),
-                            drive_operations,
-                        ));
+                std::cmp::Ordering::Less => {
+                    if revision_nonce - actual_existing_revision
+                        > MISSING_IDENTITY_REVISIONS_MAX_BYTES
+                    {
+                        // we are too far away from the actual revision
+                        return Ok((NonceTooFarInFuture, drive_operations));
                     } else {
-                        let byte_to_unset = 1
-                            << (previous_revision_position_from_top - 1
-                                + IDENTITY_NONCE_VALUE_FILTER_MAX_BYTES);
-                        let old_revision_already_set =
-                            old_missing_revisions | byte_to_unset != old_missing_revisions;
-                        if old_revision_already_set {
+                        let missing_amount_of_revisions =
+                            revision_nonce - actual_existing_revision - 1;
+                        let new_previous_missing_revisions = (existing_nonce
+                            & MISSING_IDENTITY_REVISIONS_FILTER)
+                            << (missing_amount_of_revisions + 1);
+                        // the missing_revisions_bytes are the amount of bytes to put in the missing area
+                        let missing_revisions_bytes = if missing_amount_of_revisions > 0 {
+                            ((1 << missing_amount_of_revisions) - 1)
+                                << IDENTITY_NONCE_VALUE_FILTER_MAX_BYTES
+                        } else {
+                            0
+                        };
+                        new_previous_missing_revisions | revision_nonce | missing_revisions_bytes
+                    }
+                }
+                std::cmp::Ordering::Greater => {
+                    let previous_revision_position_from_top =
+                        actual_existing_revision - revision_nonce;
+                    if previous_revision_position_from_top >= MISSING_IDENTITY_REVISIONS_MAX_BYTES {
+                        // we are too far away from the actual revision
+                        return Ok((NonceTooFarInPast, drive_operations));
+                    } else {
+                        let old_missing_revisions =
+                            existing_nonce & MISSING_IDENTITY_REVISIONS_FILTER;
+                        if old_missing_revisions == 0 {
                             return Ok((
                                 NonceAlreadyPresentInPast(previous_revision_position_from_top),
                                 drive_operations,
                             ));
                         } else {
-                            existing_nonce & !byte_to_unset
+                            let byte_to_unset = 1
+                                << (previous_revision_position_from_top - 1
+                                    + IDENTITY_NONCE_VALUE_FILTER_MAX_BYTES);
+                            let old_revision_already_set =
+                                old_missing_revisions | byte_to_unset != old_missing_revisions;
+                            if old_revision_already_set {
+                                return Ok((
+                                    NonceAlreadyPresentInPast(previous_revision_position_from_top),
+                                    drive_operations,
+                                ));
+                            } else {
+                                existing_nonce & !byte_to_unset
+                            }
                         }
                     }
                 }

--- a/packages/rs-drive/src/drive/identity/update/operations/merge_identity_nonce_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/operations/merge_identity_nonce_operations/v0/mod.rs
@@ -56,7 +56,7 @@ impl Drive {
             )?;
         }
 
-        let (existing_nonce, fees) = self.fetch_identity_nonce_with_fees(
+        let (existing_nonce, _unused_fees) = self.fetch_identity_nonce_with_fees(
             identity_id,
             block_info,
             estimated_costs_only_with_layer_info.is_none(),
@@ -69,53 +69,62 @@ impl Drive {
             revision_nonce
         } else if let Some(existing_nonce) = existing_nonce {
             let actual_existing_revision = existing_nonce & IDENTITY_NONCE_VALUE_FILTER;
-            if actual_existing_revision == revision_nonce {
-                // we were not able to update the revision as it is the same as we already had
-                return Ok((NonceAlreadyPresentAtTip, drive_operations));
-            } else if actual_existing_revision < revision_nonce {
-                if revision_nonce - actual_existing_revision > MISSING_IDENTITY_REVISIONS_MAX_BYTES
-                {
-                    // we are too far away from the actual revision
-                    return Ok((NonceTooFarInFuture, drive_operations));
-                } else {
-                    let missing_amount_of_revisions = revision_nonce - actual_existing_revision - 1;
-                    let new_previous_missing_revisions = (existing_nonce
-                        & MISSING_IDENTITY_REVISIONS_FILTER)
-                        << (missing_amount_of_revisions + 1);
-                    // the missing_revisions_bytes are the amount of bytes to put in the missing area
-                    let missing_revisions_bytes = if missing_amount_of_revisions > 0 {
-                        ((1 << missing_amount_of_revisions) - 1)
-                            << IDENTITY_NONCE_VALUE_FILTER_MAX_BYTES
-                    } else {
-                        0
-                    };
-                    new_previous_missing_revisions | revision_nonce | missing_revisions_bytes
+            // equal
+            match actual_existing_revision.cmp(&revision_nonce) {
+                std::cmp::Ordering::Equal => {
+                    // we were not able to update the revision as it is the same as we already had
+                    return Ok((NonceAlreadyPresentAtTip, drive_operations));
                 }
-            } else {
-                let previous_revision_position_from_top = actual_existing_revision - revision_nonce;
-                if previous_revision_position_from_top >= MISSING_IDENTITY_REVISIONS_MAX_BYTES {
-                    // we are too far away from the actual revision
-                    return Ok((NonceTooFarInPast, drive_operations));
-                } else {
-                    let old_missing_revisions = existing_nonce & MISSING_IDENTITY_REVISIONS_FILTER;
-                    if old_missing_revisions == 0 {
-                        return Ok((
-                            NonceAlreadyPresentInPast(previous_revision_position_from_top),
-                            drive_operations,
-                        ));
+                std::cmp::Ordering::Less => {
+                    if revision_nonce - actual_existing_revision
+                        > MISSING_IDENTITY_REVISIONS_MAX_BYTES
+                    {
+                        // we are too far away from the actual revision
+                        return Ok((NonceTooFarInFuture, drive_operations));
                     } else {
-                        let byte_to_unset = 1
-                            << (previous_revision_position_from_top - 1
-                                + IDENTITY_NONCE_VALUE_FILTER_MAX_BYTES);
-                        let old_revision_already_set =
-                            old_missing_revisions | byte_to_unset != old_missing_revisions;
-                        if old_revision_already_set {
+                        let missing_amount_of_revisions =
+                            revision_nonce - actual_existing_revision - 1;
+                        let new_previous_missing_revisions = (existing_nonce
+                            & MISSING_IDENTITY_REVISIONS_FILTER)
+                            << (missing_amount_of_revisions + 1);
+                        // the missing_revisions_bytes are the amount of bytes to put in the missing area
+                        let missing_revisions_bytes = if missing_amount_of_revisions > 0 {
+                            ((1 << missing_amount_of_revisions) - 1)
+                                << IDENTITY_NONCE_VALUE_FILTER_MAX_BYTES
+                        } else {
+                            0
+                        };
+                        new_previous_missing_revisions | revision_nonce | missing_revisions_bytes
+                    }
+                }
+                std::cmp::Ordering::Greater => {
+                    let previous_revision_position_from_top =
+                        actual_existing_revision - revision_nonce;
+                    if previous_revision_position_from_top >= MISSING_IDENTITY_REVISIONS_MAX_BYTES {
+                        // we are too far away from the actual revision
+                        return Ok((NonceTooFarInPast, drive_operations));
+                    } else {
+                        let old_missing_revisions =
+                            existing_nonce & MISSING_IDENTITY_REVISIONS_FILTER;
+                        if old_missing_revisions == 0 {
                             return Ok((
                                 NonceAlreadyPresentInPast(previous_revision_position_from_top),
                                 drive_operations,
                             ));
                         } else {
-                            existing_nonce & !byte_to_unset
+                            let byte_to_unset = 1
+                                << (previous_revision_position_from_top - 1
+                                    + IDENTITY_NONCE_VALUE_FILTER_MAX_BYTES);
+                            let old_revision_already_set =
+                                old_missing_revisions | byte_to_unset != old_missing_revisions;
+                            if old_revision_already_set {
+                                return Ok((
+                                    NonceAlreadyPresentInPast(previous_revision_position_from_top),
+                                    drive_operations,
+                                ));
+                            } else {
+                                existing_nonce & !byte_to_unset
+                            }
                         }
                     }
                 }

--- a/packages/rs-drive/src/drive/operations/drop_cache/v0/mod.rs
+++ b/packages/rs-drive/src/drive/operations/drop_cache/v0/mod.rs
@@ -1,4 +1,4 @@
-use crate::drive::cache::{DataContractCache, ProtocolVersionsCache};
+use crate::drive::cache::ProtocolVersionsCache;
 use crate::drive::Drive;
 
 impl Drive {

--- a/packages/rs-drive/src/drive/prove/prove_multiple/mod.rs
+++ b/packages/rs-drive/src/drive/prove/prove_multiple/mod.rs
@@ -30,9 +30,9 @@ impl Drive {
     /// or an `Error` if the function fails.
     pub fn prove_multiple(
         &self,
-        identity_queries: &Vec<IdentityDriveQuery>,
+        identity_queries: &[IdentityDriveQuery],
         contract_ids: &[([u8; 32], Option<bool>)], //bool represents if it is historical
-        document_queries: &Vec<SingleDocumentDriveQuery>,
+        document_queries: &[SingleDocumentDriveQuery],
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<Vec<u8>, Error> {

--- a/packages/rs-drive/src/drive/prove/prove_multiple/v0/mod.rs
+++ b/packages/rs-drive/src/drive/prove/prove_multiple/v0/mod.rs
@@ -26,9 +26,9 @@ impl Drive {
     /// or an `Error` if the function fails.
     pub(super) fn prove_multiple_v0(
         &self,
-        identity_queries: &Vec<IdentityDriveQuery>,
+        identity_queries: &[IdentityDriveQuery],
         contract_ids: &[([u8; 32], Option<bool>)], //bool is history
-        document_queries: &Vec<SingleDocumentDriveQuery>,
+        document_queries: &[SingleDocumentDriveQuery],
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<Vec<u8>, Error> {

--- a/packages/rs-drive/src/query/conditions.rs
+++ b/packages/rs-drive/src/query/conditions.rs
@@ -1283,7 +1283,7 @@ impl<'a> WhereClause {
     }
 }
 
-impl<'a> From<WhereClause> for Value {
+impl From<WhereClause> for Value {
     fn from(value: WhereClause) -> Self {
         Value::Array(vec![value.field.into(), value.operator.into(), value.value])
     }

--- a/packages/rs-drive/src/state_transition_action/document/documents_batch/document_transition/document_replace_transition_action/v0/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/document/documents_batch/document_transition/document_replace_transition_action/v0/mod.rs
@@ -6,8 +6,6 @@ use dpp::platform_value::{Identifier, Value};
 use dpp::prelude::Revision;
 use dpp::ProtocolError;
 
-use dpp::state_transition::documents_batch_transition::document_base_transition::v0::v0_methods::DocumentBaseTransitionV0Methods;
-
 use std::collections::BTreeMap;
 
 use crate::state_transition_action::document::documents_batch::document_transition::document_base_transition_action::{DocumentBaseTransitionAction, DocumentBaseTransitionActionAccessorsV0};


### PR DESCRIPTION
## Issue being fixed or feature implemented
Resolve cargo clippy and compiler warnings

Note: reviewing with ?w=1 such as https://github.com/dashpay/platform/commit/8fb4903f031fe38f1178dc4e9b8f98d3c54e72be?w=1 may be easier due to some indentation changes

## What was done?
366 - 351 = 15 warnings resolved

```
Before
> $ cargo clippy 2>&1 | grep -i "warning" | wc -l

     366

After
> $ cargo clippy 2>&1 | grep -i "warning" | wc -l

     351
```

## How Has This Been Tested?
ran `cargo t` locally

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
