### PR TITLE
feat(dpp)!: validate document type name

### DIFF
--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v0/mod.rs
@@ -24,6 +24,7 @@ use std::collections::HashSet;
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
 
+#[cfg(any(test, feature = "validation"))]
 use crate::consensus::basic::data_contract::InvalidDocumentTypeNameError;
 #[cfg(feature = "validation")]
 use crate::consensus::basic::data_contract::InvalidDocumentTypeRequiredSecurityLevelError;

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v0/mod.rs
@@ -728,3 +728,173 @@ fn insert_values_nested(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use platform_value::platform_value;
+
+    mod document_type_name {
+        use super::*;
+
+        #[test]
+        fn should_be_valid() {
+            let platform_version = PlatformVersion::latest();
+
+            let schema = platform_value!({
+                "type": "object",
+                "properties": {
+                    "valid_name": {
+                        "type": "string",
+                        "position": 0
+                    }
+                },
+                "additionalProperties": false
+            });
+
+            let result = DocumentTypeV0::try_from_schema_v0(
+                Identifier::new([1; 32]),
+                "valid_name-a-b-123",
+                schema,
+                None,
+                false,
+                false,
+                true,
+                platform_version,
+            )
+            .expect("should be valid");
+        }
+
+        #[test]
+        fn should_no_be_empty() {
+            let platform_version = PlatformVersion::latest();
+
+            let schema = platform_value!({
+                "type": "object",
+                "properties": {
+                    "valid_name": {
+                        "type": "string",
+                        "position": 0
+                    }
+                },
+                "additionalProperties": false
+            });
+
+            let result = DocumentTypeV0::try_from_schema_v0(
+                Identifier::new([1; 32]),
+                "",
+                schema,
+                None,
+                false,
+                false,
+                true,
+                platform_version,
+            );
+
+            assert!(matches!(
+                result,
+                Err(ProtocolError::ConsensusError(boxed)
+            ) if matches!(
+                boxed.as_ref(),
+                ConsensusError::BasicError(
+                    BasicError::InvalidDocumentTypeNameError(InvalidDocumentTypeNameError { .. })
+                ))
+            ));
+        }
+
+        #[test]
+        fn should_no_be_longer_than_64_chars() {
+            let platform_version = PlatformVersion::latest();
+
+            let schema = platform_value!({
+                "type": "object",
+                "properties": {
+                    "valid_name": {
+                        "type": "string",
+                        "position": 0
+                    }
+                },
+                "additionalProperties": false
+            });
+
+            let result = DocumentTypeV0::try_from_schema_v0(
+                Identifier::new([1; 32]),
+                &"a".repeat(65),
+                schema,
+                None,
+                false,
+                false,
+                true,
+                platform_version,
+            );
+
+            assert!(matches!(
+                result,
+                Err(ProtocolError::ConsensusError(boxed)
+            ) if matches!(
+                boxed.as_ref(),
+                ConsensusError::BasicError(
+                    BasicError::InvalidDocumentTypeNameError(InvalidDocumentTypeNameError { .. })
+                ))
+            ));
+        }
+
+        #[test]
+        fn should_no_be_alphanumeric() {
+            let platform_version = PlatformVersion::latest();
+
+            let schema = platform_value!({
+                "type": "object",
+                "properties": {
+                    "valid_name": {
+                        "type": "string",
+                        "position": 0
+                    }
+                },
+                "additionalProperties": false
+            });
+
+            let result = DocumentTypeV0::try_from_schema_v0(
+                Identifier::new([1; 32]),
+                "invalid name",
+                schema.clone(),
+                None,
+                false,
+                false,
+                true,
+                platform_version,
+            );
+
+            assert!(matches!(
+                result,
+                Err(ProtocolError::ConsensusError(boxed)
+            ) if matches!(
+                boxed.as_ref(),
+                ConsensusError::BasicError(
+                    BasicError::InvalidDocumentTypeNameError(InvalidDocumentTypeNameError { .. })
+                ))
+            ));
+
+            let result = DocumentTypeV0::try_from_schema_v0(
+                Identifier::new([1; 32]),
+                "invalid&name",
+                schema,
+                None,
+                false,
+                false,
+                true,
+                platform_version,
+            );
+
+            assert!(matches!(
+                result,
+                Err(ProtocolError::ConsensusError(boxed)
+            ) if matches!(
+                boxed.as_ref(),
+                ConsensusError::BasicError(
+                    BasicError::InvalidDocumentTypeNameError(InvalidDocumentTypeNameError { .. })
+                ))
+            ));
+        }
+    }
+}

--- a/packages/rs-dpp/src/data_contract/document_type/v0/random_document_type.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/v0/random_document_type.rs
@@ -402,7 +402,6 @@ impl DocumentTypeV0 {
 
         // Combine everything into the final schema
         let schema = json!({
-            "title": name,
             "type": "object",
             "properties": properties_json_schema,
             "required": required_fields.iter().cloned().collect::<Vec<_>>(),

--- a/packages/rs-dpp/src/data_contract/document_type/v0/random_document_type.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/v0/random_document_type.rs
@@ -345,7 +345,7 @@ impl DocumentTypeV0 {
                         },
                         ArrayItemType::Identifier => json!({"type": "array"}),
                         ArrayItemType::Boolean => json!({"type": "bool"}),
-                        ArrayItemType::Date => json!({"type": "date"}), 
+                        ArrayItemType::Date => json!({"type": "date"}),
                     };
 
                     json!({

--- a/packages/rs-dpp/src/errors/consensus/basic/basic_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/basic_error.rs
@@ -9,7 +9,7 @@ use crate::consensus::basic::data_contract::{
     DataContractImmutablePropertiesUpdateError, DataContractInvalidIndexDefinitionUpdateError,
     DataContractUniqueIndicesChangedError, DuplicateIndexError, DuplicateIndexNameError,
     IncompatibleDataContractSchemaError, IncompatibleRe2PatternError, InvalidCompoundIndexError,
-    InvalidDataContractIdError, InvalidDataContractVersionError,
+    InvalidDataContractIdError, InvalidDataContractVersionError, InvalidDocumentTypeNameError,
     InvalidDocumentTypeRequiredSecurityLevelError, InvalidIndexPropertyTypeError,
     InvalidIndexedPropertyConstraintError, InvalidJsonSchemaRefError,
     SystemPropertyIndexAlreadyPresentError, UndefinedIndexPropertyError,
@@ -339,6 +339,9 @@ pub enum BasicError {
 
     #[error(transparent)]
     IdentityCreditTransferToSelfError(IdentityCreditTransferToSelfError),
+
+    #[error(transparent)]
+    InvalidDocumentTypeNameError(InvalidDocumentTypeNameError),
 }
 
 impl From<BasicError> for ConsensusError {

--- a/packages/rs-dpp/src/errors/consensus/basic/data_contract/invalid_document_type_name_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/data_contract/invalid_document_type_name_error.rs
@@ -1,0 +1,36 @@
+use crate::consensus::basic::BasicError;
+use crate::consensus::ConsensusError;
+use crate::errors::ProtocolError;
+use bincode::{Decode, Encode};
+use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
+use thiserror::Error;
+
+#[derive(
+    Error, Debug, Clone, PartialEq, Eq, Encode, Decode, PlatformSerialize, PlatformDeserialize,
+)]
+#[error("document type name '{name}' is not supported. It must be from 1 to 64 alphanumeric chars, and '_' or '-'.")]
+#[platform_serialize(unversioned)]
+pub struct InvalidDocumentTypeNameError {
+    /*
+
+    DO NOT CHANGE ORDER OF FIELDS WITHOUT INTRODUCING OF NEW VERSION
+
+    */
+    name: String,
+}
+
+impl InvalidDocumentTypeNameError {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl From<InvalidDocumentTypeNameError> for ConsensusError {
+    fn from(err: InvalidDocumentTypeNameError) -> Self {
+        Self::BasicError(BasicError::InvalidDocumentTypeNameError(err))
+    }
+}

--- a/packages/rs-dpp/src/errors/consensus/basic/data_contract/mod.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/data_contract/mod.rs
@@ -11,6 +11,7 @@ mod incompatible_re2_pattern_error;
 mod invalid_compound_index_error;
 mod invalid_data_contract_id_error;
 mod invalid_data_contract_version_error;
+mod invalid_document_type_name_error;
 mod invalid_document_type_required_security_level;
 mod invalid_index_property_type_error;
 mod invalid_indexed_property_constraint_error;
@@ -42,5 +43,6 @@ pub use system_property_index_already_present_error::*;
 pub use undefined_index_property_error::*;
 pub use unique_indices_limit_reached_error::*;
 
+pub use invalid_document_type_name_error::*;
 pub use unknown_security_level_error::*;
 pub use unknown_storage_key_requirements_error::*;

--- a/packages/rs-dpp/src/errors/consensus/codes.rs
+++ b/packages/rs-dpp/src/errors/consensus/codes.rs
@@ -104,6 +104,7 @@ impl ErrorWithCode for BasicError {
             Self::MaxDocumentsTransitionsExceededError { .. } => 10412,
             Self::DocumentTransitionsAreAbsentError { .. } => 10413,
             Self::NonceOutOfBoundsError(_) => 10414,
+            Self::InvalidDocumentTypeNameError(_) => 10415,
 
             // Identity Errors: 10500-10599
             Self::DuplicatedIdentityPublicKeyBasicError(_) => 10500,

--- a/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
@@ -1045,35 +1045,33 @@ impl NetworkStrategy {
 
                             // Create `doc_type_count` doc types
                             let doc_types =
-                                    Value::Map(
-                                        doc_type_range
-                                            .clone()
-                                            .filter_map(|_| match DocumentTypeV0::random_document_type(
-                                                params.clone(),
-                                                contract_id,
-                                                rng,
-                                                platform_version,
-                                            ) {
-                                                Ok(new_document_type) => {
-                                                    let mut doc_type_clone =
-                                                        new_document_type.schema().clone();
-                                                    let name = doc_type_clone.remove("title").expect(
-                                                        "Expected to get a doc type title in ContractCreate",
-                                                    );
-                                                    Some((
-                                                        Value::Text(name.to_string()),
-                                                        doc_type_clone,
-                                                    ))
-                                                }
-                                                Err(e) => {
-                                                    panic!(
+                                Value::Map(
+                                    doc_type_range
+                                        .clone()
+                                        .filter_map(|_| match DocumentTypeV0::random_document_type(
+                                            params.clone(),
+                                            contract_id,
+                                            rng,
+                                            platform_version,
+                                        ) {
+                                            Ok(new_document_type) => {
+                                                let doc_type_clone =
+                                                    new_document_type.schema().clone();
+
+                                                Some((
+                                                    Value::Text(new_document_type.name().clone()),
+                                                    doc_type_clone,
+                                                ))
+                                            }
+                                            Err(e) => {
+                                                panic!(
                                                     "Error generating random document type: {:?}",
                                                     e
                                                 );
-                                                }
-                                            })
-                                            .collect(),
-                                    );
+                                            }
+                                        })
+                                        .collect(),
+                                );
 
                             let created_data_contract = match contract_factory.create(
                                 owner_id,

--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -1129,13 +1129,10 @@ impl Strategy {
                                             platform_version,
                                         ) {
                                             Ok(new_document_type) => {
-                                                let mut doc_type_clone =
+                                                let doc_type_clone =
                                                     new_document_type.schema().clone();
-                                                let name = doc_type_clone.remove("title").expect(
-                                            "Expected to get a doc type title in ContractCreate",
-                                        );
                                                 Some((
-                                                    Value::Text(name.to_string()),
+                                                    Value::Text(new_document_type.name().clone()),
                                                     doc_type_clone,
                                                 ))
                                             }

--- a/packages/wasm-dpp/src/errors/consensus/basic/data_contract/invalid_document_type_name_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/basic/data_contract/invalid_document_type_name_error.rs
@@ -1,0 +1,34 @@
+use dpp::consensus::basic::data_contract::InvalidJsonSchemaRefError;
+use dpp::consensus::codes::ErrorWithCode;
+use dpp::consensus::ConsensusError;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(js_name=InvalidDocumentTypeNameError)]
+pub struct InvalidDocumentTypeNameErrorWasm {
+    inner: InvalidDocumentTypeNameError,
+}
+
+#[wasm_bindgen(js_name=InvalidDocumentTypeNameError)]
+impl InvalidDocumentTypeNameErrorWasm {
+    #[wasm_bindgen(js_name=getName)]
+    pub fn get_name(&self) -> String {
+        self.inner.name()
+    }
+
+    #[wasm_bindgen(js_name=getCode)]
+    pub fn get_code(&self) -> u32 {
+        ConsensusError::from(self.inner.clone()).code()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn message(&self) -> String {
+        self.inner.to_string()
+    }
+}
+
+impl From<&InvalidDocumentTypeNameError> for InvalidDocumentTypeNameErrorWasm {
+    fn from(e: &InvalidDocumentTypeNameError) -> Self {
+        Self { inner: e.clone() }
+    }
+}

--- a/packages/wasm-dpp/src/errors/consensus/basic/data_contract/invalid_document_type_name_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/basic/data_contract/invalid_document_type_name_error.rs
@@ -1,4 +1,4 @@
-use dpp::consensus::basic::data_contract::InvalidJsonSchemaRefError;
+use dpp::consensus::basic::data_contract::InvalidDocumentTypeNameError;
 use dpp::consensus::codes::ErrorWithCode;
 use dpp::consensus::ConsensusError;
 
@@ -13,7 +13,7 @@ pub struct InvalidDocumentTypeNameErrorWasm {
 impl InvalidDocumentTypeNameErrorWasm {
     #[wasm_bindgen(js_name=getName)]
     pub fn get_name(&self) -> String {
-        self.inner.name()
+        self.inner.name().to_string()
     }
 
     #[wasm_bindgen(js_name=getCode)]

--- a/packages/wasm-dpp/src/errors/consensus/basic/data_contract/invalid_document_type_name_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/basic/data_contract/invalid_document_type_name_error.rs
@@ -9,7 +9,7 @@ pub struct InvalidDocumentTypeNameErrorWasm {
     inner: InvalidDocumentTypeNameError,
 }
 
-#[wasm_bindgen(js_name=InvalidDocumentTypeNameError)]
+#[wasm_bindgen]
 impl InvalidDocumentTypeNameErrorWasm {
     #[wasm_bindgen(js_name=getName)]
     pub fn get_name(&self) -> String {

--- a/packages/wasm-dpp/src/errors/consensus/basic/data_contract/mod.rs
+++ b/packages/wasm-dpp/src/errors/consensus/basic/data_contract/mod.rs
@@ -10,6 +10,7 @@ mod incompatible_re2_pattern_error;
 mod index_error;
 mod invalid_data_contract_id_error;
 mod invalid_data_contract_version_error;
+mod invalid_document_type_name_error;
 mod invalid_json_schema_ref_error;
 
 pub use data_contract_empty_schema_error::*;
@@ -24,4 +25,5 @@ pub use incompatible_re2_pattern_error::*;
 pub use index_error::*;
 pub use invalid_data_contract_id_error::*;
 pub use invalid_data_contract_version_error::*;
+pub use invalid_document_type_name_error::*;
 pub use invalid_json_schema_ref_error::*;

--- a/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
@@ -321,6 +321,7 @@ fn from_basic_error(basic_error: &BasicError) -> JsValue {
         BasicError::NonceOutOfBoundsError(err) => {
             IdentityContractNonceOutOfBoundsErrorWasm::from(err).into()
         }
+        BasicError::InvalidDocumentTypeError(err) => InvalidDocumentTypeErrorWasm::from(err).into(),
         ProtocolVersionParsingError(e) => ProtocolVersionParsingErrorWasm::from(e).into(),
         SerializedObjectParsingError(e) => SerializedObjectParsingErrorWasm::from(e).into(),
         JsonSchemaError(e) => JsonSchemaErrorWasm::from(e).into(),

--- a/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
@@ -64,6 +64,7 @@ use crate::errors::consensus::basic::data_contract::{
     DataContractImmutablePropertiesUpdateErrorWasm,
     DataContractInvalidIndexDefinitionUpdateErrorWasm, DataContractUniqueIndicesChangedErrorWasm,
     IncompatibleDataContractSchemaErrorWasm, InvalidDataContractIdErrorWasm,
+    InvalidDocumentTypeNameErrorWasm,
 };
 use crate::errors::consensus::basic::document::{
     DuplicateDocumentTransitionsWithIdsErrorWasm, DuplicateDocumentTransitionsWithIndicesErrorWasm,
@@ -321,7 +322,9 @@ fn from_basic_error(basic_error: &BasicError) -> JsValue {
         BasicError::NonceOutOfBoundsError(err) => {
             IdentityContractNonceOutOfBoundsErrorWasm::from(err).into()
         }
-        BasicError::InvalidDocumentTypeError(err) => InvalidDocumentTypeErrorWasm::from(err).into(),
+        BasicError::InvalidDocumentTypeNameError(err) => {
+            InvalidDocumentTypeNameErrorWasm::from(err).into()
+        }
         ProtocolVersionParsingError(e) => ProtocolVersionParsingErrorWasm::from(e).into(),
         SerializedObjectParsingError(e) => SerializedObjectParsingErrorWasm::from(e).into(),
         JsonSchemaError(e) => JsonSchemaErrorWasm::from(e).into(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, when we used JSON Schema for the entire Data Contract we validated the document type name to ensure it's not empty and doesn't use special chars. When we migrated to document type-based JSON schemas this check was lost.

## What was done?
<!--- Describe your changes in detail -->
- Added validation to ensure the name is 1 to 64 alphanumeric chars and "_", or "-". 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Document type name must be 1 to 64 alphanumeric chars and "_", or "-".  Previously created data might be invalid.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
