### PR TITLE
refactor: resolve various warnings during build or by clippy

### DIFF
--- a/packages/dapi-grpc/src/lib.rs
+++ b/packages/dapi-grpc/src/lib.rs
@@ -2,6 +2,7 @@ pub use prost::Message;
 
 #[cfg(feature = "core")]
 pub mod core {
+    #![allow(non_camel_case_types)]
     pub mod v0 {
         include!("core/proto/org.dash.platform.dapi.v0.rs");
     }

--- a/packages/rs-dpp/src/identity/mod.rs
+++ b/packages/rs-dpp/src/identity/mod.rs
@@ -18,16 +18,16 @@ pub mod signer;
 
 pub mod accessors;
 pub(crate) mod conversion;
-mod fields;
+pub mod fields;
 #[cfg(feature = "client")]
 mod identity_facade;
 #[cfg(feature = "factories")]
 pub mod identity_factory;
 pub mod identity_nonce;
-mod methods;
+pub mod methods;
 #[cfg(feature = "random-identities")]
 pub mod random;
-mod v0;
+pub mod v0;
 pub mod versions;
 
 pub use fields::*;

--- a/packages/rs-dpp/src/signing.rs
+++ b/packages/rs-dpp/src/signing.rs
@@ -6,7 +6,9 @@ use crate::identity::KeyType;
 use crate::serialization::PlatformMessageSignable;
 #[cfg(feature = "message-signature-verification")]
 use crate::validation::SimpleConsensusValidationResult;
-use crate::{BlsModule, ProtocolError};
+#[cfg(feature = "message-signing")]
+use crate::BlsModule;
+use crate::ProtocolError;
 use dashcore::signer;
 
 impl PlatformMessageSignable for &[u8] {

--- a/packages/rs-dpp/src/state_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/mod.rs
@@ -57,11 +57,13 @@ use crate::identity::identity_public_key::accessors::v0::IdentityPublicKeyGetter
 #[cfg(feature = "state-transition-signing")]
 use crate::identity::signer::Signer;
 use crate::identity::state_transition::OptionallyAssetLockProved;
+#[cfg(feature = "state-transition-signing")]
+use crate::identity::Purpose;
 #[cfg(any(
     feature = "state-transition-signing",
     feature = "state-transition-validation"
 ))]
-use crate::identity::{IdentityPublicKey, KeyType, Purpose};
+use crate::identity::{IdentityPublicKey, KeyType};
 use crate::identity::{KeyID, SecurityLevel};
 use crate::prelude::{AssetLockProof, UserFeeIncrease};
 pub use state_transitions::*;
@@ -76,15 +78,13 @@ use crate::state_transition::data_contract_update_transition::{
 use crate::state_transition::documents_batch_transition::{
     DocumentsBatchTransition, DocumentsBatchTransitionSignable,
 };
-#[cfg(any(
-    feature = "state-transition-signing",
-    feature = "state-transition-validation"
-))]
+#[cfg(feature = "state-transition-signing")]
+use crate::state_transition::errors::InvalidSignaturePublicKeyError;
+#[cfg(feature = "state-transition-signing")]
 use crate::state_transition::errors::WrongPublicKeyPurposeError;
 #[cfg(feature = "state-transition-validation")]
 use crate::state_transition::errors::{
-    InvalidIdentityPublicKeyTypeError, InvalidSignaturePublicKeyError, PublicKeyMismatchError,
-    StateTransitionIsNotSignedError,
+    InvalidIdentityPublicKeyTypeError, PublicKeyMismatchError, StateTransitionIsNotSignedError,
 };
 use crate::state_transition::identity_create_transition::{
     IdentityCreateTransition, IdentityCreateTransitionSignable,

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/document_transition/document_delete_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/document_transition/document_delete_transition/mod.rs
@@ -1,6 +1,6 @@
 mod from_document;
 pub mod v0;
-mod v0_methods;
+pub mod v0_methods;
 
 use bincode::{Decode, Encode};
 use derive_more::{Display, From};

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/document_transition/document_replace_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/document_transition/document_replace_transition/mod.rs
@@ -1,6 +1,6 @@
 mod from_document;
 pub mod v0;
-mod v0_methods;
+pub mod v0_methods;
 
 use crate::document::Document;
 use crate::ProtocolError;

--- a/packages/rs-dpp/src/util/deserializer.rs
+++ b/packages/rs-dpp/src/util/deserializer.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "cbor")]
 use crate::consensus::basic::decode::ProtocolVersionParsingError;
+#[cfg(feature = "cbor")]
 use crate::consensus::basic::BasicError;
+#[cfg(feature = "cbor")]
 use crate::consensus::ConsensusError;
 use integer_encoding::VarInt;
 use platform_version::version::FeatureVersion;

--- a/packages/rs-drive-abci/src/abci/app/consensus.rs
+++ b/packages/rs-drive-abci/src/abci/app/consensus.rs
@@ -8,7 +8,6 @@ use crate::platform_types::platform::Platform;
 use crate::rpc::core::CoreRPCLike;
 use dpp::version::PlatformVersion;
 use drive::grovedb::Transaction;
-use std::cell::{Ref, RefCell, RefMut};
 use std::fmt::Debug;
 use std::sync::RwLock;
 use tenderdash_abci::proto::abci as proto;

--- a/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
+++ b/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
@@ -1,7 +1,6 @@
 use crate::abci::app::{BlockExecutionApplication, PlatformApplication, TransactionalApplication};
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
-use crate::execution::types::block_execution_context::v0::BlockExecutionContextV0Getters;
 use crate::rpc::core::CoreRPCLike;
 use tenderdash_abci::proto::abci as proto;
 

--- a/packages/rs-drive-abci/src/abci/handler/init_chain.rs
+++ b/packages/rs-drive-abci/src/abci/handler/init_chain.rs
@@ -1,8 +1,6 @@
 use crate::abci::app::{BlockExecutionApplication, PlatformApplication, TransactionalApplication};
 use crate::error::Error;
-use crate::platform_types::platform_state::PlatformState;
 use crate::rpc::core::CoreRPCLike;
-use std::sync::Arc;
 use tenderdash_abci::proto::abci as proto;
 
 pub fn init_chain<'a, A, C>(

--- a/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
+++ b/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
@@ -86,7 +86,7 @@ where
         // special logic on init chain
         let transaction_guard = app.transaction().read().unwrap();
         if transaction_guard.is_none() {
-            return Err(Error::Abci(AbciError::BadRequest("received a prepare proposal request for the genesis height before an init chain request".to_string())))?;
+            Err(Error::Abci(AbciError::BadRequest("received a prepare proposal request for the genesis height before an init chain request".to_string())))?;
         };
         if request.round > 0 {
             transaction_guard

--- a/packages/rs-drive-abci/src/abci/handler/process_proposal.rs
+++ b/packages/rs-drive-abci/src/abci/handler/process_proposal.rs
@@ -67,15 +67,15 @@ where
             } else {
                 // We are getting a different block hash for a block of the same round
                 // This is a terrible issue
-                return Err(Error::Abci(AbciError::BadRequest(
+                Err(Error::Abci(AbciError::BadRequest(
                     "received a process proposal request twice with different hash".to_string(),
-                )));
+                )))?;
             }
         } else {
             let Some(proposal_info) = block_execution_context.proposer_results() else {
-                return Err(Error::Abci(AbciError::BadRequest(
+                Err(Error::Abci(AbciError::BadRequest(
                     "received a process proposal request twice".to_string(),
-                )));
+                )))?
             };
 
             let expected_transactions = proposal_info
@@ -154,7 +154,7 @@ where
         // special logic on init chain
         let transaction_guard = app.transaction().read().unwrap();
         if transaction_guard.is_none() {
-            return Err(Error::Abci(AbciError::BadRequest("received a process proposal request for the genesis height before an init chain request".to_string())));
+            Err(Error::Abci(AbciError::BadRequest("received a process proposal request for the genesis height before an init chain request".to_string())))?;
         }
         if request.round > 0 {
             transaction_guard

--- a/packages/rs-drive-abci/src/abci/handler/verify_vote_extension.rs
+++ b/packages/rs-drive-abci/src/abci/handler/verify_vote_extension.rs
@@ -69,7 +69,7 @@ where
 
     let expected_withdrawals = block_execution_context.unsigned_withdrawal_transactions();
 
-    if expected_withdrawals != &vote_extensions {
+    if expected_withdrawals != vote_extensions.as_slice() {
         let expected_extensions: Vec<ExtendVoteExtension> = expected_withdrawals.into();
 
         tracing::error!(

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/mod.rs
@@ -1,7 +1,6 @@
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
-use crate::platform_types::platform_state::v0::PlatformStateV0Methods;
 use crate::platform_types::platform_state::PlatformState;
 use crate::platform_types::{block_execution_outcome, block_proposal};
 use crate::rpc::core::CoreRPCLike;

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/update_state_cache/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/update_state_cache/v0/mod.rs
@@ -1,6 +1,4 @@
-use crate::error::execution::ExecutionError;
 use crate::error::Error;
-use crate::execution::types::block_execution_context::v0::BlockExecutionContextV0OwnedGetters;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::v0::PlatformStateV0Methods;
 use crate::platform_types::platform_state::PlatformState;

--- a/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_core_info/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_core_info/mod.rs
@@ -8,7 +8,6 @@ use crate::rpc::core::CoreRPCLike;
 use dpp::block::block_info::BlockInfo;
 use dpp::version::PlatformVersion;
 use drive::grovedb::Transaction;
-use std::sync::Arc;
 
 impl<C> Platform<C>
 where

--- a/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/make_sure_core_is_synced_to_chain_lock/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/make_sure_core_is_synced_to_chain_lock/mod.rs
@@ -11,11 +11,11 @@ pub mod v0;
 /// As we ask to make sure that core is synced to the chain lock, we get back one of 3
 pub enum CoreSyncStatus {
     /// Core is synced
-    CoreIsSynced,
+    Done,
     /// Core is 1 or 2 blocks off, we should retry shortly
-    CoreAlmostSynced,
+    Almost,
     /// Core is more than 2 blocks off
-    CoreNotSynced,
+    Not,
 }
 
 impl<C> Platform<C>

--- a/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/make_sure_core_is_synced_to_chain_lock/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/make_sure_core_is_synced_to_chain_lock/v0/mod.rs
@@ -4,7 +4,6 @@ use crate::rpc::core::CoreRPCLike;
 use dashcore_rpc::dashcore::ChainLock;
 use dpp::version::PlatformVersion;
 use crate::execution::platform_events::core_chain_lock::make_sure_core_is_synced_to_chain_lock::CoreSyncStatus;
-use crate::execution::platform_events::core_chain_lock::make_sure_core_is_synced_to_chain_lock::CoreSyncStatus::{CoreIsSynced, CoreAlmostSynced, CoreNotSynced};
 
 impl<C> Platform<C>
 where
@@ -21,7 +20,7 @@ where
         // We need to make sure core is synced to the core height we see as valid for the state transitions
         let best_chain_locked_height = self.core_rpc.submit_chain_lock(chain_lock)?;
         Ok(if best_chain_locked_height >= given_chain_lock_height {
-            CoreIsSynced
+            CoreSyncStatus::Done
         } else if best_chain_locked_height - given_chain_lock_height
             <= platform_version
                 .drive_abci
@@ -29,9 +28,9 @@ where
                 .core_chain_lock
                 .recent_block_count_amount
         {
-            CoreAlmostSynced
+            CoreSyncStatus::Almost
         } else {
-            CoreNotSynced
+            CoreSyncStatus::Not
         })
     }
 }

--- a/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/verify_chain_lock/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/verify_chain_lock/v0/mod.rs
@@ -34,13 +34,13 @@ where
                     {
                         Ok(sync_status) => {
                             match sync_status {
-                                CoreSyncStatus::CoreIsSynced => Ok(VerifyChainLockResult {
+                                CoreSyncStatus::Done => Ok(VerifyChainLockResult {
                                     chain_lock_signature_is_deserializable: true,
                                     found_valid_locally: Some(true),
                                     found_valid_by_core: None,
                                     core_is_synced: Some(true),
                                 }),
-                                CoreSyncStatus::CoreAlmostSynced => {
+                                CoreSyncStatus::Almost => {
                                     for _i in 0..CORE_ALMOST_SYNCED_RETRIES {
                                         // The chain lock is valid we just need to sleep a bit and retry
                                         sleep(Duration::from_millis(CORE_ALMOST_SYNCED_SLEEP_TIME));
@@ -63,7 +63,7 @@ where
                                         core_is_synced: Some(false),
                                     })
                                 }
-                                CoreSyncStatus::CoreNotSynced => Ok(VerifyChainLockResult {
+                                CoreSyncStatus::Not => Ok(VerifyChainLockResult {
                                     chain_lock_signature_is_deserializable: true,
                                     found_valid_locally: Some(valid),
                                     found_valid_by_core: Some(true),
@@ -102,13 +102,13 @@ where
                 if let Some(sync_status) = status {
                     // if we had make_sure_core_is_synced set to true
                     match sync_status {
-                        CoreSyncStatus::CoreIsSynced => Ok(VerifyChainLockResult {
+                        CoreSyncStatus::Done => Ok(VerifyChainLockResult {
                             chain_lock_signature_is_deserializable: true,
                             found_valid_locally: None,
                             found_valid_by_core: None,
                             core_is_synced: Some(true),
                         }),
-                        CoreSyncStatus::CoreAlmostSynced => {
+                        CoreSyncStatus::Almost => {
                             for _i in 0..CORE_ALMOST_SYNCED_RETRIES {
                                 // The chain lock is valid we just need to sleep a bit and retry
                                 sleep(Duration::from_millis(CORE_ALMOST_SYNCED_SLEEP_TIME));
@@ -129,7 +129,7 @@ where
                                 core_is_synced: Some(false),
                             })
                         }
-                        CoreSyncStatus::CoreNotSynced => Ok(VerifyChainLockResult {
+                        CoreSyncStatus::Not => Ok(VerifyChainLockResult {
                             chain_lock_signature_is_deserializable: true,
                             found_valid_locally: None,
                             found_valid_by_core: Some(true),

--- a/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/verify_chain_lock_through_core/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/verify_chain_lock_through_core/v0/mod.rs
@@ -2,7 +2,6 @@ use crate::error::Error;
 use dpp::dashcore::ChainLock;
 use dpp::version::PlatformVersion;
 use crate::execution::platform_events::core_chain_lock::make_sure_core_is_synced_to_chain_lock::CoreSyncStatus;
-use crate::execution::platform_events::core_chain_lock::make_sure_core_is_synced_to_chain_lock::CoreSyncStatus::{CoreAlmostSynced, CoreIsSynced, CoreNotSynced};
 
 use crate::platform_types::platform::Platform;
 
@@ -24,7 +23,7 @@ where
 
             let best_chain_locked_height = self.core_rpc.submit_chain_lock(chain_lock)?;
             Ok(if best_chain_locked_height >= given_chain_lock_height {
-                (true, Some(CoreIsSynced))
+                (true, Some(CoreSyncStatus::Done))
             } else if best_chain_locked_height - given_chain_lock_height
                 <= platform_version
                     .drive_abci
@@ -32,9 +31,9 @@ where
                     .core_chain_lock
                     .recent_block_count_amount
             {
-                (true, Some(CoreAlmostSynced))
+                (true, Some(CoreSyncStatus::Almost))
             } else {
-                (true, Some(CoreNotSynced))
+                (true, Some(CoreSyncStatus::Not))
             })
         } else {
             Ok((self.core_rpc.verify_chain_lock(chain_lock)?, None))

--- a/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/v0/mod.rs
@@ -127,7 +127,7 @@ impl<C> Platform<C> {
             ),
         ]);
 
-        for (_, (data_contract, identity_public_keys_set)) in &system_data_contract_types {
+        for (data_contract, identity_public_keys_set) in system_data_contract_types.values() {
             let public_keys = [
                 (
                     0,

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/execute_event/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/execute_event/v0/mod.rs
@@ -52,14 +52,14 @@ where
             self.validate_fees_of_event(&event, block_info, Some(transaction), platform_version)?;
 
         match event {
-            ExecutionEvent::PaidFromAssetLockDriveEvent {
+            ExecutionEvent::PaidFromAssetLock {
                 identity,
                 operations,
                 execution_operations,
                 user_fee_increase,
                 ..
             }
-            | ExecutionEvent::PaidDriveEvent {
+            | ExecutionEvent::Paid {
                 identity,
                 operations,
                 execution_operations,
@@ -108,7 +108,7 @@ where
                     ))
                 }
             }
-            ExecutionEvent::FreeDriveEvent { operations } => {
+            ExecutionEvent::Free { operations } => {
                 self.drive
                     .apply_drive_operations(
                         operations,

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/v0/mod.rs
@@ -250,8 +250,7 @@ where
 
                         StateTransitionExecutionResult::DriveAbciError(format!(
                             "{} {}",
-                            first_consensus_error.to_string(),
-                            payment_consensus_error.to_string()
+                            first_consensus_error, payment_consensus_error
                         ))
                     }
                 }

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/validate_fees_of_event/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/validate_fees_of_event/v0/mod.rs
@@ -43,7 +43,7 @@ where
         platform_version: &PlatformVersion,
     ) -> Result<ConsensusValidationResult<FeeResult>, Error> {
         match event {
-            ExecutionEvent::PaidFromAssetLockDriveEvent {
+            ExecutionEvent::PaidFromAssetLock {
                 identity,
                 added_balance,
                 operations,
@@ -94,7 +94,7 @@ where
                     ))
                 }
             }
-            ExecutionEvent::PaidDriveEvent {
+            ExecutionEvent::Paid {
                 identity,
                 removed_balance,
                 operations,
@@ -146,7 +146,7 @@ where
                     ))
                 }
             }
-            ExecutionEvent::FreeDriveEvent { .. } => Ok(ConsensusValidationResult::new_with_data(
+            ExecutionEvent::Free { .. } => Ok(ConsensusValidationResult::new_with_data(
                 FeeResult::default(),
             )),
         }

--- a/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
@@ -2,9 +2,6 @@ mod v0;
 
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
-use crate::execution::types::execution_event::ExecutionEvent::{
-    PaidDriveEvent, PaidFromAssetLockDriveEvent,
-};
 use dpp::block::epoch::Epoch;
 use dpp::fee::Credits;
 
@@ -25,7 +22,7 @@ use drive::drive::batch::DriveOperation;
 #[derive(Clone)]
 pub(in crate::execution) enum ExecutionEvent<'a> {
     /// A drive event that is paid by an identity
-    PaidDriveEvent {
+    Paid {
         /// The identity requesting the event
         identity: PartialIdentity,
         /// The removed balance in the case of a transfer or withdrawal
@@ -38,7 +35,7 @@ pub(in crate::execution) enum ExecutionEvent<'a> {
         user_fee_increase: UserFeeIncrease,
     },
     /// A drive event that is paid from an asset lock
-    PaidFromAssetLockDriveEvent {
+    PaidFromAssetLock {
         /// The identity requesting the event
         identity: PartialIdentity,
         /// The added balance
@@ -51,7 +48,8 @@ pub(in crate::execution) enum ExecutionEvent<'a> {
         user_fee_increase: UserFeeIncrease,
     },
     /// A drive event that is free
-    FreeDriveEvent {
+    #[allow(dead_code)] // TODO investigate why `variant `Free` is never constructed`
+    Free {
         /// the operations that should be performed
         operations: Vec<DriveOperation<'a>>,
     },
@@ -71,7 +69,7 @@ impl<'a> ExecutionEvent<'a> {
                 let identity = identity_create_action.into();
                 let operations =
                     action.into_high_level_drive_operations(epoch, platform_version)?;
-                Ok(PaidFromAssetLockDriveEvent {
+                Ok(ExecutionEvent::PaidFromAssetLock {
                     identity,
                     added_balance: 0,
                     operations,
@@ -85,7 +83,7 @@ impl<'a> ExecutionEvent<'a> {
                 let operations =
                     action.into_high_level_drive_operations(epoch, platform_version)?;
                 if let Some(identity) = identity {
-                    Ok(PaidFromAssetLockDriveEvent {
+                    Ok(ExecutionEvent::PaidFromAssetLock {
                         identity,
                         added_balance,
                         operations,
@@ -104,7 +102,7 @@ impl<'a> ExecutionEvent<'a> {
                 let operations =
                     action.into_high_level_drive_operations(epoch, platform_version)?;
                 if let Some(identity) = identity {
-                    Ok(PaidDriveEvent {
+                    Ok(ExecutionEvent::Paid {
                         identity,
                         removed_balance: Some(removed_balance),
                         operations,
@@ -123,7 +121,7 @@ impl<'a> ExecutionEvent<'a> {
                 let operations =
                     action.into_high_level_drive_operations(epoch, platform_version)?;
                 if let Some(identity) = identity {
-                    Ok(PaidDriveEvent {
+                    Ok(ExecutionEvent::Paid {
                         identity,
                         removed_balance: Some(removed_balance),
                         operations,
@@ -141,7 +139,7 @@ impl<'a> ExecutionEvent<'a> {
                 let operations =
                     action.into_high_level_drive_operations(epoch, platform_version)?;
                 if let Some(identity) = identity {
-                    Ok(PaidDriveEvent {
+                    Ok(ExecutionEvent::Paid {
                         identity,
                         removed_balance: None,
                         operations,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/check_tx_verification/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/check_tx_verification/v0/mod.rs
@@ -265,10 +265,8 @@ pub(super) fn state_transition_to_execution_event_for_check_tx_v0<'a, C: CoreRPC
                 )
             }
         }
-        _ => {
-            return Err(Error::Execution(ExecutionError::CorruptedCodeExecution(
-                "CheckTxLevel must be first time check or recheck",
-            )))
-        }
+        _ => Err(Error::Execution(ExecutionError::CorruptedCodeExecution(
+            "CheckTxLevel must be first time check or recheck",
+        ))),
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/common/validate_state_transition_identity_signed/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/common/validate_state_transition_identity_signed/mod.rs
@@ -1,12 +1,7 @@
-use std::sync::Arc;
-
-use dpp::identifier::Identifier;
 use dpp::identity::PartialIdentity;
-use dpp::ProtocolError;
 use dpp::state_transition::StateTransition;
 use dpp::validation::ConsensusValidationResult;
 use dpp::version::{PlatformVersion};
-use drive::drive::contract::DataContractFetchInfo;
 use drive::drive::Drive;
 use drive::grovedb::TransactionArg;
 use drive::state_transition_action::StateTransitionAction;

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/bindings/data_trigger_binding/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/bindings/data_trigger_binding/v0/mod.rs
@@ -88,7 +88,7 @@ impl DataTriggerBindingV0Getters for DataTriggerBindingV0 {
         document_type: &str,
         transition_action_type: DocumentTransitionActionType,
     ) -> bool {
-        &self.data_contract_id == data_contract_id
+        self.data_contract_id == data_contract_id
             && self.document_type == document_type
             && self.transition_action_type == transition_action_type
     }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/triggers/dpns/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/triggers/dpns/v0/mod.rs
@@ -1,7 +1,7 @@
 use dpp::consensus::state::data_trigger::data_trigger_condition_error::DataTriggerConditionError;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contracts::dpns_contract::v1::document_types::domain::properties::PARENT_DOMAIN_NAME;
-///! The `dpns_triggers` module contains data triggers specific to the DPNS data contract.
+/// The `dpns_triggers` module contains data triggers specific to the DPNS data contract.
 use dpp::util::hash::hash_double;
 use std::collections::BTreeMap;
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/triggers/feature_flags/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/triggers/feature_flags/v0/mod.rs
@@ -1,4 +1,4 @@
-///! The `feature_flags_data_triggers` module contains data triggers related to feature flags.
+//! The `feature_flags_data_triggers` module contains data triggers related to feature flags.
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
 use crate::platform_types::platform_state::v0::PlatformStateV0Methods;

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/triggers/withdrawals/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/triggers/withdrawals/v0/mod.rs
@@ -1,4 +1,4 @@
-///! The `withdrawals_data_triggers` module contains data triggers related to withdrawals.
+//! The `withdrawals_data_triggers` module contains data triggers related to withdrawals.
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer/balance/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer/balance/v0/mod.rs
@@ -35,7 +35,7 @@ impl IdentityCreditTransferTransitionBalanceValidationV0 for IdentityCreditTrans
         platform_version: &PlatformVersion,
     ) -> Result<SimpleConsensusValidationResult, Error> {
         let balance = if let Some(identity) = identity {
-            let balance = if let Some(balance) = identity.balance {
+            if let Some(balance) = identity.balance {
                 balance
             } else {
                 let maybe_existing_identity_balance = platform.drive.fetch_identity_balance(
@@ -53,8 +53,7 @@ impl IdentityCreditTransferTransitionBalanceValidationV0 for IdentityCreditTrans
                 identity.balance = Some(existing_identity_balance);
 
                 existing_identity_balance
-            };
-            balance
+            }
         } else {
             let maybe_existing_identity_balance = platform.drive.fetch_identity_balance(
                 self.identity_id().to_buffer(),

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_withdrawal/balance/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_withdrawal/balance/v0/mod.rs
@@ -35,7 +35,7 @@ impl IdentityCreditTransferTransitionBalanceValidationV0 for IdentityCreditWithd
         platform_version: &PlatformVersion,
     ) -> Result<SimpleConsensusValidationResult, Error> {
         let balance = if let Some(identity) = identity {
-            let balance = if let Some(balance) = identity.balance {
+            if let Some(balance) = identity.balance {
                 balance
             } else {
                 let maybe_existing_identity_balance = platform.drive.fetch_identity_balance(
@@ -53,8 +53,7 @@ impl IdentityCreditTransferTransitionBalanceValidationV0 for IdentityCreditWithd
                 identity.balance = Some(existing_identity_balance);
 
                 existing_identity_balance
-            };
-            balance
+            }
         } else {
             let maybe_existing_identity_balance = platform.drive.fetch_identity_balance(
                 self.identity_id().to_buffer(),

--- a/packages/rs-drive-abci/src/logging/destination.rs
+++ b/packages/rs-drive-abci/src/logging/destination.rs
@@ -258,7 +258,6 @@ impl TryFrom<&LogConfig> for Reopen<File> {
         let open_fn = move || {
             OpenOptions::new()
                 .create(true)
-                .write(true)
                 .append(true)
                 .mode(mode)
                 .open(&opened_path)

--- a/packages/rs-drive-abci/src/platform_types/platform/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mod.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 
 use dashcore_rpc::dashcore::BlockHash;
 
-use crate::execution::types::block_execution_context::BlockExecutionContext;
 use crate::platform_types::platform_state::v0::PlatformStateV0Methods;
 use crate::platform_types::platform_state::PlatformState;
 use dpp::version::{PlatformVersion, PlatformVersionCurrentVersion};

--- a/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
@@ -35,7 +35,7 @@ pub enum PlatformState {
 
 /// Platform state
 #[derive(Clone, Debug, Encode, Decode, From)]
-pub(crate) enum PlatformStateForSaving {
+pub enum PlatformStateForSaving {
     /// Version 0
     V0(PlatformStateForSavingV0),
 }

--- a/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
@@ -41,6 +41,12 @@ pub enum PlatformStateForSaving {
 }
 
 impl PlatformStateForSaving {
+    /// Retrieves the current protocol version used in consensus.
+    ///
+    /// Matches against `PlatformStateForSaving` variants to extract the protocol version.
+    ///
+    /// # Returns
+    /// A `ProtocolVersion` indicating the current consensus protocol version.
     #[allow(dead_code)]
     #[deprecated(note = "This function is marked as unused.")]
     #[allow(deprecated)]

--- a/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
@@ -114,7 +114,7 @@ fn hex_encoded_validator_sets(validator_sets: &IndexMap<QuorumHash, ValidatorSet
 
 /// Platform state
 #[derive(Clone, Debug, Encode, Decode)]
-pub(super) struct PlatformStateForSavingV0 {
+pub struct PlatformStateForSavingV0 {
     /// Information about the genesis block
     pub genesis_block_info: Option<BlockInfo>,
     /// Information about the last block

--- a/packages/rs-drive-abci/src/platform_types/withdrawal/unsigned_withdrawal_txs/v0/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/withdrawal/unsigned_withdrawal_txs/v0/mod.rs
@@ -49,7 +49,7 @@ impl UnsignedWithdrawalTxs {
 
     /// Verifies that the collection of unsigned withdrawal transactions matches the given vote extensions
     /// created based on these transactions
-    pub fn are_matching_with_vote_extensions(&self, other: &Vec<VoteExtension>) -> bool {
+    pub fn are_matching_with_vote_extensions(&self, other: &[VoteExtension]) -> bool {
         if self.0.len() != other.len() {
             return false;
         };
@@ -84,8 +84,8 @@ impl Display for UnsignedWithdrawalTxs {
     }
 }
 
-impl PartialEq<Vec<ExtendVoteExtension>> for UnsignedWithdrawalTxs {
-    fn eq(&self, other: &Vec<ExtendVoteExtension>) -> bool {
+impl PartialEq<[ExtendVoteExtension]> for UnsignedWithdrawalTxs {
+    fn eq(&self, other: &[ExtendVoteExtension]) -> bool {
         if self.0.len() != other.len() {
             return false;
         };

--- a/packages/rs-drive-abci/src/query/data_contract_based_queries/data_contract_history/mod.rs
+++ b/packages/rs-drive-abci/src/query/data_contract_based_queries/data_contract_history/mod.rs
@@ -49,7 +49,7 @@ impl<C> Platform<C> {
             RequestVersion::V0(request_v0) => {
                 let result = self.query_data_contract_history_v0(
                     request_v0,
-                    &platform_state,
+                    platform_state,
                     platform_version,
                 )?;
 

--- a/packages/rs-drive-abci/src/query/identity_based_queries/identity/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/identity/v0/mod.rs
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     fn test_invalid_identity_id() {
-        let (platform, state, version) = setup_platform();
+        let (platform, state, _unused_version) = setup_platform();
 
         let version = PlatformVersion::latest();
 

--- a/packages/rs-drive-abci/src/query/service.rs
+++ b/packages/rs-drive-abci/src/query/service.rs
@@ -64,7 +64,7 @@ impl QueryService {
 
             let platform_version = platform_state
                 .current_platform_version()
-                .map_err(|e| Status::unavailable("platform is not initialized"))?;
+                .map_err(|_| Status::unavailable("platform is not initialized"))?;
 
             let mut result = query_method(
                 &platform,

--- a/packages/rs-drive-abci/src/rpc/core.rs
+++ b/packages/rs-drive-abci/src/rpc/core.rs
@@ -117,7 +117,7 @@ pub trait CoreRPCLike {
     fn masternode_sync_status(&self) -> Result<MnSyncStatus, Error>;
 
     /// Sends raw transaction to the network
-    fn send_raw_transaction(&self, transaction: &Vec<u8>) -> Result<Txid, Error>;
+    fn send_raw_transaction(&self, transaction: &[u8]) -> Result<Txid, Error>;
 }
 
 #[derive(Debug)]
@@ -312,8 +312,8 @@ impl CoreRPCLike for DefaultCoreRPC {
         retry!(self.inner.mnsync_status())
     }
 
-    fn send_raw_transaction(&self, transaction: &Vec<u8>) -> Result<Txid, Error> {
-        retry!(self.inner.send_raw_transaction(transaction.as_slice()))
+    fn send_raw_transaction(&self, transaction: &[u8]) -> Result<Txid, Error> {
+        retry!(self.inner.send_raw_transaction(transaction))
     }
 
     fn get_asset_unlock_statuses(

--- a/packages/rs-drive-abci/tests/strategy_tests/execution.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/execution.rs
@@ -791,7 +791,7 @@ pub(crate) fn continue_chain_for_strategy(
     let platform = abci_app.platform;
     let ChainExecutionParameters {
         block_start,
-        core_height_start,
+        core_height_start: _,
         block_count,
         proposers: proposers_with_updates,
         quorums,

--- a/packages/rs-drive-abci/tests/strategy_tests/upgrade_fork_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/upgrade_fork_tests.rs
@@ -968,7 +968,6 @@ mod tests {
                 let state = platform.state.load();
                 {
                     let counter = &platform.drive.cache.protocol_versions_counter.read();
-                    let counter = &platform.drive.cache.protocol_versions_counter.read();
                     assert_eq!(
                         (counter.get(&1), counter.get(&TEST_PROTOCOL_VERSION_2)),
                         (Some(&172), Some(&24))

--- a/packages/rs-drive-proof-verifier/src/proof.rs
+++ b/packages/rs-drive-proof-verifier/src/proof.rs
@@ -371,16 +371,16 @@ fn parse_key_request_type(request: &Option<GrpcKeyType>) -> Result<KeyRequestTyp
                 .map(|(k, v)| {
                      let v = v.security_level_map
                             .iter()
-                            .map(|(level, kind)| {
-                                let kt = match GrpcKeyKind::from_i32(*kind) {
-                                    Some(GrpcKeyKind::CurrentKeyOfKindRequest) => {
+                            .map(|(level, &kind)| {
+                                let kt = match GrpcKeyKind::try_from(kind) {
+                                    Ok(GrpcKeyKind::CurrentKeyOfKindRequest) => {
                                         Ok(KeyKindRequestType::CurrentKeyOfKindRequest)
                                     }
-                                    Some(GrpcKeyKind::AllKeysOfKindRequest) => {
+                                    Ok(GrpcKeyKind::AllKeysOfKindRequest) => {
                                         Ok(KeyKindRequestType::AllKeysOfKindRequest)
                                     }
-                                    None => Err(Error::RequestDecodeError {
-                                        error: format!("missing requested key type: {}", *kind),
+                                    _ => Err(Error::RequestDecodeError {
+                                        error: format!("missing requested key type: {}", kind),
                                     }),
                                 };
                                 match kt  {

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -11,7 +11,6 @@ authors = [
 edition = "2021"
 rust-version = "1.76"
 license = "MIT"
-private = true
 
 [dependencies]
 parking_lot = "0.12.1"

--- a/packages/rs-drive/src/query/conditions.rs
+++ b/packages/rs-drive/src/query/conditions.rs
@@ -1151,7 +1151,7 @@ impl<'a> WhereClause {
                 negated,
                 expr,
                 pattern,
-                escape_char,
+                escape_char: _,
             } => {
                 let where_operator = WhereOperator::StartsWith;
                 if *negated {

--- a/packages/rs-drive/src/state_transition_action/identity/identity_update/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_update/mod.rs
@@ -3,7 +3,6 @@ pub mod transformer;
 /// v0
 pub mod v0;
 
-use crate::state_transition_action::identity::identity_credit_withdrawal::IdentityCreditWithdrawalTransitionAction;
 use crate::state_transition_action::identity::identity_update::v0::IdentityUpdateTransitionActionV0;
 use derive_more::From;
 use dpp::identity::{IdentityPublicKey, KeyID, TimestampMillis};

--- a/packages/rs-drive/tests/query_tests.rs
+++ b/packages/rs-drive/tests/query_tests.rs
@@ -32,21 +32,6 @@
 
 use ciborium::cbor;
 #[cfg(feature = "full")]
-use grovedb::TransactionArg;
-#[cfg(feature = "full")]
-use std::borrow::Cow;
-#[cfg(feature = "full")]
-use std::collections::HashMap;
-#[cfg(feature = "full")]
-use std::fs::File;
-#[cfg(feature = "full")]
-use std::io::{self, BufRead};
-#[cfg(feature = "full")]
-use std::option::Option::None;
-#[cfg(feature = "full")]
-use std::sync::Arc;
-
-#[cfg(feature = "full")]
 use dpp::data_contract::DataContractFactory;
 #[cfg(feature = "full")]
 use drive::common;
@@ -69,6 +54,8 @@ use drive::query::DriveQuery;
 #[cfg(feature = "full")]
 #[cfg(test)]
 use drive::tests::helpers::setup::setup_drive;
+#[cfg(feature = "full")]
+use grovedb::TransactionArg;
 use rand::random;
 #[cfg(feature = "full")]
 use rand::seq::SliceRandom;
@@ -78,6 +65,18 @@ use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "full")]
 use serde_json::json;
+#[cfg(feature = "full")]
+use std::borrow::Cow;
+#[cfg(feature = "full")]
+use std::collections::HashMap;
+#[cfg(feature = "full")]
+use std::fs::File;
+#[cfg(feature = "full")]
+use std::io::{self, BufRead};
+#[cfg(feature = "full")]
+use std::option::Option::None;
+#[cfg(feature = "full")]
+use std::sync::Arc;
 
 #[cfg(feature = "full")]
 use dpp::document::Document;
@@ -85,6 +84,8 @@ use dpp::document::Document;
 use dpp::platform_value::Value;
 use dpp::platform_value::{platform_value, Bytes32, Identifier};
 
+#[cfg(feature = "full")]
+use base64::Engine;
 #[cfg(feature = "full")]
 use dpp::block::block_info::BlockInfo;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
@@ -2970,14 +2971,15 @@ fn test_family_with_nulls_query() {
             let document =
                 Document::from_bytes(result.as_slice(), person_document_type, platform_version)
                     .expect("we should be able to deserialize the document");
-            base64::encode(document.id().as_slice())
+            base64::engine::general_purpose::STANDARD.encode(document.id().as_slice())
         })
         .collect();
 
     for i in 0..10 {
         drive
             .delete_document_for_contract(
-                base64::decode(ids.get(i).unwrap())
+                base64::engine::general_purpose::STANDARD
+                    .decode(ids.get(i).unwrap())
                     .expect("expected to decode from base64")
                     .try_into()
                     .expect("expected to get 32 bytes"),

--- a/packages/rs-platform-serialization-derive/Cargo.toml
+++ b/packages/rs-platform-serialization-derive/Cargo.toml
@@ -6,7 +6,6 @@ version = "1.0.0-dev.7"
 edition = "2021"
 rust-version = "1.76"
 license = "MIT"
-private = true
 
 [lib]
 proc-macro = true

--- a/packages/rs-platform-serialization/Cargo.toml
+++ b/packages/rs-platform-serialization/Cargo.toml
@@ -6,7 +6,6 @@ version = "1.0.0-dev.7"
 edition = "2021"
 rust-version = "1.76"
 license = "MIT"
-private = true
 
 [dependencies]
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }

--- a/packages/rs-platform-value-convertible/Cargo.toml
+++ b/packages/rs-platform-value-convertible/Cargo.toml
@@ -6,7 +6,6 @@ version = "1.0.0-dev.7"
 edition = "2021"
 rust-version = "1.76"
 license = "MIT"
-private = true
 
 [lib]
 proc-macro = true

--- a/packages/rs-platform-value/Cargo.toml
+++ b/packages/rs-platform-value/Cargo.toml
@@ -6,7 +6,6 @@ version = "1.0.0-dev.7"
 edition = "2021"
 rust-version = "1.76"
 license = "MIT"
-private = true
 
 [dependencies]
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -6,7 +6,6 @@ version = "1.0.0-dev.7"
 edition = "2021"
 rust-version = "1.76"
 license = "MIT"
-private = true
 
 [dependencies]
 thiserror = { version = "1.0" }

--- a/packages/rs-platform-versioning/Cargo.toml
+++ b/packages/rs-platform-versioning/Cargo.toml
@@ -6,7 +6,6 @@ version = "1.0.0-dev.7"
 edition = "2021"
 rust-version = "1.76"
 license = "MIT"
-private = true
 
 [lib]
 proc-macro = true

--- a/packages/rs-sdk/src/core_client.rs
+++ b/packages/rs-sdk/src/core_client.rs
@@ -76,6 +76,8 @@ impl CoreClient {
     /// ## See also
     ///
     /// * [Dash Core documentation](https://docs.dash.org/projects/core/en/stable/docs/api/remote-procedure-calls-wallet.html#listunspent)
+    #[allow(dead_code)]
+    #[deprecated(note = "This function is marked as unused.")]
     pub fn list_unspent(
         &self,
         minimum_sum_satoshi: Option<u64>,
@@ -93,6 +95,8 @@ impl CoreClient {
     }
 
     /// Return address to which change of transaction can be sent.
+    #[allow(dead_code)]
+    #[deprecated(note = "This function is marked as unused.")]
     pub fn get_balance(&self) -> Result<Amount, Error> {
         self.core
             .lock()

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -57,7 +57,8 @@
 //! To enable logging, you can use the `tracing_subscriber` crate which allows applications to customize how events are processed and recorded.
 //! An example can be found in `tests/common.rs:setup_logs()`.
 //!
-#![warn(missing_docs)]
+// TODO re-enable when docs are complete
+// #![warn(missing_docs)]
 #![allow(rustdoc::private_intra_doc_links)]
 
 pub mod core;

--- a/packages/rs-sdk/src/mock/sdk.rs
+++ b/packages/rs-sdk/src/mock/sdk.rs
@@ -317,6 +317,8 @@ impl MockDashPlatformSdk {
     }
 
     /// Wrapper around [FromProof] that uses mock expectations instead of executing [FromProof] trait.
+    #[allow(dead_code)]
+    #[deprecated(note = "This function is marked as unused.")]
     pub(crate) fn parse_proof<I, O: FromProof<I>>(
         &self,
         request: O::Request,

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -259,7 +259,7 @@ impl Sdk {
 
         if should_query_platform {
             let platform_nonce = IdentityNonceFetcher::fetch_with_settings(
-                &self,
+                self,
                 identity_id,
                 settings.request_settings,
             )
@@ -284,12 +284,10 @@ impl Sdk {
                         } else {
                             platform_nonce
                         }
+                    } else if bump_first {
+                        *current_nonce + 1
                     } else {
-                        if bump_first {
-                            *current_nonce + 1
-                        } else {
-                            *current_nonce
-                        }
+                        *current_nonce
                     };
                     e.insert((insert_nonce, current_time_s));
                     Ok(insert_nonce & IDENTITY_NONCE_VALUE_FILTER)
@@ -353,7 +351,7 @@ impl Sdk {
 
         if should_query_platform {
             let platform_nonce = IdentityContractNonceFetcher::fetch_with_settings(
-                &self,
+                self,
                 (identity_id, contract_id),
                 settings.request_settings,
             )
@@ -378,12 +376,10 @@ impl Sdk {
                         } else {
                             platform_nonce
                         }
+                    } else if bump_first {
+                        *current_nonce + 1
                     } else {
-                        if bump_first {
-                            *current_nonce + 1
-                        } else {
-                            *current_nonce
-                        }
+                        *current_nonce
                     };
                     e.insert((insert_nonce, current_time_s));
                     Ok(insert_nonce & IDENTITY_NONCE_VALUE_FILTER)

--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -379,7 +379,7 @@ impl Strategy {
     /// ```
     pub fn contract_state_transitions(
         &mut self,
-        current_identities: &Vec<Identity>,
+        current_identities: &[Identity],
         identity_nonce_counter: &mut BTreeMap<Identifier, u64>,
         signer: &SimpleSigner,
         rng: &mut StdRng,
@@ -463,7 +463,7 @@ impl Strategy {
     /// ```
     pub fn contract_update_state_transitions(
         &mut self,
-        current_identities: &Vec<Identity>,
+        current_identities: &[Identity],
         block_height: u64,
         initial_block_height: u64,
         signer: &SimpleSigner,
@@ -585,7 +585,7 @@ impl Strategy {
         ) -> PartialIdentity,
         create_asset_lock: &mut impl FnMut(u64) -> Option<(AssetLockProof, PrivateKey)>,
         block_info: &BlockInfo,
-        current_identities: &mut Vec<Identity>,
+        current_identities: &mut [Identity],
         known_contracts: &mut BTreeMap<String, DataContract>,
         signer: &mut SimpleSigner,
         identity_nonce_counter: &mut BTreeMap<Identifier, u64>,
@@ -1105,7 +1105,7 @@ impl Strategy {
 
                     // Generate state transition for identity transfer operation
                     OperationType::IdentityTransfer if current_identities.len() > 1 => {
-                        let identities_clone = current_identities.clone();
+                        let identities_clone = current_identities.to_owned();
                         // Sender is the first in the list, which should be loaded_identity
                         let owner = &mut current_identities[0];
                         // Recipient is the second in the list

--- a/packages/strategy-tests/src/operations.rs
+++ b/packages/strategy-tests/src/operations.rs
@@ -349,16 +349,16 @@ pub enum OperationType {
 
 #[derive(Clone, Debug, Encode, Decode)]
 enum OperationTypeInSerializationFormat {
-    OperationTypeInSerializationFormatDocument(Vec<u8>),
-    OperationTypeInSerializationFormatIdentityTopUp,
-    OperationTypeInSerializationFormatIdentityUpdate(IdentityUpdateOp),
-    OperationTypeInSerializationFormatIdentityWithdrawal,
-    OperationTypeInSerializationFormatContractCreate(
+    Document(Vec<u8>),
+    IdentityTopUp,
+    IdentityUpdate(IdentityUpdateOp),
+    IdentityWithdrawal,
+    ContractCreate(
         RandomDocumentTypeParameters,
         DocumentTypeCount,
     ),
-    OperationTypeInSerializationFormatContractUpdate(Vec<u8>),
-    OperationTypeInSerializationFormatIdentityTransfer,
+    ContractUpdate(Vec<u8>),
+    IdentityTransfer,
 }
 
 impl PlatformSerializableWithPlatformVersion for OperationType {
@@ -380,27 +380,27 @@ impl PlatformSerializableWithPlatformVersion for OperationType {
             OperationType::Document(document_op) => {
                 // let's just serialize it to make things easier
                 let document_op_in_serialization_format = document_op.serialize_consume_to_bytes_with_platform_version(platform_version)?;
-                OperationTypeInSerializationFormat::OperationTypeInSerializationFormatDocument(document_op_in_serialization_format)
+                OperationTypeInSerializationFormat::Document(document_op_in_serialization_format)
             }
             OperationType::IdentityTopUp => {
-                OperationTypeInSerializationFormat::OperationTypeInSerializationFormatIdentityTopUp
+                OperationTypeInSerializationFormat::IdentityTopUp
             }
             OperationType::IdentityUpdate(identity_update_op) => {
-                OperationTypeInSerializationFormat::OperationTypeInSerializationFormatIdentityUpdate(identity_update_op)
+                OperationTypeInSerializationFormat::IdentityUpdate(identity_update_op)
             }
             OperationType::IdentityWithdrawal => {
-                OperationTypeInSerializationFormat::OperationTypeInSerializationFormatIdentityWithdrawal
+                OperationTypeInSerializationFormat::IdentityWithdrawal
             }
             OperationType::ContractCreate(p, c) => {
-                OperationTypeInSerializationFormat::OperationTypeInSerializationFormatContractCreate(p,c)
+                OperationTypeInSerializationFormat::ContractCreate(p, c)
             }
             OperationType::ContractUpdate(update_op) => {
                 // let's just serialize it to make things easier
                 let contract_op_in_serialization_format = update_op.serialize_consume_to_bytes_with_platform_version(platform_version)?;
-                OperationTypeInSerializationFormat::OperationTypeInSerializationFormatContractUpdate(contract_op_in_serialization_format)
+                OperationTypeInSerializationFormat::ContractUpdate(contract_op_in_serialization_format)
             }
             OperationType::IdentityTransfer => {
-                OperationTypeInSerializationFormat::OperationTypeInSerializationFormatIdentityTransfer
+                OperationTypeInSerializationFormat::IdentityTransfer
             }
         };
         let config = bincode::config::standard()
@@ -431,27 +431,27 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Ope
                 })?
                 .0;
         Ok(match operation_type {
-            OperationTypeInSerializationFormat::OperationTypeInSerializationFormatDocument(serialized_op) => {
+            OperationTypeInSerializationFormat::Document(serialized_op) => {
                 let document_op = DocumentOp::versioned_deserialize(serialized_op.as_slice(), validate, platform_version)?;
                 OperationType::Document(document_op)
             }
-            OperationTypeInSerializationFormat::OperationTypeInSerializationFormatIdentityTopUp => {
+            OperationTypeInSerializationFormat::IdentityTopUp => {
                 OperationType::IdentityTopUp
             }
-            OperationTypeInSerializationFormat::OperationTypeInSerializationFormatIdentityUpdate(identity_update_op) => {
+            OperationTypeInSerializationFormat::IdentityUpdate(identity_update_op) => {
                 OperationType::IdentityUpdate(identity_update_op)
             }
-            OperationTypeInSerializationFormat::OperationTypeInSerializationFormatIdentityWithdrawal => {
+            OperationTypeInSerializationFormat::IdentityWithdrawal => {
                 OperationType::IdentityWithdrawal
             }
-            OperationTypeInSerializationFormat::OperationTypeInSerializationFormatContractCreate(p, c) => {
+            OperationTypeInSerializationFormat::ContractCreate(p, c) => {
                 OperationType::ContractCreate(p, c)
             }
-            OperationTypeInSerializationFormat::OperationTypeInSerializationFormatContractUpdate(serialized_op) => {
+            OperationTypeInSerializationFormat::ContractUpdate(serialized_op) => {
                 let update_op = DataContractUpdateOp::versioned_deserialize(serialized_op.as_slice(), validate, platform_version)?;
                 OperationType::ContractUpdate(update_op)
             }
-            OperationTypeInSerializationFormat::OperationTypeInSerializationFormatIdentityTransfer => {
+            OperationTypeInSerializationFormat::IdentityTransfer => {
                 OperationType::IdentityTransfer
             }
         })

--- a/packages/strategy-tests/src/transitions.rs
+++ b/packages/strategy-tests/src/transitions.rs
@@ -637,10 +637,9 @@ pub fn create_identities_state_transitions(
     // Update keys with new KeyIDs and add them to signer
     let mut current_id_num = starting_id_num;
     for (key, _) in &mut keys {
-        if let IdentityPublicKey::V0(ref mut id_pub_key_v0) = key {
-            id_pub_key_v0.set_id(current_id_num);
-            current_id_num += 1; // Increment for each key
-        }
+        let IdentityPublicKey::V0(ref mut id_pub_key_v0) = key;
+        id_pub_key_v0.set_id(current_id_num);
+        current_id_num += 1; // Increment for each key
     }
     signer.add_keys(keys);
 
@@ -658,10 +657,9 @@ pub fn create_identities_state_transitions(
                 .values_mut()
                 .enumerate()
                 .for_each(|(key_index, public_key)| {
-                    if let IdentityPublicKey::V0(ref mut id_pub_key_v0) = public_key {
-                        let new_id = identity_starting_id + key_index as u32;
-                        id_pub_key_v0.set_id(new_id);
-                    }
+                    let IdentityPublicKey::V0(ref mut id_pub_key_v0) = public_key;
+                    let new_id = identity_starting_id + key_index as u32;
+                    id_pub_key_v0.set_id(new_id);
                 });
 
             // Attempt to create an asset lock

--- a/packages/wasm-dpp/src/data_contract/data_contract_facade.rs
+++ b/packages/wasm-dpp/src/data_contract/data_contract_facade.rs
@@ -8,7 +8,6 @@ use dpp::identifier::Identifier;
 use crate::data_contract::state_transition::DataContractCreateTransitionWasm;
 use crate::data_contract::state_transition::DataContractUpdateTransitionWasm;
 use crate::data_contract::DataContractWasm;
-use crate::entropy_generator::ExternalEntropyGenerator;
 use crate::errors::protocol_error::from_protocol_error;
 use crate::utils::{
     get_bool_from_options, ToSerdeJSONExt, WithJsError, SKIP_VALIDATION_PROPERTY_NAME,

--- a/packages/wasm-dpp/src/data_contract_factory/data_contract_factory.rs
+++ b/packages/wasm-dpp/src/data_contract_factory/data_contract_factory.rs
@@ -4,7 +4,6 @@ use dpp::data_contract::created_data_contract::CreatedDataContract;
 use dpp::{data_contract::DataContractFactory, platform_value, prelude::Identifier, ProtocolError};
 use wasm_bindgen::prelude::*;
 
-use crate::entropy_generator::ExternalEntropyGenerator;
 use crate::utils::{ToSerdeJSONExt, WithJsError};
 
 use crate::data_contract::{DataContractCreateTransitionWasm, DataContractWasm};

--- a/packages/wasm-dpp/src/document/extended_document.rs
+++ b/packages/wasm-dpp/src/document/extended_document.rs
@@ -19,6 +19,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::buffer::Buffer;
 use crate::data_contract::DataContractWasm;
+#[allow(deprecated)] // BinaryType is unsed in unused code below
 use crate::document::BinaryType;
 use crate::document::{ConversionOptions, DocumentWasm};
 use crate::errors::RustConversionError;

--- a/packages/wasm-dpp/src/errors/consensus/state/identity/invalid_identity_contract_nonce_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/state/identity/invalid_identity_contract_nonce_error.rs
@@ -27,8 +27,7 @@ impl InvalidIdentityNonceErrorWasm {
     #[wasm_bindgen(js_name=getCurrentIdentityContractNonce)]
     pub fn current_identity_contract_nonce(&self) -> Option<u64> {
         self.inner
-            .current_identity_contract_nonce()
-            .map(|nonce| *nonce)
+            .current_identity_contract_nonce().copied()
     }
 
     #[wasm_bindgen(js_name=getSettingIdentityContractNonce)]

--- a/packages/wasm-dpp/src/identity/state_transition/identity_credit_withdrawal_transition/transition.rs
+++ b/packages/wasm-dpp/src/identity/state_transition/identity_credit_withdrawal_transition/transition.rs
@@ -78,7 +78,7 @@ impl IdentityCreditWithdrawalTransitionWasm {
 
     #[wasm_bindgen(js_name=getAmount)]
     pub fn get_amount(&self) -> u64 {
-        self.0.amount() as u64
+        self.0.amount()
     }
 
     #[wasm_bindgen(js_name=setAmount)]
@@ -88,12 +88,12 @@ impl IdentityCreditWithdrawalTransitionWasm {
 
     #[wasm_bindgen(js_name=getCoreFeePerByte)]
     pub fn get_core_fee_per_byte(&self) -> u32 {
-        self.0.core_fee_per_byte() as u32
+        self.0.core_fee_per_byte()
     }
 
     #[wasm_bindgen(js_name=setCoreFeePerByte)]
     pub fn set_core_fee_per_byte(&mut self, core_fee_per_byte: u32) {
-        self.0.set_core_fee_per_byte(core_fee_per_byte as u32);
+        self.0.set_core_fee_per_byte(core_fee_per_byte);
     }
 
     #[wasm_bindgen(js_name=getPooling)]
@@ -126,7 +126,7 @@ impl IdentityCreditWithdrawalTransitionWasm {
 
     #[wasm_bindgen(js_name=getNonce)]
     pub fn get_nonce(&self) -> u64 {
-        self.0.nonce() as u64
+        self.0.nonce()
     }
 
     #[wasm_bindgen(js_name=setNonce)]
@@ -385,7 +385,7 @@ impl IdentityCreditWithdrawalTransitionWasm {
     #[wasm_bindgen(js_name=setSignature)]
     pub fn set_signature(&mut self, signature: Option<Vec<u8>>) {
         self.0
-            .set_signature(BinaryData::new(signature.unwrap_or(vec![])))
+            .set_signature(BinaryData::new(signature.unwrap_or_default()))
     }
 
     #[wasm_bindgen]

--- a/packages/wasm-dpp/src/identity/state_transition/identity_credit_withdrawal_transition/transition.rs
+++ b/packages/wasm-dpp/src/identity/state_transition/identity_credit_withdrawal_transition/transition.rs
@@ -46,7 +46,7 @@ impl IdentityCreditWithdrawalTransitionWasm {
         let platform_version =
             &PlatformVersion::get(platform_version).map_err(|e| JsValue::from(e.to_string()))?;
 
-        IdentityCreditWithdrawalTransition::default_versioned(&platform_version)
+        IdentityCreditWithdrawalTransition::default_versioned(platform_version)
             .map(Into::into)
             .map_err(from_dpp_err)
     }

--- a/packages/wasm-dpp/src/identity/state_transition/identity_public_key_transitions.rs
+++ b/packages/wasm-dpp/src/identity/state_transition/identity_public_key_transitions.rs
@@ -19,6 +19,8 @@ use dpp::version::PlatformVersion;
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct ToObjectOptions {
+    #[allow(dead_code)]
+    #[deprecated(note = "This function is marked as unused.")]
     pub skip_signature: Option<bool>,
 }
 

--- a/packages/wasm-dpp/src/lib.rs
+++ b/packages/wasm-dpp/src/lib.rs
@@ -19,7 +19,7 @@ mod identifier;
 mod identity;
 mod metadata;
 // mod state_repository;
-mod state_transition;
+pub mod state_transition;
 // mod version;
 
 mod utils;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Resolve build warnings

## What was done?
Resolve build warnings

cargo check --tests now returns only 1 warning; which according to @QuantumExplorer should be resolved in future?
```
> $ cargo check --tests                                                                                                                                                                                                       [±wip/refac/clippy ●]
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/pasta/workspace/platform/packages/wasm-dpp/Cargo.toml
workspace: /Users/pasta/workspace/platform/Cargo.toml
warning: /Users/pasta/workspace/platform/packages/rs-drive-proof-verifier/Cargo.toml: unused manifest key: package.crate-type
warning: skipping duplicate package `embedded` found at `/Users/pasta/.cargo/git/checkouts/rust-dashcore-b01a88e2cb0da4a0/25053c8/dash/embedded`
warning: use of deprecated method `tenderdash_abci::signatures::Signable::sign_digest`: replaced by calculate_sign_hash() to unify naming between core, platform and tenderdash
  --> packages/rs-drive-proof-verifier/src/verify.rs:78:10
   |
78 |         .sign_digest(
   |          ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: `drive-proof-verifier` (lib) generated 1 warning
warning: `drive-proof-verifier` (lib test) generated 1 warning (1 duplicate)
    Finished dev [unoptimized + debuginfo] target(s) in 0.76s
```

## How Has This Been Tested?
cargo t in root

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
