### PR TITLE
fix: update strategy test document transitions with initial contract ids

### DIFF
--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -420,7 +420,19 @@ impl Strategy {
                         updated_contract_data.set_owner_id(contract.owner_id());
                     }
                 }
-
+                
+                // Update any document transitions that registered to the old contract id
+                let mut operations = std::mem::replace(&mut self.operations, Vec::new());
+                for op in operations.iter_mut() {
+                    if let OperationType::Document(document_op) = &mut op.op_type {
+                        document_op.contract = contract.clone();
+                        let document_type = contract.document_type_cloned_for_name(document_op.document_type.name())
+                            .expect("Expected to get a document type for name while creating initial strategy contracts");
+                        document_op.document_type = document_type.clone();
+                    }
+                }
+                self.operations = operations;
+                                
                 DataContractCreateTransition::new_from_data_contract(
                     contract.clone(),
                     *identity_nonce,

--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -428,7 +428,7 @@ impl Strategy {
                         document_op.contract = contract.clone();
                         let document_type = contract.document_type_cloned_for_name(document_op.document_type.name())
                             .expect("Expected to get a document type for name while creating initial strategy contracts");
-                        document_op.document_type = document_type.clone();
+                        document_op.document_type = document_type;
                     }
                 }
                 self.operations = operations;

--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -430,8 +430,7 @@ impl Strategy {
                 }
                 
                 // Update any document transitions that registered to the old contract id
-                let mut operations = std::mem::replace(&mut self.operations, Vec::new());
-                for op in operations.iter_mut() {
+                for op in self.operations.iter_mut() {
                     if let OperationType::Document(document_op) = &mut op.op_type {
                         document_op.contract = contract.clone();
                         let document_type = contract.document_type_cloned_for_name(document_op.document_type.name())
@@ -439,7 +438,6 @@ impl Strategy {
                         document_op.document_type = document_type;
                     }
                 }
-                self.operations = operations;
                                 
                 DataContractCreateTransition::new_from_data_contract(
                     contract.clone(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Contracts registered on the first block of a strategy get a new random id, and if we want to register documents to these new contracts in the same strategy, we need to update the document transitions with the new id.

## What was done?
<!--- Describe your changes in detail -->
Update the document transitions from `operations` with the new contract ids from contracts_with_updates. There's a corresponding PR in rs-platform-explorer. Now we can register documents to contracts that are created within the same strategy.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Platform TUI strategy tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
