### PR TITLE
refactor: drop unused includes; use calculate_sign_hash

### DIFF
--- a/packages/rs-drive-proof-verifier/src/verify.rs
+++ b/packages/rs-drive-proof-verifier/src/verify.rs
@@ -75,7 +75,7 @@ pub(crate) fn verify_tenderdash_proof(
 
     // Verify signature
     let sign_digest = commit
-        .sign_digest(
+        .calculate_sign_hash(
             &chain_id,
             quorum_type.try_into().expect("quorum type out of range"),
             &quorum_hash,

--- a/packages/rs-drive/src/drive/grove_operations/grove_apply_batch/mod.rs
+++ b/packages/rs-drive/src/drive/grove_operations/grove_apply_batch/mod.rs
@@ -1,7 +1,6 @@
 
 use crate::drive::batch::GroveDbOpBatch;
 use crate::drive::Drive;
-use crate::error::drive::DriveError;
 use crate::error::Error;
 use dpp::version::drive_versions::DriveVersion;
 use grovedb::TransactionArg;

--- a/packages/rs-drive/src/drive/grove_operations/grove_apply_partial_batch/mod.rs
+++ b/packages/rs-drive/src/drive/grove_operations/grove_apply_partial_batch/mod.rs
@@ -1,7 +1,6 @@
 
 use crate::drive::batch::GroveDbOpBatch;
 use crate::drive::Drive;
-use crate::error::drive::DriveError;
 use crate::error::Error;
 use crate::query::GroveError;
 use dpp::version::drive_versions::DriveVersion;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fix compilation warnings

## What was done?
Fix them; @lklimek stated we should indeed use calculate_sign_hash

## How Has This Been Tested?
Build locally

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
