### PR TITLE
feat(dapi): use broadcast_tx instead of deprecated broadcast_tx_sync

### DIFF
--- a/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.js
@@ -44,7 +44,7 @@ function broadcastStateTransitionHandlerFactory(rpcClient, createGrpcErrorFromDr
     let response;
 
     try {
-      response = await rpcClient.request('broadcast_tx_sync', { tx });
+      response = await rpcClient.request('broadcast_tx', { tx });
     } catch (e) {
       if (e.message === 'socket hang up') {
         throw new UnavailableGrpcError('Tenderdash is not available');

--- a/packages/dapi/test/unit/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.spec.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/platform/broadcastStateTransitionHandlerFactory.spec.js
@@ -114,7 +114,7 @@ describe('broadcastStateTransitionHandlerFactory', () => {
     const tx = stateTransitionFixture.toBuffer().toString('base64');
 
     expect(result).to.be.an.instanceOf(BroadcastStateTransitionResponse);
-    expect(rpcClientMock.request).to.be.calledOnceWith('broadcast_tx_sync', { tx });
+    expect(rpcClientMock.request).to.be.calledOnceWith('broadcast_tx', { tx });
   });
 
   it('should throw a UnavailableGrpcError if tenderdash hands up', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Replaced `broadcas_tx_sync` Tednerdash call with `broadcast_tx` in DAPI.

Currently, `broadcas_tx_sync` is an alias to `broadcas_tx` call in Tenderdash. 
@lklimek deprecates it. 

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
