### PR TITLE
feat(sdk): reuse dapi connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,6 +3537,8 @@ dependencies = [
  "futures",
  "hex",
  "http",
+ "lazy_static",
+ "lru",
  "rand",
  "sha2",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,7 +3537,6 @@ dependencies = [
  "futures",
  "hex",
  "http",
- "lazy_static",
  "lru",
  "rand",
  "sha2",

--- a/packages/rs-dapi-client/Cargo.toml
+++ b/packages/rs-dapi-client/Cargo.toml
@@ -25,6 +25,6 @@ sha2 = { version = "0.10", optional = true }
 chrono = { version = "0.4.31", optional = true }
 hex = { version = "0.4.3", optional = true }
 lru = { version = "0.12.3" }
-lazy_static = { version = "1.4.0" }
+
 [dev-dependencies]
 tokio = { version = "1.32.0", features = ["macros"] }

--- a/packages/rs-dapi-client/Cargo.toml
+++ b/packages/rs-dapi-client/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1.32.0", default-features = false }
 sha2 = { version = "0.10", optional = true }
 chrono = { version = "0.4.31", optional = true }
 hex = { version = "0.4.3", optional = true }
-
+lru = { version = "0.12.3" }
+lazy_static = { version = "1.4.0" }
 [dev-dependencies]
 tokio = { version = "1.32.0", features = ["macros"] }

--- a/packages/rs-dapi-client/src/address_list.rs
+++ b/packages/rs-dapi-client/src/address_list.rs
@@ -160,8 +160,14 @@ impl AddressList {
 
     /// Randomly select a not banned address.
     pub fn get_live_address(&self) -> Option<&Address> {
-        let now = time::Instant::now();
         let mut rng = SmallRng::from_entropy();
+
+        self.unbanned().into_iter().choose(&mut rng)
+    }
+
+    /// Get all addresses that are not banned.
+    fn unbanned(&self) -> Vec<&Address> {
+        let now = time::Instant::now();
 
         self.addresses
             .iter()
@@ -170,7 +176,25 @@ impl AddressList {
                     .map(|banned_until| banned_until < now)
                     .unwrap_or(true)
             })
-            .choose(&mut rng)
+            .collect()
+    }
+
+    /// Get number of available, not banned addresses.
+    pub fn available(&self) -> usize {
+        self.unbanned().len()
+    }
+
+    /// Get number of all addresses, both banned and not banned.
+    pub fn len(&self) -> usize {
+        self.addresses.len()
+    }
+
+    /// Check if the list is empty.
+    /// Returns true if there are no addresses in the list.
+    /// Returns false if there is at least one address in the list.
+    /// Banned addresses are also counted.
+    pub fn is_empty(&self) -> bool {
+        self.addresses.is_empty()
     }
 }
 

--- a/packages/rs-dapi-client/src/connection_pool.rs
+++ b/packages/rs-dapi-client/src/connection_pool.rs
@@ -95,7 +95,7 @@ impl From<PoolItem> for PlatformGrpcClient {
     fn from(client: PoolItem) -> Self {
         match client {
             PoolItem::Platform(client) => client,
-            _ => panic!("ClientType is not Platform"),
+            _ => panic!("ClientType is not Platform: {:?}", client),
         }
     }
 }
@@ -104,7 +104,7 @@ impl From<PoolItem> for CoreGrpcClient {
     fn from(client: PoolItem) -> Self {
         match client {
             PoolItem::Core(client) => client,
-            _ => panic!("ClientType is not Core"),
+            _ => panic!("ClientType is not Core: {:?}", client),
         }
     }
 }

--- a/packages/rs-dapi-client/src/connection_pool.rs
+++ b/packages/rs-dapi-client/src/connection_pool.rs
@@ -1,0 +1,110 @@
+use std::sync::{Arc, Mutex};
+
+use http::Uri;
+use lru::LruCache;
+
+use crate::{
+    request_settings::AppliedRequestSettings,
+    transport::{CoreGrpcClient, PlatformGrpcClient},
+};
+
+/// ConnectionPool represents pool of connections to DAPI nodes.
+///
+/// It can be cloned and shared between threads.
+/// Cloning the pool will create a new reference to the same pool.
+#[derive(Debug, Clone)]
+pub struct ConnectionPool {
+    inner: Arc<Mutex<LruCache<String, PoolItem>>>,
+}
+
+impl ConnectionPool {
+    /// Create a new pool with a given capacity.
+    /// The pool will evict the least recently used item when the capacity is reached.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the capacity is zero.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(LruCache::new(
+                capacity.try_into().expect("must be non-zero"),
+            ))),
+        }
+    }
+}
+
+impl Default for ConnectionPool {
+    fn default() -> Self {
+        Self::new(50)
+    }
+}
+
+impl ConnectionPool {
+    /// Get item from the pool for the given uri and settings.
+    pub fn get(&self, uri: &Uri, settings: Option<&AppliedRequestSettings>) -> Option<PoolItem> {
+        let key = format!("{}{:?}", uri, settings);
+        self.inner.lock().expect("must lock").get(&key).cloned()
+    }
+
+    /// Get value from cache or create it using provided closure.
+    /// If value is already in the cache, it will be returned.
+    /// If value is not in the cache, it will be created by calling `create()` and stored in the cache.
+    pub fn get_or_create(
+        &self,
+        uri: &Uri,
+        settings: Option<&AppliedRequestSettings>,
+        create: impl FnOnce() -> PoolItem,
+    ) -> PoolItem {
+        if let Some(cli) = self.get(uri, settings) {
+            return cli;
+        }
+
+        let cli = create();
+        self.put(uri, settings, cli.clone());
+        cli
+    }
+
+    /// Put item into the pool for the given uri and settings.
+    pub fn put(&self, uri: &Uri, settings: Option<&AppliedRequestSettings>, value: PoolItem) {
+        let key = format!("{}{:?}", uri, settings);
+        self.inner.lock().expect("must lock").put(key, value);
+    }
+}
+
+/// Item stored in the pool.
+///
+/// We use an enum as we need to represent two different types of clients.
+#[derive(Clone, Debug)]
+pub enum PoolItem {
+    Core(CoreGrpcClient),
+    Platform(PlatformGrpcClient),
+}
+
+impl From<PlatformGrpcClient> for PoolItem {
+    fn from(client: PlatformGrpcClient) -> Self {
+        Self::Platform(client)
+    }
+}
+impl From<CoreGrpcClient> for PoolItem {
+    fn from(client: CoreGrpcClient) -> Self {
+        Self::Core(client)
+    }
+}
+
+impl From<PoolItem> for PlatformGrpcClient {
+    fn from(client: PoolItem) -> Self {
+        match client {
+            PoolItem::Platform(client) => client,
+            _ => panic!("ClientType is not Platform"),
+        }
+    }
+}
+
+impl From<PoolItem> for CoreGrpcClient {
+    fn from(client: PoolItem) -> Self {
+        match client {
+            PoolItem::Core(client) => client,
+            _ => panic!("ClientType is not Core"),
+        }
+    }
+}

--- a/packages/rs-dapi-client/src/lib.rs
+++ b/packages/rs-dapi-client/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(missing_docs)]
 
 mod address_list;
+mod connection_pool;
 mod dapi_client;
 #[cfg(feature = "dump")]
 pub mod dump;

--- a/packages/rs-dapi-client/src/transport.rs
+++ b/packages/rs-dapi-client/src/transport.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod grpc;
 
+use crate::connection_pool::ConnectionPool;
 pub use crate::request_settings::AppliedRequestSettings;
 use crate::{CanRetry, RequestSettings};
 use dapi_grpc::mock::Mockable;
@@ -50,8 +51,12 @@ pub trait TransportClient: Send + Sized {
     type Error: CanRetry + Send + Debug;
 
     /// Build client using node's url.
-    fn with_uri(uri: Uri) -> Self;
+    fn with_uri(uri: Uri, pool: &ConnectionPool) -> Self;
 
     /// Build client using node's url and [AppliedRequestSettings].
-    fn with_uri_and_settings(uri: Uri, settings: &AppliedRequestSettings) -> Self;
+    fn with_uri_and_settings(
+        uri: Uri,
+        settings: &AppliedRequestSettings,
+        pool: &ConnectionPool,
+    ) -> Self;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

We establish new connection to DAPI for every request. This has significant impact on performance.

## What was done?

Implemented connection pool that allows reuse of clients.

At his point, the connection pool uses LRU (least-recently used) algorithm to evict unused peers.

## How Has This Been Tested?

1. Run rs-sdk tests in network mode.
2. Tested on testnet using `load_test` from rs-platform-explorer.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
