### PR TITLE
fix(sdk): dapi client pool should separate platform and core clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,6 +856,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,6 +2874,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3688,6 +3704,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,6 +3775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scheduled-thread-pool"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3775,6 +3823,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4458,6 +4529,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4597,7 +4679,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.12.4",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/packages/dapi-grpc/Cargo.toml
+++ b/packages/dapi-grpc/Cargo.toml
@@ -21,8 +21,15 @@ default = ["core", "platform", "client", "serde", "server"]
 core = []
 platform = []
 # Re-export Dash Platform protobuf types as `dapi_grpc::platform::proto`
+# Note: client needs tls and tls-roots to connect to testnet which uses TLS.
 tenderdash-proto = []
-client = ["tonic/channel", "tonic/transport", "platform"]
+client = [
+  "tonic/channel",
+  "tonic/transport",
+  "tonic/tls",
+  "tonic/tls-roots",
+  "platform",
+]
 server = ["tonic/channel", "tonic/transport", "platform"]
 serde = ["dep:serde", "dep:serde_bytes"]
 mocks = ["dep:serde_json"]

--- a/packages/rs-dapi-client/src/transport/grpc.rs
+++ b/packages/rs-dapi-client/src/transport/grpc.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use super::{CanRetry, TransportClient, TransportRequest};
-use crate::connection_pool::ConnectionPool;
+use crate::connection_pool::{ConnectionPool, PoolPrefix};
 use crate::{request_settings::AppliedRequestSettings, RequestSettings};
 use dapi_grpc::core::v0::core_client::CoreClient;
 use dapi_grpc::core::v0::{self as core_proto};
@@ -34,7 +34,7 @@ impl TransportClient for PlatformGrpcClient {
     type Error = dapi_grpc::tonic::Status;
 
     fn with_uri(uri: Uri, pool: &ConnectionPool) -> Self {
-        pool.get_or_create(&uri, None, || {
+        pool.get_or_create(PoolPrefix::Platform, &uri, None, || {
             Self::new(create_channel(uri.clone(), None)).into()
         })
         .into()
@@ -45,7 +45,7 @@ impl TransportClient for PlatformGrpcClient {
         settings: &AppliedRequestSettings,
         pool: &ConnectionPool,
     ) -> Self {
-        pool.get_or_create(&uri, Some(settings), || {
+        pool.get_or_create(PoolPrefix::Platform, &uri, Some(settings), || {
             Self::new(create_channel(uri.clone(), Some(settings))).into()
         })
         .into()
@@ -56,7 +56,7 @@ impl TransportClient for CoreGrpcClient {
     type Error = dapi_grpc::tonic::Status;
 
     fn with_uri(uri: Uri, pool: &ConnectionPool) -> Self {
-        pool.get_or_create(&uri, None, || {
+        pool.get_or_create(PoolPrefix::Core, &uri, None, || {
             Self::new(create_channel(uri.clone(), None)).into()
         })
         .into()
@@ -67,7 +67,7 @@ impl TransportClient for CoreGrpcClient {
         settings: &AppliedRequestSettings,
         pool: &ConnectionPool,
     ) -> Self {
-        pool.get_or_create(&uri, Some(settings), || {
+        pool.get_or_create(PoolPrefix::Core, &uri, Some(settings), || {
             Self::new(create_channel(uri.clone(), Some(settings))).into()
         })
         .into()

--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -75,7 +75,7 @@ pub type KeyMaps = BTreeMap<Purpose, BTreeMap<SecurityLevel, Vec<KeyType>>>;
 ///
 /// # Fields
 /// - `start_identities`: Specifies identities to be established at the simulation's outset, including their initial attributes and balances. This setup allows for immediate participation of these identities in the blockchain's simulated activities.
-/// 
+///
 /// - `start_contracts`: Maps each created data contract to potential updates, enabling the simulation of contract evolution. Each tuple consists of a `CreatedDataContract` and an optional mapping of block heights to subsequent contract versions, facilitating time-sensitive contract transformations.
 ///
 /// - `operations`: Enumerates discrete operations to be executed within the strategy. These operations represent individual actions or sequences of actions, such as document manipulations, identity updates, or contract interactions, each contributing to the overarching simulation narrative.
@@ -1442,7 +1442,7 @@ impl Strategy {
                 )
                 .expect("Expected to get identity public key in initial_contract_state_transitions");
                 let key_id = identity_public_key.id();
-                
+
                 let partial_identity = identity.clone().into_partial_identity_info();
                 let partial_identity_public_key = partial_identity.loaded_public_keys.values()
                     .find(|&public_key| public_key.id() == key_id)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Connection pool should distinguish between Core and Platform connections

## What was done?

Added prefix to key in connection pool, describing type of connection (Core or Platform) to use.

## How Has This Been Tested?

Tested using rs-platform-explorer strategy tests against testnet.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
