### PR TITLE
ci: enforce warnings as errors

### DIFF
--- a/.github/workflows/tests-rs-package.yml
+++ b/.github/workflows/tests-rs-package.yml
@@ -222,6 +222,7 @@ jobs:
           set -ex
           features="${{ steps.crate_info.outputs.features }}"
           fails=""
+          RUSTFLAGS="-D warnings"
           cargo check --no-default-features --package "${{ inputs.package }}" --locked
           for feature in $features ;  do
             echo " ============== Verify feature $feature =============="

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v0/mod.rs
@@ -24,6 +24,7 @@ use std::collections::HashSet;
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
 
+#[cfg(feature = "validation")]
 use crate::consensus::basic::data_contract::InvalidDocumentTypeRequiredSecurityLevelError;
 #[cfg(feature = "validation")]
 use crate::consensus::basic::document::MissingPositionsInDocumentTypePropertiesError;

--- a/packages/rs-dpp/src/document/serialization_traits/platform_serialization_conversion/v0/mod.rs
+++ b/packages/rs-dpp/src/document/serialization_traits/platform_serialization_conversion/v0/mod.rs
@@ -1,4 +1,5 @@
 use crate::data_contract::document_type::DocumentTypeRef;
+#[cfg(feature = "validation")]
 use crate::validation::ConsensusValidationResult;
 use crate::version::PlatformVersion;
 use crate::ProtocolError;

--- a/packages/rs-dpp/src/document/v0/serialize.rs
+++ b/packages/rs-dpp/src/document/v0/serialize.rs
@@ -26,7 +26,9 @@ use platform_version::version::FeatureVersion;
 use std::collections::BTreeMap;
 
 use crate::consensus::basic::decode::DecodingError;
+#[cfg(feature = "validation")]
 use crate::consensus::basic::BasicError;
+#[cfg(feature = "validation")]
 use crate::consensus::ConsensusError;
 use std::io::{BufReader, Read};
 

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/methods/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/methods/mod.rs
@@ -6,7 +6,9 @@ use crate::document::Document;
 use crate::identity::signer::Signer;
 #[cfg(feature = "state-transition-signing")]
 use crate::identity::IdentityPublicKey;
-use crate::prelude::{IdentityNonce, UserFeeIncrease};
+use crate::prelude::IdentityNonce;
+#[cfg(feature = "state-transition-signing")]
+use crate::prelude::UserFeeIncrease;
 use crate::state_transition::documents_batch_transition::document_transition::DocumentTransition;
 use crate::state_transition::documents_batch_transition::methods::v0::DocumentsBatchTransitionMethodsV0;
 use crate::state_transition::documents_batch_transition::DocumentsBatchTransition;

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/methods/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/methods/v0/mod.rs
@@ -7,7 +7,9 @@ use crate::identity::signer::Signer;
 #[cfg(feature = "state-transition-signing")]
 use crate::identity::IdentityPublicKey;
 use crate::identity::SecurityLevel;
-use crate::prelude::{IdentityNonce, UserFeeIncrease};
+use crate::prelude::IdentityNonce;
+#[cfg(feature = "state-transition-signing")]
+use crate::prelude::UserFeeIncrease;
 use crate::state_transition::documents_batch_transition::accessors::DocumentsBatchTransitionAccessorsV0;
 use crate::state_transition::documents_batch_transition::document_base_transition::v0::v0_methods::DocumentBaseTransitionV0Methods;
 use crate::state_transition::documents_batch_transition::document_transition::{

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/documents_batch_transition/v0/v0_methods.rs
@@ -8,7 +8,9 @@ use crate::identity::signer::Signer;
 use crate::identity::SecurityLevel;
 #[cfg(feature = "state-transition-signing")]
 use crate::prelude::IdentityPublicKey;
-use crate::prelude::{IdentityNonce, UserFeeIncrease};
+use crate::prelude::IdentityNonce;
+#[cfg(feature = "state-transition-signing")]
+use crate::prelude::UserFeeIncrease;
 use crate::state_transition::documents_batch_transition::accessors::DocumentsBatchTransitionAccessorsV0;
 #[cfg(feature = "state-transition-signing")]
 use crate::state_transition::documents_batch_transition::document_create_transition::DocumentCreateTransition;

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_update_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_update_transition/v0/v0_methods.rs
@@ -19,7 +19,9 @@ use crate::identity::{Identity, IdentityPublicKey};
 use crate::identity::accessors::IdentityGettersV0;
 #[cfg(feature = "state-transition-signing")]
 use crate::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use crate::prelude::{IdentityNonce, UserFeeIncrease};
+use crate::prelude::IdentityNonce;
+#[cfg(feature = "state-transition-signing")]
+use crate::prelude::UserFeeIncrease;
 use crate::state_transition::identity_update_transition::accessors::IdentityUpdateTransitionAccessorsV0;
 use crate::state_transition::identity_update_transition::methods::IdentityUpdateTransitionMethodsV0;
 use crate::state_transition::identity_update_transition::v0::IdentityUpdateTransitionV0;

--- a/packages/rs-drive-abci/src/main.rs
+++ b/packages/rs-drive-abci/src/main.rs
@@ -12,6 +12,7 @@ use drive_abci::rpc::core::DefaultCoreRPC;
 use drive_abci::{logging, server};
 use itertools::Itertools;
 use std::fs::remove_file;
+#[cfg(tokio_unstable)]
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -20,8 +21,6 @@ use tokio::runtime::{Builder, Runtime};
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
 
 const SHUTDOWN_TIMEOUT_MILIS: u64 = 5000; // 5s; Docker defaults to 10s
 
@@ -165,26 +164,28 @@ fn main() -> Result<(), ExitCode> {
         panic!("tokio_unstable flag should be set");
 
         // Initialize Tokio console subscriber
+        #[cfg(tokio_unstable)]
+        {
+            let socket_addr: SocketAddr = config
+                .tokio_console_address
+                .parse()
+                .expect("cannot parse tokio console address");
 
-        let socket_addr: SocketAddr = config
-            .tokio_console_address
-            .parse()
-            .expect("cannot parse tokio console address");
+            let console_layer = console_subscriber::ConsoleLayer::builder()
+                .retention(Duration::from_secs(config.tokio_console_retention_secs))
+                .server_addr(socket_addr)
+                .spawn();
 
-        let console_layer = console_subscriber::ConsoleLayer::builder()
-            .retention(Duration::from_secs(config.tokio_console_retention_secs))
-            .server_addr(socket_addr)
-            .spawn();
-
-        tracing_subscriber::registry()
-            .with(
-                loggers
-                    .tracing_subscriber_layers()
-                    .expect("should return layers"),
-            )
-            .with(console_layer)
-            .try_init()
-            .expect("can't init tracing subscribers");
+            tracing_subscriber::registry()
+                .with(
+                    loggers
+                        .tracing_subscriber_layers()
+                        .expect("should return layers"),
+                )
+                .with(console_layer)
+                .try_init()
+                .expect("can't init tracing subscribers");
+        }
     } else {
         loggers.install();
     }

--- a/packages/rs-drive-abci/src/main.rs
+++ b/packages/rs-drive-abci/src/main.rs
@@ -21,6 +21,10 @@ use tokio::runtime::{Builder, Runtime};
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
+#[cfg(tokio_unstable)]
+use tracing_subscriber::layer::SubscriberExt;
+#[cfg(tokio_unstable)]
+use tracing_subscriber::util::SubscriberInitExt;
 
 const SHUTDOWN_TIMEOUT_MILIS: u64 = 5000; // 5s; Docker defaults to 10s
 

--- a/packages/rs-drive-abci/src/utils/spawn.rs
+++ b/packages/rs-drive-abci/src/utils/spawn.rs
@@ -3,7 +3,7 @@ use tokio::task::JoinHandle;
 
 /// Spawn a blocking tokio task with name if tokio_unstable flag is set
 pub fn spawn_blocking_task_with_name_if_supported<Function, Output>(
-    name: &str,
+    _sometimes_used_name: &str,
     function: Function,
 ) -> io::Result<JoinHandle<Output>>
 where
@@ -13,7 +13,7 @@ where
     #[cfg(all(tokio_unstable, feature = "console"))]
     {
         tokio::task::Builder::new()
-            .name(name)
+            .name(_sometimes_used_name)
             .spawn_blocking(function)
     }
 

--- a/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
@@ -179,6 +179,7 @@ pub enum CoreHeightIncrease {
     #[default]
     NoCoreHeightIncrease,
     RandomCoreHeightIncrease(Frequency),
+    #[allow(dead_code)] // TODO investigate why this is never constructed according to compiler
     KnownCoreHeightIncreases(Vec<u32>),
 }
 

--- a/packages/rs-drive/src/common/mod.rs
+++ b/packages/rs-drive/src/common/mod.rs
@@ -60,10 +60,12 @@ use dpp::data_contract::DataContract;
 
 #[cfg(feature = "full")]
 use dpp::block::block_info::BlockInfo;
+#[cfg(feature = "fixtures-and-mocks")]
 use dpp::prelude::Identifier;
 
 #[cfg(feature = "fixtures-and-mocks")]
 use dpp::tests::json_document::json_document_to_contract_with_ids;
+#[cfg(feature = "fixtures-and-mocks")]
 use dpp::version::PlatformVersion;
 
 #[cfg(test)]

--- a/packages/rs-drive/src/drive/batch/transitions/contract/data_contract_create_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/contract/data_contract_create_transition.rs
@@ -14,7 +14,7 @@ impl DriveHighLevelOperationConverter for DataContractCreateTransitionAction {
         _epoch: &Epoch,
         _platform_version: &PlatformVersion,
     ) -> Result<Vec<DriveOperation<'a>>, Error> {
-        let operations = vec![
+        Ok(vec![
             IdentityOperation(IdentityOperationType::UpdateIdentityNonce {
                 identity_id: self.data_contract_ref().owner_id().into_buffer(),
                 nonce: self.identity_nonce(),
@@ -31,8 +31,6 @@ impl DriveHighLevelOperationConverter for DataContractCreateTransitionAction {
                 contract: Cow::Owned(self.data_contract()),
                 storage_flags: None,
             }),
-        ];
-
-        Ok(operations)
+        ])
     }
 }

--- a/packages/rs-drive/src/drive/contract/contract_fetch_info.rs
+++ b/packages/rs-drive/src/drive/contract/contract_fetch_info.rs
@@ -1,7 +1,9 @@
 use crate::drive::flags::StorageFlags;
 use dpp::data_contract::DataContract;
+#[cfg(feature = "fixtures-and-mocks")]
 use dpp::data_contracts;
 use dpp::fee::fee_result::FeeResult;
+#[cfg(feature = "fixtures-and-mocks")]
 use dpp::system_data_contracts::load_system_data_contract;
 #[cfg(feature = "fixtures-and-mocks")]
 use dpp::tests::fixtures::get_dashpay_contract_fixture;
@@ -10,6 +12,7 @@ use dpp::tests::fixtures::get_dpns_data_contract_fixture;
 #[cfg(feature = "fixtures-and-mocks")]
 use dpp::tests::fixtures::get_masternode_reward_shares_data_contract_fixture;
 use grovedb_costs::OperationCost;
+#[cfg(feature = "fixtures-and-mocks")]
 use platform_version::version::PlatformVersion;
 
 #[cfg(any(feature = "full", feature = "verify"))]

--- a/packages/rs-drive/src/drive/credit_pools/mod.rs
+++ b/packages/rs-drive/src/drive/credit_pools/mod.rs
@@ -47,6 +47,7 @@ use crate::fee_pools::epochs::paths::EpochProposers;
 use dpp::block::epoch::{Epoch, EpochIndex};
 #[cfg(feature = "full")]
 use dpp::fee::epoch::SignedCreditsPerEpoch;
+#[cfg(feature = "full")]
 use dpp::fee::SignedCredits;
 #[cfg(feature = "full")]
 use grovedb::query_result_type::QueryResultType;

--- a/packages/rs-drive/src/drive/document/mod.rs
+++ b/packages/rs-drive/src/drive/document/mod.rs
@@ -33,7 +33,7 @@
 //! Namely functions to return the paths to certain objects and the path sizes.
 //!
 
-#[cfg(any(feature = "full", feature = "verify"))]
+#[cfg(feature = "full")]
 use crate::drive::defaults::DEFAULT_HASH_SIZE_U8;
 #[cfg(feature = "full")]
 use crate::drive::flags::StorageFlags;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Enforce warnings as errors in CI

## What was done?
Enforce warnings as errors; and fix a few more warnings

## How Has This Been Tested?
Running cargo check --tests locally in root; and cargo hack check

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
