### PR TITLE
fix: resolve strategy-tests test failures

### DIFF
--- a/packages/strategy-tests/Cargo.toml
+++ b/packages/strategy-tests/Cargo.toml
@@ -22,7 +22,9 @@ hex = "0.4.3"
 serde_json = "1.0"
 dpp = { path = "../rs-dpp", features = [
   "abci",
+  "client",
   "random-documents",
+  "state-transitions",
   "state-transition-signing",
   "random-identities",
   "random-public-keys",


### PR DESCRIPTION
## Issue being fixed or feature implemented
introduced in #1729

```
> cargo t

error[E0599]: no method named `create_data_contract_create_transition` found for enum `DataContractFactory` in the current scope
    --> packages/strategy-tests/src/lib.rs:1186:34
     |
1185 |   ...                   let transition = match contract_factory
     |  ______________________________________________-
1186 | | ...                       .create_data_contract_create_transition(created_data_contract)
     | |                           -^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `DataContractFactory`
     | |___________________________|
     |
```

## What was done?
strategy-tests relies on rs-dpp; the usage of create_data_contract_create_transition requires features "client" and "state-transitions"

these weren't present; add them to Cargo.toml

## How Has This Been Tested?
cargo t in root and strategy-tests

it should be investigated why cargo t in root doesn't catch this.

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
