### PR TITLE
fix(drive): no longer build full grovedb when using verify feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,7 +1824,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "grovedb"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=d007bed7544bf837bdf155e696a530b90d5f82e5#d007bed7544bf837bdf155e696a530b90d5f82e5"
+source = "git+https://github.com/dashpay/grovedb?rev=9eae5457f18d307d673767c8d772630a9d0ad66d#9eae5457f18d307d673767c8d772630a9d0ad66d"
 dependencies = [
  "bincode 1.3.3",
  "grovedb-costs",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=d007bed7544bf837bdf155e696a530b90d5f82e5#d007bed7544bf837bdf155e696a530b90d5f82e5"
+source = "git+https://github.com/dashpay/grovedb?rev=9eae5457f18d307d673767c8d772630a9d0ad66d#9eae5457f18d307d673767c8d772630a9d0ad66d"
 dependencies = [
  "integer-encoding 3.0.4",
  "intmap",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=d007bed7544bf837bdf155e696a530b90d5f82e5#d007bed7544bf837bdf155e696a530b90d5f82e5"
+source = "git+https://github.com/dashpay/grovedb?rev=9eae5457f18d307d673767c8d772630a9d0ad66d#9eae5457f18d307d673767c8d772630a9d0ad66d"
 dependencies = [
  "blake3",
  "byteorder",
@@ -1879,12 +1879,12 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=d007bed7544bf837bdf155e696a530b90d5f82e5#d007bed7544bf837bdf155e696a530b90d5f82e5"
+source = "git+https://github.com/dashpay/grovedb?rev=9eae5457f18d307d673767c8d772630a9d0ad66d#9eae5457f18d307d673767c8d772630a9d0ad66d"
 
 [[package]]
 name = "grovedb-storage"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=d007bed7544bf837bdf155e696a530b90d5f82e5#d007bed7544bf837bdf155e696a530b90d5f82e5"
+source = "git+https://github.com/dashpay/grovedb?rev=9eae5457f18d307d673767c8d772630a9d0ad66d#9eae5457f18d307d673767c8d772630a9d0ad66d"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -1903,7 +1903,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?rev=d007bed7544bf837bdf155e696a530b90d5f82e5#d007bed7544bf837bdf155e696a530b90d5f82e5"
+source = "git+https://github.com/dashpay/grovedb?rev=9eae5457f18d307d673767c8d772630a9d0ad66d#9eae5457f18d307d673767c8d772630a9d0ad66d"
 dependencies = [
  "hex",
  "itertools 0.10.5",

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -40,10 +40,10 @@ enum-map = { version = "2.0.3", optional = true }
 intmap = { version = "2.0.0", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.11.0", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "d007bed7544bf837bdf155e696a530b90d5f82e5", optional = true }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "d007bed7544bf837bdf155e696a530b90d5f82e5", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "d007bed7544bf837bdf155e696a530b90d5f82e5" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "d007bed7544bf837bdf155e696a530b90d5f82e5", optional = true }
+grovedb = { git = "https://github.com/dashpay/grovedb", rev = "9eae5457f18d307d673767c8d772630a9d0ad66d", optional = true, default-features = false }
+grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "9eae5457f18d307d673767c8d772630a9d0ad66d", optional = true }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "9eae5457f18d307d673767c8d772630a9d0ad66d" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "9eae5457f18d307d673767c8d772630a9d0ad66d", optional = true }
 
 [dev-dependencies]
 anyhow = { version = "1.0.75" }
@@ -71,6 +71,7 @@ harness = false
 default = ["full", "verify", "fixtures-and-mocks"]
 fixtures-and-mocks = ["full", "dpp/fixtures-and-mocks", "verify"]
 full = [
+  "grovedb/full",
   "grovedb/estimated_costs",
   "grovedb-storage",
   "grovedb-costs",

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -75,14 +75,5 @@ pub use sdk::{RequestSettings, Sdk, SdkBuilder};
 pub use dpp;
 pub use rs_dapi_client as dapi_client;
 
-pub use dpp::version;
-pub use dpp::bincode;
-pub use dpp::bls_signatures;
-pub use dpp::data_contracts;
-pub use dpp::ed25519_dalek;
-pub use dpp::jsonschema;
-pub use dpp::platform_serialization;
-pub use dpp::platform_value;
-
 /// Version of the SDK
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -72,5 +72,17 @@ pub mod sdk;
 pub use error::Error;
 pub use sdk::{RequestSettings, Sdk, SdkBuilder};
 
+pub use dpp;
+pub use rs_dapi_client as dapi_client;
+
+pub use dpp::version;
+pub use dpp::bincode;
+pub use dpp::bls_signatures;
+pub use dpp::data_contracts;
+pub use dpp::ed25519_dalek;
+pub use dpp::jsonschema;
+pub use dpp::platform_serialization;
+pub use dpp::platform_value;
+
 /// Version of the SDK
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Full Grovedb was being built even when we were asking for only compiling the verify feature. This now fixes this.


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [X] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
