### PR TITLE
fix(platform): wrong state used to get current validator set

### DIFF
--- a/packages/rs-drive-abci/src/error/execution.rs
+++ b/packages/rs-drive-abci/src/error/execution.rs
@@ -53,7 +53,7 @@ pub enum ExecutionError {
 
     /// The platform encountered a corrupted cache state error.
     #[error("platform corrupted cached state error: {0}")]
-    CorruptedCachedState(&'static str),
+    CorruptedCachedState(String),
 
     /// The fork is not yet active for core.
     #[error("initialization fork not active: {0}")]

--- a/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
@@ -131,9 +131,9 @@ where
             return Ok(validation_result.into());
         }
 
-        let current_quorum_hash = block_platform_state
-            .current_validator_set_quorum_hash()
-            .into();
+        let state_cache = self.state.load();
+        let current_quorum_hash = state_cache.current_validator_set_quorum_hash().into();
+
         if current_quorum_hash != commit_info.quorum_hash {
             validation_result.add_error(AbciError::WrongFinalizeBlockReceived(format!(
                 "received a block for h: {} r: {} with validator set quorum hash {} expected current validator set quorum hash is {}",
@@ -168,9 +168,7 @@ where
         {
             // Verify commit
 
-            let quorum_public_key = block_platform_state
-                .current_validator_set()?
-                .threshold_public_key();
+            let quorum_public_key = state_cache.current_validator_set()?.threshold_public_key();
             let quorum_type = self.config.validator_set_quorum_type();
             // TODO: We already had commit in the function above, why do we need to create it again with clone?
             let commit = Commit::new_from_cleaned(

--- a/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
@@ -131,8 +131,8 @@ where
             return Ok(validation_result.into());
         }
 
-        let state_cache = self.state.load();
-        let current_quorum_hash = state_cache.current_validator_set_quorum_hash().into();
+        let last_committed_state = self.state.load();
+        let current_quorum_hash = last_committed_state.current_validator_set_quorum_hash().into();
 
         if current_quorum_hash != commit_info.quorum_hash {
             validation_result.add_error(AbciError::WrongFinalizeBlockReceived(format!(
@@ -168,7 +168,7 @@ where
         {
             // Verify commit
 
-            let quorum_public_key = state_cache.current_validator_set()?.threshold_public_key();
+            let quorum_public_key = last_committed_state.current_validator_set()?.threshold_public_key();
             let quorum_type = self.config.validator_set_quorum_type();
             // TODO: We already had commit in the function above, why do we need to create it again with clone?
             let commit = Commit::new_from_cleaned(

--- a/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
@@ -132,7 +132,9 @@ where
         }
 
         let last_committed_state = self.state.load();
-        let current_quorum_hash = last_committed_state.current_validator_set_quorum_hash().into();
+        let current_quorum_hash = last_committed_state
+            .current_validator_set_quorum_hash()
+            .into();
 
         if current_quorum_hash != commit_info.quorum_hash {
             validation_result.add_error(AbciError::WrongFinalizeBlockReceived(format!(
@@ -168,7 +170,9 @@ where
         {
             // Verify commit
 
-            let quorum_public_key = last_committed_state.current_validator_set()?.threshold_public_key();
+            let quorum_public_key = last_committed_state
+                .current_validator_set()?
+                .threshold_public_key();
             let quorum_type = self.config.validator_set_quorum_type();
             // TODO: We already had commit in the function above, why do we need to create it again with clone?
             let commit = Commit::new_from_cleaned(

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v0/mod.rs
@@ -65,8 +65,8 @@ where
                 .validator_sets()
                 .get_index_of(&platform_state.current_validator_set_quorum_hash())
                 .ok_or(Error::Execution(ExecutionError::CorruptedCachedState(
-                    format!("perform_rotation: current validator set quorum hash {} not in current known validator sets [{}] processing block {}", platform_state.current_validator_set_quorum_hash().to_string(), platform_state
-                        .validator_sets().keys().into_iter().map(|quorum_hash| quorum_hash.to_string()).join(" | "),
+                    format!("perform_rotation: current validator set quorum hash {} not in current known validator sets [{}] processing block {}", platform_state.current_validator_set_quorum_hash(), platform_state
+                        .validator_sets().keys().map(|quorum_hash| quorum_hash.to_string()).join(" | "),
                             platform_state.last_committed_block_height() + 1,
                 ))))?;
             // we should rotate the quorum

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v0/mod.rs
@@ -10,6 +10,7 @@ use crate::platform_types::platform_state::v0::PlatformStateV0Methods;
 use crate::platform_types::platform_state::PlatformState;
 use crate::platform_types::validator_set::v0::ValidatorSetV0Getters;
 use crate::rpc::core::CoreRPCLike;
+use itertools::Itertools;
 
 use tenderdash_abci::proto::abci::ValidatorSetUpdate;
 
@@ -64,13 +65,15 @@ where
                 .validator_sets()
                 .get_index_of(&platform_state.current_validator_set_quorum_hash())
                 .ok_or(Error::Execution(ExecutionError::CorruptedCachedState(
-                    "current quorums do not contain current validator set",
-                )))?;
+                    format!("perform_rotation: current validator set quorum hash {} not in current known validator sets [{}] processing block {}", platform_state.current_validator_set_quorum_hash().to_string(), platform_state
+                        .validator_sets().keys().into_iter().map(|quorum_hash| quorum_hash.to_string()).join(" | "),
+                            platform_state.last_committed_block_height() + 1,
+                ))))?;
             // we should rotate the quorum
             let quorum_count = platform_state.validator_sets().len();
             match quorum_count {
                 0 => Err(Error::Execution(ExecutionError::CorruptedCachedState(
-                    "no current quorums",
+                    "no current quorums".to_string(),
                 ))),
                 1 => Ok(None),
                 count => {

--- a/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_masternode_identities/update_operator_identity/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_masternode_identities/update_operator_identity/v0/mod.rs
@@ -57,9 +57,10 @@ where
             .full_masternode_list()
             .get(pro_tx_hash)
             .ok_or_else(|| {
-                Error::Execution(ExecutionError::CorruptedCachedState(
-                    "expected masternode to be in state",
-                ))
+                Error::Execution(ExecutionError::CorruptedCachedState(format!(
+                    "expected masternode {} to be in state",
+                    pro_tx_hash.to_string()
+                )))
             })?;
 
         let old_operator_identifier = Self::get_operator_identifier_from_masternode_list_item(

--- a/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_masternode_identities/update_voter_identity/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_masternode_identities/update_voter_identity/v0/mod.rs
@@ -49,7 +49,7 @@ where
             .ok_or_else(|| {
                 Error::Execution(ExecutionError::CorruptedCachedState(format!(
                     "expected masternode {} to be in state",
-                    pro_tx_hash.to_string()
+                    pro_tx_hash
                 )))
             })?;
 

--- a/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_masternode_identities/update_voter_identity/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_masternode_identities/update_voter_identity/v0/mod.rs
@@ -47,9 +47,10 @@ where
             .full_masternode_list()
             .get(pro_tx_hash)
             .ok_or_else(|| {
-                Error::Execution(ExecutionError::CorruptedCachedState(
-                    "expected masternode to be in state",
-                ))
+                Error::Execution(ExecutionError::CorruptedCachedState(format!(
+                    "expected masternode {} to be in state",
+                    pro_tx_hash.to_string()
+                )))
             })?;
 
         let old_voter_identifier =

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_update/structure/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_update/structure/v0/mod.rs
@@ -1,6 +1,7 @@
 use crate::error::Error;
 use dpp::consensus::basic::identity::{
-    DisablingKeyIdAlsoBeingAddedInSameTransitionError, DuplicatedIdentityPublicKeyIdBasicError, InvalidIdentityUpdateTransitionEmptyError,
+    DisablingKeyIdAlsoBeingAddedInSameTransitionError, DuplicatedIdentityPublicKeyIdBasicError,
+    InvalidIdentityUpdateTransitionEmptyError,
 };
 use dpp::consensus::state::identity::max_identity_public_key_limit_reached_error::MaxIdentityPublicKeyLimitReachedError;
 use dpp::consensus::ConsensusError;

--- a/packages/rs-drive-abci/src/platform_types/platform/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mod.rs
@@ -184,7 +184,7 @@ impl<C> Platform<C> {
                 Platform::<C>::fetch_platform_state(&drive, None, platform_version)?
             else {
                 return Err(Error::Execution(ExecutionError::CorruptedCachedState(
-                    "execution state should be stored as well as protocol version",
+                    "execution state should be stored as well as protocol version".to_string(),
                 )));
             };
 

--- a/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
@@ -20,6 +20,7 @@ use dpp::block::extended_block_info::v0::ExtendedBlockInfoV0Getters;
 use dpp::bls_signatures::PublicKey as ThresholdBlsPublicKey;
 use dpp::version::{PlatformVersion, TryIntoPlatformVersioned};
 
+use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter};
 
@@ -586,7 +587,8 @@ impl PlatformStateV0Methods for PlatformStateV0 {
         self.validator_sets
             .get(&self.current_validator_set_quorum_hash)
             .ok_or(Error::Execution(ExecutionError::CorruptedCachedState(
-                "current validator quorum hash not in current known validator sets",
+                format!("current_validator_set: current validator quorum hash {} not in current known validator sets {} last committed block is {} (we might be processing new block)", self.current_validator_set_quorum_hash.to_string(), self.validator_sets.keys().into_iter().map(|quorum_hash| quorum_hash.to_string()).join(" | "),
+                        self.last_committed_block_info.as_ref().map(|block_info| block_info.basic_info().height).unwrap_or_default()),
             )))
     }
 

--- a/packages/rs-drive-abci/src/platform_types/validator_set/v0/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/validator_set/v0/mod.rs
@@ -57,19 +57,30 @@ impl ValidatorSetV0 {
     ) -> Result<ValidatorSetUpdate, Error> {
         if self.quorum_hash != rhs.quorum_hash {
             return Err(Error::Execution(ExecutionError::CorruptedCachedState(
-                "updating validator set doesn't match quorum hash",
+                format!(
+                    "updating validator set doesn't match quorum hash ours: {} theirs: {}",
+                    self.quorum_hash.to_string(),
+                    rhs.quorum_hash.to_string()
+                ),
             )));
         }
 
         if self.core_height != rhs.core_height {
             return Err(Error::Execution(ExecutionError::CorruptedCachedState(
-                "updating validator set doesn't match core height",
+                format!(
+                    "updating validator set doesn't match core height ours: {} theirs: {}",
+                    self.core_height, rhs.core_height
+                ),
             )));
         }
 
         if self.threshold_public_key != rhs.threshold_public_key {
             return Err(Error::Execution(ExecutionError::CorruptedCachedState(
-                "updating validator set doesn't match threshold public key",
+                format!(
+                    "updating validator set doesn't match threshold public key ours: {} theirs: {}",
+                    hex::encode(*self.threshold_public_key.to_bytes()),
+                    hex::encode(*rhs.threshold_public_key.to_bytes())
+                ),
             )));
         }
 
@@ -80,7 +91,10 @@ impl ValidatorSetV0 {
                 rhs.members.get(pro_tx_hash).map_or_else(
                     || {
                         Some(Err(Error::Execution(ExecutionError::CorruptedCachedState(
-                            "validator set does not contain all same members",
+                            format!(
+                                "validator set does not contain all same members, missing {}",
+                                pro_tx_hash.to_string()
+                            ),
                         ))))
                     },
                     |new_validator_state| {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
This PR https://github.com/dashpay/platform/pull/1733 introduced a bug that is described in this document: https://docs.google.com/document/d/10VkH30CuRmNXLGOJsdS5hvIKjtzDniPsFL3mG6ymTLw

Basically we were using updated validator sets and trying to find the current quorum by hash inside of them. But it might have been dropped.

## What was done?

Using the current validator sets in state instead of block state to find the current quorum by hash.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [X] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
