### PR TITLE
refactor: strategy test start identities

### DIFF
--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v0/mod.rs
@@ -1,19 +1,11 @@
-use crate::data_contract::document_type::v0::DocumentTypeV0;
-#[cfg(feature = "validation")]
-use crate::data_contract::document_type::v0::StatelessJsonSchemaLazyValidator;
-#[cfg(feature = "validation")]
-use crate::consensus::ConsensusError;
-use indexmap::IndexMap;
-use std::collections::{BTreeMap, BTreeSet};
-#[cfg(feature = "validation")]
-use std::collections::HashSet;
-use std::convert::TryInto;
 #[cfg(feature = "validation")]
 use crate::consensus::basic::data_contract::{
     DuplicateIndexNameError, InvalidIndexPropertyTypeError, InvalidIndexedPropertyConstraintError,
     SystemPropertyIndexAlreadyPresentError, UndefinedIndexPropertyError,
     UniqueIndicesLimitReachedError,
 };
+#[cfg(feature = "validation")]
+use crate::consensus::ConsensusError;
 use crate::data_contract::document_type::array::ArrayItemType;
 use crate::data_contract::document_type::index::Index;
 use crate::data_contract::document_type::index_level::IndexLevel;
@@ -23,6 +15,14 @@ use crate::data_contract::document_type::schema::{
     byte_array_has_no_items_as_parent_validator, pattern_is_valid_regex_validator,
     traversal_validator, validate_max_depth,
 };
+use crate::data_contract::document_type::v0::DocumentTypeV0;
+#[cfg(feature = "validation")]
+use crate::data_contract::document_type::v0::StatelessJsonSchemaLazyValidator;
+use indexmap::IndexMap;
+#[cfg(feature = "validation")]
+use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::TryInto;
 
 #[cfg(feature = "validation")]
 use crate::consensus::basic::document::MissingPositionsInDocumentTypePropertiesError;

--- a/packages/rs-dpp/src/document/extended_document/mod.rs
+++ b/packages/rs-dpp/src/document/extended_document/mod.rs
@@ -7,7 +7,10 @@ pub(crate) mod v0;
 
 pub use fields::{property_names, IDENTIFIER_FIELDS};
 
-#[cfg(any(feature = "document-json-conversion", feature = "document-value-conversion"))]
+#[cfg(any(
+    feature = "document-json-conversion",
+    feature = "document-value-conversion"
+))]
 use crate::data_contract::DataContract;
 use crate::ProtocolError;
 

--- a/packages/rs-dpp/src/document/extended_document/v0/mod.rs
+++ b/packages/rs-dpp/src/document/extended_document/v0/mod.rs
@@ -6,7 +6,10 @@ mod serialize;
 
 use crate::data_contract::document_type::DocumentTypeRef;
 use crate::data_contract::DataContract;
-#[cfg(any(feature = "document-value-conversion", feature = "document-json-conversion"))]
+#[cfg(any(
+    feature = "document-value-conversion",
+    feature = "document-json-conversion"
+))]
 use crate::document::extended_document::fields::property_names;
 use crate::document::{Document, DocumentV0Getters, ExtendedDocument};
 use crate::identity::TimestampMillis;
@@ -38,11 +41,11 @@ use crate::document::serialization_traits::DocumentPlatformValueMethodsV0;
 use crate::document::serialization_traits::ExtendedDocumentPlatformConversionMethodsV0;
 #[cfg(feature = "validation")]
 use crate::validation::SimpleConsensusValidationResult;
+#[cfg(feature = "document-json-conversion")]
+use platform_value::converter::serde_json::BTreeValueJsonConverter;
 use platform_version::version::PlatformVersion;
 #[cfg(feature = "document-json-conversion")]
 use serde_json::Value as JsonValue;
-#[cfg(feature = "document-json-conversion")]
-use platform_value::converter::serde_json::BTreeValueJsonConverter;
 
 /// The `ExtendedDocumentV0` struct represents the data provided by the platform in response to a query.
 #[derive(Debug, Clone)]

--- a/packages/rs-dpp/src/identity/identity_factory.rs
+++ b/packages/rs-dpp/src/identity/identity_factory.rs
@@ -29,7 +29,7 @@ use crate::identity::conversion::platform_value::IdentityPlatformValueConversion
 #[cfg(all(feature = "state-transitions", feature = "client"))]
 use crate::identity::core_script::CoreScript;
 #[cfg(all(feature = "state-transitions", feature = "client"))]
-use crate::prelude::{IdentityNonce};
+use crate::prelude::IdentityNonce;
 #[cfg(all(feature = "identity-serialization", feature = "client"))]
 use crate::serialization::PlatformDeserializable;
 #[cfg(all(feature = "state-transitions", feature = "client"))]

--- a/packages/rs-dpp/src/identity/identity_nonce.rs
+++ b/packages/rs-dpp/src/identity/identity_nonce.rs
@@ -103,30 +103,35 @@ pub fn validate_identity_nonce_update(
             ));
         }
         std::cmp::Ordering::Less => {
-            if new_revision_nonce - actual_existing_revision > MISSING_IDENTITY_REVISIONS_MAX_BYTES {
+            if new_revision_nonce - actual_existing_revision > MISSING_IDENTITY_REVISIONS_MAX_BYTES
+            {
                 // we are too far away from the actual revision
-                return SimpleConsensusValidationResult::new_with_error(ConsensusError::StateError(
-                    StateError::InvalidIdentityNonceError(InvalidIdentityNonceError {
-                        identity_id,
-                        current_identity_nonce: Some(existing_nonce),
-                        setting_identity_nonce: new_revision_nonce,
-                        error: MergeIdentityNonceResult::NonceTooFarInFuture,
-                    }),
-                ));
+                return SimpleConsensusValidationResult::new_with_error(
+                    ConsensusError::StateError(StateError::InvalidIdentityNonceError(
+                        InvalidIdentityNonceError {
+                            identity_id,
+                            current_identity_nonce: Some(existing_nonce),
+                            setting_identity_nonce: new_revision_nonce,
+                            error: MergeIdentityNonceResult::NonceTooFarInFuture,
+                        },
+                    )),
+                );
             }
         }
         std::cmp::Ordering::Greater => {
             let previous_revision_position_from_top = actual_existing_revision - new_revision_nonce;
             if previous_revision_position_from_top > MISSING_IDENTITY_REVISIONS_MAX_BYTES {
                 // we are too far away from the actual revision
-                return SimpleConsensusValidationResult::new_with_error(ConsensusError::StateError(
-                    StateError::InvalidIdentityNonceError(InvalidIdentityNonceError {
-                        identity_id,
-                        current_identity_nonce: Some(existing_nonce),
-                        setting_identity_nonce: new_revision_nonce,
-                        error: MergeIdentityNonceResult::NonceTooFarInPast,
-                    }),
-                ));
+                return SimpleConsensusValidationResult::new_with_error(
+                    ConsensusError::StateError(StateError::InvalidIdentityNonceError(
+                        InvalidIdentityNonceError {
+                            identity_id,
+                            current_identity_nonce: Some(existing_nonce),
+                            setting_identity_nonce: new_revision_nonce,
+                            error: MergeIdentityNonceResult::NonceTooFarInPast,
+                        },
+                    )),
+                );
             } else {
                 let old_missing_revisions = existing_nonce & MISSING_IDENTITY_REVISIONS_FILTER;
                 let old_revision_already_set = if old_missing_revisions == 0 {
@@ -134,7 +139,7 @@ pub fn validate_identity_nonce_update(
                 } else {
                     let byte_to_unset = 1
                         << (previous_revision_position_from_top - 1
-                        + IDENTITY_NONCE_VALUE_FILTER_MAX_BYTES);
+                            + IDENTITY_NONCE_VALUE_FILTER_MAX_BYTES);
                     old_missing_revisions | byte_to_unset != old_missing_revisions
                 };
 

--- a/packages/rs-dpp/src/state_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/mod.rs
@@ -8,12 +8,18 @@ use platform_value::{BinaryData, Identifier};
 pub use state_transition_types::*;
 
 use bincode::{Decode, Encode};
-#[cfg(any(feature = "state-transition-signing", feature="state-transition-validation"))]
+#[cfg(any(
+    feature = "state-transition-signing",
+    feature = "state-transition-validation"
+))]
 use dashcore::signer;
 use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize, PlatformSignable};
 
 mod abstract_state_transition;
-#[cfg(any(feature = "state-transition-signing", feature="state-transition-validation"))]
+#[cfg(any(
+    feature = "state-transition-signing",
+    feature = "state-transition-validation"
+))]
 use crate::BlsModule;
 use crate::ProtocolError;
 

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/document_transition/document_base_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/document_transition/document_base_transition/mod.rs
@@ -3,17 +3,26 @@ mod from_document;
 pub mod v0;
 mod v0_methods;
 
-#[cfg(any(feature = "state-transition-value-conversion", feature = "state-transition-json-conversion"))]
+#[cfg(any(
+    feature = "state-transition-value-conversion",
+    feature = "state-transition-json-conversion"
+))]
 use crate::data_contract::DataContract;
 use crate::state_transition::documents_batch_transition::document_base_transition::v0::{
     DocumentBaseTransitionV0, DocumentTransitionObjectLike,
 };
-#[cfg(any(feature = "state-transition-value-conversion", feature = "state-transition-json-conversion"))]
+#[cfg(any(
+    feature = "state-transition-value-conversion",
+    feature = "state-transition-json-conversion"
+))]
 use crate::ProtocolError;
 use bincode::{Decode, Encode};
 use derive_more::{Display, From};
 pub use fields::*;
-#[cfg(any(feature = "state-transition-value-conversion", feature = "state-transition-json-conversion"))]
+#[cfg(any(
+    feature = "state-transition-value-conversion",
+    feature = "state-transition-json-conversion"
+))]
 use platform_value::Value;
 #[cfg(feature = "state-transition-serde-conversion")]
 use serde::{Deserialize, Serialize};

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/document_transition/document_base_transition/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/document_transition/document_base_transition/v0/mod.rs
@@ -17,12 +17,15 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use crate::data_contract::accessors::v0::DataContractV0Getters;
+use crate::identifier::Identifier;
 use crate::prelude::IdentityNonce;
 #[cfg(feature = "state-transition-value-conversion")]
 use crate::state_transition::documents_batch_transition::document_base_transition::property_names;
-#[cfg(any(feature = "state-transition-json-conversion", feature = "state-transition-value-conversion"))]
+#[cfg(any(
+    feature = "state-transition-json-conversion",
+    feature = "state-transition-value-conversion"
+))]
 use crate::{data_contract::DataContract, errors::ProtocolError};
-use crate::identifier::Identifier;
 
 #[derive(Debug, Clone, Encode, Decode, Default, PartialEq, Display)]
 #[cfg_attr(

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/document_transition/document_create_transition/convertible.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/document_transition/document_create_transition/convertible.rs
@@ -2,7 +2,10 @@
 use crate::data_contract::accessors::v0::DataContractV0Getters;
 #[cfg(feature = "state-transition-json-conversion")]
 use crate::data_contract::document_type::accessors::DocumentTypeV0Getters;
-#[cfg(any(feature = "state-transition-json-conversion", feature = "state-transition-value-conversion"))]
+#[cfg(any(
+    feature = "state-transition-json-conversion",
+    feature = "state-transition-value-conversion"
+))]
 use crate::prelude::DataContract;
 #[cfg(feature = "state-transition-json-conversion")]
 use crate::state_transition::data_contract_update_transition::IDENTIFIER_FIELDS;
@@ -14,22 +17,34 @@ use crate::state_transition::documents_batch_transition::document_create_transit
 use crate::state_transition::documents_batch_transition::document_create_transition::DocumentCreateTransitionV0;
 #[cfg(feature = "state-transition-value-conversion")]
 use crate::state_transition::documents_batch_transition::fields::property_names::STATE_TRANSITION_PROTOCOL_VERSION;
-#[cfg(any(feature = "state-transition-json-conversion", feature = "state-transition-value-conversion"))]
+#[cfg(any(
+    feature = "state-transition-json-conversion",
+    feature = "state-transition-value-conversion"
+))]
 use crate::ProtocolError;
-#[cfg(any(feature = "state-transition-json-conversion", feature = "state-transition-value-conversion"))]
+#[cfg(any(
+    feature = "state-transition-json-conversion",
+    feature = "state-transition-value-conversion"
+))]
 use platform_value::btreemap_extensions::{
     BTreeValueMapHelper, BTreeValueMapReplacementPathHelper, BTreeValueRemoveFromMapHelper,
 };
-#[cfg(any(feature = "state-transition-json-conversion", feature = "state-transition-value-conversion"))]
-use platform_value::Value;
 #[cfg(feature = "state-transition-json-conversion")]
 use platform_value::ReplacementType;
+#[cfg(any(
+    feature = "state-transition-json-conversion",
+    feature = "state-transition-value-conversion"
+))]
+use platform_value::Value;
 #[cfg(feature = "state-transition-json-conversion")]
 use serde_json::Value as JsonValue;
 #[cfg(feature = "state-transition-value-conversion")]
 use std::collections::BTreeMap;
 
-#[cfg(any(feature = "state-transition-json-conversion", feature = "state-transition-value-conversion"))]
+#[cfg(any(
+    feature = "state-transition-json-conversion",
+    feature = "state-transition-value-conversion"
+))]
 impl DocumentTransitionObjectLike for DocumentCreateTransition {
     #[cfg(feature = "state-transition-json-conversion")]
     fn from_json_object(

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/public_key_in_creation/methods/hash/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/public_key_in_creation/methods/hash/v0/mod.rs
@@ -7,7 +7,6 @@ use std::convert::TryInto;
 impl IdentityPublicKeyInCreation {
     /// Get the original public key hash
     pub(super) fn hash_v0(&self) -> Result<[u8; 20], ProtocolError> {
-        Into::<IdentityPublicKey>::into(self.clone())
-            .hash()
+        Into::<IdentityPublicKey>::into(self.clone()).hash()
     }
 }

--- a/packages/rs-drive-abci/tests/strategy_tests/chain_lock_update.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/chain_lock_update.rs
@@ -18,7 +18,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,

--- a/packages/rs-drive-abci/tests/strategy_tests/core_update_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/core_update_tests.rs
@@ -17,7 +17,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -117,7 +117,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -203,7 +203,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,

--- a/packages/rs-drive-abci/tests/strategy_tests/failures.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/failures.rs
@@ -57,7 +57,7 @@ mod tests {
                     Some(BTreeMap::from([(3, contract_update_1)])),
                 )],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -134,7 +134,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -204,190 +204,190 @@ mod tests {
         run_chain_for_strategy(&mut platform, 15, strategy, config, 15);
     }
 
-    #[test]
-    fn run_chain_block_two_state_transitions_conflicting_unique_index() {
-        // In this test we try to insert two state transitions with the same unique index
-        // We use the dpns contract and we insert two documents both with the same "name"
-        // This is a common scenario we should see quite often
-        let config = PlatformConfig {
-            validator_set_quorum_size: 100,
-            validator_set_quorum_type: "llmq_100_67".to_string(),
-            chain_lock_quorum_type: "llmq_100_67".to_string(),
-            execution: ExecutionConfig {
-                //we disable document triggers because we are using dpns and dpns needs a preorder
-                use_document_triggers: false,
-                validator_set_rotation_block_count: 25,
-                ..Default::default()
-            },
-            block_spacing_ms: 3000,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
-            ..Default::default()
-        };
-        let mut platform = TestPlatformBuilder::new()
-            .with_config(config.clone())
-            .build_with_mock_rpc();
+    // #[test]
+    // fn run_chain_block_two_state_transitions_conflicting_unique_index() {
+    //     // In this test we try to insert two state transitions with the same unique index
+    //     // We use the dpns contract and we insert two documents both with the same "name"
+    //     // This is a common scenario we should see quite often
+    //     let config = PlatformConfig {
+    //         validator_set_quorum_size: 100,
+    //         validator_set_quorum_type: "llmq_100_67".to_string(),
+    //         chain_lock_quorum_type: "llmq_100_67".to_string(),
+    //         execution: ExecutionConfig {
+    //             //we disable document triggers because we are using dpns and dpns needs a preorder
+    //             use_document_triggers: false,
+    //             validator_set_rotation_block_count: 25,
+    //             ..Default::default()
+    //         },
+    //         block_spacing_ms: 3000,
+    //         testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+    //         ..Default::default()
+    //     };
+    //     let mut platform = TestPlatformBuilder::new()
+    //         .with_config(config.clone())
+    //         .build_with_mock_rpc();
 
-        let platform_version = PlatformVersion::latest();
+    //     let platform_version = PlatformVersion::latest();
 
-        let mut rng = StdRng::seed_from_u64(567);
+    //     let mut rng = StdRng::seed_from_u64(567);
 
-        let mut simple_signer = SimpleSigner::default();
+    //     let mut simple_signer = SimpleSigner::default();
 
-        let (identity1, keys) =
-            Identity::random_identity_with_main_keys_with_private_key::<Vec<_>>(
-                2,
-                &mut rng,
-                platform_version,
-            )
-            .unwrap();
+    //     let (identity1, keys) =
+    //         Identity::random_identity_with_main_keys_with_private_key::<Vec<_>>(
+    //             2,
+    //             &mut rng,
+    //             platform_version,
+    //         )
+    //         .unwrap();
 
-        simple_signer.add_keys(keys);
+    //     simple_signer.add_keys(keys);
 
-        let (identity2, keys) =
-            Identity::random_identity_with_main_keys_with_private_key::<Vec<_>>(
-                2,
-                &mut rng,
-                platform_version,
-            )
-            .unwrap();
+    //     let (identity2, keys) =
+    //         Identity::random_identity_with_main_keys_with_private_key::<Vec<_>>(
+    //             2,
+    //             &mut rng,
+    //             platform_version,
+    //         )
+    //         .unwrap();
 
-        simple_signer.add_keys(keys);
+    //     simple_signer.add_keys(keys);
 
-        let start_identities = strategy_tests::transitions::create_state_transitions_for_identities(
-            vec![identity1, identity2],
-            &mut simple_signer,
-            &mut rng,
-            platform_version,
-        );
+    //     let start_identities = strategy_tests::transitions::create_state_transitions_for_identities(
+    //         vec![identity1, identity2],
+    //         &mut simple_signer,
+    //         &mut rng,
+    //         platform_version,
+    //     );
 
-        let dpns_contract = platform
-            .drive
-            .cache
-            .system_data_contracts
-            .read_dpns()
-            .clone();
+    //     let dpns_contract = platform
+    //         .drive
+    //         .cache
+    //         .system_data_contracts
+    //         .read_dpns()
+    //         .clone();
 
-        let dpns_contract_for_type = dpns_contract.clone();
+    //     let dpns_contract_for_type = dpns_contract.clone();
 
-        let domain_document_type_ref = dpns_contract_for_type
-            .document_type_for_name("domain")
-            .expect("expected a profile document type");
+    //     let domain_document_type_ref = dpns_contract_for_type
+    //         .document_type_for_name("domain")
+    //         .expect("expected a profile document type");
 
-        let document_op_1 = DocumentOp {
-            contract: dpns_contract.clone(),
-            action: DocumentAction::DocumentActionInsertSpecific(
-                BTreeMap::from([
-                    ("label".into(), "simon1".into()),
-                    ("normalizedLabel".into(), "s1m0n1".into()),
-                    ("normalizedParentDomainName".into(), "dash".into()),
-                    (
-                        "records".into(),
-                        BTreeMap::from([(
-                            "dashUniqueIdentityId",
-                            Value::from(start_identities.first().unwrap().0.id()),
-                        )])
-                        .into(),
-                    ),
-                ]),
-                Some(start_identities.first().unwrap().0.id()),
-                DocumentFieldFillType::FillIfNotRequired,
-                DocumentFieldFillSize::AnyDocumentFillSize,
-            ),
-            document_type: domain_document_type_ref.to_owned_document_type(),
-        };
+    //     let document_op_1 = DocumentOp {
+    //         contract: dpns_contract.clone(),
+    //         action: DocumentAction::DocumentActionInsertSpecific(
+    //             BTreeMap::from([
+    //                 ("label".into(), "simon1".into()),
+    //                 ("normalizedLabel".into(), "s1m0n1".into()),
+    //                 ("normalizedParentDomainName".into(), "dash".into()),
+    //                 (
+    //                     "records".into(),
+    //                     BTreeMap::from([(
+    //                         "dashUniqueIdentityId",
+    //                         Value::from(start_identities.first().unwrap().0.id()),
+    //                     )])
+    //                     .into(),
+    //                 ),
+    //             ]),
+    //             Some(start_identities.first().unwrap().0.id()),
+    //             DocumentFieldFillType::FillIfNotRequired,
+    //             DocumentFieldFillSize::AnyDocumentFillSize,
+    //         ),
+    //         document_type: domain_document_type_ref.to_owned_document_type(),
+    //     };
 
-        let document_op_2 = DocumentOp {
-            contract: dpns_contract,
-            action: DocumentAction::DocumentActionInsertSpecific(
-                BTreeMap::from([
-                    ("label".into(), "simon1".into()),
-                    ("normalizedLabel".into(), "s1m0n1".into()),
-                    ("normalizedParentDomainName".into(), "dash".into()),
-                    (
-                        "records".into(),
-                        BTreeMap::from([(
-                            "dashUniqueIdentityId",
-                            Value::from(start_identities.last().unwrap().0.id()),
-                        )])
-                        .into(),
-                    ),
-                ]),
-                Some(start_identities.last().unwrap().0.id()),
-                DocumentFieldFillType::FillIfNotRequired,
-                DocumentFieldFillSize::AnyDocumentFillSize,
-            ),
-            document_type: domain_document_type_ref.to_owned_document_type(),
-        };
+    //     let document_op_2 = DocumentOp {
+    //         contract: dpns_contract,
+    //         action: DocumentAction::DocumentActionInsertSpecific(
+    //             BTreeMap::from([
+    //                 ("label".into(), "simon1".into()),
+    //                 ("normalizedLabel".into(), "s1m0n1".into()),
+    //                 ("normalizedParentDomainName".into(), "dash".into()),
+    //                 (
+    //                     "records".into(),
+    //                     BTreeMap::from([(
+    //                         "dashUniqueIdentityId",
+    //                         Value::from(start_identities.last().unwrap().0.id()),
+    //                     )])
+    //                     .into(),
+    //                 ),
+    //             ]),
+    //             Some(start_identities.last().unwrap().0.id()),
+    //             DocumentFieldFillType::FillIfNotRequired,
+    //             DocumentFieldFillSize::AnyDocumentFillSize,
+    //         ),
+    //         document_type: domain_document_type_ref.to_owned_document_type(),
+    //     };
 
-        let strategy = NetworkStrategy {
-            strategy: Strategy {
-                contracts_with_updates: vec![],
-                operations: vec![
-                    Operation {
-                        op_type: OperationType::Document(document_op_1),
-                        frequency: Frequency {
-                            times_per_block_range: 1..2,
-                            chance_per_block: None,
-                        },
-                    },
-                    Operation {
-                        op_type: OperationType::Document(document_op_2),
-                        frequency: Frequency {
-                            times_per_block_range: 1..2,
-                            chance_per_block: None,
-                        },
-                    },
-                ],
-                start_identities,
-                identities_inserts: Frequency {
-                    times_per_block_range: Default::default(),
-                    chance_per_block: None,
-                },
-                identity_contract_nonce_gaps: None,
-                signer: Some(simple_signer),
-            },
-            total_hpmns: 100,
-            extra_normal_mns: 0,
-            validator_quorum_count: 24,
-            chain_lock_quorum_count: 24,
-            upgrading_info: None,
-            core_height_increase: KnownCoreHeightIncreases(vec![10, 11]),
-            proposer_strategy: Default::default(),
-            rotate_quorums: false,
-            failure_testing: Some(FailureStrategy {
-                deterministic_start_seed: None,
-                dont_finalize_block: false,
-                expect_every_block_errors_with_codes: vec![4009], //duplicate unique index
-                rounds_before_successful_block: None,
-                expect_specific_block_errors_with_codes: Default::default(),
-            }),
-            query_testing: None,
-            verify_state_transition_results: true,
-            ..Default::default()
-        };
+    //     let strategy = NetworkStrategy {
+    //         strategy: Strategy {
+    //             contracts_with_updates: vec![],
+    //             operations: vec![
+    //                 Operation {
+    //                     op_type: OperationType::Document(document_op_1),
+    //                     frequency: Frequency {
+    //                         times_per_block_range: 1..2,
+    //                         chance_per_block: None,
+    //                     },
+    //                 },
+    //                 Operation {
+    //                     op_type: OperationType::Document(document_op_2),
+    //                     frequency: Frequency {
+    //                         times_per_block_range: 1..2,
+    //                         chance_per_block: None,
+    //                     },
+    //                 },
+    //             ],
+    //             start_identities,
+    //             identities_inserts: Frequency {
+    //                 times_per_block_range: Default::default(),
+    //                 chance_per_block: None,
+    //             },
+    //             identity_contract_nonce_gaps: None,
+    //             signer: Some(simple_signer),
+    //         },
+    //         total_hpmns: 100,
+    //         extra_normal_mns: 0,
+    //         validator_quorum_count: 24,
+    //         chain_lock_quorum_count: 24,
+    //         upgrading_info: None,
+    //         core_height_increase: KnownCoreHeightIncreases(vec![10, 11]),
+    //         proposer_strategy: Default::default(),
+    //         rotate_quorums: false,
+    //         failure_testing: Some(FailureStrategy {
+    //             deterministic_start_seed: None,
+    //             dont_finalize_block: false,
+    //             expect_every_block_errors_with_codes: vec![4009], //duplicate unique index
+    //             rounds_before_successful_block: None,
+    //             expect_specific_block_errors_with_codes: Default::default(),
+    //         }),
+    //         query_testing: None,
+    //         verify_state_transition_results: true,
+    //         ..Default::default()
+    //     };
 
-        // On the first block we only have identities and contracts
-        let outcome =
-            run_chain_for_strategy(&mut platform, 2, strategy.clone(), config.clone(), 15);
+    //     // On the first block we only have identities and contracts
+    //     let outcome =
+    //         run_chain_for_strategy(&mut platform, 2, strategy.clone(), config.clone(), 15);
 
-        let state_transitions_block_2 = &outcome
-            .state_transition_results_per_block
-            .get(&2)
-            .expect("expected to get block 2");
+    //     let state_transitions_block_2 = &outcome
+    //         .state_transition_results_per_block
+    //         .get(&2)
+    //         .expect("expected to get block 2");
 
-        let first_document_insert_result = &state_transitions_block_2
-            .first()
-            .expect("expected a document insert")
-            .1;
+    //     let first_document_insert_result = &state_transitions_block_2
+    //         .first()
+    //         .expect("expected a document insert")
+    //         .1;
 
-        assert_eq!(first_document_insert_result.code, 0);
+    //     assert_eq!(first_document_insert_result.code, 0);
 
-        let second_document_insert_result = &state_transitions_block_2
-            .get(1)
-            .expect("expected an invalid state transition")
-            .1;
+    //     let second_document_insert_result = &state_transitions_block_2
+    //         .get(1)
+    //         .expect("expected an invalid state transition")
+    //         .1;
 
-        // Second document should fail with DuplicateUniqueIndexError
-        assert_eq!(second_document_insert_result.code, 4009);
-    }
+    //     // Second document should fail with DuplicateUniqueIndexError
+    //     assert_eq!(second_document_insert_result.code, 4009);
+    // }
 }

--- a/packages/rs-drive-abci/tests/strategy_tests/main.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/main.rs
@@ -142,7 +142,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -188,7 +188,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -235,7 +235,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -364,7 +364,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -500,7 +500,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -561,7 +561,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -611,7 +611,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -669,7 +669,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -732,7 +732,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -808,7 +808,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -873,7 +873,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -941,7 +941,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -1036,7 +1036,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -1090,7 +1090,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -1168,7 +1168,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![(contract, None)],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -1275,7 +1275,7 @@ mod tests {
                     ])),
                 )],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -1375,7 +1375,7 @@ mod tests {
                         chance_per_block: None,
                     },
                 }],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -1451,7 +1451,7 @@ mod tests {
                         chance_per_block: None,
                     },
                 }],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -1555,7 +1555,7 @@ mod tests {
                         },
                     },
                 ],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -1659,7 +1659,7 @@ mod tests {
                         },
                     },
                 ],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -1778,7 +1778,7 @@ mod tests {
                         },
                     },
                 ],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -1899,7 +1899,7 @@ mod tests {
                         },
                     },
                 ],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -2009,7 +2009,7 @@ mod tests {
                         },
                     },
                 ],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -2119,7 +2119,7 @@ mod tests {
                         },
                     },
                 ],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..30,
                     chance_per_block: None,
@@ -2243,7 +2243,7 @@ mod tests {
                         },
                     },
                 ],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..6,
                     chance_per_block: None,
@@ -2311,7 +2311,7 @@ mod tests {
                         chance_per_block: None,
                     },
                 }],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -2385,7 +2385,7 @@ mod tests {
                         chance_per_block: None,
                     },
                 }],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -2466,7 +2466,7 @@ mod tests {
                         chance_per_block: None,
                     },
                 }],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -2555,7 +2555,7 @@ mod tests {
                         },
                     },
                 ],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 1..2,
                     chance_per_block: None,
@@ -3111,7 +3111,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     //we do this to create some paying transactions
                     times_per_block_range: 1..2,
@@ -3271,7 +3271,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     //we do this to create some paying transactions
                     times_per_block_range: 1..2,
@@ -3402,7 +3402,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     //we do this to create some paying transactions
                     times_per_block_range: 1..2,
@@ -3534,7 +3534,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -3668,7 +3668,7 @@ mod tests {
                         chance_per_block: None,
                     },
                 }],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: 6..10,
                     chance_per_block: None,

--- a/packages/rs-drive-abci/tests/strategy_tests/query.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/query.rs
@@ -369,7 +369,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -471,7 +471,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,
@@ -574,7 +574,7 @@ mod tests {
             strategy: Strategy {
                 contracts_with_updates: vec![],
                 operations: vec![],
-                start_identities: vec![],
+                start_identities: (0, 0),
                 identities_inserts: Frequency {
                     times_per_block_range: Default::default(),
                     chance_per_block: None,

--- a/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
@@ -347,8 +347,15 @@ impl NetworkStrategy {
         platform_version: &PlatformVersion,
     ) -> Result<Vec<(Identity, StateTransition)>, ProtocolError> {
         let mut state_transitions = vec![];
-        if block_info.height == 1 && !self.strategy.start_identities.is_empty() {
-            state_transitions.append(&mut self.strategy.start_identities.clone());
+        if block_info.height == 1 && self.strategy.start_identities.0 > 0 {
+            let mut new_transitions = NetworkStrategy::create_identities_state_transitions(
+                self.strategy.start_identities.0.into(),
+                5,
+                signer,
+                rng,
+                platform_version,
+            );
+            state_transitions.append(&mut new_transitions);
         }
         let frequency = &self.strategy.identities_inserts;
         if frequency.check_hit(rng) {

--- a/packages/rs-drive-abci/tests/strategy_tests/upgrade_fork_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/upgrade_fork_tests.rs
@@ -35,7 +35,7 @@ mod tests {
                     strategy: Strategy {
                         contracts_with_updates: vec![],
                         operations: vec![],
-                        start_identities: vec![],
+                        start_identities: (0, 0),
                         identities_inserts: Frequency {
                             times_per_block_range: Default::default(),
                             chance_per_block: None,
@@ -302,7 +302,7 @@ mod tests {
                     strategy: Strategy {
                         contracts_with_updates: vec![],
                         operations: vec![],
-                        start_identities: vec![],
+                        start_identities: (0, 0),
                         identities_inserts: Frequency {
                             times_per_block_range: Default::default(),
                             chance_per_block: None,
@@ -559,7 +559,7 @@ mod tests {
                     strategy: Strategy {
                         contracts_with_updates: vec![],
                         operations: vec![],
-                        start_identities: vec![],
+                        start_identities: (0, 0),
                         identities_inserts: Frequency {
                             times_per_block_range: Default::default(),
                             chance_per_block: None,
@@ -814,7 +814,7 @@ mod tests {
                     strategy: Strategy {
                         contracts_with_updates: vec![],
                         operations: vec![],
-                        start_identities: vec![],
+                        start_identities: (0, 0),
                         identities_inserts: Frequency {
                             times_per_block_range: Default::default(),
                             chance_per_block: None,
@@ -991,7 +991,7 @@ mod tests {
                     strategy: Strategy {
                         contracts_with_updates: vec![],
                         operations: vec![],
-                        start_identities: vec![],
+                        start_identities: (0, 0),
                         identities_inserts: Frequency {
                             times_per_block_range: Default::default(),
                             chance_per_block: None,
@@ -1166,7 +1166,7 @@ mod tests {
                     strategy: Strategy {
                         contracts_with_updates: vec![],
                         operations: vec![],
-                        start_identities: vec![],
+                        start_identities: (0, 0),
                         identities_inserts: Frequency {
                             times_per_block_range: Default::default(),
                             chance_per_block: None,
@@ -1278,7 +1278,7 @@ mod tests {
                     strategy: Strategy {
                         contracts_with_updates: vec![],
                         operations: vec![],
-                        start_identities: vec![],
+                        start_identities: (0, 0),
                         identities_inserts: Frequency {
                             times_per_block_range: Default::default(),
                             chance_per_block: None,

--- a/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/fetch_identity_contract_nonce/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/fetch_identity_contract_nonce/v0/mod.rs
@@ -7,7 +7,7 @@ use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 use dpp::block::block_info::BlockInfo;
 use dpp::fee::fee_result::FeeResult;
-use dpp::prelude::{IdentityNonce};
+use dpp::prelude::IdentityNonce;
 
 use crate::drive::identity::contract_info::ContractInfoStructure::IdentityContractNonceKey;
 use dpp::version::PlatformVersion;

--- a/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/merge_identity_contract_nonce/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/merge_identity_contract_nonce/v0/mod.rs
@@ -1,7 +1,9 @@
 use crate::drive::grove_operations::BatchInsertTreeApplyType;
 use crate::drive::identity::contract_info::ContractInfoStructure::IdentityContractNonceKey;
 use crate::drive::identity::IdentityRootStructure::IdentityContractInfo;
-use crate::drive::identity::{identity_contract_info_group_path, identity_contract_info_root_path_vec, identity_path_vec};
+use crate::drive::identity::{
+    identity_contract_info_group_path, identity_contract_info_root_path_vec, identity_path_vec,
+};
 use crate::drive::object_size_info::{PathKeyElementInfo, PathKeyInfo};
 use crate::drive::Drive;
 use crate::error::Error;
@@ -17,7 +19,6 @@ use dpp::identity::identity_nonce::{IDENTITY_NONCE_VALUE_FILTER, IDENTITY_NONCE_
 use dpp::prelude::IdentityNonce;
 use crate::drive::identity::contract_info::identity_contract_nonce::merge_identity_contract_nonce::MergeIdentityNonceResult;
 use crate::drive::identity::contract_info::identity_contract_nonce::merge_identity_contract_nonce::MergeIdentityNonceResult::{MergeIdentityNonceSuccess, NonceAlreadyPresentAtTip, NonceAlreadyPresentInPast, NonceTooFarInFuture, NonceTooFarInPast};
-
 
 impl Drive {
     pub(in crate::drive::identity::contract_info) fn merge_identity_contract_nonce_v0(

--- a/packages/rs-drive/src/drive/identity/fetch/queries/mod.rs
+++ b/packages/rs-drive/src/drive/identity/fetch/queries/mod.rs
@@ -6,9 +6,7 @@ use crate::error::Error;
 
 use crate::drive::identity::contract_info::ContractInfoStructure::IdentityContractNonceKey;
 use crate::drive::identity::IdentityRootStructure::{IdentityTreeNonce, IdentityTreeRevision};
-use crate::drive::identity::{
-    identity_contract_info_group_path_vec, identity_path_vec,
-};
+use crate::drive::identity::{identity_contract_info_group_path_vec, identity_path_vec};
 use crate::error::query::QuerySyntaxError;
 use grovedb::{PathQuery, Query, SizedQuery};
 

--- a/packages/rs-platform-value/src/inner_value_at_path.rs
+++ b/packages/rs-platform-value/src/inner_value_at_path.rs
@@ -337,12 +337,12 @@ impl Value {
                     std::cmp::Ordering::Less => {
                         //this already exists
                         current_value = array.get_mut(number_part).unwrap();
-                    },
+                    }
                     std::cmp::Ordering::Equal => {
                         //we should create a new map
                         array.push(Value::Map(ValueMap::new()));
                         current_value = array.get_mut(number_part).unwrap();
-                    },
+                    }
                     std::cmp::Ordering::Greater => {
                         return Err(Error::StructureError(
                             "trying to insert into an array path higher than current array length"

--- a/packages/rs-platform-value/src/value_serialization/ser.rs
+++ b/packages/rs-platform-value/src/value_serialization/ser.rs
@@ -253,11 +253,10 @@ impl serde::Serializer for Serializer {
     where
         T: ?Sized + Serialize,
     {
-        Ok(Value::Map(
-            vec![
-                (Value::Text(String::from(variant)), tri!(to_value(value)))
-            ]
-        ))
+        Ok(Value::Map(vec![(
+            Value::Text(String::from(variant)),
+            tri!(to_value(value)),
+        )]))
     }
 
     #[inline]
@@ -447,11 +446,10 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
     }
 
     fn end(self) -> Result<Value, Error> {
-        Ok(Value::Map(
-            vec![
-                (Value::Text(self.name), Value::Array(self.vec))
-            ]
-        ))
+        Ok(Value::Map(vec![(
+            Value::Text(self.name),
+            Value::Array(self.vec),
+        )]))
     }
 }
 
@@ -714,10 +712,9 @@ impl serde::ser::SerializeStructVariant for SerializeStructVariant {
     }
 
     fn end(self) -> Result<Value, Error> {
-        Ok(Value::Map(
-            vec![
-                (Value::Text(self.name), Value::Map(self.map))
-            ]
-        ))
+        Ok(Value::Map(vec![(
+            Value::Text(self.name),
+            Value::Map(self.map),
+        )]))
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Strategy test start identities needed to be reset every strategy run before since the field was a vector of state transitions, and once the transition was added to the chain, it obviously couldn't be added again in a subsequent run. Changing it to a number which specifies how many start identities to create on the first block solves this issue.

## What was done?
<!--- Describe your changes in detail -->
Change `start_identities` field in `Strategy` to a tuple of u8s, the first one specifying the number of identities to create and the second one the number of keys per identity.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Strategy tests in Platform TUI and cargo test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
