### PR TITLE
feat(platform)!: identity create replay protection

### DIFF
--- a/packages/dapi-grpc/src/core/proto/org.dash.platform.dapi.v0.rs
+++ b/packages/dapi-grpc/src/core/proto/org.dash.platform.dapi.v0.rs
@@ -1,9 +1,7 @@
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetStatusRequest {}
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -25,7 +23,6 @@ pub struct GetStatusResponse {
 }
 /// Nested message and enum types in `GetStatusResponse`.
 pub mod get_status_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -37,7 +34,6 @@ pub mod get_status_response {
         #[prost(string, tag = "3")]
         pub agent: ::prost::alloc::string::String,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -49,7 +45,6 @@ pub mod get_status_response {
         #[prost(uint32, tag = "3")]
         pub median: u32,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -71,7 +66,6 @@ pub mod get_status_response {
         #[prost(double, tag = "8")]
         pub sync_progress: f64,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -89,7 +83,6 @@ pub mod get_status_response {
     }
     /// Nested message and enum types in `Masternode`.
     pub mod masternode {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
         #[derive(
             Clone,
             Copy,
@@ -145,7 +138,6 @@ pub mod get_status_response {
             }
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -155,7 +147,6 @@ pub mod get_status_response {
         #[prost(double, tag = "2")]
         pub incremental: f64,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -165,7 +156,6 @@ pub mod get_status_response {
         #[prost(message, optional, tag = "2")]
         pub fee: ::core::option::Option<NetworkFee>,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(
         Clone,
         Copy,
@@ -209,7 +199,6 @@ pub mod get_status_response {
         }
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -219,7 +208,6 @@ pub struct GetBlockRequest {
 }
 /// Nested message and enum types in `GetBlockRequest`.
 pub mod get_block_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Block {
@@ -229,7 +217,6 @@ pub mod get_block_request {
         Hash(::prost::alloc::string::String),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -237,7 +224,6 @@ pub struct GetBlockResponse {
     #[prost(bytes = "vec", tag = "1")]
     pub block: ::prost::alloc::vec::Vec<u8>,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -249,7 +235,6 @@ pub struct BroadcastTransactionRequest {
     #[prost(bool, tag = "3")]
     pub bypass_limits: bool,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -257,7 +242,6 @@ pub struct BroadcastTransactionResponse {
     #[prost(string, tag = "1")]
     pub transaction_id: ::prost::alloc::string::String,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -265,7 +249,6 @@ pub struct GetTransactionRequest {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -283,7 +266,6 @@ pub struct GetTransactionResponse {
     #[prost(bool, tag = "6")]
     pub is_chain_locked: bool,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -297,7 +279,6 @@ pub struct BlockHeadersWithChainLocksRequest {
 }
 /// Nested message and enum types in `BlockHeadersWithChainLocksRequest`.
 pub mod block_headers_with_chain_locks_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum FromBlock {
@@ -307,7 +288,6 @@ pub mod block_headers_with_chain_locks_request {
         FromBlockHeight(u32),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -319,7 +299,6 @@ pub struct BlockHeadersWithChainLocksResponse {
 }
 /// Nested message and enum types in `BlockHeadersWithChainLocksResponse`.
 pub mod block_headers_with_chain_locks_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Responses {
@@ -329,7 +308,6 @@ pub mod block_headers_with_chain_locks_response {
         ChainLock(::prost::alloc::vec::Vec<u8>),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -337,7 +315,6 @@ pub struct BlockHeaders {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub headers: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -345,7 +322,6 @@ pub struct GetEstimatedTransactionFeeRequest {
     #[prost(uint32, tag = "1")]
     pub blocks: u32,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -353,7 +329,6 @@ pub struct GetEstimatedTransactionFeeResponse {
     #[prost(double, tag = "1")]
     pub fee: f64,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -369,7 +344,6 @@ pub struct TransactionsWithProofsRequest {
 }
 /// Nested message and enum types in `TransactionsWithProofsRequest`.
 pub mod transactions_with_proofs_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum FromBlock {
@@ -379,7 +353,6 @@ pub mod transactions_with_proofs_request {
         FromBlockHeight(u32),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -393,7 +366,6 @@ pub struct BloomFilter {
     #[prost(uint32, tag = "4")]
     pub n_flags: u32,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -403,7 +375,6 @@ pub struct TransactionsWithProofsResponse {
 }
 /// Nested message and enum types in `TransactionsWithProofsResponse`.
 pub mod transactions_with_proofs_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Responses {
@@ -415,7 +386,6 @@ pub mod transactions_with_proofs_response {
         RawMerkleBlock(::prost::alloc::vec::Vec<u8>),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -423,301 +393,12 @@ pub struct RawTransactions {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub transactions: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstantSendLockMessages {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub messages: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
-}
-/// Generated client implementations.
-pub mod core_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
-    #[derive(Debug, Clone)]
-    pub struct CoreClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl CoreClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> CoreClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_origin(inner: T, origin: Uri) -> Self {
-            let inner = tonic::client::Grpc::with_origin(inner, origin);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> CoreClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            CoreClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with the given encoding.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.send_compressed(encoding);
-            self
-        }
-        /// Enable decompressing responses.
-        #[must_use]
-        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.accept_compressed(encoding);
-            self
-        }
-        /// Limits the maximum size of a decoded message.
-        ///
-        /// Default: `4MB`
-        #[must_use]
-        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_decoding_message_size(limit);
-            self
-        }
-        /// Limits the maximum size of an encoded message.
-        ///
-        /// Default: `usize::MAX`
-        #[must_use]
-        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_encoding_message_size(limit);
-            self
-        }
-        pub async fn get_status(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetStatusRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetStatusResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Core/getStatus",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("org.dash.platform.dapi.v0.Core", "getStatus"));
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_block(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetBlockRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetBlockResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Core/getBlock",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("org.dash.platform.dapi.v0.Core", "getBlock"));
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn broadcast_transaction(
-            &mut self,
-            request: impl tonic::IntoRequest<super::BroadcastTransactionRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::BroadcastTransactionResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Core/broadcastTransaction",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Core",
-                        "broadcastTransaction",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_transaction(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetTransactionRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetTransactionResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Core/getTransaction",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("org.dash.platform.dapi.v0.Core", "getTransaction"),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_estimated_transaction_fee(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetEstimatedTransactionFeeRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetEstimatedTransactionFeeResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Core/getEstimatedTransactionFee",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Core",
-                        "getEstimatedTransactionFee",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn subscribe_to_block_headers_with_chain_locks(
-            &mut self,
-            request: impl tonic::IntoRequest<super::BlockHeadersWithChainLocksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<
-                tonic::codec::Streaming<super::BlockHeadersWithChainLocksResponse>,
-            >,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Core/subscribeToBlockHeadersWithChainLocks",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Core",
-                        "subscribeToBlockHeadersWithChainLocks",
-                    ),
-                );
-            self.inner.server_streaming(req, path, codec).await
-        }
-        pub async fn subscribe_to_transactions_with_proofs(
-            &mut self,
-            request: impl tonic::IntoRequest<super::TransactionsWithProofsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<
-                tonic::codec::Streaming<super::TransactionsWithProofsResponse>,
-            >,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Core/subscribeToTransactionsWithProofs",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Core",
-                        "subscribeToTransactionsWithProofs",
-                    ),
-                );
-            self.inner.server_streaming(req, path, codec).await
-        }
-    }
 }
 /// Generated server implementations.
 pub mod core_server {

--- a/packages/dapi-grpc/src/core/proto/org.dash.platform.dapi.v0.rs
+++ b/packages/dapi-grpc/src/core/proto/org.dash.platform.dapi.v0.rs
@@ -1,7 +1,9 @@
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetStatusRequest {}
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -23,6 +25,7 @@ pub struct GetStatusResponse {
 }
 /// Nested message and enum types in `GetStatusResponse`.
 pub mod get_status_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -34,6 +37,7 @@ pub mod get_status_response {
         #[prost(string, tag = "3")]
         pub agent: ::prost::alloc::string::String,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -45,6 +49,7 @@ pub mod get_status_response {
         #[prost(uint32, tag = "3")]
         pub median: u32,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -66,6 +71,7 @@ pub mod get_status_response {
         #[prost(double, tag = "8")]
         pub sync_progress: f64,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -83,6 +89,7 @@ pub mod get_status_response {
     }
     /// Nested message and enum types in `Masternode`.
     pub mod masternode {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
         #[derive(
             Clone,
             Copy,
@@ -138,6 +145,7 @@ pub mod get_status_response {
             }
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -147,6 +155,7 @@ pub mod get_status_response {
         #[prost(double, tag = "2")]
         pub incremental: f64,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -156,6 +165,7 @@ pub mod get_status_response {
         #[prost(message, optional, tag = "2")]
         pub fee: ::core::option::Option<NetworkFee>,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[derive(
         Clone,
         Copy,
@@ -199,6 +209,7 @@ pub mod get_status_response {
         }
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -208,6 +219,7 @@ pub struct GetBlockRequest {
 }
 /// Nested message and enum types in `GetBlockRequest`.
 pub mod get_block_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Block {
@@ -217,6 +229,7 @@ pub mod get_block_request {
         Hash(::prost::alloc::string::String),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -224,6 +237,7 @@ pub struct GetBlockResponse {
     #[prost(bytes = "vec", tag = "1")]
     pub block: ::prost::alloc::vec::Vec<u8>,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -235,6 +249,7 @@ pub struct BroadcastTransactionRequest {
     #[prost(bool, tag = "3")]
     pub bypass_limits: bool,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -242,6 +257,7 @@ pub struct BroadcastTransactionResponse {
     #[prost(string, tag = "1")]
     pub transaction_id: ::prost::alloc::string::String,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -249,6 +265,7 @@ pub struct GetTransactionRequest {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -266,6 +283,7 @@ pub struct GetTransactionResponse {
     #[prost(bool, tag = "6")]
     pub is_chain_locked: bool,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -279,6 +297,7 @@ pub struct BlockHeadersWithChainLocksRequest {
 }
 /// Nested message and enum types in `BlockHeadersWithChainLocksRequest`.
 pub mod block_headers_with_chain_locks_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum FromBlock {
@@ -288,6 +307,7 @@ pub mod block_headers_with_chain_locks_request {
         FromBlockHeight(u32),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -299,6 +319,7 @@ pub struct BlockHeadersWithChainLocksResponse {
 }
 /// Nested message and enum types in `BlockHeadersWithChainLocksResponse`.
 pub mod block_headers_with_chain_locks_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Responses {
@@ -308,6 +329,7 @@ pub mod block_headers_with_chain_locks_response {
         ChainLock(::prost::alloc::vec::Vec<u8>),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -315,6 +337,7 @@ pub struct BlockHeaders {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub headers: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -322,6 +345,7 @@ pub struct GetEstimatedTransactionFeeRequest {
     #[prost(uint32, tag = "1")]
     pub blocks: u32,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -329,6 +353,7 @@ pub struct GetEstimatedTransactionFeeResponse {
     #[prost(double, tag = "1")]
     pub fee: f64,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -344,6 +369,7 @@ pub struct TransactionsWithProofsRequest {
 }
 /// Nested message and enum types in `TransactionsWithProofsRequest`.
 pub mod transactions_with_proofs_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum FromBlock {
@@ -353,6 +379,7 @@ pub mod transactions_with_proofs_request {
         FromBlockHeight(u32),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -366,6 +393,7 @@ pub struct BloomFilter {
     #[prost(uint32, tag = "4")]
     pub n_flags: u32,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -375,6 +403,7 @@ pub struct TransactionsWithProofsResponse {
 }
 /// Nested message and enum types in `TransactionsWithProofsResponse`.
 pub mod transactions_with_proofs_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Responses {
@@ -386,6 +415,7 @@ pub mod transactions_with_proofs_response {
         RawMerkleBlock(::prost::alloc::vec::Vec<u8>),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -393,12 +423,301 @@ pub struct RawTransactions {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub transactions: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstantSendLockMessages {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub messages: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+/// Generated client implementations.
+pub mod core_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct CoreClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl CoreClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> CoreClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> CoreClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            CoreClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn get_status(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetStatusRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetStatusResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Core/getStatus",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("org.dash.platform.dapi.v0.Core", "getStatus"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_block(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetBlockRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetBlockResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Core/getBlock",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("org.dash.platform.dapi.v0.Core", "getBlock"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn broadcast_transaction(
+            &mut self,
+            request: impl tonic::IntoRequest<super::BroadcastTransactionRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::BroadcastTransactionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Core/broadcastTransaction",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Core",
+                        "broadcastTransaction",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_transaction(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetTransactionRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetTransactionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Core/getTransaction",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("org.dash.platform.dapi.v0.Core", "getTransaction"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_estimated_transaction_fee(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetEstimatedTransactionFeeRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetEstimatedTransactionFeeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Core/getEstimatedTransactionFee",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Core",
+                        "getEstimatedTransactionFee",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn subscribe_to_block_headers_with_chain_locks(
+            &mut self,
+            request: impl tonic::IntoRequest<super::BlockHeadersWithChainLocksRequest>,
+        ) -> std::result::Result<
+            tonic::Response<
+                tonic::codec::Streaming<super::BlockHeadersWithChainLocksResponse>,
+            >,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Core/subscribeToBlockHeadersWithChainLocks",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Core",
+                        "subscribeToBlockHeadersWithChainLocks",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
+        }
+        pub async fn subscribe_to_transactions_with_proofs(
+            &mut self,
+            request: impl tonic::IntoRequest<super::TransactionsWithProofsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<
+                tonic::codec::Streaming<super::TransactionsWithProofsResponse>,
+            >,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Core/subscribeToTransactionsWithProofs",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Core",
+                        "subscribeToTransactionsWithProofs",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
+        }
+    }
 }
 /// Generated server implementations.
 pub mod core_server {

--- a/packages/dapi-grpc/src/platform/proto/org.dash.platform.dapi.v0.rs
+++ b/packages/dapi-grpc/src/platform/proto/org.dash.platform.dapi.v0.rs
@@ -1,49 +1,37 @@
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proof {
     #[prost(bytes = "vec", tag = "1")]
-    #[serde(with = "serde_bytes")]
     pub grovedb_proof: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "2")]
-    #[serde(with = "serde_bytes")]
     pub quorum_hash: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "3")]
-    #[serde(with = "serde_bytes")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint32, tag = "4")]
     pub round: u32,
     #[prost(bytes = "vec", tag = "5")]
-    #[serde(with = "serde_bytes")]
     pub block_id_hash: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint32, tag = "6")]
     pub quorum_type: u32,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseMetadata {
     #[prost(uint64, tag = "1")]
-    #[serde(with = "crate::deserialization::from_to_string")]
     pub height: u64,
     #[prost(uint32, tag = "2")]
     pub core_chain_locked_height: u32,
     #[prost(uint32, tag = "3")]
     pub epoch: u32,
     #[prost(uint64, tag = "4")]
-    #[serde(with = "crate::deserialization::from_to_string")]
     pub time_ms: u64,
     #[prost(uint32, tag = "5")]
     pub protocol_version: u32,
     #[prost(string, tag = "6")]
     pub chain_id: ::prost::alloc::string::String,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -55,8 +43,6 @@ pub struct StateTransitionBroadcastError {
     #[prost(bytes = "vec", tag = "3")]
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -64,14 +50,10 @@ pub struct BroadcastStateTransitionRequest {
     #[prost(bytes = "vec", tag = "1")]
     pub state_transition: ::prost::alloc::vec::Vec<u8>,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BroadcastStateTransitionResponse {}
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -83,20 +65,15 @@ pub struct GetIdentityRequest {
 }
 /// Nested message and enum types in `GetIdentityRequest`.
 pub mod get_identity_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
-        #[serde(with = "serde_bytes")]
         pub id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -104,8 +81,6 @@ pub mod get_identity_request {
         V0(GetIdentityRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -117,20 +92,15 @@ pub struct GetIdentityNonceRequest {
 }
 /// Nested message and enum types in `GetIdentityNonceRequest`.
 pub mod get_identity_nonce_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityNonceRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
-        #[serde(with = "serde_bytes")]
         pub identity_id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -138,8 +108,6 @@ pub mod get_identity_nonce_request {
         V0(GetIdentityNonceRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -151,22 +119,17 @@ pub struct GetIdentityContractNonceRequest {
 }
 /// Nested message and enum types in `GetIdentityContractNonceRequest`.
 pub mod get_identity_contract_nonce_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityContractNonceRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
-        #[serde(with = "serde_bytes")]
         pub identity_id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bytes = "vec", tag = "2")]
         pub contract_id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "3")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -174,8 +137,6 @@ pub mod get_identity_contract_nonce_request {
         V0(GetIdentityContractNonceRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -187,20 +148,15 @@ pub struct GetIdentityBalanceRequest {
 }
 /// Nested message and enum types in `GetIdentityBalanceRequest`.
 pub mod get_identity_balance_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityBalanceRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
-        #[serde(with = "serde_bytes")]
         pub id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -208,8 +164,6 @@ pub mod get_identity_balance_request {
         V0(GetIdentityBalanceRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -223,20 +177,15 @@ pub struct GetIdentityBalanceAndRevisionRequest {
 }
 /// Nested message and enum types in `GetIdentityBalanceAndRevisionRequest`.
 pub mod get_identity_balance_and_revision_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityBalanceAndRevisionRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
-        #[serde(with = "serde_bytes")]
         pub id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -244,8 +193,6 @@ pub mod get_identity_balance_and_revision_request {
         V0(GetIdentityBalanceAndRevisionRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -260,8 +207,6 @@ pub struct GetIdentityResponse {
 }
 /// Nested message and enum types in `GetIdentityResponse`.
 pub mod get_identity_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -273,8 +218,6 @@ pub mod get_identity_response {
     }
     /// Nested message and enum types in `GetIdentityResponseV0`.
     pub mod get_identity_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -284,8 +227,6 @@ pub mod get_identity_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -293,8 +234,6 @@ pub mod get_identity_response {
         V0(GetIdentityResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -306,20 +245,15 @@ pub struct GetIdentitiesRequest {
 }
 /// Nested message and enum types in `GetIdentitiesRequest`.
 pub mod get_identities_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentitiesRequestV0 {
         #[prost(bytes = "vec", repeated, tag = "1")]
-        #[serde(with = "crate::deserialization::vec_base64string")]
         pub ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -327,8 +261,6 @@ pub mod get_identities_request {
         V0(GetIdentitiesRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -343,8 +275,6 @@ pub struct GetIdentitiesResponse {
 }
 /// Nested message and enum types in `GetIdentitiesResponse`.
 pub mod get_identities_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -352,8 +282,6 @@ pub mod get_identities_response {
         #[prost(bytes = "vec", tag = "1")]
         pub value: ::prost::alloc::vec::Vec<u8>,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -363,8 +291,6 @@ pub mod get_identities_response {
         #[prost(message, optional, tag = "2")]
         pub value: ::core::option::Option<IdentityValue>,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -372,8 +298,6 @@ pub mod get_identities_response {
         #[prost(message, repeated, tag = "1")]
         pub identity_entries: ::prost::alloc::vec::Vec<IdentityEntry>,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -385,8 +309,6 @@ pub mod get_identities_response {
     }
     /// Nested message and enum types in `GetIdentitiesResponseV0`.
     pub mod get_identities_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -396,8 +318,6 @@ pub mod get_identities_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -405,8 +325,6 @@ pub mod get_identities_response {
         V0(GetIdentitiesResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -421,8 +339,6 @@ pub struct GetIdentityNonceResponse {
 }
 /// Nested message and enum types in `GetIdentityNonceResponse`.
 pub mod get_identity_nonce_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -434,8 +350,6 @@ pub mod get_identity_nonce_response {
     }
     /// Nested message and enum types in `GetIdentityNonceResponseV0`.
     pub mod get_identity_nonce_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -445,8 +359,6 @@ pub mod get_identity_nonce_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -454,8 +366,6 @@ pub mod get_identity_nonce_response {
         V0(GetIdentityNonceResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -470,8 +380,6 @@ pub struct GetIdentityContractNonceResponse {
 }
 /// Nested message and enum types in `GetIdentityContractNonceResponse`.
 pub mod get_identity_contract_nonce_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -488,8 +396,6 @@ pub mod get_identity_contract_nonce_response {
     }
     /// Nested message and enum types in `GetIdentityContractNonceResponseV0`.
     pub mod get_identity_contract_nonce_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -499,8 +405,6 @@ pub mod get_identity_contract_nonce_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -508,8 +412,6 @@ pub mod get_identity_contract_nonce_response {
         V0(GetIdentityContractNonceResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -524,8 +426,6 @@ pub struct GetIdentityBalanceResponse {
 }
 /// Nested message and enum types in `GetIdentityBalanceResponse`.
 pub mod get_identity_balance_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -537,8 +437,6 @@ pub mod get_identity_balance_response {
     }
     /// Nested message and enum types in `GetIdentityBalanceResponseV0`.
     pub mod get_identity_balance_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -548,8 +446,6 @@ pub mod get_identity_balance_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -557,8 +453,6 @@ pub mod get_identity_balance_response {
         V0(GetIdentityBalanceResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -575,8 +469,6 @@ pub struct GetIdentityBalanceAndRevisionResponse {
 }
 /// Nested message and enum types in `GetIdentityBalanceAndRevisionResponse`.
 pub mod get_identity_balance_and_revision_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -593,8 +485,6 @@ pub mod get_identity_balance_and_revision_response {
     }
     /// Nested message and enum types in `GetIdentityBalanceAndRevisionResponseV0`.
     pub mod get_identity_balance_and_revision_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -604,8 +494,6 @@ pub mod get_identity_balance_and_revision_response {
             #[prost(uint64, tag = "2")]
             pub revision: u64,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -615,8 +503,6 @@ pub mod get_identity_balance_and_revision_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -624,8 +510,6 @@ pub mod get_identity_balance_and_revision_response {
         V0(GetIdentityBalanceAndRevisionResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -635,8 +519,6 @@ pub struct KeyRequestType {
 }
 /// Nested message and enum types in `KeyRequestType`.
 pub mod key_request_type {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Request {
@@ -648,14 +530,10 @@ pub mod key_request_type {
         SearchKey(super::SearchKey),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AllKeys {}
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -663,8 +541,6 @@ pub struct SpecificKeys {
     #[prost(uint32, repeated, tag = "1")]
     pub key_ids: ::prost::alloc::vec::Vec<u32>,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -672,8 +548,6 @@ pub struct SearchKey {
     #[prost(map = "uint32, message", tag = "1")]
     pub purpose_map: ::std::collections::HashMap<u32, SecurityLevelMap>,
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -686,8 +560,6 @@ pub struct SecurityLevelMap {
 }
 /// Nested message and enum types in `SecurityLevelMap`.
 pub mod security_level_map {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(
         Clone,
         Copy,
@@ -727,8 +599,6 @@ pub mod security_level_map {
         }
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -740,14 +610,11 @@ pub struct GetIdentityKeysRequest {
 }
 /// Nested message and enum types in `GetIdentityKeysRequest`.
 pub mod get_identity_keys_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityKeysRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
-        #[serde(with = "serde_bytes")]
         pub identity_id: ::prost::alloc::vec::Vec<u8>,
         #[prost(message, optional, tag = "2")]
         pub request_type: ::core::option::Option<super::KeyRequestType>,
@@ -758,8 +625,6 @@ pub mod get_identity_keys_request {
         #[prost(bool, tag = "5")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -767,8 +632,6 @@ pub mod get_identity_keys_request {
         V0(GetIdentityKeysRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -783,8 +646,6 @@ pub struct GetIdentityKeysResponse {
 }
 /// Nested message and enum types in `GetIdentityKeysResponse`.
 pub mod get_identity_keys_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -796,8 +657,6 @@ pub mod get_identity_keys_response {
     }
     /// Nested message and enum types in `GetIdentityKeysResponseV0`.
     pub mod get_identity_keys_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -805,8 +664,6 @@ pub mod get_identity_keys_response {
             #[prost(bytes = "vec", repeated, tag = "1")]
             pub keys_bytes: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -816,8 +673,6 @@ pub mod get_identity_keys_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -825,8 +680,6 @@ pub mod get_identity_keys_response {
         V0(GetIdentityKeysResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -838,8 +691,6 @@ pub struct GetProofsRequest {
 }
 /// Nested message and enum types in `GetProofsRequest`.
 pub mod get_proofs_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -853,8 +704,6 @@ pub mod get_proofs_request {
     }
     /// Nested message and enum types in `GetProofsRequestV0`.
     pub mod get_proofs_request_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -868,22 +717,17 @@ pub mod get_proofs_request {
             #[prost(bytes = "vec", tag = "4")]
             pub document_id: ::prost::alloc::vec::Vec<u8>,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct IdentityRequest {
             #[prost(bytes = "vec", tag = "1")]
-            #[serde(with = "serde_bytes")]
             pub identity_id: ::prost::alloc::vec::Vec<u8>,
             #[prost(enumeration = "identity_request::Type", tag = "2")]
             pub request_type: i32,
         }
         /// Nested message and enum types in `IdentityRequest`.
         pub mod identity_request {
-            #[derive(::serde::Serialize, ::serde::Deserialize)]
-            #[serde(rename_all = "snake_case")]
             #[derive(
                 Clone,
                 Copy,
@@ -927,8 +771,6 @@ pub mod get_proofs_request {
                 }
             }
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -937,8 +779,6 @@ pub mod get_proofs_request {
             pub contract_id: ::prost::alloc::vec::Vec<u8>,
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -946,8 +786,6 @@ pub mod get_proofs_request {
         V0(GetProofsRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -962,8 +800,6 @@ pub struct GetProofsResponse {
 }
 /// Nested message and enum types in `GetProofsResponse`.
 pub mod get_proofs_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -975,8 +811,6 @@ pub mod get_proofs_response {
     }
     /// Nested message and enum types in `GetProofsResponseV0`.
     pub mod get_proofs_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -984,8 +818,6 @@ pub mod get_proofs_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -993,8 +825,6 @@ pub mod get_proofs_response {
         V0(GetProofsResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1006,20 +836,15 @@ pub struct GetDataContractRequest {
 }
 /// Nested message and enum types in `GetDataContractRequest`.
 pub mod get_data_contract_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetDataContractRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
-        #[serde(with = "serde_bytes")]
         pub id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1027,8 +852,6 @@ pub mod get_data_contract_request {
         V0(GetDataContractRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1043,8 +866,6 @@ pub struct GetDataContractResponse {
 }
 /// Nested message and enum types in `GetDataContractResponse`.
 pub mod get_data_contract_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1056,8 +877,6 @@ pub mod get_data_contract_response {
     }
     /// Nested message and enum types in `GetDataContractResponseV0`.
     pub mod get_data_contract_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1067,8 +886,6 @@ pub mod get_data_contract_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1076,8 +893,6 @@ pub mod get_data_contract_response {
         V0(GetDataContractResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1089,20 +904,15 @@ pub struct GetDataContractsRequest {
 }
 /// Nested message and enum types in `GetDataContractsRequest`.
 pub mod get_data_contracts_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetDataContractsRequestV0 {
         #[prost(bytes = "vec", repeated, tag = "1")]
-        #[serde(with = "crate::deserialization::vec_base64string")]
         pub ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1110,8 +920,6 @@ pub mod get_data_contracts_request {
         V0(GetDataContractsRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1126,8 +934,6 @@ pub struct GetDataContractsResponse {
 }
 /// Nested message and enum types in `GetDataContractsResponse`.
 pub mod get_data_contracts_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1137,8 +943,6 @@ pub mod get_data_contracts_response {
         #[prost(message, optional, tag = "2")]
         pub data_contract: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1146,8 +950,6 @@ pub mod get_data_contracts_response {
         #[prost(message, repeated, tag = "1")]
         pub data_contract_entries: ::prost::alloc::vec::Vec<DataContractEntry>,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1159,8 +961,6 @@ pub mod get_data_contracts_response {
     }
     /// Nested message and enum types in `GetDataContractsResponseV0`.
     pub mod get_data_contracts_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1170,8 +970,6 @@ pub mod get_data_contracts_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1179,8 +977,6 @@ pub mod get_data_contracts_response {
         V0(GetDataContractsResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1192,27 +988,21 @@ pub struct GetDataContractHistoryRequest {
 }
 /// Nested message and enum types in `GetDataContractHistoryRequest`.
 pub mod get_data_contract_history_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetDataContractHistoryRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
-        #[serde(with = "serde_bytes")]
         pub id: ::prost::alloc::vec::Vec<u8>,
         #[prost(message, optional, tag = "2")]
         pub limit: ::core::option::Option<u32>,
         #[prost(message, optional, tag = "3")]
         pub offset: ::core::option::Option<u32>,
         #[prost(uint64, tag = "4")]
-        #[serde(with = "crate::deserialization::from_to_string")]
         pub start_at_ms: u64,
         #[prost(bool, tag = "5")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1220,8 +1010,6 @@ pub mod get_data_contract_history_request {
         V0(GetDataContractHistoryRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1236,8 +1024,6 @@ pub struct GetDataContractHistoryResponse {
 }
 /// Nested message and enum types in `GetDataContractHistoryResponse`.
 pub mod get_data_contract_history_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1251,8 +1037,6 @@ pub mod get_data_contract_history_response {
     }
     /// Nested message and enum types in `GetDataContractHistoryResponseV0`.
     pub mod get_data_contract_history_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1262,8 +1046,6 @@ pub mod get_data_contract_history_response {
             #[prost(bytes = "vec", tag = "2")]
             pub value: ::prost::alloc::vec::Vec<u8>,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1273,8 +1055,6 @@ pub mod get_data_contract_history_response {
                 DataContractHistoryEntry,
             >,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1284,8 +1064,6 @@ pub mod get_data_contract_history_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1293,8 +1071,6 @@ pub mod get_data_contract_history_response {
         V0(GetDataContractHistoryResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1306,22 +1082,17 @@ pub struct GetDocumentsRequest {
 }
 /// Nested message and enum types in `GetDocumentsRequest`.
 pub mod get_documents_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetDocumentsRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
-        #[serde(with = "serde_bytes")]
         pub data_contract_id: ::prost::alloc::vec::Vec<u8>,
         #[prost(string, tag = "2")]
         pub document_type: ::prost::alloc::string::String,
         #[prost(bytes = "vec", tag = "3")]
-        #[serde(with = "serde_bytes")]
         pub r#where: ::prost::alloc::vec::Vec<u8>,
         #[prost(bytes = "vec", tag = "4")]
-        #[serde(with = "serde_bytes")]
         pub order_by: ::prost::alloc::vec::Vec<u8>,
         #[prost(uint32, tag = "5")]
         pub limit: u32,
@@ -1332,8 +1103,6 @@ pub mod get_documents_request {
     }
     /// Nested message and enum types in `GetDocumentsRequestV0`.
     pub mod get_documents_request_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Start {
@@ -1343,8 +1112,6 @@ pub mod get_documents_request {
             StartAt(::prost::alloc::vec::Vec<u8>),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1352,8 +1119,6 @@ pub mod get_documents_request {
         V0(GetDocumentsRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1368,8 +1133,6 @@ pub struct GetDocumentsResponse {
 }
 /// Nested message and enum types in `GetDocumentsResponse`.
 pub mod get_documents_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1381,8 +1144,6 @@ pub mod get_documents_response {
     }
     /// Nested message and enum types in `GetDocumentsResponseV0`.
     pub mod get_documents_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1390,8 +1151,6 @@ pub mod get_documents_response {
             #[prost(bytes = "vec", repeated, tag = "1")]
             pub documents: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1401,8 +1160,6 @@ pub mod get_documents_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1410,8 +1167,6 @@ pub mod get_documents_response {
         V0(GetDocumentsResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1425,20 +1180,15 @@ pub struct GetIdentitiesByPublicKeyHashesRequest {
 }
 /// Nested message and enum types in `GetIdentitiesByPublicKeyHashesRequest`.
 pub mod get_identities_by_public_key_hashes_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentitiesByPublicKeyHashesRequestV0 {
         #[prost(bytes = "vec", repeated, tag = "1")]
-        #[serde(with = "crate::deserialization::vec_base64string")]
         pub public_key_hashes: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1446,8 +1196,6 @@ pub mod get_identities_by_public_key_hashes_request {
         V0(GetIdentitiesByPublicKeyHashesRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1464,20 +1212,15 @@ pub struct GetIdentitiesByPublicKeyHashesResponse {
 }
 /// Nested message and enum types in `GetIdentitiesByPublicKeyHashesResponse`.
 pub mod get_identities_by_public_key_hashes_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PublicKeyHashIdentityEntry {
         #[prost(bytes = "vec", tag = "1")]
-        #[serde(with = "serde_bytes")]
         pub public_key_hash: ::prost::alloc::vec::Vec<u8>,
         #[prost(message, optional, tag = "2")]
         pub value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1485,8 +1228,6 @@ pub mod get_identities_by_public_key_hashes_response {
         #[prost(message, repeated, tag = "1")]
         pub identity_entries: ::prost::alloc::vec::Vec<PublicKeyHashIdentityEntry>,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1503,8 +1244,6 @@ pub mod get_identities_by_public_key_hashes_response {
     }
     /// Nested message and enum types in `GetIdentitiesByPublicKeyHashesResponseV0`.
     pub mod get_identities_by_public_key_hashes_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1514,8 +1253,6 @@ pub mod get_identities_by_public_key_hashes_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1523,8 +1260,6 @@ pub mod get_identities_by_public_key_hashes_response {
         V0(GetIdentitiesByPublicKeyHashesResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1538,20 +1273,15 @@ pub struct GetIdentityByPublicKeyHashRequest {
 }
 /// Nested message and enum types in `GetIdentityByPublicKeyHashRequest`.
 pub mod get_identity_by_public_key_hash_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityByPublicKeyHashRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
-        #[serde(with = "serde_bytes")]
         pub public_key_hash: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1559,8 +1289,6 @@ pub mod get_identity_by_public_key_hash_request {
         V0(GetIdentityByPublicKeyHashRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1577,8 +1305,6 @@ pub struct GetIdentityByPublicKeyHashResponse {
 }
 /// Nested message and enum types in `GetIdentityByPublicKeyHashResponse`.
 pub mod get_identity_by_public_key_hash_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1595,8 +1321,6 @@ pub mod get_identity_by_public_key_hash_response {
     }
     /// Nested message and enum types in `GetIdentityByPublicKeyHashResponseV0`.
     pub mod get_identity_by_public_key_hash_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1606,8 +1330,6 @@ pub mod get_identity_by_public_key_hash_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1615,8 +1337,6 @@ pub mod get_identity_by_public_key_hash_response {
         V0(GetIdentityByPublicKeyHashResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1630,8 +1350,6 @@ pub struct WaitForStateTransitionResultRequest {
 }
 /// Nested message and enum types in `WaitForStateTransitionResultRequest`.
 pub mod wait_for_state_transition_result_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1641,8 +1359,6 @@ pub mod wait_for_state_transition_result_request {
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1650,8 +1366,6 @@ pub mod wait_for_state_transition_result_request {
         V0(WaitForStateTransitionResultRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1668,8 +1382,6 @@ pub struct WaitForStateTransitionResultResponse {
 }
 /// Nested message and enum types in `WaitForStateTransitionResultResponse`.
 pub mod wait_for_state_transition_result_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1686,8 +1398,6 @@ pub mod wait_for_state_transition_result_response {
     }
     /// Nested message and enum types in `WaitForStateTransitionResultResponseV0`.
     pub mod wait_for_state_transition_result_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1697,8 +1407,6 @@ pub mod wait_for_state_transition_result_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1706,8 +1414,6 @@ pub mod wait_for_state_transition_result_response {
         V0(WaitForStateTransitionResultResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1717,8 +1423,6 @@ pub struct GetConsensusParamsRequest {
 }
 /// Nested message and enum types in `GetConsensusParamsRequest`.
 pub mod get_consensus_params_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1728,8 +1432,6 @@ pub mod get_consensus_params_request {
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1737,8 +1439,6 @@ pub mod get_consensus_params_request {
         V0(GetConsensusParamsRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1748,8 +1448,6 @@ pub struct GetConsensusParamsResponse {
 }
 /// Nested message and enum types in `GetConsensusParamsResponse`.
 pub mod get_consensus_params_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1761,8 +1459,6 @@ pub mod get_consensus_params_response {
         #[prost(string, tag = "3")]
         pub time_iota_ms: ::prost::alloc::string::String,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1774,8 +1470,6 @@ pub mod get_consensus_params_response {
         #[prost(string, tag = "3")]
         pub max_bytes: ::prost::alloc::string::String,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1785,8 +1479,6 @@ pub mod get_consensus_params_response {
         #[prost(message, optional, tag = "2")]
         pub evidence: ::core::option::Option<ConsensusParamsEvidence>,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1794,8 +1486,6 @@ pub mod get_consensus_params_response {
         V0(GetConsensusParamsResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1809,8 +1499,6 @@ pub struct GetProtocolVersionUpgradeStateRequest {
 }
 /// Nested message and enum types in `GetProtocolVersionUpgradeStateRequest`.
 pub mod get_protocol_version_upgrade_state_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1818,8 +1506,6 @@ pub mod get_protocol_version_upgrade_state_request {
         #[prost(bool, tag = "1")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1827,8 +1513,6 @@ pub mod get_protocol_version_upgrade_state_request {
         V0(GetProtocolVersionUpgradeStateRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1845,8 +1529,6 @@ pub struct GetProtocolVersionUpgradeStateResponse {
 }
 /// Nested message and enum types in `GetProtocolVersionUpgradeStateResponse`.
 pub mod get_protocol_version_upgrade_state_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1863,8 +1545,6 @@ pub mod get_protocol_version_upgrade_state_response {
     }
     /// Nested message and enum types in `GetProtocolVersionUpgradeStateResponseV0`.
     pub mod get_protocol_version_upgrade_state_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1872,8 +1552,6 @@ pub mod get_protocol_version_upgrade_state_response {
             #[prost(message, repeated, tag = "1")]
             pub versions: ::prost::alloc::vec::Vec<VersionEntry>,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1883,8 +1561,6 @@ pub mod get_protocol_version_upgrade_state_response {
             #[prost(uint32, tag = "2")]
             pub vote_count: u32,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1894,8 +1570,6 @@ pub mod get_protocol_version_upgrade_state_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1903,8 +1577,6 @@ pub mod get_protocol_version_upgrade_state_response {
         V0(GetProtocolVersionUpgradeStateResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1921,8 +1593,6 @@ pub struct GetProtocolVersionUpgradeVoteStatusRequest {
 }
 /// Nested message and enum types in `GetProtocolVersionUpgradeVoteStatusRequest`.
 pub mod get_protocol_version_upgrade_vote_status_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1934,8 +1604,6 @@ pub mod get_protocol_version_upgrade_vote_status_request {
         #[prost(bool, tag = "3")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1943,8 +1611,6 @@ pub mod get_protocol_version_upgrade_vote_status_request {
         V0(GetProtocolVersionUpgradeVoteStatusRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1964,8 +1630,6 @@ pub struct GetProtocolVersionUpgradeVoteStatusResponse {
 }
 /// Nested message and enum types in `GetProtocolVersionUpgradeVoteStatusResponse`.
 pub mod get_protocol_version_upgrade_vote_status_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1982,8 +1646,6 @@ pub mod get_protocol_version_upgrade_vote_status_response {
     }
     /// Nested message and enum types in `GetProtocolVersionUpgradeVoteStatusResponseV0`.
     pub mod get_protocol_version_upgrade_vote_status_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1991,8 +1653,6 @@ pub mod get_protocol_version_upgrade_vote_status_response {
             #[prost(message, repeated, tag = "1")]
             pub version_signals: ::prost::alloc::vec::Vec<VersionSignal>,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2002,8 +1662,6 @@ pub mod get_protocol_version_upgrade_vote_status_response {
             #[prost(uint32, tag = "2")]
             pub version: u32,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -2013,8 +1671,6 @@ pub mod get_protocol_version_upgrade_vote_status_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -2022,8 +1678,6 @@ pub mod get_protocol_version_upgrade_vote_status_response {
         V0(GetProtocolVersionUpgradeVoteStatusResponseV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2033,8 +1687,6 @@ pub struct GetEpochsInfoRequest {
 }
 /// Nested message and enum types in `GetEpochsInfoRequest`.
 pub mod get_epochs_info_request {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2048,8 +1700,6 @@ pub mod get_epochs_info_request {
         #[prost(bool, tag = "4")]
         pub prove: bool,
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -2057,8 +1707,6 @@ pub mod get_epochs_info_request {
         V0(GetEpochsInfoRequestV0),
     }
 }
-#[derive(::serde::Serialize, ::serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -2073,8 +1721,6 @@ pub struct GetEpochsInfoResponse {
 }
 /// Nested message and enum types in `GetEpochsInfoResponse`.
 pub mod get_epochs_info_response {
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2086,8 +1732,6 @@ pub mod get_epochs_info_response {
     }
     /// Nested message and enum types in `GetEpochsInfoResponseV0`.
     pub mod get_epochs_info_response_v0 {
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2095,8 +1739,6 @@ pub mod get_epochs_info_response {
             #[prost(message, repeated, tag = "1")]
             pub epoch_infos: ::prost::alloc::vec::Vec<EpochInfo>,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2114,8 +1756,6 @@ pub mod get_epochs_info_response {
             #[prost(uint32, tag = "6")]
             pub protocol_version: u32,
         }
-        #[derive(::serde::Serialize, ::serde::Deserialize)]
-        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -2125,697 +1765,11 @@ pub mod get_epochs_info_response {
             Proof(super::super::Proof),
         }
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
         #[prost(message, tag = "1")]
         V0(GetEpochsInfoResponseV0),
-    }
-}
-/// Generated client implementations.
-pub mod platform_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
-    #[derive(Debug, Clone)]
-    pub struct PlatformClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl PlatformClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> PlatformClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_origin(inner: T, origin: Uri) -> Self {
-            let inner = tonic::client::Grpc::with_origin(inner, origin);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> PlatformClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            PlatformClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with the given encoding.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.send_compressed(encoding);
-            self
-        }
-        /// Enable decompressing responses.
-        #[must_use]
-        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.accept_compressed(encoding);
-            self
-        }
-        /// Limits the maximum size of a decoded message.
-        ///
-        /// Default: `4MB`
-        #[must_use]
-        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_decoding_message_size(limit);
-            self
-        }
-        /// Limits the maximum size of an encoded message.
-        ///
-        /// Default: `usize::MAX`
-        #[must_use]
-        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_encoding_message_size(limit);
-            self
-        }
-        pub async fn broadcast_state_transition(
-            &mut self,
-            request: impl tonic::IntoRequest<super::BroadcastStateTransitionRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::BroadcastStateTransitionResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/broadcastStateTransition",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "broadcastStateTransition",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_identity(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetIdentityRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetIdentityResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getIdentity",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("org.dash.platform.dapi.v0.Platform", "getIdentity"),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_identities(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetIdentitiesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetIdentitiesResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getIdentities",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getIdentities",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_identity_keys(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetIdentityKeysRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetIdentityKeysResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getIdentityKeys",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getIdentityKeys",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_identity_nonce(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetIdentityNonceRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetIdentityNonceResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getIdentityNonce",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getIdentityNonce",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_identity_contract_nonce(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetIdentityContractNonceRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetIdentityContractNonceResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getIdentityContractNonce",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getIdentityContractNonce",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_identity_balance(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetIdentityBalanceRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetIdentityBalanceResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getIdentityBalance",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getIdentityBalance",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_identity_balance_and_revision(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetIdentityBalanceAndRevisionRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetIdentityBalanceAndRevisionResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getIdentityBalanceAndRevision",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getIdentityBalanceAndRevision",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_proofs(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetProofsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetProofsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getProofs",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("org.dash.platform.dapi.v0.Platform", "getProofs"),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_data_contract(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetDataContractRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetDataContractResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getDataContract",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getDataContract",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_data_contract_history(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetDataContractHistoryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetDataContractHistoryResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getDataContractHistory",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getDataContractHistory",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_data_contracts(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetDataContractsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetDataContractsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getDataContracts",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getDataContracts",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_documents(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetDocumentsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetDocumentsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getDocuments",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("org.dash.platform.dapi.v0.Platform", "getDocuments"),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_identities_by_public_key_hashes(
-            &mut self,
-            request: impl tonic::IntoRequest<
-                super::GetIdentitiesByPublicKeyHashesRequest,
-            >,
-        ) -> std::result::Result<
-            tonic::Response<super::GetIdentitiesByPublicKeyHashesResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getIdentitiesByPublicKeyHashes",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getIdentitiesByPublicKeyHashes",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_identity_by_public_key_hash(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetIdentityByPublicKeyHashRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetIdentityByPublicKeyHashResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getIdentityByPublicKeyHash",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getIdentityByPublicKeyHash",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn wait_for_state_transition_result(
-            &mut self,
-            request: impl tonic::IntoRequest<super::WaitForStateTransitionResultRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::WaitForStateTransitionResultResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/waitForStateTransitionResult",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "waitForStateTransitionResult",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_consensus_params(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetConsensusParamsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetConsensusParamsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getConsensusParams",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getConsensusParams",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_protocol_version_upgrade_state(
-            &mut self,
-            request: impl tonic::IntoRequest<
-                super::GetProtocolVersionUpgradeStateRequest,
-            >,
-        ) -> std::result::Result<
-            tonic::Response<super::GetProtocolVersionUpgradeStateResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getProtocolVersionUpgradeState",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getProtocolVersionUpgradeState",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_protocol_version_upgrade_vote_status(
-            &mut self,
-            request: impl tonic::IntoRequest<
-                super::GetProtocolVersionUpgradeVoteStatusRequest,
-            >,
-        ) -> std::result::Result<
-            tonic::Response<super::GetProtocolVersionUpgradeVoteStatusResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getProtocolVersionUpgradeVoteStatus",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getProtocolVersionUpgradeVoteStatus",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn get_epochs_info(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetEpochsInfoRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetEpochsInfoResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/org.dash.platform.dapi.v0.Platform/getEpochsInfo",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "org.dash.platform.dapi.v0.Platform",
-                        "getEpochsInfo",
-                    ),
-                );
-            self.inner.unary(req, path, codec).await
-        }
     }
 }
 /// Generated server implementations.

--- a/packages/dapi-grpc/src/platform/proto/org.dash.platform.dapi.v0.rs
+++ b/packages/dapi-grpc/src/platform/proto/org.dash.platform.dapi.v0.rs
@@ -1,37 +1,49 @@
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proof {
     #[prost(bytes = "vec", tag = "1")]
+    #[serde(with = "serde_bytes")]
     pub grovedb_proof: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "2")]
+    #[serde(with = "serde_bytes")]
     pub quorum_hash: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "3")]
+    #[serde(with = "serde_bytes")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint32, tag = "4")]
     pub round: u32,
     #[prost(bytes = "vec", tag = "5")]
+    #[serde(with = "serde_bytes")]
     pub block_id_hash: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint32, tag = "6")]
     pub quorum_type: u32,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResponseMetadata {
     #[prost(uint64, tag = "1")]
+    #[serde(with = "crate::deserialization::from_to_string")]
     pub height: u64,
     #[prost(uint32, tag = "2")]
     pub core_chain_locked_height: u32,
     #[prost(uint32, tag = "3")]
     pub epoch: u32,
     #[prost(uint64, tag = "4")]
+    #[serde(with = "crate::deserialization::from_to_string")]
     pub time_ms: u64,
     #[prost(uint32, tag = "5")]
     pub protocol_version: u32,
     #[prost(string, tag = "6")]
     pub chain_id: ::prost::alloc::string::String,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -43,6 +55,8 @@ pub struct StateTransitionBroadcastError {
     #[prost(bytes = "vec", tag = "3")]
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -50,10 +64,14 @@ pub struct BroadcastStateTransitionRequest {
     #[prost(bytes = "vec", tag = "1")]
     pub state_transition: ::prost::alloc::vec::Vec<u8>,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BroadcastStateTransitionResponse {}
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -65,15 +83,20 @@ pub struct GetIdentityRequest {
 }
 /// Nested message and enum types in `GetIdentityRequest`.
 pub mod get_identity_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
         pub id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -81,6 +104,8 @@ pub mod get_identity_request {
         V0(GetIdentityRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -92,15 +117,20 @@ pub struct GetIdentityNonceRequest {
 }
 /// Nested message and enum types in `GetIdentityNonceRequest`.
 pub mod get_identity_nonce_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityNonceRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
         pub identity_id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -108,6 +138,8 @@ pub mod get_identity_nonce_request {
         V0(GetIdentityNonceRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -119,17 +151,22 @@ pub struct GetIdentityContractNonceRequest {
 }
 /// Nested message and enum types in `GetIdentityContractNonceRequest`.
 pub mod get_identity_contract_nonce_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityContractNonceRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
         pub identity_id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bytes = "vec", tag = "2")]
         pub contract_id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "3")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -137,6 +174,8 @@ pub mod get_identity_contract_nonce_request {
         V0(GetIdentityContractNonceRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -148,15 +187,20 @@ pub struct GetIdentityBalanceRequest {
 }
 /// Nested message and enum types in `GetIdentityBalanceRequest`.
 pub mod get_identity_balance_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityBalanceRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
         pub id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -164,6 +208,8 @@ pub mod get_identity_balance_request {
         V0(GetIdentityBalanceRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -177,15 +223,20 @@ pub struct GetIdentityBalanceAndRevisionRequest {
 }
 /// Nested message and enum types in `GetIdentityBalanceAndRevisionRequest`.
 pub mod get_identity_balance_and_revision_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityBalanceAndRevisionRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
         pub id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -193,6 +244,8 @@ pub mod get_identity_balance_and_revision_request {
         V0(GetIdentityBalanceAndRevisionRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -207,6 +260,8 @@ pub struct GetIdentityResponse {
 }
 /// Nested message and enum types in `GetIdentityResponse`.
 pub mod get_identity_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -218,6 +273,8 @@ pub mod get_identity_response {
     }
     /// Nested message and enum types in `GetIdentityResponseV0`.
     pub mod get_identity_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -227,6 +284,8 @@ pub mod get_identity_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -234,6 +293,8 @@ pub mod get_identity_response {
         V0(GetIdentityResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -245,15 +306,20 @@ pub struct GetIdentitiesRequest {
 }
 /// Nested message and enum types in `GetIdentitiesRequest`.
 pub mod get_identities_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentitiesRequestV0 {
         #[prost(bytes = "vec", repeated, tag = "1")]
+        #[serde(with = "crate::deserialization::vec_base64string")]
         pub ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -261,6 +327,8 @@ pub mod get_identities_request {
         V0(GetIdentitiesRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -275,6 +343,8 @@ pub struct GetIdentitiesResponse {
 }
 /// Nested message and enum types in `GetIdentitiesResponse`.
 pub mod get_identities_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -282,6 +352,8 @@ pub mod get_identities_response {
         #[prost(bytes = "vec", tag = "1")]
         pub value: ::prost::alloc::vec::Vec<u8>,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -291,6 +363,8 @@ pub mod get_identities_response {
         #[prost(message, optional, tag = "2")]
         pub value: ::core::option::Option<IdentityValue>,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -298,6 +372,8 @@ pub mod get_identities_response {
         #[prost(message, repeated, tag = "1")]
         pub identity_entries: ::prost::alloc::vec::Vec<IdentityEntry>,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -309,6 +385,8 @@ pub mod get_identities_response {
     }
     /// Nested message and enum types in `GetIdentitiesResponseV0`.
     pub mod get_identities_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -318,6 +396,8 @@ pub mod get_identities_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -325,6 +405,8 @@ pub mod get_identities_response {
         V0(GetIdentitiesResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -339,6 +421,8 @@ pub struct GetIdentityNonceResponse {
 }
 /// Nested message and enum types in `GetIdentityNonceResponse`.
 pub mod get_identity_nonce_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -350,6 +434,8 @@ pub mod get_identity_nonce_response {
     }
     /// Nested message and enum types in `GetIdentityNonceResponseV0`.
     pub mod get_identity_nonce_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -359,6 +445,8 @@ pub mod get_identity_nonce_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -366,6 +454,8 @@ pub mod get_identity_nonce_response {
         V0(GetIdentityNonceResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -380,6 +470,8 @@ pub struct GetIdentityContractNonceResponse {
 }
 /// Nested message and enum types in `GetIdentityContractNonceResponse`.
 pub mod get_identity_contract_nonce_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -396,6 +488,8 @@ pub mod get_identity_contract_nonce_response {
     }
     /// Nested message and enum types in `GetIdentityContractNonceResponseV0`.
     pub mod get_identity_contract_nonce_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -405,6 +499,8 @@ pub mod get_identity_contract_nonce_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -412,6 +508,8 @@ pub mod get_identity_contract_nonce_response {
         V0(GetIdentityContractNonceResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -426,6 +524,8 @@ pub struct GetIdentityBalanceResponse {
 }
 /// Nested message and enum types in `GetIdentityBalanceResponse`.
 pub mod get_identity_balance_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -437,6 +537,8 @@ pub mod get_identity_balance_response {
     }
     /// Nested message and enum types in `GetIdentityBalanceResponseV0`.
     pub mod get_identity_balance_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -446,6 +548,8 @@ pub mod get_identity_balance_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -453,6 +557,8 @@ pub mod get_identity_balance_response {
         V0(GetIdentityBalanceResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -469,6 +575,8 @@ pub struct GetIdentityBalanceAndRevisionResponse {
 }
 /// Nested message and enum types in `GetIdentityBalanceAndRevisionResponse`.
 pub mod get_identity_balance_and_revision_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -485,6 +593,8 @@ pub mod get_identity_balance_and_revision_response {
     }
     /// Nested message and enum types in `GetIdentityBalanceAndRevisionResponseV0`.
     pub mod get_identity_balance_and_revision_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -494,6 +604,8 @@ pub mod get_identity_balance_and_revision_response {
             #[prost(uint64, tag = "2")]
             pub revision: u64,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -503,6 +615,8 @@ pub mod get_identity_balance_and_revision_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -510,6 +624,8 @@ pub mod get_identity_balance_and_revision_response {
         V0(GetIdentityBalanceAndRevisionResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -519,6 +635,8 @@ pub struct KeyRequestType {
 }
 /// Nested message and enum types in `KeyRequestType`.
 pub mod key_request_type {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Request {
@@ -530,10 +648,14 @@ pub mod key_request_type {
         SearchKey(super::SearchKey),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AllKeys {}
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -541,6 +663,8 @@ pub struct SpecificKeys {
     #[prost(uint32, repeated, tag = "1")]
     pub key_ids: ::prost::alloc::vec::Vec<u32>,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -548,6 +672,8 @@ pub struct SearchKey {
     #[prost(map = "uint32, message", tag = "1")]
     pub purpose_map: ::std::collections::HashMap<u32, SecurityLevelMap>,
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -560,6 +686,8 @@ pub struct SecurityLevelMap {
 }
 /// Nested message and enum types in `SecurityLevelMap`.
 pub mod security_level_map {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(
         Clone,
         Copy,
@@ -599,6 +727,8 @@ pub mod security_level_map {
         }
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -610,11 +740,14 @@ pub struct GetIdentityKeysRequest {
 }
 /// Nested message and enum types in `GetIdentityKeysRequest`.
 pub mod get_identity_keys_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityKeysRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
         pub identity_id: ::prost::alloc::vec::Vec<u8>,
         #[prost(message, optional, tag = "2")]
         pub request_type: ::core::option::Option<super::KeyRequestType>,
@@ -625,6 +758,8 @@ pub mod get_identity_keys_request {
         #[prost(bool, tag = "5")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -632,6 +767,8 @@ pub mod get_identity_keys_request {
         V0(GetIdentityKeysRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -646,6 +783,8 @@ pub struct GetIdentityKeysResponse {
 }
 /// Nested message and enum types in `GetIdentityKeysResponse`.
 pub mod get_identity_keys_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -657,6 +796,8 @@ pub mod get_identity_keys_response {
     }
     /// Nested message and enum types in `GetIdentityKeysResponseV0`.
     pub mod get_identity_keys_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -664,6 +805,8 @@ pub mod get_identity_keys_response {
             #[prost(bytes = "vec", repeated, tag = "1")]
             pub keys_bytes: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -673,6 +816,8 @@ pub mod get_identity_keys_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -680,6 +825,8 @@ pub mod get_identity_keys_response {
         V0(GetIdentityKeysResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -691,6 +838,8 @@ pub struct GetProofsRequest {
 }
 /// Nested message and enum types in `GetProofsRequest`.
 pub mod get_proofs_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -704,6 +853,8 @@ pub mod get_proofs_request {
     }
     /// Nested message and enum types in `GetProofsRequestV0`.
     pub mod get_proofs_request_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -717,17 +868,22 @@ pub mod get_proofs_request {
             #[prost(bytes = "vec", tag = "4")]
             pub document_id: ::prost::alloc::vec::Vec<u8>,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct IdentityRequest {
             #[prost(bytes = "vec", tag = "1")]
+            #[serde(with = "serde_bytes")]
             pub identity_id: ::prost::alloc::vec::Vec<u8>,
             #[prost(enumeration = "identity_request::Type", tag = "2")]
             pub request_type: i32,
         }
         /// Nested message and enum types in `IdentityRequest`.
         pub mod identity_request {
+            #[derive(::serde::Serialize, ::serde::Deserialize)]
+            #[serde(rename_all = "snake_case")]
             #[derive(
                 Clone,
                 Copy,
@@ -771,6 +927,8 @@ pub mod get_proofs_request {
                 }
             }
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -779,6 +937,8 @@ pub mod get_proofs_request {
             pub contract_id: ::prost::alloc::vec::Vec<u8>,
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -786,6 +946,8 @@ pub mod get_proofs_request {
         V0(GetProofsRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -800,6 +962,8 @@ pub struct GetProofsResponse {
 }
 /// Nested message and enum types in `GetProofsResponse`.
 pub mod get_proofs_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -811,6 +975,8 @@ pub mod get_proofs_response {
     }
     /// Nested message and enum types in `GetProofsResponseV0`.
     pub mod get_proofs_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -818,6 +984,8 @@ pub mod get_proofs_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -825,6 +993,8 @@ pub mod get_proofs_response {
         V0(GetProofsResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -836,15 +1006,20 @@ pub struct GetDataContractRequest {
 }
 /// Nested message and enum types in `GetDataContractRequest`.
 pub mod get_data_contract_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetDataContractRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
         pub id: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -852,6 +1027,8 @@ pub mod get_data_contract_request {
         V0(GetDataContractRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -866,6 +1043,8 @@ pub struct GetDataContractResponse {
 }
 /// Nested message and enum types in `GetDataContractResponse`.
 pub mod get_data_contract_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -877,6 +1056,8 @@ pub mod get_data_contract_response {
     }
     /// Nested message and enum types in `GetDataContractResponseV0`.
     pub mod get_data_contract_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -886,6 +1067,8 @@ pub mod get_data_contract_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -893,6 +1076,8 @@ pub mod get_data_contract_response {
         V0(GetDataContractResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -904,15 +1089,20 @@ pub struct GetDataContractsRequest {
 }
 /// Nested message and enum types in `GetDataContractsRequest`.
 pub mod get_data_contracts_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetDataContractsRequestV0 {
         #[prost(bytes = "vec", repeated, tag = "1")]
+        #[serde(with = "crate::deserialization::vec_base64string")]
         pub ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -920,6 +1110,8 @@ pub mod get_data_contracts_request {
         V0(GetDataContractsRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -934,6 +1126,8 @@ pub struct GetDataContractsResponse {
 }
 /// Nested message and enum types in `GetDataContractsResponse`.
 pub mod get_data_contracts_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -943,6 +1137,8 @@ pub mod get_data_contracts_response {
         #[prost(message, optional, tag = "2")]
         pub data_contract: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -950,6 +1146,8 @@ pub mod get_data_contracts_response {
         #[prost(message, repeated, tag = "1")]
         pub data_contract_entries: ::prost::alloc::vec::Vec<DataContractEntry>,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -961,6 +1159,8 @@ pub mod get_data_contracts_response {
     }
     /// Nested message and enum types in `GetDataContractsResponseV0`.
     pub mod get_data_contracts_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -970,6 +1170,8 @@ pub mod get_data_contracts_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -977,6 +1179,8 @@ pub mod get_data_contracts_response {
         V0(GetDataContractsResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -988,21 +1192,27 @@ pub struct GetDataContractHistoryRequest {
 }
 /// Nested message and enum types in `GetDataContractHistoryRequest`.
 pub mod get_data_contract_history_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetDataContractHistoryRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
         pub id: ::prost::alloc::vec::Vec<u8>,
         #[prost(message, optional, tag = "2")]
         pub limit: ::core::option::Option<u32>,
         #[prost(message, optional, tag = "3")]
         pub offset: ::core::option::Option<u32>,
         #[prost(uint64, tag = "4")]
+        #[serde(with = "crate::deserialization::from_to_string")]
         pub start_at_ms: u64,
         #[prost(bool, tag = "5")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1010,6 +1220,8 @@ pub mod get_data_contract_history_request {
         V0(GetDataContractHistoryRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1024,6 +1236,8 @@ pub struct GetDataContractHistoryResponse {
 }
 /// Nested message and enum types in `GetDataContractHistoryResponse`.
 pub mod get_data_contract_history_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1037,6 +1251,8 @@ pub mod get_data_contract_history_response {
     }
     /// Nested message and enum types in `GetDataContractHistoryResponseV0`.
     pub mod get_data_contract_history_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1046,6 +1262,8 @@ pub mod get_data_contract_history_response {
             #[prost(bytes = "vec", tag = "2")]
             pub value: ::prost::alloc::vec::Vec<u8>,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1055,6 +1273,8 @@ pub mod get_data_contract_history_response {
                 DataContractHistoryEntry,
             >,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1064,6 +1284,8 @@ pub mod get_data_contract_history_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1071,6 +1293,8 @@ pub mod get_data_contract_history_response {
         V0(GetDataContractHistoryResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1082,17 +1306,22 @@ pub struct GetDocumentsRequest {
 }
 /// Nested message and enum types in `GetDocumentsRequest`.
 pub mod get_documents_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetDocumentsRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
         pub data_contract_id: ::prost::alloc::vec::Vec<u8>,
         #[prost(string, tag = "2")]
         pub document_type: ::prost::alloc::string::String,
         #[prost(bytes = "vec", tag = "3")]
+        #[serde(with = "serde_bytes")]
         pub r#where: ::prost::alloc::vec::Vec<u8>,
         #[prost(bytes = "vec", tag = "4")]
+        #[serde(with = "serde_bytes")]
         pub order_by: ::prost::alloc::vec::Vec<u8>,
         #[prost(uint32, tag = "5")]
         pub limit: u32,
@@ -1103,6 +1332,8 @@ pub mod get_documents_request {
     }
     /// Nested message and enum types in `GetDocumentsRequestV0`.
     pub mod get_documents_request_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Start {
@@ -1112,6 +1343,8 @@ pub mod get_documents_request {
             StartAt(::prost::alloc::vec::Vec<u8>),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1119,6 +1352,8 @@ pub mod get_documents_request {
         V0(GetDocumentsRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1133,6 +1368,8 @@ pub struct GetDocumentsResponse {
 }
 /// Nested message and enum types in `GetDocumentsResponse`.
 pub mod get_documents_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1144,6 +1381,8 @@ pub mod get_documents_response {
     }
     /// Nested message and enum types in `GetDocumentsResponseV0`.
     pub mod get_documents_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1151,6 +1390,8 @@ pub mod get_documents_response {
             #[prost(bytes = "vec", repeated, tag = "1")]
             pub documents: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1160,6 +1401,8 @@ pub mod get_documents_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1167,6 +1410,8 @@ pub mod get_documents_response {
         V0(GetDocumentsResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1180,15 +1425,20 @@ pub struct GetIdentitiesByPublicKeyHashesRequest {
 }
 /// Nested message and enum types in `GetIdentitiesByPublicKeyHashesRequest`.
 pub mod get_identities_by_public_key_hashes_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentitiesByPublicKeyHashesRequestV0 {
         #[prost(bytes = "vec", repeated, tag = "1")]
+        #[serde(with = "crate::deserialization::vec_base64string")]
         pub public_key_hashes: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1196,6 +1446,8 @@ pub mod get_identities_by_public_key_hashes_request {
         V0(GetIdentitiesByPublicKeyHashesRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1212,15 +1464,20 @@ pub struct GetIdentitiesByPublicKeyHashesResponse {
 }
 /// Nested message and enum types in `GetIdentitiesByPublicKeyHashesResponse`.
 pub mod get_identities_by_public_key_hashes_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PublicKeyHashIdentityEntry {
         #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
         pub public_key_hash: ::prost::alloc::vec::Vec<u8>,
         #[prost(message, optional, tag = "2")]
         pub value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1228,6 +1485,8 @@ pub mod get_identities_by_public_key_hashes_response {
         #[prost(message, repeated, tag = "1")]
         pub identity_entries: ::prost::alloc::vec::Vec<PublicKeyHashIdentityEntry>,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1244,6 +1503,8 @@ pub mod get_identities_by_public_key_hashes_response {
     }
     /// Nested message and enum types in `GetIdentitiesByPublicKeyHashesResponseV0`.
     pub mod get_identities_by_public_key_hashes_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1253,6 +1514,8 @@ pub mod get_identities_by_public_key_hashes_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1260,6 +1523,8 @@ pub mod get_identities_by_public_key_hashes_response {
         V0(GetIdentitiesByPublicKeyHashesResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1273,15 +1538,20 @@ pub struct GetIdentityByPublicKeyHashRequest {
 }
 /// Nested message and enum types in `GetIdentityByPublicKeyHashRequest`.
 pub mod get_identity_by_public_key_hash_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct GetIdentityByPublicKeyHashRequestV0 {
         #[prost(bytes = "vec", tag = "1")]
+        #[serde(with = "serde_bytes")]
         pub public_key_hash: ::prost::alloc::vec::Vec<u8>,
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1289,6 +1559,8 @@ pub mod get_identity_by_public_key_hash_request {
         V0(GetIdentityByPublicKeyHashRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1305,6 +1577,8 @@ pub struct GetIdentityByPublicKeyHashResponse {
 }
 /// Nested message and enum types in `GetIdentityByPublicKeyHashResponse`.
 pub mod get_identity_by_public_key_hash_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1321,6 +1595,8 @@ pub mod get_identity_by_public_key_hash_response {
     }
     /// Nested message and enum types in `GetIdentityByPublicKeyHashResponseV0`.
     pub mod get_identity_by_public_key_hash_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1330,6 +1606,8 @@ pub mod get_identity_by_public_key_hash_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1337,6 +1615,8 @@ pub mod get_identity_by_public_key_hash_response {
         V0(GetIdentityByPublicKeyHashResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1350,6 +1630,8 @@ pub struct WaitForStateTransitionResultRequest {
 }
 /// Nested message and enum types in `WaitForStateTransitionResultRequest`.
 pub mod wait_for_state_transition_result_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1359,6 +1641,8 @@ pub mod wait_for_state_transition_result_request {
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1366,6 +1650,8 @@ pub mod wait_for_state_transition_result_request {
         V0(WaitForStateTransitionResultRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1382,6 +1668,8 @@ pub struct WaitForStateTransitionResultResponse {
 }
 /// Nested message and enum types in `WaitForStateTransitionResultResponse`.
 pub mod wait_for_state_transition_result_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1398,6 +1686,8 @@ pub mod wait_for_state_transition_result_response {
     }
     /// Nested message and enum types in `WaitForStateTransitionResultResponseV0`.
     pub mod wait_for_state_transition_result_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1407,6 +1697,8 @@ pub mod wait_for_state_transition_result_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1414,6 +1706,8 @@ pub mod wait_for_state_transition_result_response {
         V0(WaitForStateTransitionResultResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1423,6 +1717,8 @@ pub struct GetConsensusParamsRequest {
 }
 /// Nested message and enum types in `GetConsensusParamsRequest`.
 pub mod get_consensus_params_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1432,6 +1728,8 @@ pub mod get_consensus_params_request {
         #[prost(bool, tag = "2")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1439,6 +1737,8 @@ pub mod get_consensus_params_request {
         V0(GetConsensusParamsRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1448,6 +1748,8 @@ pub struct GetConsensusParamsResponse {
 }
 /// Nested message and enum types in `GetConsensusParamsResponse`.
 pub mod get_consensus_params_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1459,6 +1761,8 @@ pub mod get_consensus_params_response {
         #[prost(string, tag = "3")]
         pub time_iota_ms: ::prost::alloc::string::String,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1470,6 +1774,8 @@ pub mod get_consensus_params_response {
         #[prost(string, tag = "3")]
         pub max_bytes: ::prost::alloc::string::String,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1479,6 +1785,8 @@ pub mod get_consensus_params_response {
         #[prost(message, optional, tag = "2")]
         pub evidence: ::core::option::Option<ConsensusParamsEvidence>,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1486,6 +1794,8 @@ pub mod get_consensus_params_response {
         V0(GetConsensusParamsResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1499,6 +1809,8 @@ pub struct GetProtocolVersionUpgradeStateRequest {
 }
 /// Nested message and enum types in `GetProtocolVersionUpgradeStateRequest`.
 pub mod get_protocol_version_upgrade_state_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1506,6 +1818,8 @@ pub mod get_protocol_version_upgrade_state_request {
         #[prost(bool, tag = "1")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1513,6 +1827,8 @@ pub mod get_protocol_version_upgrade_state_request {
         V0(GetProtocolVersionUpgradeStateRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1529,6 +1845,8 @@ pub struct GetProtocolVersionUpgradeStateResponse {
 }
 /// Nested message and enum types in `GetProtocolVersionUpgradeStateResponse`.
 pub mod get_protocol_version_upgrade_state_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1545,6 +1863,8 @@ pub mod get_protocol_version_upgrade_state_response {
     }
     /// Nested message and enum types in `GetProtocolVersionUpgradeStateResponseV0`.
     pub mod get_protocol_version_upgrade_state_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1552,6 +1872,8 @@ pub mod get_protocol_version_upgrade_state_response {
             #[prost(message, repeated, tag = "1")]
             pub versions: ::prost::alloc::vec::Vec<VersionEntry>,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1561,6 +1883,8 @@ pub mod get_protocol_version_upgrade_state_response {
             #[prost(uint32, tag = "2")]
             pub vote_count: u32,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1570,6 +1894,8 @@ pub mod get_protocol_version_upgrade_state_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1577,6 +1903,8 @@ pub mod get_protocol_version_upgrade_state_response {
         V0(GetProtocolVersionUpgradeStateResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::VersionedGrpcMessage)]
 #[grpc_versions(0)]
 #[derive(::dapi_grpc_macros::Mockable)]
@@ -1593,6 +1921,8 @@ pub struct GetProtocolVersionUpgradeVoteStatusRequest {
 }
 /// Nested message and enum types in `GetProtocolVersionUpgradeVoteStatusRequest`.
 pub mod get_protocol_version_upgrade_vote_status_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1604,6 +1934,8 @@ pub mod get_protocol_version_upgrade_vote_status_request {
         #[prost(bool, tag = "3")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1611,6 +1943,8 @@ pub mod get_protocol_version_upgrade_vote_status_request {
         V0(GetProtocolVersionUpgradeVoteStatusRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1630,6 +1964,8 @@ pub struct GetProtocolVersionUpgradeVoteStatusResponse {
 }
 /// Nested message and enum types in `GetProtocolVersionUpgradeVoteStatusResponse`.
 pub mod get_protocol_version_upgrade_vote_status_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1646,6 +1982,8 @@ pub mod get_protocol_version_upgrade_vote_status_response {
     }
     /// Nested message and enum types in `GetProtocolVersionUpgradeVoteStatusResponseV0`.
     pub mod get_protocol_version_upgrade_vote_status_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1653,6 +1991,8 @@ pub mod get_protocol_version_upgrade_vote_status_response {
             #[prost(message, repeated, tag = "1")]
             pub version_signals: ::prost::alloc::vec::Vec<VersionSignal>,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1662,6 +2002,8 @@ pub mod get_protocol_version_upgrade_vote_status_response {
             #[prost(uint32, tag = "2")]
             pub version: u32,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1671,6 +2013,8 @@ pub mod get_protocol_version_upgrade_vote_status_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1678,6 +2022,8 @@ pub mod get_protocol_version_upgrade_vote_status_response {
         V0(GetProtocolVersionUpgradeVoteStatusResponseV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(::dapi_grpc_macros::Mockable)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1687,6 +2033,8 @@ pub struct GetEpochsInfoRequest {
 }
 /// Nested message and enum types in `GetEpochsInfoRequest`.
 pub mod get_epochs_info_request {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1700,6 +2048,8 @@ pub mod get_epochs_info_request {
         #[prost(bool, tag = "4")]
         pub prove: bool,
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
@@ -1707,6 +2057,8 @@ pub mod get_epochs_info_request {
         V0(GetEpochsInfoRequestV0),
     }
 }
+#[derive(::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[derive(
     ::dapi_grpc_macros::VersionedGrpcMessage,
     ::dapi_grpc_macros::VersionedGrpcResponse
@@ -1721,6 +2073,8 @@ pub struct GetEpochsInfoResponse {
 }
 /// Nested message and enum types in `GetEpochsInfoResponse`.
 pub mod get_epochs_info_response {
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[derive(::dapi_grpc_macros::Mockable)]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1732,6 +2086,8 @@ pub mod get_epochs_info_response {
     }
     /// Nested message and enum types in `GetEpochsInfoResponseV0`.
     pub mod get_epochs_info_response_v0 {
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1739,6 +2095,8 @@ pub mod get_epochs_info_response {
             #[prost(message, repeated, tag = "1")]
             pub epoch_infos: ::prost::alloc::vec::Vec<EpochInfo>,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[derive(::dapi_grpc_macros::Mockable)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1756,6 +2114,8 @@ pub mod get_epochs_info_response {
             #[prost(uint32, tag = "6")]
             pub protocol_version: u32,
         }
+        #[derive(::serde::Serialize, ::serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
         #[allow(clippy::derive_partial_eq_without_eq)]
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Result {
@@ -1765,11 +2125,697 @@ pub mod get_epochs_info_response {
             Proof(super::super::Proof),
         }
     }
+    #[derive(::serde::Serialize, ::serde::Deserialize)]
+    #[serde(rename_all = "snake_case")]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Version {
         #[prost(message, tag = "1")]
         V0(GetEpochsInfoResponseV0),
+    }
+}
+/// Generated client implementations.
+pub mod platform_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct PlatformClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl PlatformClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> PlatformClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> PlatformClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            PlatformClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn broadcast_state_transition(
+            &mut self,
+            request: impl tonic::IntoRequest<super::BroadcastStateTransitionRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::BroadcastStateTransitionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/broadcastStateTransition",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "broadcastStateTransition",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_identity(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetIdentityRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetIdentityResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getIdentity",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("org.dash.platform.dapi.v0.Platform", "getIdentity"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_identities(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetIdentitiesRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetIdentitiesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getIdentities",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getIdentities",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_identity_keys(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetIdentityKeysRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetIdentityKeysResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getIdentityKeys",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getIdentityKeys",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_identity_nonce(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetIdentityNonceRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetIdentityNonceResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getIdentityNonce",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getIdentityNonce",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_identity_contract_nonce(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetIdentityContractNonceRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetIdentityContractNonceResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getIdentityContractNonce",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getIdentityContractNonce",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_identity_balance(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetIdentityBalanceRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetIdentityBalanceResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getIdentityBalance",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getIdentityBalance",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_identity_balance_and_revision(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetIdentityBalanceAndRevisionRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetIdentityBalanceAndRevisionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getIdentityBalanceAndRevision",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getIdentityBalanceAndRevision",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_proofs(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetProofsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetProofsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getProofs",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("org.dash.platform.dapi.v0.Platform", "getProofs"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_data_contract(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetDataContractRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetDataContractResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getDataContract",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getDataContract",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_data_contract_history(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetDataContractHistoryRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetDataContractHistoryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getDataContractHistory",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getDataContractHistory",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_data_contracts(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetDataContractsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetDataContractsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getDataContracts",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getDataContracts",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_documents(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetDocumentsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetDocumentsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getDocuments",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("org.dash.platform.dapi.v0.Platform", "getDocuments"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_identities_by_public_key_hashes(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::GetIdentitiesByPublicKeyHashesRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::GetIdentitiesByPublicKeyHashesResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getIdentitiesByPublicKeyHashes",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getIdentitiesByPublicKeyHashes",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_identity_by_public_key_hash(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetIdentityByPublicKeyHashRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetIdentityByPublicKeyHashResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getIdentityByPublicKeyHash",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getIdentityByPublicKeyHash",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn wait_for_state_transition_result(
+            &mut self,
+            request: impl tonic::IntoRequest<super::WaitForStateTransitionResultRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::WaitForStateTransitionResultResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/waitForStateTransitionResult",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "waitForStateTransitionResult",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_consensus_params(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetConsensusParamsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetConsensusParamsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getConsensusParams",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getConsensusParams",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_protocol_version_upgrade_state(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::GetProtocolVersionUpgradeStateRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::GetProtocolVersionUpgradeStateResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getProtocolVersionUpgradeState",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getProtocolVersionUpgradeState",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_protocol_version_upgrade_vote_status(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                super::GetProtocolVersionUpgradeVoteStatusRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::GetProtocolVersionUpgradeVoteStatusResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getProtocolVersionUpgradeVoteStatus",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getProtocolVersionUpgradeVoteStatus",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn get_epochs_info(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetEpochsInfoRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetEpochsInfoResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/org.dash.platform.dapi.v0.Platform/getEpochsInfo",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "org.dash.platform.dapi.v0.Platform",
+                        "getEpochsInfo",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.

--- a/packages/rs-dapi-client/Cargo.toml
+++ b/packages/rs-dapi-client/Cargo.toml
@@ -14,7 +14,7 @@ offline-testing = []
 
 [dependencies]
 backon = "0.4.1"
-dapi-grpc = { path = "../dapi-grpc" , features = ["core", "client", "serde"], default-features = false}
+dapi-grpc = { path = "../dapi-grpc" }
 futures = "0.3.28"
 http = "0.2.9"
 rand = { version = "0.8.5", features = ["small_rng"] }

--- a/packages/rs-dapi-grpc-macros/Cargo.toml
+++ b/packages/rs-dapi-grpc-macros/Cargo.toml
@@ -15,4 +15,4 @@ heck = "0.5.0"
 
 [dev-dependencies]
 
-dapi-grpc = { path = "../dapi-grpc" , features = ["client", "serde"], default-features = false}
+dapi-grpc = { path = "../dapi-grpc" }

--- a/packages/rs-dpp/src/asset_lock/mod.rs
+++ b/packages/rs-dpp/src/asset_lock/mod.rs
@@ -2,6 +2,8 @@ use crate::asset_lock::reduced_asset_lock_value::AssetLockValue;
 
 pub mod reduced_asset_lock_value;
 
+pub type PastAssetLockStateTransitionHashes = Vec<Vec<u8>>;
+
 /// An enumeration of the possible states when querying platform to get the stored state of an outpoint
 /// representing if the asset lock was already used or not.
 pub enum StoredAssetLockInfo {

--- a/packages/rs-dpp/src/asset_lock/reduced_asset_lock_value/mod.rs
+++ b/packages/rs-dpp/src/asset_lock/reduced_asset_lock_value/mod.rs
@@ -4,6 +4,7 @@ use crate::ProtocolError;
 use bincode::{Decode, Encode};
 use derive_more::From;
 use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
+use platform_value::Bytes32;
 use platform_version::version::PlatformVersion;
 
 mod v0;
@@ -21,6 +22,7 @@ impl AssetLockValue {
         initial_credit_value: Credits,
         tx_out_script: Vec<u8>,
         remaining_credit_value: Credits,
+        used_tags: Vec<Bytes32>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         match platform_version
@@ -33,6 +35,7 @@ impl AssetLockValue {
                 initial_credit_value,
                 tx_out_script,
                 remaining_credit_value,
+                used_tags,
             })),
             version => Err(ProtocolError::UnknownVersionMismatch {
                 method: "ReducedAssetLockValue::new".to_string(),
@@ -67,6 +70,12 @@ impl AssetLockValueGettersV0 for AssetLockValue {
             AssetLockValue::V0(v0) => v0.remaining_credit_value,
         }
     }
+
+    fn used_tags_ref(&self) -> &Vec<Bytes32> {
+        match self {
+            AssetLockValue::V0(v0) => &v0.used_tags,
+        }
+    }
 }
 
 impl AssetLockValueSettersV0 for AssetLockValue {
@@ -85,6 +94,18 @@ impl AssetLockValueSettersV0 for AssetLockValue {
     fn set_remaining_credit_value(&mut self, value: Credits) {
         match self {
             AssetLockValue::V0(v0) => v0.remaining_credit_value = value,
+        }
+    }
+
+    fn set_used_tags(&mut self, tags: Vec<Bytes32>) {
+        match self {
+            AssetLockValue::V0(v0) => v0.used_tags = tags,
+        }
+    }
+
+    fn add_used_tag(&mut self, tag: Bytes32) {
+        match self {
+            AssetLockValue::V0(v0) => v0.used_tags.push(tag),
         }
     }
 }

--- a/packages/rs-dpp/src/asset_lock/reduced_asset_lock_value/v0/mod.rs
+++ b/packages/rs-dpp/src/asset_lock/reduced_asset_lock_value/v0/mod.rs
@@ -1,11 +1,16 @@
 use crate::fee::Credits;
 use bincode::{Decode, Encode};
+use platform_value::Bytes32;
 
 #[derive(Debug, Clone, Encode, Decode, PartialEq)]
 pub struct AssetLockValueV0 {
     pub(super) initial_credit_value: Credits,
     pub(super) tx_out_script: Vec<u8>,
     pub(super) remaining_credit_value: Credits,
+    /// The used tags can represent any token of that we want to say has been used
+    /// In practice for Platform this means that we are storing the asset lock transactions
+    /// to prevent replay attacks.
+    pub(super) used_tags: Vec<Bytes32>,
 }
 
 pub trait AssetLockValueGettersV0 {
@@ -14,10 +19,15 @@ pub trait AssetLockValueGettersV0 {
 
     fn tx_out_script_owned(self) -> Vec<u8>;
     fn remaining_credit_value(&self) -> Credits;
+
+    fn used_tags_ref(&self) -> &Vec<Bytes32>;
 }
 
 pub trait AssetLockValueSettersV0 {
     fn set_initial_credit_value(&mut self, value: Credits);
     fn set_tx_out_script(&mut self, value: Vec<u8>);
     fn set_remaining_credit_value(&mut self, value: Credits);
+
+    fn set_used_tags(&mut self, tags: Vec<Bytes32>);
+    fn add_used_tag(&mut self, tag: Bytes32);
 }

--- a/packages/rs-dpp/src/balances/credits.rs
+++ b/packages/rs-dpp/src/balances/credits.rs
@@ -12,6 +12,9 @@ use crate::ProtocolError;
 use integer_encoding::VarInt;
 use std::convert::TryFrom;
 
+/// Duffs type
+pub type Duffs = u64;
+
 /// Credits type
 
 pub type Credits = u64;

--- a/packages/rs-dpp/src/errors/consensus/basic/basic_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/basic_error.rs
@@ -33,7 +33,7 @@ use crate::consensus::basic::identity::{
     DataContractBoundsNotPresentError, DisablingKeyIdAlsoBeingAddedInSameTransitionError,
     DuplicatedIdentityPublicKeyBasicError, DuplicatedIdentityPublicKeyIdBasicError,
     IdentityAssetLockProofLockedTransactionMismatchError,
-    IdentityAssetLockTransactionIsNotFoundError,
+    IdentityAssetLockStateTransitionReplayError, IdentityAssetLockTransactionIsNotFoundError,
     IdentityAssetLockTransactionOutPointAlreadyConsumedError,
     IdentityAssetLockTransactionOutPointNotEnoughBalanceError,
     IdentityAssetLockTransactionOutputNotFoundError, IdentityCreditTransferToSelfError,
@@ -251,6 +251,9 @@ pub enum BasicError {
     IdentityAssetLockTransactionOutPointNotEnoughBalanceError(
         IdentityAssetLockTransactionOutPointNotEnoughBalanceError,
     ),
+
+    #[error(transparent)]
+    IdentityAssetLockStateTransitionReplayError(IdentityAssetLockStateTransitionReplayError),
 
     #[error(transparent)]
     IdentityAssetLockTransactionOutputNotFoundError(

--- a/packages/rs-dpp/src/errors/consensus/basic/identity/identity_asset_lock_state_transition_replay_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/identity/identity_asset_lock_state_transition_replay_error.rs
@@ -1,0 +1,56 @@
+use crate::consensus::basic::BasicError;
+use crate::consensus::ConsensusError;
+use crate::errors::ProtocolError;
+use bincode::{Decode, Encode};
+use dashcore::Txid;
+use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
+use platform_value::Bytes32;
+use thiserror::Error;
+
+#[derive(
+    Error, Debug, Clone, PartialEq, Eq, Encode, Decode, PlatformSerialize, PlatformDeserialize,
+)]
+#[error("Asset lock transaction {transaction_id} is trying to be replayed and will be discarded")]
+#[platform_serialize(unversioned)]
+pub struct IdentityAssetLockStateTransitionReplayError {
+    /*
+
+    DO NOT CHANGE ORDER OF FIELDS WITHOUT INTRODUCING OF NEW VERSION
+
+    */
+    #[platform_serialize(with_serde)]
+    #[bincode(with_serde)]
+    transaction_id: Txid,
+
+    output_index: usize,
+
+    state_transition_id: Bytes32,
+}
+
+impl IdentityAssetLockStateTransitionReplayError {
+    pub fn new(transaction_id: Txid, output_index: usize, state_transition_id: Bytes32) -> Self {
+        Self {
+            transaction_id,
+            output_index,
+            state_transition_id,
+        }
+    }
+
+    pub fn transaction_id(&self) -> Txid {
+        self.transaction_id
+    }
+
+    pub fn state_transition_id(&self) -> Bytes32 {
+        self.state_transition_id
+    }
+
+    pub fn output_index(&self) -> usize {
+        self.output_index
+    }
+}
+
+impl From<IdentityAssetLockStateTransitionReplayError> for ConsensusError {
+    fn from(err: IdentityAssetLockStateTransitionReplayError) -> Self {
+        Self::BasicError(BasicError::IdentityAssetLockStateTransitionReplayError(err))
+    }
+}

--- a/packages/rs-dpp/src/errors/consensus/basic/identity/mod.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/identity/mod.rs
@@ -3,6 +3,7 @@ pub use disabling_key_id_also_being_added_in_same_transition_error::*;
 pub use duplicated_identity_public_key_basic_error::*;
 pub use duplicated_identity_public_key_id_basic_error::*;
 pub use identity_asset_lock_proof_locked_transaction_mismatch_error::*;
+pub use identity_asset_lock_state_transition_replay_error::*;
 pub use identity_asset_lock_transaction_is_not_found_error::*;
 pub use identity_asset_lock_transaction_out_point_already_consumed_error::*;
 pub use identity_asset_lock_transaction_out_point_not_enough_balance_error::*;
@@ -37,6 +38,7 @@ mod identity_asset_lock_proof_locked_transaction_mismatch_error;
 mod identity_asset_lock_transaction_is_not_found_error;
 mod identity_asset_lock_transaction_out_point_already_consumed_error;
 
+mod identity_asset_lock_state_transition_replay_error;
 mod identity_asset_lock_transaction_out_point_not_enough_balance_error;
 mod identity_asset_lock_transaction_output_not_found_error;
 mod identity_credit_transfer_to_self_error;

--- a/packages/rs-dpp/src/errors/consensus/basic/value_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/value_error.rs
@@ -27,6 +27,10 @@ impl ValueError {
         }
     }
 
+    pub fn new_from_string(value_error: String) -> Self {
+        Self { value_error }
+    }
+
     pub fn value_error(&self) -> &str {
         &self.value_error
     }

--- a/packages/rs-dpp/src/errors/consensus/codes.rs
+++ b/packages/rs-dpp/src/errors/consensus/codes.rs
@@ -141,6 +141,7 @@ impl ErrorWithCode for BasicError {
             Self::IdentityCreditTransferToSelfError(_) => 10528,
             Self::MasterPublicKeyUpdateError(_) => 10529,
             Self::IdentityAssetLockTransactionOutPointNotEnoughBalanceError(_) => 10530,
+            Self::IdentityAssetLockStateTransitionReplayError(_) => 10531,
 
             // State Transition Errors: 10600-10699
             Self::InvalidStateTransitionTypeError { .. } => 10600,

--- a/packages/rs-dpp/src/state_transition/serialization.rs
+++ b/packages/rs-dpp/src/state_transition/serialization.rs
@@ -58,7 +58,7 @@ mod tests {
         let platform_version = LATEST_PLATFORM_VERSION;
         let identity = Identity::random_identity(5, Some(5), platform_version)
             .expect("expected a random identity");
-        let asset_lock_proof = raw_instant_asset_lock_proof_fixture(None);
+        let asset_lock_proof = raw_instant_asset_lock_proof_fixture(None, None);
 
         let identity_create_transition = IdentityCreateTransition::V0(
             IdentityCreateTransitionV0::try_from_identity(
@@ -84,7 +84,7 @@ mod tests {
         let platform_version = PlatformVersion::latest();
         let identity = Identity::random_identity(5, Some(5), platform_version)
             .expect("expected a random identity");
-        let asset_lock_proof = raw_instant_asset_lock_proof_fixture(None);
+        let asset_lock_proof = raw_instant_asset_lock_proof_fixture(None, None);
 
         let identity_topup_transition = IdentityTopUpTransitionV0 {
             asset_lock_proof: AssetLockProof::Instant(asset_lock_proof),

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/methods/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/methods/mod.rs
@@ -8,6 +8,7 @@ use crate::identity::signer::Signer;
 use crate::identity::Identity;
 #[cfg(feature = "state-transition-signing")]
 use crate::prelude::AssetLockProof;
+#[cfg(feature = "state-transition-signing")]
 use crate::prelude::UserFeeIncrease;
 #[cfg(feature = "state-transition-signing")]
 use crate::state_transition::identity_create_transition::v0::IdentityCreateTransitionV0;

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/methods/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/methods/mod.rs
@@ -8,6 +8,7 @@ use crate::identity::signer::Signer;
 use crate::identity::Identity;
 #[cfg(feature = "state-transition-signing")]
 use crate::prelude::AssetLockProof;
+use crate::prelude::UserFeeIncrease;
 #[cfg(feature = "state-transition-signing")]
 use crate::state_transition::identity_create_transition::v0::IdentityCreateTransitionV0;
 use crate::state_transition::identity_create_transition::IdentityCreateTransition;
@@ -27,6 +28,7 @@ impl IdentityCreateTransitionMethodsV0 for IdentityCreateTransition {
         asset_lock_proof_private_key: &[u8],
         signer: &S,
         bls: &impl BlsModule,
+        user_fee_increase: UserFeeIncrease,
         platform_version: &PlatformVersion,
     ) -> Result<StateTransition, ProtocolError> {
         match platform_version
@@ -40,6 +42,7 @@ impl IdentityCreateTransitionMethodsV0 for IdentityCreateTransition {
                 asset_lock_proof_private_key,
                 signer,
                 bls,
+                user_fee_increase,
                 platform_version,
             )?),
             v => Err(ProtocolError::UnknownVersionError(format!(

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/methods/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/methods/v0/mod.rs
@@ -4,6 +4,7 @@ use crate::identity::signer::Signer;
 use crate::identity::Identity;
 #[cfg(feature = "state-transition-signing")]
 use crate::prelude::AssetLockProof;
+#[cfg(feature = "state-transition-signing")]
 use crate::prelude::UserFeeIncrease;
 #[cfg(feature = "state-transition-signing")]
 use crate::state_transition::StateTransition;

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/methods/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/methods/v0/mod.rs
@@ -4,6 +4,7 @@ use crate::identity::signer::Signer;
 use crate::identity::Identity;
 #[cfg(feature = "state-transition-signing")]
 use crate::prelude::AssetLockProof;
+use crate::prelude::UserFeeIncrease;
 #[cfg(feature = "state-transition-signing")]
 use crate::state_transition::StateTransition;
 use crate::state_transition::StateTransitionType;
@@ -20,6 +21,7 @@ pub trait IdentityCreateTransitionMethodsV0 {
         asset_lock_proof_private_key: &[u8],
         signer: &S,
         bls: &impl BlsModule,
+        user_fee_increase: UserFeeIncrease,
         platform_version: &PlatformVersion,
     ) -> Result<StateTransition, ProtocolError>;
     /// Get State Transition type

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/v0/v0_methods.rs
@@ -16,6 +16,7 @@ use crate::identity::Identity;
 use crate::identity::KeyType::ECDSA_HASH160;
 #[cfg(feature = "state-transition-signing")]
 use crate::prelude::AssetLockProof;
+#[cfg(feature = "state-transition-signing")]
 use crate::prelude::UserFeeIncrease;
 #[cfg(feature = "state-transition-signing")]
 use crate::serialization::Signable;
@@ -42,8 +43,10 @@ impl IdentityCreateTransitionMethodsV0 for IdentityCreateTransitionV0 {
         user_fee_increase: UserFeeIncrease,
         _platform_version: &PlatformVersion,
     ) -> Result<StateTransition, ProtocolError> {
-        let mut identity_create_transition = IdentityCreateTransitionV0::default();
-        identity_create_transition.user_fee_increase = user_fee_increase;
+        let mut identity_create_transition = IdentityCreateTransitionV0 {
+            user_fee_increase,
+            ..Default::default()
+        };
         let public_keys = identity
             .public_keys()
             .iter()

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_transition/v0/v0_methods.rs
@@ -16,6 +16,7 @@ use crate::identity::Identity;
 use crate::identity::KeyType::ECDSA_HASH160;
 #[cfg(feature = "state-transition-signing")]
 use crate::prelude::AssetLockProof;
+use crate::prelude::UserFeeIncrease;
 #[cfg(feature = "state-transition-signing")]
 use crate::serialization::Signable;
 use crate::state_transition::identity_create_transition::accessors::IdentityCreateTransitionAccessorsV0;
@@ -38,9 +39,11 @@ impl IdentityCreateTransitionMethodsV0 for IdentityCreateTransitionV0 {
         asset_lock_proof_private_key: &[u8],
         signer: &S,
         bls: &impl BlsModule,
+        user_fee_increase: UserFeeIncrease,
         _platform_version: &PlatformVersion,
     ) -> Result<StateTransition, ProtocolError> {
         let mut identity_create_transition = IdentityCreateTransitionV0::default();
+        identity_create_transition.user_fee_increase = user_fee_increase;
         let public_keys = identity
             .public_keys()
             .iter()

--- a/packages/rs-dpp/src/state_transition/state_transitions/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/mod.rs
@@ -2,6 +2,7 @@ mod common_fields;
 mod contract;
 pub(crate) mod document;
 pub mod identity;
+pub mod signable_bytes_hasher;
 
 pub use contract::*;
 pub use document::*;

--- a/packages/rs-dpp/src/state_transition/state_transitions/signable_bytes_hasher.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/signable_bytes_hasher.rs
@@ -1,0 +1,48 @@
+use crate::util::hash::hash_double;
+use platform_value::Bytes32;
+
+/// This is a structure to hash signable bytes when we are not sure if we will need the hashing
+#[derive(Debug, Clone)]
+pub enum SignableBytesHasher {
+    Bytes(Vec<u8>),
+    PreHashed(Bytes32),
+}
+
+impl SignableBytesHasher {
+    pub fn into_hashed_bytes(self) -> Bytes32 {
+        match self {
+            SignableBytesHasher::Bytes(signable_bytes) => hash_double(signable_bytes).into(),
+            SignableBytesHasher::PreHashed(pre_hashed) => pre_hashed,
+        }
+    }
+
+    pub fn to_hashed_bytes(&self) -> Bytes32 {
+        match self {
+            SignableBytesHasher::Bytes(signable_bytes) => hash_double(signable_bytes).into(),
+            SignableBytesHasher::PreHashed(pre_hashed) => *pre_hashed,
+        }
+    }
+
+    pub fn hash_bytes(&mut self) -> Bytes32 {
+        match self {
+            SignableBytesHasher::Bytes(signable_bytes) => {
+                let bytes_32: Bytes32 = hash_double(signable_bytes).into();
+                *self = SignableBytesHasher::PreHashed(bytes_32);
+                bytes_32
+            }
+            SignableBytesHasher::PreHashed(pre_hashed) => *pre_hashed,
+        }
+    }
+
+    pub fn hash_bytes_and_check_if_vec_contains(&mut self, vec: &[Bytes32]) -> bool {
+        match self {
+            SignableBytesHasher::Bytes(signable_bytes) => {
+                let bytes_32: Bytes32 = hash_double(signable_bytes).into();
+                let contains = vec.contains(&bytes_32);
+                *self = SignableBytesHasher::PreHashed(bytes_32);
+                contains
+            }
+            SignableBytesHasher::PreHashed(pre_hashed) => vec.contains(pre_hashed),
+        }
+    }
+}

--- a/packages/rs-dpp/src/tests/fixtures/identity_create_transition_fixture.rs
+++ b/packages/rs-dpp/src/tests/fixtures/identity_create_transition_fixture.rs
@@ -11,7 +11,7 @@ use platform_value::string_encoding::{decode, Encoding};
 //[198, 23, 40, 120, 58, 93, 0, 165, 27, 49, 4, 117, 107, 204,  67, 46, 164, 216, 230, 135, 201, 92, 31, 155, 62, 131, 211, 177, 139, 175, 163, 237]
 
 pub fn identity_create_transition_fixture(one_time_private_key: Option<PrivateKey>) -> Value {
-    let asset_lock_proof = raw_instant_asset_lock_proof_fixture(one_time_private_key);
+    let asset_lock_proof = raw_instant_asset_lock_proof_fixture(one_time_private_key, None);
 
     platform_value!({
         "protocolVersion": version::LATEST_VERSION,

--- a/packages/rs-dpp/src/tests/fixtures/identity_topup_transition_fixture.rs
+++ b/packages/rs-dpp/src/tests/fixtures/identity_topup_transition_fixture.rs
@@ -9,7 +9,7 @@ use crate::version;
 //[198, 23, 40, 120, 58, 93, 0, 165, 27, 49, 4, 117, 107, 204,  67, 46, 164, 216, 230, 135, 201, 92, 31, 155, 62, 131, 211, 177, 139, 175, 163, 237]
 
 pub fn identity_topup_transition_fixture(one_time_private_key: Option<PrivateKey>) -> Value {
-    let asset_lock_proof = raw_instant_asset_lock_proof_fixture(one_time_private_key);
+    let asset_lock_proof = raw_instant_asset_lock_proof_fixture(one_time_private_key, None);
     platform_value!({
         "protocolVersion": version::LATEST_VERSION,
         "type": StateTransitionType::IdentityTopUp as u8,

--- a/packages/rs-dpp/src/tests/fixtures/instant_asset_lock_proof_fixture.rs
+++ b/packages/rs-dpp/src/tests/fixtures/instant_asset_lock_proof_fixture.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use dashcore::bls_sig_utils::BLSSignature;
 use dashcore::hash_types::CycleHash;
 
+use crate::balances::credits::Duffs;
 use dashcore::secp256k1::rand::thread_rng;
 use dashcore::secp256k1::Secp256k1;
 use dashcore::transaction::special_transaction::asset_lock::AssetLockPayload;
@@ -19,8 +20,9 @@ use crate::identity::state_transition::asset_lock_proof::{AssetLockProof, Instan
 
 pub fn raw_instant_asset_lock_proof_fixture(
     one_time_private_key: Option<PrivateKey>,
+    amount: Option<Duffs>,
 ) -> InstantAssetLockProof {
-    let transaction = instant_asset_lock_proof_transaction_fixture(one_time_private_key);
+    let transaction = instant_asset_lock_proof_transaction_fixture(one_time_private_key, amount);
 
     let instant_lock = instant_asset_lock_is_lock_fixture(transaction.txid());
 
@@ -29,8 +31,9 @@ pub fn raw_instant_asset_lock_proof_fixture(
 
 pub fn instant_asset_lock_proof_fixture(
     one_time_private_key: Option<PrivateKey>,
+    amount: Option<Duffs>,
 ) -> AssetLockProof {
-    let transaction = instant_asset_lock_proof_transaction_fixture(one_time_private_key);
+    let transaction = instant_asset_lock_proof_transaction_fixture(one_time_private_key, amount);
 
     let instant_lock = instant_asset_lock_is_lock_fixture(transaction.txid());
 
@@ -41,6 +44,7 @@ pub fn instant_asset_lock_proof_fixture(
 
 pub fn instant_asset_lock_proof_transaction_fixture(
     one_time_private_key: Option<PrivateKey>,
+    amount: Option<Duffs>,
 ) -> Transaction {
     let mut rng = thread_rng();
     let secp = Secp256k1::new();
@@ -74,12 +78,12 @@ pub fn instant_asset_lock_proof_transaction_fixture(
     let one_time_key_hash = one_time_public_key.pubkey_hash();
 
     let funding_output = TxOut {
-        value: 100000000, // 1 Dash
+        value: amount.unwrap_or(100000000), // 1 Dash
         script_pubkey: ScriptBuf::new_p2pkh(&one_time_key_hash),
     };
 
     let burn_output = TxOut {
-        value: 100000000, // 1 Dash
+        value: amount.unwrap_or(100000000), // 1 Dash
         script_pubkey: ScriptBuf::new_op_return(&[]),
     };
 

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -44,7 +44,7 @@ tracing = { version = "0.1.37", default-features = false, features = [] }
 clap = { version = "4.4.10", features = ["derive"] }
 envy = { version = "0.4.2" }
 dotenvy = { version = "0.15.7" }
-dapi-grpc = { path = "../dapi-grpc", features = ["server"], default-features = false }
+dapi-grpc = { path = "../dapi-grpc" }
 tracing-subscriber = { version = "0.3.16", default-features = false, features = [
   "env-filter",
   "ansi",

--- a/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
@@ -233,7 +233,7 @@ mod tests {
     use dpp::data_contract::document_type::v0::DocumentTypeV0;
     use dpp::data_contract::document_type::DocumentType;
     use dpp::identity::contract_bounds::ContractBounds::SingleContractDocumentType;
-    use dpp::platform_value::{BinaryData, Bytes32};
+    use dpp::platform_value::Bytes32;
     use dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
     use dpp::state_transition::identity_create_transition::accessors::IdentityCreateTransitionAccessorsV0;
     use dpp::state_transition::public_key_in_creation::accessors::IdentityPublicKeyInCreationV0Setters;
@@ -1395,9 +1395,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identifier = asset_lock_proof
             .create_identifier()
@@ -1581,9 +1582,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identifier = asset_lock_proof
             .create_identifier()
@@ -1636,9 +1638,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof_top_up = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof_top_up = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identity_top_up_transition: StateTransition =
             IdentityTopUpTransition::try_from_identity(
@@ -1718,9 +1721,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identifier = asset_lock_proof
             .create_identifier()
@@ -1773,9 +1777,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof_top_up = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof_top_up = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identity_top_up_transition: StateTransition =
             IdentityTopUpTransition::try_from_identity(
@@ -1881,9 +1886,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identifier = asset_lock_proof
             .create_identifier()
@@ -1906,9 +1912,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof_top_up = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof_top_up = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identity_top_up_transition: StateTransition =
             IdentityTopUpTransition::try_from_identity(
@@ -1979,9 +1986,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identifier = asset_lock_proof
             .create_identifier()
@@ -2034,9 +2042,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof_top_up = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof_top_up = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identity_top_up_transition: StateTransition =
             IdentityTopUpTransition::try_from_identity(
@@ -2195,9 +2204,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identifier = asset_lock_proof
             .create_identifier()
@@ -2223,7 +2233,7 @@ mod tests {
             )
             .expect("expected an identity create transition");
 
-        let mut valid_identity_create_transition = identity_create_transition.clone();
+        let valid_identity_create_transition = identity_create_transition.clone();
 
         // let's add an error so this fails on state validation
 
@@ -2324,9 +2334,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof_top_up = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof_top_up = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identity_top_up_transition: StateTransition =
             IdentityTopUpTransition::try_from_identity(

--- a/packages/rs-drive-abci/src/execution/platform_events/block_fee_processing/add_process_epoch_change_operations/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_fee_processing/add_process_epoch_change_operations/mod.rs
@@ -8,13 +8,11 @@ use crate::error::Error;
 
 use crate::execution::types::block_fees::BlockFees;
 
-use crate::execution::types::block_state_info::BlockStateInfo;
 use crate::execution::types::storage_fee_distribution_outcome;
 
 use crate::error::execution::ExecutionError;
 use crate::execution::types::block_execution_context::BlockExecutionContext;
 
-use crate::platform_types::epoch_info::EpochInfo;
 use crate::platform_types::platform::Platform;
 
 impl<CoreRPCLike> Platform<CoreRPCLike> {

--- a/packages/rs-drive-abci/src/execution/platform_events/block_fee_processing/add_process_epoch_change_operations/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_fee_processing/add_process_epoch_change_operations/v0/mod.rs
@@ -47,13 +47,11 @@ use crate::error::Error;
 use crate::execution::types::block_fees::v0::BlockFeesV0Getters;
 use crate::execution::types::block_fees::BlockFees;
 use crate::execution::types::block_state_info::v0::BlockStateInfoV0Getters;
-use crate::execution::types::block_state_info::BlockStateInfo;
 use crate::execution::types::storage_fee_distribution_outcome;
 
 use crate::execution::types::block_execution_context::v0::BlockExecutionContextV0Getters;
 use crate::execution::types::block_execution_context::BlockExecutionContext;
 use crate::platform_types::epoch_info::v0::EpochInfoV0Getters;
-use crate::platform_types::epoch_info::EpochInfo;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::v0::PlatformStateV0Methods;
 use drive::fee_pools::epochs::operations_factory::EpochOperations;

--- a/packages/rs-drive-abci/src/execution/platform_events/block_fee_processing/process_block_fees/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_fee_processing/process_block_fees/mod.rs
@@ -10,10 +10,8 @@ use crate::execution::types::block_execution_context::BlockExecutionContext;
 
 use crate::execution::types::block_fees::BlockFees;
 
-use crate::execution::types::block_state_info::BlockStateInfo;
 use crate::execution::types::processed_block_fees_outcome;
 
-use crate::platform_types::epoch_info::EpochInfo;
 use crate::platform_types::platform::Platform;
 
 impl<CoreRPCLike> Platform<CoreRPCLike> {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/check_tx_verification/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/check_tx_verification/v0/mod.rs
@@ -6,6 +6,8 @@ use crate::platform_types::platform_state::v0::PlatformStateV0Methods;
 use crate::rpc::core::CoreRPCLike;
 use dpp::identity::state_transition::OptionallyAssetLockProved;
 use dpp::prelude::ConsensusValidationResult;
+use dpp::serialization::Signable;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 use dpp::ProtocolError;
 
 use dpp::state_transition::StateTransition;
@@ -200,10 +202,13 @@ pub(super) fn state_transition_to_execution_event_for_check_tx_v0<'a, C: CoreRPC
         }
         CheckTxLevel::Recheck => {
             if let Some(asset_lock_proof) = state_transition.optional_asset_lock_proof() {
+                let mut signable_bytes_hasher =
+                    SignableBytesHasher::Bytes(state_transition.signable_bytes()?);
                 // we should check that the asset lock is still valid
                 let validation_result = asset_lock_proof
                     .verify_is_not_spent_and_has_enough_balance(
                         platform,
+                        &mut signable_bytes_hasher,
                         state_transition
                             .required_asset_lock_balance_for_processing_start(platform_version),
                         None,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/validate/chain/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/validate/chain/mod.rs
@@ -7,6 +7,7 @@ use dpp::consensus::basic::identity::{
 };
 use dpp::fee::Credits;
 use dpp::identity::state_transition::asset_lock_proof::chain::ChainAssetLockProof;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 use dpp::validation::ConsensusValidationResult;
 use dpp::version::PlatformVersion;
 use drive::grovedb::TransactionArg;
@@ -20,6 +21,7 @@ impl AssetLockProofValidation for ChainAssetLockProof {
     fn validate<C: CoreRPCLike>(
         &self,
         platform_ref: &PlatformRef<C>,
+        signable_bytes_hasher: &mut SignableBytesHasher,
         required_balance: Credits,
         validation_mode: ValidationMode,
         transaction: TransactionArg,
@@ -39,6 +41,7 @@ impl AssetLockProofValidation for ChainAssetLockProof {
 
         self.verify_is_not_spent_and_has_enough_balance(
             platform_ref,
+            signable_bytes_hasher,
             required_balance,
             transaction,
             platform_version,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/validate/instant/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/validate/instant/mod.rs
@@ -6,6 +6,7 @@ use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
 use dpp::consensus::basic::identity::InvalidInstantAssetLockProofSignatureError;
 use dpp::fee::Credits;
 use dpp::identity::state_transition::asset_lock_proof::InstantAssetLockProof;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 
 use dpp::validation::ConsensusValidationResult;
 use dpp::version::PlatformVersion;
@@ -20,6 +21,7 @@ impl AssetLockProofValidation for InstantAssetLockProof {
     fn validate<C: CoreRPCLike>(
         &self,
         platform_ref: &PlatformRef<C>,
+        signable_bytes_hasher: &mut SignableBytesHasher,
         required_balance: Credits,
         validation_mode: ValidationMode,
         transaction: TransactionArg,
@@ -29,6 +31,7 @@ impl AssetLockProofValidation for InstantAssetLockProof {
 
         let validation_result = self.verify_is_not_spent_and_has_enough_balance(
             platform_ref,
+            signable_bytes_hasher,
             required_balance,
             transaction,
             platform_version,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/validate/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/validate/mod.rs
@@ -8,6 +8,7 @@ use crate::rpc::core::CoreRPCLike;
 use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
 use dpp::fee::Credits;
 use dpp::prelude::AssetLockProof;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 use dpp::validation::ConsensusValidationResult;
 use dpp::version::PlatformVersion;
 use drive::grovedb::TransactionArg;
@@ -31,6 +32,7 @@ pub trait AssetLockProofValidation {
     fn validate<C: CoreRPCLike>(
         &self,
         platform_ref: &PlatformRef<C>,
+        signable_bytes_hasher: &mut SignableBytesHasher,
         required_balance: Credits,
         validation_mode: ValidationMode,
         transaction: TransactionArg,
@@ -42,6 +44,7 @@ impl AssetLockProofValidation for AssetLockProof {
     fn validate<C: CoreRPCLike>(
         &self,
         platform_ref: &PlatformRef<C>,
+        signable_bytes_hasher: &mut SignableBytesHasher,
         required_balance: Credits,
         validation_mode: ValidationMode,
         transaction: TransactionArg,
@@ -50,6 +53,7 @@ impl AssetLockProofValidation for AssetLockProof {
         match self {
             AssetLockProof::Instant(proof) => proof.validate(
                 platform_ref,
+                signable_bytes_hasher,
                 required_balance,
                 validation_mode,
                 transaction,
@@ -57,6 +61,7 @@ impl AssetLockProofValidation for AssetLockProof {
             ),
             AssetLockProof::Chain(proof) => proof.validate(
                 platform_ref,
+                signable_bytes_hasher,
                 required_balance,
                 validation_mode,
                 transaction,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/verify_is_not_spent/chain/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/verify_is_not_spent/chain/mod.rs
@@ -3,6 +3,7 @@ use crate::error::Error;
 use crate::platform_types::platform::PlatformRef;
 use dpp::fee::Credits;
 use dpp::identity::state_transition::asset_lock_proof::chain::ChainAssetLockProof;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 use dpp::validation::ConsensusValidationResult;
 use dpp::version::PlatformVersion;
 use drive::grovedb::TransactionArg;
@@ -15,12 +16,14 @@ impl AssetLockProofVerifyIsNotSpent for ChainAssetLockProof {
     fn verify_is_not_spent_and_has_enough_balance<C>(
         &self,
         platform_ref: &PlatformRef<C>,
+        signable_bytes_hasher: &mut SignableBytesHasher,
         required_balance: Credits,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<ConsensusValidationResult<AssetLockValue>, Error> {
         verify_asset_lock_is_not_spent_and_has_enough_balance(
             platform_ref,
+            signable_bytes_hasher,
             self.out_point,
             required_balance,
             transaction,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/verify_is_not_spent/instant/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/verify_is_not_spent/instant/mod.rs
@@ -5,6 +5,7 @@ use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
 
 use dpp::fee::Credits;
 use dpp::identity::state_transition::asset_lock_proof::InstantAssetLockProof;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 use dpp::validation::ConsensusValidationResult;
 use dpp::version::PlatformVersion;
 use drive::grovedb::TransactionArg;
@@ -17,6 +18,7 @@ impl AssetLockProofVerifyIsNotSpent for InstantAssetLockProof {
     fn verify_is_not_spent_and_has_enough_balance<C>(
         &self,
         platform_ref: &PlatformRef<C>,
+        signable_bytes_hasher: &mut SignableBytesHasher,
         required_balance: Credits,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
@@ -31,6 +33,7 @@ impl AssetLockProofVerifyIsNotSpent for InstantAssetLockProof {
 
         verify_asset_lock_is_not_spent_and_has_enough_balance(
             platform_ref,
+            signable_bytes_hasher,
             asset_lock_outpoint,
             required_balance,
             transaction,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/verify_is_not_spent/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/verify_is_not_spent/mod.rs
@@ -9,6 +9,7 @@ use dpp::dashcore::OutPoint;
 use dpp::fee::Credits;
 
 use dpp::prelude::AssetLockProof;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 use dpp::validation::ConsensusValidationResult;
 use dpp::version::PlatformVersion;
 use drive::grovedb::TransactionArg;
@@ -35,6 +36,7 @@ pub trait AssetLockProofVerifyIsNotSpent {
     fn verify_is_not_spent_and_has_enough_balance<C>(
         &self,
         platform_ref: &PlatformRef<C>,
+        signable_bytes_hasher: &mut SignableBytesHasher,
         required_balance: Credits,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
@@ -45,6 +47,7 @@ impl AssetLockProofVerifyIsNotSpent for AssetLockProof {
     fn verify_is_not_spent_and_has_enough_balance<C>(
         &self,
         platform_ref: &PlatformRef<C>,
+        signable_bytes_hasher: &mut SignableBytesHasher,
         required_balance: Credits,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
@@ -52,12 +55,14 @@ impl AssetLockProofVerifyIsNotSpent for AssetLockProof {
         match self {
             AssetLockProof::Instant(proof) => proof.verify_is_not_spent_and_has_enough_balance(
                 platform_ref,
+                signable_bytes_hasher,
                 required_balance,
                 transaction,
                 platform_version,
             ),
             AssetLockProof::Chain(proof) => proof.verify_is_not_spent_and_has_enough_balance(
                 platform_ref,
+                signable_bytes_hasher,
                 required_balance,
                 transaction,
                 platform_version,
@@ -69,6 +74,7 @@ impl AssetLockProofVerifyIsNotSpent for AssetLockProof {
 #[inline(always)]
 fn verify_asset_lock_is_not_spent_and_has_enough_balance<C>(
     platform_ref: &PlatformRef<C>,
+    signable_bytes_hasher: &mut SignableBytesHasher,
     out_point: OutPoint,
     required_balance: Credits,
     transaction: TransactionArg,
@@ -84,6 +90,7 @@ fn verify_asset_lock_is_not_spent_and_has_enough_balance<C>(
     {
         0 => verify_asset_lock_is_not_spent_and_has_enough_balance_v0(
             platform_ref,
+            signable_bytes_hasher,
             out_point,
             required_balance,
             transaction,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/verify_is_not_spent/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/common/asset_lock/proof/verify_is_not_spent/v0/mod.rs
@@ -3,6 +3,7 @@ use crate::platform_types::platform::PlatformRef;
 use dpp::asset_lock::reduced_asset_lock_value::{AssetLockValue, AssetLockValueGettersV0};
 use dpp::asset_lock::StoredAssetLockInfo;
 use dpp::consensus::basic::identity::{
+    IdentityAssetLockStateTransitionReplayError,
     IdentityAssetLockTransactionOutPointAlreadyConsumedError,
     IdentityAssetLockTransactionOutPointNotEnoughBalanceError,
 };
@@ -10,6 +11,7 @@ use dpp::dashcore::OutPoint;
 use dpp::fee::Credits;
 use dpp::platform_value::Bytes36;
 use dpp::prelude::ConsensusValidationResult;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 use dpp::version::PlatformVersion;
 use drive::grovedb::TransactionArg;
 
@@ -17,6 +19,7 @@ use drive::grovedb::TransactionArg;
 #[inline(always)]
 pub(super) fn verify_asset_lock_is_not_spent_and_has_enough_balance_v0<C>(
     platform_ref: &PlatformRef<C>,
+    signable_bytes_hasher: &mut SignableBytesHasher,
     out_point: OutPoint,
     required_balance: Credits,
     transaction: TransactionArg,
@@ -58,6 +61,19 @@ pub(super) fn verify_asset_lock_is_not_spent_and_has_enough_balance_v0<C>(
                         reduced_asset_lock_value.initial_credit_value(),
                         reduced_asset_lock_value.remaining_credit_value(),
                         required_balance,
+                    )
+                    .into(),
+                ))
+            } else if signable_bytes_hasher
+                .hash_bytes_and_check_if_vec_contains(reduced_asset_lock_value.used_tags_ref())
+            {
+                // Here we check that the transaction was not already tried to be execution
+                // This is the replay attack prevention
+                Ok(ConsensusValidationResult::new_with_error(
+                    IdentityAssetLockStateTransitionReplayError::new(
+                        out_point.txid,
+                        out_point.vout as usize,
+                        signable_bytes_hasher.to_hashed_bytes(),
                     )
                     .into(),
                 ))

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/state/v0/mod.rs
@@ -20,9 +20,9 @@ use dpp::data_contract::document_type::schema::{
 };
 use dpp::data_contract::errors::DataContractError;
 use dpp::data_contract::schema::DataContractSchemaMethodsV0;
-use dpp::data_contract::{DataContract, JsonValue};
+use dpp::data_contract::JsonValue;
 use dpp::platform_value::converter::serde_json::BTreeValueJsonConverter;
-use dpp::platform_value::{Value, ValueMap};
+use dpp::platform_value::ValueMap;
 
 use dpp::prelude::ConsensusValidationResult;
 use dpp::state_transition::data_contract_update_transition::accessors::DataContractUpdateTransitionAccessorsV0;

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
@@ -276,6 +276,7 @@ mod tests {
                 pk.as_slice(),
                 &signer,
                 &NativeBlsModule,
+                0,
                 platform_version,
             )
             .expect("expected an identity create transition");
@@ -422,6 +423,7 @@ mod tests {
                 pk.as_slice(),
                 &signer,
                 &NativeBlsModule,
+                0,
                 platform_version,
             )
             .expect("expected an identity create transition");
@@ -483,6 +485,7 @@ mod tests {
                 pk.as_slice(),
                 &signer,
                 &NativeBlsModule,
+                0,
                 platform_version,
             )
             .expect("expected an identity create transition");
@@ -510,7 +513,7 @@ mod tests {
 
         assert_eq!(processing_result.valid_count(), 1);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 3143370);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 3170170);
 
         platform
             .drive
@@ -525,7 +528,7 @@ mod tests {
             .expect("expected to get identity balance")
             .expect("expected there to be an identity balance for this identity");
 
-        assert_eq!(identity_balance, 99911323830); // The identity balance is smaller than if there hadn't been any issue
+        assert_eq!(identity_balance, 99911297030); // The identity balance is smaller than if there hadn't been any issue
     }
 
     #[test]
@@ -615,7 +618,7 @@ mod tests {
             .create_identifier()
             .expect("expected an identifier");
 
-        let identity: Identity = IdentityV0 {
+        let mut identity: Identity = IdentityV0 {
             id: identifier,
             public_keys: BTreeMap::from([
                 (0, master_key.clone()),
@@ -633,6 +636,7 @@ mod tests {
                 pk.as_slice(),
                 &signer,
                 &NativeBlsModule,
+                0,
                 platform_version,
             )
             .expect("expected an identity create transition");
@@ -691,5 +695,75 @@ mod tests {
         assert_eq!(processing_result.valid_count(), 0);
 
         assert_eq!(processing_result.aggregated_fees().processing_fee, 0);
+
+        // Okay now let us try to reuse the asset lock
+
+        let (new_public_key, new_private_key) =
+            IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+                1,
+                Some(13),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_key(new_public_key.clone(), new_private_key.clone());
+
+        // let's set the new key to the identity (replacing the one that was causing the issue
+        identity.set_public_keys(BTreeMap::from([
+            (0, master_key.clone()),
+            (1, new_public_key.clone()),
+        ]));
+
+        let identity_create_transition: StateTransition =
+            IdentityCreateTransition::try_from_identity_with_signer(
+                &identity,
+                asset_lock_proof,
+                pk.as_slice(),
+                &signer,
+                &NativeBlsModule,
+                0,
+                platform_version,
+            )
+            .expect("expected an identity create transition");
+
+        let identity_create_serialized_transition = identity_create_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![identity_create_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.invalid_paid_count(), 0);
+
+        assert_eq!(processing_result.invalid_unpaid_count(), 0);
+
+        assert_eq!(processing_result.valid_count(), 1);
+
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 3170170);
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit");
+
+        let identity_balance = platform
+            .drive
+            .fetch_identity_balance(identity.id().into_buffer(), None, platform_version)
+            .expect("expected to get identity balance")
+            .expect("expected there to be an identity balance for this identity");
+
+        assert_eq!(identity_balance, 99911297030); // The identity balance is smaller than if there hadn't been any issue
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
@@ -190,3 +190,506 @@ impl StateTransitionStateValidationForIdentityCreateTransitionV0 for IdentityCre
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::dashcore::{Network, PrivateKey};
+    use dpp::identity::accessors::{IdentityGettersV0, IdentitySettersV0};
+    use dpp::identity::KeyType::ECDSA_SECP256K1;
+    use dpp::identity::{Identity, IdentityPublicKey, IdentityV0};
+    use dpp::native_bls::NativeBlsModule;
+    use dpp::prelude::Identifier;
+    use dpp::serialization::PlatformSerializable;
+    use dpp::state_transition::identity_create_transition::methods::IdentityCreateTransitionMethodsV0;
+    use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
+    use dpp::state_transition::StateTransition;
+    use dpp::tests::fixtures::instant_asset_lock_proof_fixture;
+    use platform_version::version::PlatformVersion;
+    use rand::prelude::StdRng;
+    use rand::SeedableRng;
+    use simple_signer::signer::SimpleSigner;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_identity_create_validation() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_initial_state_structure();
+
+        platform
+            .core_rpc
+            .expect_verify_instant_lock()
+            .returning(|_, _| Ok(true));
+
+        let platform_state = platform.state.load();
+
+        let mut signer = SimpleSigner::default();
+
+        let mut rng = StdRng::seed_from_u64(567);
+
+        let (master_key, master_private_key) =
+            IdentityPublicKey::random_ecdsa_master_authentication_key(
+                0,
+                Some(58),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_key(master_key.clone(), master_private_key.clone());
+
+        let (key, private_key) = IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+            1,
+            Some(999),
+            platform_version,
+        )
+        .expect("expected to get key pair");
+
+        signer.add_key(key.clone(), private_key.clone());
+
+        let (_, pk) = ECDSA_SECP256K1
+            .random_public_and_private_key_data(&mut rng, platform_version)
+            .unwrap();
+
+        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
+            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
+        ));
+
+        let identifier = asset_lock_proof
+            .create_identifier()
+            .expect("expected an identifier");
+
+        let identity: Identity = IdentityV0 {
+            id: identifier,
+            public_keys: BTreeMap::from([(0, master_key.clone()), (1, key.clone())]),
+            balance: 1000000000,
+            revision: 0,
+        }
+        .into();
+
+        let identity_create_transition: StateTransition =
+            IdentityCreateTransition::try_from_identity_with_signer(
+                &identity,
+                asset_lock_proof,
+                pk.as_slice(),
+                &signer,
+                &NativeBlsModule,
+                platform_version,
+            )
+            .expect("expected an identity create transition");
+
+        let identity_create_serialized_transition = identity_create_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![identity_create_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.valid_count(), 1);
+
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 2566730);
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit");
+
+        let identity_balance = platform
+            .drive
+            .fetch_identity_balance(identity.id().into_buffer(), None, platform_version)
+            .expect("expected to get identity balance")
+            .expect("expected there to be an identity balance for this identity");
+
+        assert_eq!(identity_balance, 99916163270);
+    }
+
+    #[test]
+    fn test_identity_create_asset_lock_reuse_after_issue() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_initial_state_structure();
+
+        platform
+            .core_rpc
+            .expect_verify_instant_lock()
+            .returning(|_, _| Ok(true));
+
+        let platform_state = platform.state.load();
+
+        let mut signer = SimpleSigner::default();
+
+        let mut rng = StdRng::seed_from_u64(567);
+
+        let (master_key, master_private_key) =
+            IdentityPublicKey::random_ecdsa_master_authentication_key(
+                0,
+                Some(58),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_key(master_key.clone(), master_private_key.clone());
+
+        let (critical_public_key_that_is_already_in_system, private_key) =
+            IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+                1,
+                Some(999),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        // Let's start by adding this critical key to another identity
+
+        let (another_master_key, _) = IdentityPublicKey::random_ecdsa_master_authentication_key(
+            0,
+            Some(53),
+            platform_version,
+        )
+        .expect("expected to get key pair");
+
+        let identity_already_in_system: Identity = IdentityV0 {
+            id: Identifier::random_with_rng(&mut rng),
+            public_keys: BTreeMap::from([
+                (0, another_master_key.clone()),
+                (1, critical_public_key_that_is_already_in_system.clone()),
+            ]),
+            balance: 100000,
+            revision: 0,
+        }
+        .into();
+
+        // We just add this identity to the system first
+
+        platform
+            .drive
+            .add_new_identity(
+                identity_already_in_system,
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add a new identity");
+
+        signer.add_key(
+            critical_public_key_that_is_already_in_system.clone(),
+            private_key.clone(),
+        );
+
+        let (_, pk) = ECDSA_SECP256K1
+            .random_public_and_private_key_data(&mut rng, platform_version)
+            .unwrap();
+
+        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
+            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
+        ));
+
+        let identifier = asset_lock_proof
+            .create_identifier()
+            .expect("expected an identifier");
+
+        let mut identity: Identity = IdentityV0 {
+            id: identifier,
+            public_keys: BTreeMap::from([
+                (0, master_key.clone()),
+                (1, critical_public_key_that_is_already_in_system.clone()),
+            ]),
+            balance: 1000000000,
+            revision: 0,
+        }
+        .into();
+
+        let identity_create_transition: StateTransition =
+            IdentityCreateTransition::try_from_identity_with_signer(
+                &identity,
+                asset_lock_proof.clone(),
+                pk.as_slice(),
+                &signer,
+                &NativeBlsModule,
+                platform_version,
+            )
+            .expect("expected an identity create transition");
+
+        let identity_create_serialized_transition = identity_create_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![identity_create_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.invalid_paid_count(), 1);
+
+        assert_eq!(processing_result.invalid_unpaid_count(), 0);
+
+        assert_eq!(processing_result.valid_count(), 0);
+
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 10013800); // 10000000 penalty + 13800 processing
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit");
+
+        // Okay now let us try to reuse the asset lock
+
+        let (new_public_key, new_private_key) =
+            IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+                1,
+                Some(13),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_key(new_public_key.clone(), new_private_key.clone());
+
+        // let's set the new key to the identity (replacing the one that was causing the issue
+        identity.set_public_keys(BTreeMap::from([
+            (0, master_key.clone()),
+            (1, new_public_key.clone()),
+        ]));
+
+        let identity_create_transition: StateTransition =
+            IdentityCreateTransition::try_from_identity_with_signer(
+                &identity,
+                asset_lock_proof,
+                pk.as_slice(),
+                &signer,
+                &NativeBlsModule,
+                platform_version,
+            )
+            .expect("expected an identity create transition");
+
+        let identity_create_serialized_transition = identity_create_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![identity_create_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.invalid_paid_count(), 0);
+
+        assert_eq!(processing_result.invalid_unpaid_count(), 0);
+
+        assert_eq!(processing_result.valid_count(), 1);
+
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 3143370);
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit");
+
+        let identity_balance = platform
+            .drive
+            .fetch_identity_balance(identity.id().into_buffer(), None, platform_version)
+            .expect("expected to get identity balance")
+            .expect("expected there to be an identity balance for this identity");
+
+        assert_eq!(identity_balance, 99911323830); // The identity balance is smaller than if there hadn't been any issue
+    }
+
+    #[test]
+    fn test_identity_create_asset_lock_replay_attack() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_initial_state_structure();
+
+        platform
+            .core_rpc
+            .expect_verify_instant_lock()
+            .returning(|_, _| Ok(true));
+
+        let platform_state = platform.state.load();
+
+        let mut signer = SimpleSigner::default();
+
+        let mut rng = StdRng::seed_from_u64(567);
+
+        let (master_key, master_private_key) =
+            IdentityPublicKey::random_ecdsa_master_authentication_key(
+                0,
+                Some(58),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_key(master_key.clone(), master_private_key.clone());
+
+        let (critical_public_key_that_is_already_in_system, private_key) =
+            IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+                1,
+                Some(999),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        // Let's start by adding this critical key to another identity
+
+        let (another_master_key, _) = IdentityPublicKey::random_ecdsa_master_authentication_key(
+            0,
+            Some(53),
+            platform_version,
+        )
+        .expect("expected to get key pair");
+
+        let identity_already_in_system: Identity = IdentityV0 {
+            id: Identifier::random_with_rng(&mut rng),
+            public_keys: BTreeMap::from([
+                (0, another_master_key.clone()),
+                (1, critical_public_key_that_is_already_in_system.clone()),
+            ]),
+            balance: 100000,
+            revision: 0,
+        }
+        .into();
+
+        // We just add this identity to the system first
+
+        platform
+            .drive
+            .add_new_identity(
+                identity_already_in_system,
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add a new identity");
+
+        signer.add_key(
+            critical_public_key_that_is_already_in_system.clone(),
+            private_key.clone(),
+        );
+
+        let (_, pk) = ECDSA_SECP256K1
+            .random_public_and_private_key_data(&mut rng, platform_version)
+            .unwrap();
+
+        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
+            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
+        ));
+
+        let identifier = asset_lock_proof
+            .create_identifier()
+            .expect("expected an identifier");
+
+        let identity: Identity = IdentityV0 {
+            id: identifier,
+            public_keys: BTreeMap::from([
+                (0, master_key.clone()),
+                (1, critical_public_key_that_is_already_in_system.clone()),
+            ]),
+            balance: 1000000000,
+            revision: 0,
+        }
+        .into();
+
+        let identity_create_transition: StateTransition =
+            IdentityCreateTransition::try_from_identity_with_signer(
+                &identity,
+                asset_lock_proof.clone(),
+                pk.as_slice(),
+                &signer,
+                &NativeBlsModule,
+                platform_version,
+            )
+            .expect("expected an identity create transition");
+
+        let identity_create_serialized_transition = identity_create_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![identity_create_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.invalid_paid_count(), 1);
+
+        assert_eq!(processing_result.invalid_unpaid_count(), 0);
+
+        assert_eq!(processing_result.valid_count(), 0);
+
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 10013800); // 10000000 penalty + 13800 processing
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit");
+
+        // let's try to replay the bad transaction
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![identity_create_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.invalid_paid_count(), 0);
+
+        assert_eq!(processing_result.invalid_unpaid_count(), 1);
+
+        assert_eq!(processing_result.valid_count(), 0);
+
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 0);
+    }
+}

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
@@ -253,9 +253,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identifier = asset_lock_proof
             .create_identifier()
@@ -397,9 +398,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identifier = asset_lock_proof
             .create_identifier()
@@ -532,6 +534,447 @@ mod tests {
     }
 
     #[test]
+    fn test_identity_create_asset_lock_reuse_after_max_issues() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_initial_state_structure();
+
+        platform
+            .core_rpc
+            .expect_verify_instant_lock()
+            .returning(|_, _| Ok(true));
+
+        let platform_state = platform.state.load();
+
+        let mut signer = SimpleSigner::default();
+
+        let mut rng = StdRng::seed_from_u64(567);
+
+        let (master_key, master_private_key) =
+            IdentityPublicKey::random_ecdsa_master_authentication_key(
+                0,
+                Some(58),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_key(master_key.clone(), master_private_key.clone());
+
+        let (critical_public_key_that_is_already_in_system, private_key) =
+            IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+                1,
+                Some(999),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        // Let's start by adding this critical key to another identity
+
+        let (another_master_key, _) = IdentityPublicKey::random_ecdsa_master_authentication_key(
+            0,
+            Some(53),
+            platform_version,
+        )
+        .expect("expected to get key pair");
+
+        let identity_already_in_system: Identity = IdentityV0 {
+            id: Identifier::random_with_rng(&mut rng),
+            public_keys: BTreeMap::from([
+                (0, another_master_key.clone()),
+                (1, critical_public_key_that_is_already_in_system.clone()),
+            ]),
+            balance: 100000,
+            revision: 0,
+        }
+        .into();
+
+        // We just add this identity to the system first
+
+        platform
+            .drive
+            .add_new_identity(
+                identity_already_in_system,
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add a new identity");
+
+        signer.add_key(
+            critical_public_key_that_is_already_in_system.clone(),
+            private_key.clone(),
+        );
+
+        let (_, pk) = ECDSA_SECP256K1
+            .random_public_and_private_key_data(&mut rng, platform_version)
+            .unwrap();
+
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
+
+        let identifier = asset_lock_proof
+            .create_identifier()
+            .expect("expected an identifier");
+
+        for i in 0..16 {
+            let (new_master_key, new_master_private_key) =
+                IdentityPublicKey::random_ecdsa_master_authentication_key(
+                    0,
+                    Some(58 + i),
+                    platform_version,
+                )
+                .expect("expected to get key pair");
+
+            signer.add_key(new_master_key.clone(), new_master_private_key.clone());
+
+            let identity: Identity = IdentityV0 {
+                id: identifier,
+                public_keys: BTreeMap::from([
+                    (0, new_master_key.clone()),
+                    (1, critical_public_key_that_is_already_in_system.clone()),
+                ]),
+                balance: 1000000000,
+                revision: 0,
+            }
+            .into();
+
+            let identity_create_transition: StateTransition =
+                IdentityCreateTransition::try_from_identity_with_signer(
+                    &identity,
+                    asset_lock_proof.clone(),
+                    pk.as_slice(),
+                    &signer,
+                    &NativeBlsModule,
+                    0,
+                    platform_version,
+                )
+                .expect("expected an identity create transition");
+
+            let identity_create_serialized_transition = identity_create_transition
+                .serialize_to_bytes()
+                .expect("serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &vec![identity_create_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                )
+                .expect("expected to process state transition");
+
+            assert_eq!(processing_result.invalid_paid_count(), 1);
+
+            assert_eq!(processing_result.invalid_unpaid_count(), 0);
+
+            assert_eq!(processing_result.valid_count(), 0);
+
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 10013800); // 10000000 penalty + 13800 processing
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit");
+        }
+
+        // Okay now let us try to reuse the asset lock, there should be no balance
+
+        let (new_public_key, new_private_key) =
+            IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+                1,
+                Some(13),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_key(new_public_key.clone(), new_private_key.clone());
+
+        let identity: Identity = IdentityV0 {
+            id: identifier,
+            public_keys: BTreeMap::from([(0, master_key.clone()), (1, new_public_key.clone())]),
+            balance: 1000000000,
+            revision: 0,
+        }
+        .into();
+
+        let identity_create_transition: StateTransition =
+            IdentityCreateTransition::try_from_identity_with_signer(
+                &identity,
+                asset_lock_proof,
+                pk.as_slice(),
+                &signer,
+                &NativeBlsModule,
+                0,
+                platform_version,
+            )
+            .expect("expected an identity create transition");
+
+        let identity_create_serialized_transition = identity_create_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![identity_create_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.invalid_paid_count(), 0);
+
+        assert_eq!(processing_result.invalid_unpaid_count(), 1);
+
+        assert_eq!(processing_result.valid_count(), 0);
+
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 0);
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit");
+    }
+
+    #[test]
+    fn test_identity_create_asset_lock_use_all_funds() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_initial_state_structure();
+
+        platform
+            .core_rpc
+            .expect_verify_instant_lock()
+            .returning(|_, _| Ok(true));
+
+        let platform_state = platform.state.load();
+
+        let mut signer = SimpleSigner::default();
+
+        let mut rng = StdRng::seed_from_u64(567);
+
+        let (master_key, master_private_key) =
+            IdentityPublicKey::random_ecdsa_master_authentication_key(
+                0,
+                Some(58),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_key(master_key.clone(), master_private_key.clone());
+
+        let (critical_public_key_that_is_already_in_system, private_key) =
+            IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+                1,
+                Some(999),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        // Let's start by adding this critical key to another identity
+
+        let (another_master_key, _) = IdentityPublicKey::random_ecdsa_master_authentication_key(
+            0,
+            Some(53),
+            platform_version,
+        )
+        .expect("expected to get key pair");
+
+        let identity_already_in_system: Identity = IdentityV0 {
+            id: Identifier::random_with_rng(&mut rng),
+            public_keys: BTreeMap::from([
+                (0, another_master_key.clone()),
+                (1, critical_public_key_that_is_already_in_system.clone()),
+            ]),
+            balance: 100000,
+            revision: 0,
+        }
+        .into();
+
+        // We just add this identity to the system first
+
+        platform
+            .drive
+            .add_new_identity(
+                identity_already_in_system,
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add a new identity");
+
+        signer.add_key(
+            critical_public_key_that_is_already_in_system.clone(),
+            private_key.clone(),
+        );
+
+        let (_, pk) = ECDSA_SECP256K1
+            .random_public_and_private_key_data(&mut rng, platform_version)
+            .unwrap();
+
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            Some(220000),
+        );
+
+        let identifier = asset_lock_proof
+            .create_identifier()
+            .expect("expected an identifier");
+
+        // this should work for 2 times only
+        for i in 0..2 {
+            let (new_master_key, new_master_private_key) =
+                IdentityPublicKey::random_ecdsa_master_authentication_key(
+                    0,
+                    Some(58 + i),
+                    platform_version,
+                )
+                .expect("expected to get key pair");
+
+            signer.add_key(new_master_key.clone(), new_master_private_key.clone());
+
+            let identity: Identity = IdentityV0 {
+                id: identifier,
+                public_keys: BTreeMap::from([
+                    (0, new_master_key.clone()),
+                    (1, critical_public_key_that_is_already_in_system.clone()),
+                ]),
+                balance: 1000000000,
+                revision: 0,
+            }
+            .into();
+
+            let identity_create_transition: StateTransition =
+                IdentityCreateTransition::try_from_identity_with_signer(
+                    &identity,
+                    asset_lock_proof.clone(),
+                    pk.as_slice(),
+                    &signer,
+                    &NativeBlsModule,
+                    0,
+                    platform_version,
+                )
+                .expect("expected an identity create transition");
+
+            let identity_create_serialized_transition = identity_create_transition
+                .serialize_to_bytes()
+                .expect("serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &vec![identity_create_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                )
+                .expect("expected to process state transition");
+
+            assert_eq!(processing_result.invalid_paid_count(), 1);
+
+            assert_eq!(processing_result.invalid_unpaid_count(), 0);
+
+            assert_eq!(processing_result.valid_count(), 0);
+
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 10013800); // 10000000 penalty + 13800 processing
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit");
+        }
+
+        // Okay now let us try to reuse the asset lock, there should be no balance
+
+        let (new_public_key, new_private_key) =
+            IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+                1,
+                Some(13),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_key(new_public_key.clone(), new_private_key.clone());
+
+        let identity: Identity = IdentityV0 {
+            id: identifier,
+            public_keys: BTreeMap::from([(0, master_key.clone()), (1, new_public_key.clone())]),
+            balance: 1000000000,
+            revision: 0,
+        }
+        .into();
+
+        let identity_create_transition: StateTransition =
+            IdentityCreateTransition::try_from_identity_with_signer(
+                &identity,
+                asset_lock_proof,
+                pk.as_slice(),
+                &signer,
+                &NativeBlsModule,
+                0,
+                platform_version,
+            )
+            .expect("expected an identity create transition");
+
+        let identity_create_serialized_transition = identity_create_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![identity_create_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.invalid_paid_count(), 0);
+
+        assert_eq!(processing_result.invalid_unpaid_count(), 1);
+
+        assert_eq!(processing_result.valid_count(), 0);
+
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 0);
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit");
+    }
+
+    #[test]
     fn test_identity_create_asset_lock_replay_attack() {
         let platform_version = PlatformVersion::latest();
         let mut platform = TestPlatformBuilder::new()
@@ -610,9 +1053,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identifier = asset_lock_proof
             .create_identifier()

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/state/v0/mod.rs
@@ -8,7 +8,6 @@ use dpp::consensus::signature::{BasicECDSAError, SignatureError};
 
 use dpp::consensus::state::identity::IdentityAlreadyExistsError;
 use dpp::dashcore::hashes::Hash;
-use dpp::dashcore::signer::double_sha;
 use dpp::dashcore::{signer, ScriptBuf, Txid};
 use dpp::identity::KeyType;
 
@@ -26,7 +25,6 @@ use drive::state_transition_action::identity::identity_create::IdentityCreateTra
 use drive::state_transition_action::StateTransitionAction;
 
 use crate::error::execution::ExecutionError;
-use crate::error::execution::ExecutionError::CorruptedCodeExecution;
 use crate::execution::types::execution_operation::signature_verification_operation::SignatureVerificationOperation;
 use crate::execution::types::execution_operation::{ValidationOperation, SHA256_BLOCK_SIZE};
 use crate::execution::types::state_transition_execution_context::{

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
@@ -103,14 +103,11 @@ mod tests {
     use crate::test::helpers::setup::TestPlatformBuilder;
     use dpp::block::block_info::BlockInfo;
     use dpp::dashcore::{Network, PrivateKey};
-    use dpp::identity::accessors::{IdentityGettersV0, IdentitySettersV0};
+    use dpp::identity::accessors::IdentityGettersV0;
     use dpp::identity::KeyType::ECDSA_SECP256K1;
     use dpp::identity::{Identity, IdentityPublicKey, IdentityV0};
-    use dpp::native_bls::NativeBlsModule;
     use dpp::prelude::Identifier;
     use dpp::serialization::PlatformSerializable;
-    use dpp::state_transition::identity_create_transition::methods::IdentityCreateTransitionMethodsV0;
-    use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
     use dpp::state_transition::identity_topup_transition::methods::IdentityTopUpTransitionMethodsV0;
     use dpp::state_transition::identity_topup_transition::IdentityTopUpTransition;
     use dpp::state_transition::StateTransition;
@@ -188,13 +185,10 @@ mod tests {
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
 
-        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
-            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
-        ));
-
-        let identifier = asset_lock_proof
-            .create_identifier()
-            .expect("expected an identifier");
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap()),
+            None,
+        );
 
         let identity_top_up_transition: StateTransition =
             IdentityTopUpTransition::try_from_identity(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
@@ -97,3 +97,154 @@ impl StateTransitionBasicStructureValidationV0 for IdentityTopUpTransition {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::dashcore::{Network, PrivateKey};
+    use dpp::identity::accessors::{IdentityGettersV0, IdentitySettersV0};
+    use dpp::identity::KeyType::ECDSA_SECP256K1;
+    use dpp::identity::{Identity, IdentityPublicKey, IdentityV0};
+    use dpp::native_bls::NativeBlsModule;
+    use dpp::prelude::Identifier;
+    use dpp::serialization::PlatformSerializable;
+    use dpp::state_transition::identity_create_transition::methods::IdentityCreateTransitionMethodsV0;
+    use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
+    use dpp::state_transition::identity_topup_transition::methods::IdentityTopUpTransitionMethodsV0;
+    use dpp::state_transition::identity_topup_transition::IdentityTopUpTransition;
+    use dpp::state_transition::StateTransition;
+    use dpp::tests::fixtures::instant_asset_lock_proof_fixture;
+    use platform_version::version::PlatformVersion;
+    use rand::prelude::StdRng;
+    use rand::SeedableRng;
+    use simple_signer::signer::SimpleSigner;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_identity_top_up_validation() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_initial_state_structure();
+
+        platform
+            .core_rpc
+            .expect_verify_instant_lock()
+            .returning(|_, _| Ok(true));
+
+        let platform_state = platform.state.load();
+
+        let mut signer = SimpleSigner::default();
+
+        let mut rng = StdRng::seed_from_u64(567);
+
+        let (master_key, master_private_key) =
+            IdentityPublicKey::random_ecdsa_master_authentication_key(
+                0,
+                Some(58),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_key(master_key.clone(), master_private_key.clone());
+
+        let (critical_public_key, private_key) =
+            IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+                1,
+                Some(999),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        let identity_already_in_system: Identity = IdentityV0 {
+            id: Identifier::random_with_rng(&mut rng),
+            public_keys: BTreeMap::from([
+                (0, master_key.clone()),
+                (1, critical_public_key.clone()),
+            ]),
+            balance: 50000000000,
+            revision: 0,
+        }
+        .into();
+
+        // We just add this identity to the system first
+
+        platform
+            .drive
+            .add_new_identity(
+                identity_already_in_system.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add a new identity");
+
+        signer.add_key(critical_public_key.clone(), private_key.clone());
+
+        let (_, pk) = ECDSA_SECP256K1
+            .random_public_and_private_key_data(&mut rng, platform_version)
+            .unwrap();
+
+        let asset_lock_proof = instant_asset_lock_proof_fixture(Some(
+            PrivateKey::from_slice(pk.as_slice(), Network::Testnet).unwrap(),
+        ));
+
+        let identifier = asset_lock_proof
+            .create_identifier()
+            .expect("expected an identifier");
+
+        let identity_top_up_transition: StateTransition =
+            IdentityTopUpTransition::try_from_identity(
+                &identity_already_in_system,
+                asset_lock_proof,
+                pk.as_slice(),
+                0,
+                platform_version,
+                None,
+            )
+            .expect("expected an identity create transition");
+
+        let identity_top_up_serialized_transition = identity_top_up_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![identity_top_up_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.valid_count(), 1);
+
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 1146640);
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit");
+
+        let identity_balance = platform
+            .drive
+            .fetch_identity_balance(
+                identity_already_in_system.id().into_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to get identity balance")
+            .expect("expected there to be an identity balance for this identity");
+
+        assert_eq!(identity_balance, 149993048360); // about 0.5 Dash starting balance + 1 Dash asset lock top up
+    }
+}

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/transform_into_action/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/transform_into_action/v0/mod.rs
@@ -7,7 +7,6 @@ use dpp::consensus::basic::identity::IdentityAssetLockTransactionOutPointNotEnou
 
 use dpp::consensus::signature::{BasicECDSAError, SignatureError};
 use dpp::dashcore::hashes::Hash;
-use dpp::dashcore::signer::double_sha;
 use dpp::dashcore::{signer, ScriptBuf, Txid};
 use dpp::identity::state_transition::AssetLockProved;
 use dpp::identity::KeyType;
@@ -23,7 +22,6 @@ use drive::state_transition_action::identity::identity_topup::IdentityTopUpTrans
 use drive::state_transition_action::StateTransitionAction;
 
 use crate::error::execution::ExecutionError;
-use crate::error::execution::ExecutionError::CorruptedCodeExecution;
 use drive::grovedb::TransactionArg;
 
 use crate::execution::types::execution_operation::{SHA256_BLOCK_SIZE, ValidationOperation};

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/transform_into_action/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/transform_into_action/v0/mod.rs
@@ -143,6 +143,7 @@ impl IdentityTopUpStateTransitionStateValidationV0 for IdentityTopUpTransition {
                 initial_balance_amount,
                 tx_out.script_pubkey.0,
                 initial_balance_amount,
+                vec![],
                 platform_version,
             )?
         };

--- a/packages/rs-drive-abci/tests/strategy_tests/main.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/main.rs
@@ -32,8 +32,6 @@
 
 extern crate core;
 
-use dashcore_rpc::dashcore::QuorumHash;
-
 use dpp::bls_signatures::PrivateKey as BlsPrivateKey;
 
 use drive_abci::test::helpers::setup::TestPlatformBuilder;
@@ -77,7 +75,7 @@ mod tests {
     use crate::strategy::{FailureStrategy, MasternodeListChangesStrategy};
     use dashcore_rpc::dashcore::hashes::Hash;
     use dashcore_rpc::dashcore::BlockHash;
-    use dashcore_rpc::dashcore_rpc_json::{AssetUnlockStatus, ExtendedQuorumDetails};
+    use dashcore_rpc::dashcore_rpc_json::AssetUnlockStatus;
     use dashcore_rpc::json::AssetUnlockStatusResult;
     use dpp::block::extended_block_info::v0::ExtendedBlockInfoV0Getters;
     use std::sync::{Arc, Mutex};

--- a/packages/rs-drive-proof-verifier/Cargo.toml
+++ b/packages/rs-drive-proof-verifier/Cargo.toml
@@ -14,7 +14,7 @@ json = ["dep:serde_json"]
 [dependencies]
 
 thiserror = { version = "1.0.58" }
-dapi-grpc = { path = "../dapi-grpc", features = ["core", "client", "serde"], default-features = false }
+dapi-grpc = { path = "../dapi-grpc" }
 drive = { path = "../rs-drive", default-features = false, features = [
   "verify",
 ] }

--- a/packages/rs-drive/src/drive/batch/drive_op_batch/system.rs
+++ b/packages/rs-drive/src/drive/batch/drive_op_batch/system.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 use dpp::block::block_info::BlockInfo;
 use dpp::fee::Credits;
-use dpp::platform_value::Bytes36;
+use dpp::platform_value::{Bytes32, Bytes36};
 
 use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
 use dpp::version::PlatformVersion;

--- a/packages/rs-drive/src/drive/batch/drive_op_batch/system.rs
+++ b/packages/rs-drive/src/drive/batch/drive_op_batch/system.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 use dpp::block::block_info::BlockInfo;
 use dpp::fee::Credits;
-use dpp::platform_value::{Bytes32, Bytes36};
+use dpp::platform_value::Bytes36;
 
 use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
 use dpp::version::PlatformVersion;

--- a/packages/rs-drive/src/drive/batch/transitions/system/partially_use_asset_lock.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/system/partially_use_asset_lock.rs
@@ -17,11 +17,25 @@ impl DriveHighLevelOperationConverter for PartiallyUseAssetLockAction {
     ) -> Result<Vec<DriveOperation<'b>>, Error> {
         let initial_credit_value = self.initial_credit_value();
         // The remaining credit value is already computed here
-        let remaining_credit_value = self.remaining_credit_value();
+        let mut remaining_credit_value = self.remaining_credit_value();
         let used_credits = self.used_credits();
         let asset_lock_outpoint = self.asset_lock_outpoint();
 
-        let previous_transaction_hashes = self.previous_transaction_hashes_ref().clone();
+        let previous_transaction_hashes = if self.previous_transaction_hashes_ref().len() as u16
+            >= platform_version
+                .drive_abci
+                .validation_and_processing
+                .state_transitions
+                .max_asset_lock_usage_attempts
+        {
+            // There have been 16 failed attempts at using the asset lock
+            // In this case the remaining credit value is burned and there is no need to keep around previous
+            // transaction hashes
+            remaining_credit_value = 0;
+            vec![]
+        } else {
+            self.previous_transaction_hashes_ref().clone()
+        };
 
         let tx_out_script = self.asset_lock_script_owned();
 

--- a/packages/rs-drive/src/drive/batch/transitions/system/partially_use_asset_lock.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/system/partially_use_asset_lock.rs
@@ -21,6 +21,8 @@ impl DriveHighLevelOperationConverter for PartiallyUseAssetLockAction {
         let used_credits = self.used_credits();
         let asset_lock_outpoint = self.asset_lock_outpoint();
 
+        let previous_transaction_hashes = self.previous_transaction_hashes_ref().clone();
+
         let tx_out_script = self.asset_lock_script_owned();
 
         let drive_operations = vec![
@@ -33,6 +35,7 @@ impl DriveHighLevelOperationConverter for PartiallyUseAssetLockAction {
                     initial_credit_value,
                     tx_out_script,
                     remaining_credit_value,
+                    previous_transaction_hashes,
                     platform_version,
                 )?,
             }),

--- a/packages/rs-drive/src/state_transition_action/identity/identity_create/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_create/transformer.rs
@@ -4,25 +4,22 @@ use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
 use dpp::consensus::basic::value_error::ValueError;
 use dpp::consensus::basic::BasicError;
 use dpp::consensus::ConsensusError;
+use dpp::platform_value::Bytes32;
 use dpp::serialization::Signable;
 use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 
 impl IdentityCreateTransitionAction {
     /// try from
     pub fn try_from(
         value: IdentityCreateTransition,
+        signable_bytes_hasher: SignableBytesHasher,
         asset_lock_value_to_be_consumed: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
-        //todo: this is already done in signature verification, ideally we should reuse it
-        let signable_bytes = value.signable_bytes().map_err(|e| {
-            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
-                e.to_string(),
-            )))
-        })?;
         match value {
             IdentityCreateTransition::V0(v0) => Ok(IdentityCreateTransitionActionV0::try_from(
                 v0,
-                signable_bytes,
+                signable_bytes_hasher,
                 asset_lock_value_to_be_consumed,
             )?
             .into()),
@@ -32,20 +29,14 @@ impl IdentityCreateTransitionAction {
     /// try from borrowed
     pub fn try_from_borrowed(
         value: &IdentityCreateTransition,
+        signable_bytes_hasher: SignableBytesHasher,
         asset_lock_value_to_be_consumed: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
-        //todo: this is already done in signature verification, ideally we should reuse it
-        let signable_bytes = value.signable_bytes().map_err(|e| {
-            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
-                e.to_string(),
-            )))
-        })?;
-
         match value {
             IdentityCreateTransition::V0(v0) => {
                 Ok(IdentityCreateTransitionActionV0::try_from_borrowed(
                     v0,
-                    signable_bytes,
+                    signable_bytes_hasher,
                     asset_lock_value_to_be_consumed,
                 )?
                 .into())

--- a/packages/rs-drive/src/state_transition_action/identity/identity_create/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_create/transformer.rs
@@ -1,7 +1,10 @@
 use crate::state_transition_action::identity::identity_create::v0::IdentityCreateTransitionActionV0;
 use crate::state_transition_action::identity::identity_create::IdentityCreateTransitionAction;
 use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
+use dpp::consensus::basic::value_error::ValueError;
+use dpp::consensus::basic::BasicError;
 use dpp::consensus::ConsensusError;
+use dpp::serialization::Signable;
 use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
 
 impl IdentityCreateTransitionAction {
@@ -10,9 +13,16 @@ impl IdentityCreateTransitionAction {
         value: IdentityCreateTransition,
         asset_lock_value_to_be_consumed: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
+        //todo: this is already done in signature verification, ideally we should reuse it
+        let signable_bytes = value.signable_bytes().map_err(|e| {
+            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
+                e.to_string(),
+            )))
+        })?;
         match value {
             IdentityCreateTransition::V0(v0) => Ok(IdentityCreateTransitionActionV0::try_from(
                 v0,
+                signable_bytes,
                 asset_lock_value_to_be_consumed,
             )?
             .into()),
@@ -24,10 +34,18 @@ impl IdentityCreateTransitionAction {
         value: &IdentityCreateTransition,
         asset_lock_value_to_be_consumed: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
+        //todo: this is already done in signature verification, ideally we should reuse it
+        let signable_bytes = value.signable_bytes().map_err(|e| {
+            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
+                e.to_string(),
+            )))
+        })?;
+
         match value {
             IdentityCreateTransition::V0(v0) => {
                 Ok(IdentityCreateTransitionActionV0::try_from_borrowed(
                     v0,
+                    signable_bytes,
                     asset_lock_value_to_be_consumed,
                 )?
                 .into())

--- a/packages/rs-drive/src/state_transition_action/identity/identity_create/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_create/transformer.rs
@@ -1,11 +1,7 @@
 use crate::state_transition_action::identity::identity_create::v0::IdentityCreateTransitionActionV0;
 use crate::state_transition_action::identity::identity_create::IdentityCreateTransitionAction;
 use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
-use dpp::consensus::basic::value_error::ValueError;
-use dpp::consensus::basic::BasicError;
 use dpp::consensus::ConsensusError;
-use dpp::platform_value::Bytes32;
-use dpp::serialization::Signable;
 use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
 use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 

--- a/packages/rs-drive/src/state_transition_action/identity/identity_create/v0/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_create/v0/mod.rs
@@ -7,7 +7,7 @@ use dpp::identity::{IdentityPublicKey, IdentityV0, PartialIdentity};
 use dpp::asset_lock::reduced_asset_lock_value::{AssetLockValue, AssetLockValueGettersV0};
 use dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dpp::identity::Identity;
-use dpp::platform_value::Bytes36;
+use dpp::platform_value::{Bytes32, Bytes36};
 use dpp::prelude::UserFeeIncrease;
 use dpp::version::PlatformVersion;
 use dpp::ProtocolError;
@@ -15,6 +15,8 @@ use dpp::ProtocolError;
 /// action v0
 #[derive(Debug, Clone)]
 pub struct IdentityCreateTransitionActionV0 {
+    /// The state transition signable bytes hash
+    pub signable_bytes_hash: Bytes32,
     /// public keys
     pub public_keys: Vec<IdentityPublicKey>,
     /// the initial balance amount is equal to the remaining asset lock value

--- a/packages/rs-drive/src/state_transition_action/identity/identity_create/v0/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_create/v0/mod.rs
@@ -7,8 +7,9 @@ use dpp::identity::{IdentityPublicKey, IdentityV0, PartialIdentity};
 use dpp::asset_lock::reduced_asset_lock_value::{AssetLockValue, AssetLockValueGettersV0};
 use dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dpp::identity::Identity;
-use dpp::platform_value::{Bytes32, Bytes36};
+use dpp::platform_value::Bytes36;
 use dpp::prelude::UserFeeIncrease;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 use dpp::version::PlatformVersion;
 use dpp::ProtocolError;
 
@@ -16,7 +17,7 @@ use dpp::ProtocolError;
 #[derive(Debug, Clone)]
 pub struct IdentityCreateTransitionActionV0 {
     /// The state transition signable bytes hash
-    pub signable_bytes_hash: Bytes32,
+    pub signable_bytes_hasher: SignableBytesHasher,
     /// public keys
     pub public_keys: Vec<IdentityPublicKey>,
     /// the initial balance amount is equal to the remaining asset lock value

--- a/packages/rs-drive/src/state_transition_action/identity/identity_create/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_create/v0/transformer.rs
@@ -5,11 +5,13 @@ use dpp::consensus::ConsensusError;
 use dpp::platform_value::Bytes36;
 
 use dpp::state_transition::state_transitions::identity::identity_create_transition::v0::IdentityCreateTransitionV0;
+use dpp::util::hash::hash_double;
 
 impl IdentityCreateTransitionActionV0 {
     /// try from
     pub fn try_from(
         value: IdentityCreateTransitionV0,
+        signable_bytes: Vec<u8>,
         asset_lock_value_to_be_consumed: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
         let IdentityCreateTransitionV0 {
@@ -26,7 +28,10 @@ impl IdentityCreateTransitionActionV0 {
             )
         })?;
 
+        let signable_bytes_hash = hash_double(signable_bytes).into();
+
         Ok(IdentityCreateTransitionActionV0 {
+            signable_bytes_hash,
             public_keys: public_keys.into_iter().map(|a| a.into()).collect(),
             asset_lock_value_to_be_consumed,
             identity_id,
@@ -38,6 +43,7 @@ impl IdentityCreateTransitionActionV0 {
     /// try from borrowed
     pub fn try_from_borrowed(
         value: &IdentityCreateTransitionV0,
+        signable_bytes: Vec<u8>,
         asset_lock_value_to_be_consumed: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
         let IdentityCreateTransitionV0 {
@@ -55,7 +61,10 @@ impl IdentityCreateTransitionActionV0 {
             )
         })?;
 
+        let signable_bytes_hash = hash_double(signable_bytes).into();
+
         Ok(IdentityCreateTransitionActionV0 {
+            signable_bytes_hash,
             public_keys: public_keys.iter().map(|key| key.into()).collect(),
             asset_lock_value_to_be_consumed,
             identity_id: *identity_id,

--- a/packages/rs-drive/src/state_transition_action/identity/identity_create/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_create/v0/transformer.rs
@@ -6,7 +6,6 @@ use dpp::platform_value::Bytes36;
 use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 
 use dpp::state_transition::state_transitions::identity::identity_create_transition::v0::IdentityCreateTransitionV0;
-use dpp::util::hash::hash_double;
 
 impl IdentityCreateTransitionActionV0 {
     /// try from

--- a/packages/rs-drive/src/state_transition_action/identity/identity_create/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_create/v0/transformer.rs
@@ -3,6 +3,7 @@ use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
 use dpp::consensus::basic::identity::IdentityAssetLockTransactionOutputNotFoundError;
 use dpp::consensus::ConsensusError;
 use dpp::platform_value::Bytes36;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 
 use dpp::state_transition::state_transitions::identity::identity_create_transition::v0::IdentityCreateTransitionV0;
 use dpp::util::hash::hash_double;
@@ -11,7 +12,7 @@ impl IdentityCreateTransitionActionV0 {
     /// try from
     pub fn try_from(
         value: IdentityCreateTransitionV0,
-        signable_bytes: Vec<u8>,
+        signable_bytes_hasher: SignableBytesHasher,
         asset_lock_value_to_be_consumed: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
         let IdentityCreateTransitionV0 {
@@ -28,10 +29,8 @@ impl IdentityCreateTransitionActionV0 {
             )
         })?;
 
-        let signable_bytes_hash = hash_double(signable_bytes).into();
-
         Ok(IdentityCreateTransitionActionV0 {
-            signable_bytes_hash,
+            signable_bytes_hasher,
             public_keys: public_keys.into_iter().map(|a| a.into()).collect(),
             asset_lock_value_to_be_consumed,
             identity_id,
@@ -43,7 +42,7 @@ impl IdentityCreateTransitionActionV0 {
     /// try from borrowed
     pub fn try_from_borrowed(
         value: &IdentityCreateTransitionV0,
-        signable_bytes: Vec<u8>,
+        signable_bytes_hasher: SignableBytesHasher,
         asset_lock_value_to_be_consumed: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
         let IdentityCreateTransitionV0 {
@@ -61,10 +60,8 @@ impl IdentityCreateTransitionActionV0 {
             )
         })?;
 
-        let signable_bytes_hash = hash_double(signable_bytes).into();
-
         Ok(IdentityCreateTransitionActionV0 {
-            signable_bytes_hash,
+            signable_bytes_hasher,
             public_keys: public_keys.iter().map(|key| key.into()).collect(),
             asset_lock_value_to_be_consumed,
             identity_id: *identity_id,

--- a/packages/rs-drive/src/state_transition_action/identity/identity_topup/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_topup/transformer.rs
@@ -1,7 +1,10 @@
 use crate::state_transition_action::identity::identity_topup::v0::IdentityTopUpTransitionActionV0;
 use crate::state_transition_action::identity::identity_topup::IdentityTopUpTransitionAction;
 use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
+use dpp::consensus::basic::value_error::ValueError;
+use dpp::consensus::basic::BasicError;
 use dpp::consensus::ConsensusError;
+use dpp::serialization::Signable;
 use dpp::state_transition::identity_topup_transition::IdentityTopUpTransition;
 
 impl IdentityTopUpTransitionAction {
@@ -10,10 +13,20 @@ impl IdentityTopUpTransitionAction {
         value: IdentityTopUpTransition,
         top_up_asset_lock_value: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
+        //todo: this is already done in signature verification, ideally we should reuse it
+        let signable_bytes = value.signable_bytes().map_err(|e| {
+            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
+                e.to_string(),
+            )))
+        })?;
+
         match value {
-            IdentityTopUpTransition::V0(v0) => {
-                Ok(IdentityTopUpTransitionActionV0::try_from(v0, top_up_asset_lock_value)?.into())
-            }
+            IdentityTopUpTransition::V0(v0) => Ok(IdentityTopUpTransitionActionV0::try_from(
+                v0,
+                signable_bytes,
+                top_up_asset_lock_value,
+            )?
+            .into()),
         }
     }
 
@@ -22,11 +35,22 @@ impl IdentityTopUpTransitionAction {
         value: &IdentityTopUpTransition,
         top_up_asset_lock_value: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
+        //todo: this is already done in signature verification, ideally we should reuse it
+        let signable_bytes = value.signable_bytes().map_err(|e| {
+            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
+                e.to_string(),
+            )))
+        })?;
+
         match value {
-            IdentityTopUpTransition::V0(v0) => Ok(
-                IdentityTopUpTransitionActionV0::try_from_borrowed(v0, top_up_asset_lock_value)?
-                    .into(),
-            ),
+            IdentityTopUpTransition::V0(v0) => {
+                Ok(IdentityTopUpTransitionActionV0::try_from_borrowed(
+                    v0,
+                    signable_bytes,
+                    top_up_asset_lock_value,
+                )?
+                .into())
+            }
         }
     }
 }

--- a/packages/rs-drive/src/state_transition_action/identity/identity_topup/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_topup/transformer.rs
@@ -1,29 +1,21 @@
 use crate::state_transition_action::identity::identity_topup::v0::IdentityTopUpTransitionActionV0;
 use crate::state_transition_action::identity::identity_topup::IdentityTopUpTransitionAction;
 use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
-use dpp::consensus::basic::value_error::ValueError;
-use dpp::consensus::basic::BasicError;
 use dpp::consensus::ConsensusError;
-use dpp::serialization::Signable;
 use dpp::state_transition::identity_topup_transition::IdentityTopUpTransition;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 
 impl IdentityTopUpTransitionAction {
     /// try from
     pub fn try_from(
         value: IdentityTopUpTransition,
+        signable_bytes_hasher: SignableBytesHasher,
         top_up_asset_lock_value: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
-        //todo: this is already done in signature verification, ideally we should reuse it
-        let signable_bytes = value.signable_bytes().map_err(|e| {
-            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
-                e.to_string(),
-            )))
-        })?;
-
         match value {
             IdentityTopUpTransition::V0(v0) => Ok(IdentityTopUpTransitionActionV0::try_from(
                 v0,
-                signable_bytes,
+                signable_bytes_hasher,
                 top_up_asset_lock_value,
             )?
             .into()),
@@ -33,20 +25,14 @@ impl IdentityTopUpTransitionAction {
     /// try from borrowed
     pub fn try_from_borrowed(
         value: &IdentityTopUpTransition,
+        signable_bytes_hasher: SignableBytesHasher,
         top_up_asset_lock_value: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
-        //todo: this is already done in signature verification, ideally we should reuse it
-        let signable_bytes = value.signable_bytes().map_err(|e| {
-            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
-                e.to_string(),
-            )))
-        })?;
-
         match value {
             IdentityTopUpTransition::V0(v0) => {
                 Ok(IdentityTopUpTransitionActionV0::try_from_borrowed(
                     v0,
-                    signable_bytes,
+                    signable_bytes_hasher,
                     top_up_asset_lock_value,
                 )?
                 .into())

--- a/packages/rs-drive/src/state_transition_action/identity/identity_topup/v0/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_topup/v0/mod.rs
@@ -3,14 +3,15 @@ mod transformer;
 use dpp::identifier::Identifier;
 
 use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
-use dpp::platform_value::{Bytes32, Bytes36};
+use dpp::platform_value::Bytes36;
 use dpp::prelude::UserFeeIncrease;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 
 /// action v0
 #[derive(Debug, Clone)]
 pub struct IdentityTopUpTransitionActionV0 {
     /// The state transition signable bytes hash
-    pub signable_bytes_hash: Bytes32,
+    pub signable_bytes_hasher: SignableBytesHasher,
     /// we top up the remaining amount of the asset lock value
     pub top_up_asset_lock_value: AssetLockValue,
     /// identity id

--- a/packages/rs-drive/src/state_transition_action/identity/identity_topup/v0/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_topup/v0/mod.rs
@@ -3,12 +3,14 @@ mod transformer;
 use dpp::identifier::Identifier;
 
 use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
-use dpp::platform_value::Bytes36;
+use dpp::platform_value::{Bytes32, Bytes36};
 use dpp::prelude::UserFeeIncrease;
 
 /// action v0
 #[derive(Debug, Clone)]
 pub struct IdentityTopUpTransitionActionV0 {
+    /// The state transition signable bytes hash
+    pub signable_bytes_hash: Bytes32,
     /// we top up the remaining amount of the asset lock value
     pub top_up_asset_lock_value: AssetLockValue,
     /// identity id

--- a/packages/rs-drive/src/state_transition_action/identity/identity_topup/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_topup/v0/transformer.rs
@@ -5,11 +5,13 @@ use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
 use dpp::consensus::ConsensusError;
 use dpp::platform_value::Bytes36;
 use dpp::state_transition::state_transitions::identity::identity_topup_transition::v0::IdentityTopUpTransitionV0;
+use dpp::util::hash::hash_double;
 
 impl IdentityTopUpTransitionActionV0 {
     /// try from
     pub fn try_from(
         value: IdentityTopUpTransitionV0,
+        signable_bytes: Vec<u8>,
         top_up_asset_lock_value: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
         let IdentityTopUpTransitionV0 {
@@ -25,7 +27,10 @@ impl IdentityTopUpTransitionActionV0 {
             )
         })?;
 
+        let signable_bytes_hash = hash_double(signable_bytes).into();
+
         Ok(IdentityTopUpTransitionActionV0 {
+            signable_bytes_hash,
             top_up_asset_lock_value,
             identity_id,
             asset_lock_outpoint: Bytes36::new(asset_lock_outpoint.into()),
@@ -36,6 +41,7 @@ impl IdentityTopUpTransitionActionV0 {
     /// try from borrowed
     pub fn try_from_borrowed(
         value: &IdentityTopUpTransitionV0,
+        signable_bytes: Vec<u8>,
         top_up_asset_lock_value: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
         let IdentityTopUpTransitionV0 {
@@ -51,7 +57,10 @@ impl IdentityTopUpTransitionActionV0 {
             )
         })?;
 
+        let signable_bytes_hash = hash_double(signable_bytes).into();
+
         Ok(IdentityTopUpTransitionActionV0 {
+            signable_bytes_hash,
             top_up_asset_lock_value,
             identity_id: *identity_id,
             asset_lock_outpoint: Bytes36::new(asset_lock_outpoint.into()),

--- a/packages/rs-drive/src/state_transition_action/identity/identity_topup/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_topup/v0/transformer.rs
@@ -6,7 +6,6 @@ use dpp::consensus::ConsensusError;
 use dpp::platform_value::Bytes36;
 use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 use dpp::state_transition::state_transitions::identity::identity_topup_transition::v0::IdentityTopUpTransitionV0;
-use dpp::util::hash::hash_double;
 
 impl IdentityTopUpTransitionActionV0 {
     /// try from

--- a/packages/rs-drive/src/state_transition_action/identity/identity_topup/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_topup/v0/transformer.rs
@@ -4,6 +4,7 @@ use dpp::consensus::basic::identity::IdentityAssetLockTransactionOutputNotFoundE
 use dpp::asset_lock::reduced_asset_lock_value::AssetLockValue;
 use dpp::consensus::ConsensusError;
 use dpp::platform_value::Bytes36;
+use dpp::state_transition::signable_bytes_hasher::SignableBytesHasher;
 use dpp::state_transition::state_transitions::identity::identity_topup_transition::v0::IdentityTopUpTransitionV0;
 use dpp::util::hash::hash_double;
 
@@ -11,7 +12,7 @@ impl IdentityTopUpTransitionActionV0 {
     /// try from
     pub fn try_from(
         value: IdentityTopUpTransitionV0,
-        signable_bytes: Vec<u8>,
+        signable_bytes_hasher: SignableBytesHasher,
         top_up_asset_lock_value: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
         let IdentityTopUpTransitionV0 {
@@ -27,10 +28,8 @@ impl IdentityTopUpTransitionActionV0 {
             )
         })?;
 
-        let signable_bytes_hash = hash_double(signable_bytes).into();
-
         Ok(IdentityTopUpTransitionActionV0 {
-            signable_bytes_hash,
+            signable_bytes_hasher,
             top_up_asset_lock_value,
             identity_id,
             asset_lock_outpoint: Bytes36::new(asset_lock_outpoint.into()),
@@ -41,7 +40,7 @@ impl IdentityTopUpTransitionActionV0 {
     /// try from borrowed
     pub fn try_from_borrowed(
         value: &IdentityTopUpTransitionV0,
-        signable_bytes: Vec<u8>,
+        signable_bytes_hasher: SignableBytesHasher,
         top_up_asset_lock_value: AssetLockValue,
     ) -> Result<Self, ConsensusError> {
         let IdentityTopUpTransitionV0 {
@@ -57,10 +56,8 @@ impl IdentityTopUpTransitionActionV0 {
             )
         })?;
 
-        let signable_bytes_hash = hash_double(signable_bytes).into();
-
         Ok(IdentityTopUpTransitionActionV0 {
-            signable_bytes_hash,
+            signable_bytes_hasher,
             top_up_asset_lock_value,
             identity_id: *identity_id,
             asset_lock_outpoint: Bytes36::new(asset_lock_outpoint.into()),

--- a/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/mod.rs
@@ -1,7 +1,7 @@
 use crate::state_transition_action::system::partially_use_asset_lock_action::v0::PartiallyUseAssetLockActionV0;
 use derive_more::From;
 use dpp::fee::Credits;
-use dpp::platform_value::Bytes36;
+use dpp::platform_value::{Bytes32, Bytes36};
 use dpp::prelude::UserFeeIncrease;
 
 mod transformer;
@@ -56,6 +56,12 @@ impl PartiallyUseAssetLockActionAccessorsV0 for PartiallyUseAssetLockAction {
     fn user_fee_increase(&self) -> UserFeeIncrease {
         match self {
             PartiallyUseAssetLockAction::V0(transition) => transition.user_fee_increase,
+        }
+    }
+
+    fn previous_transaction_hashes_ref(&self) -> &Vec<Bytes32> {
+        match self {
+            PartiallyUseAssetLockAction::V0(transition) => &transition.previous_transaction_hashes,
         }
     }
 }

--- a/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/transformer.rs
@@ -2,8 +2,12 @@ use crate::state_transition_action::identity::identity_create::IdentityCreateTra
 use crate::state_transition_action::identity::identity_topup::IdentityTopUpTransitionAction;
 use crate::state_transition_action::system::partially_use_asset_lock_action::v0::PartiallyUseAssetLockActionV0;
 use crate::state_transition_action::system::partially_use_asset_lock_action::PartiallyUseAssetLockAction;
+use dpp::consensus::basic::value_error::ValueError;
+use dpp::consensus::basic::BasicError;
 use dpp::consensus::ConsensusError;
 use dpp::fee::Credits;
+use dpp::platform_value::Bytes32;
+use dpp::serialization::Signable;
 use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
 use dpp::state_transition::identity_topup_transition::IdentityTopUpTransition;
 
@@ -14,15 +18,23 @@ impl PartiallyUseAssetLockAction {
         asset_lock_initial_balance_amount: Credits,
         asset_lock_output_script: Vec<u8>,
         asset_lock_remaining_balance_amount: Credits,
+        previous_transaction_hashes: Vec<Bytes32>,
         used_credits: Credits,
     ) -> Result<Self, ConsensusError> {
+        let signable_bytes = value.signable_bytes().map_err(|e| {
+            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
+                e.to_string(),
+            )))
+        })?;
         match value {
             IdentityCreateTransition::V0(v0) => Ok(
                 PartiallyUseAssetLockActionV0::try_from_identity_create_transition(
                     v0,
+                    signable_bytes,
                     asset_lock_initial_balance_amount,
                     asset_lock_output_script,
                     asset_lock_remaining_balance_amount,
+                    previous_transaction_hashes,
                     used_credits,
                 )?
                 .into(),
@@ -36,15 +48,23 @@ impl PartiallyUseAssetLockAction {
         asset_lock_initial_balance_amount: Credits,
         asset_lock_output_script: Vec<u8>,
         asset_lock_remaining_balance_amount: Credits,
+        previous_transaction_hashes: Vec<Bytes32>,
         used_credits: Credits,
     ) -> Result<Self, ConsensusError> {
+        let signable_bytes = value.signable_bytes().map_err(|e| {
+            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
+                e.to_string(),
+            )))
+        })?;
         match value {
             IdentityCreateTransition::V0(v0) => Ok(
                 PartiallyUseAssetLockActionV0::try_from_borrowed_identity_create_transition(
                     v0,
+                    signable_bytes,
                     asset_lock_initial_balance_amount,
                     asset_lock_output_script,
                     asset_lock_remaining_balance_amount,
+                    previous_transaction_hashes,
                     used_credits,
                 )?
                 .into(),
@@ -90,15 +110,24 @@ impl PartiallyUseAssetLockAction {
         asset_lock_initial_balance_amount: Credits,
         asset_lock_output_script: Vec<u8>,
         asset_lock_remaining_balance_amount: Credits,
+        previous_transaction_hashes: Vec<Bytes32>,
         used_credits: Credits,
     ) -> Result<Self, ConsensusError> {
+        let signable_bytes = value.signable_bytes().map_err(|e| {
+            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
+                e.to_string(),
+            )))
+        })?;
+
         match value {
             IdentityTopUpTransition::V0(v0) => Ok(
                 PartiallyUseAssetLockActionV0::try_from_identity_top_up_transition(
                     v0,
+                    signable_bytes,
                     asset_lock_initial_balance_amount,
                     asset_lock_output_script,
                     asset_lock_remaining_balance_amount,
+                    previous_transaction_hashes,
                     used_credits,
                 )?
                 .into(),
@@ -112,15 +141,24 @@ impl PartiallyUseAssetLockAction {
         asset_lock_initial_balance_amount: Credits,
         asset_lock_output_script: Vec<u8>,
         asset_lock_remaining_balance_amount: Credits,
+        previous_transaction_hashes: Vec<Bytes32>,
         used_credits: Credits,
     ) -> Result<Self, ConsensusError> {
+        let signable_bytes = value.signable_bytes().map_err(|e| {
+            ConsensusError::BasicError(BasicError::ValueError(ValueError::new_from_string(
+                e.to_string(),
+            )))
+        })?;
+
         match value {
             IdentityTopUpTransition::V0(v0) => Ok(
                 PartiallyUseAssetLockActionV0::try_from_borrowed_identity_top_up_transition(
                     v0,
+                    signable_bytes,
                     asset_lock_initial_balance_amount,
                     asset_lock_output_script,
                     asset_lock_remaining_balance_amount,
+                    previous_transaction_hashes,
                     used_credits,
                 )?
                 .into(),

--- a/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/v0/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/v0/mod.rs
@@ -1,5 +1,5 @@
 use dpp::fee::Credits;
-use dpp::platform_value::Bytes36;
+use dpp::platform_value::{Bytes32, Bytes36};
 use dpp::prelude::UserFeeIncrease;
 mod transformer;
 #[derive(Default, Debug, Clone)]
@@ -8,6 +8,8 @@ pub struct PartiallyUseAssetLockActionV0 {
     pub asset_lock_outpoint: Bytes36,
     /// initial credit value
     pub initial_credit_value: Credits,
+    /// the previous transaction signable bytes hashes that tried to used this asset lock, but failed
+    pub previous_transaction_hashes: Vec<Bytes32>,
     /// asset lock script
     pub asset_lock_script: Vec<u8>,
     /// remaining credit value AFTER used credits are deducted
@@ -35,4 +37,7 @@ pub trait PartiallyUseAssetLockActionAccessorsV0 {
     fn used_credits(&self) -> Credits;
     /// fee multiplier
     fn user_fee_increase(&self) -> UserFeeIncrease;
+
+    /// the previous transaction signable bytes hashes that tried to used this asset lock, but failed
+    fn previous_transaction_hashes_ref(&self) -> &Vec<Bytes32>;
 }

--- a/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/v0/transformer.rs
@@ -1,23 +1,29 @@
 use crate::state_transition_action::identity::identity_create::v0::IdentityCreateTransitionActionV0;
 use crate::state_transition_action::identity::identity_topup::v0::IdentityTopUpTransitionActionV0;
 use crate::state_transition_action::system::partially_use_asset_lock_action::v0::PartiallyUseAssetLockActionV0;
-use dpp::asset_lock::reduced_asset_lock_value::AssetLockValueGettersV0;
+use dpp::asset_lock::reduced_asset_lock_value::{AssetLockValueGettersV0, AssetLockValueSettersV0};
 use dpp::consensus::basic::identity::IdentityAssetLockTransactionOutputNotFoundError;
 use dpp::consensus::ConsensusError;
 use dpp::fee::Credits;
-use dpp::platform_value::Bytes36;
+use dpp::platform_value::{Bytes32, Bytes36};
 use dpp::state_transition::identity_create_transition::v0::IdentityCreateTransitionV0;
 use dpp::state_transition::identity_topup_transition::v0::IdentityTopUpTransitionV0;
+use dpp::util::hash::hash_double;
 
 impl PartiallyUseAssetLockActionV0 {
     /// try from identity create transition
     pub fn try_from_identity_create_transition(
         value: IdentityCreateTransitionV0,
+        signable_bytes: Vec<u8>,
         asset_lock_initial_balance_amount: Credits,
         asset_lock_output_script: Vec<u8>,
         asset_lock_remaining_balance_amount: Credits,
+        mut previous_transaction_hashes: Vec<Bytes32>,
         desired_used_credits: Credits,
     ) -> Result<Self, ConsensusError> {
+        let signable_bytes_hash = hash_double(signable_bytes);
+        previous_transaction_hashes.push(signable_bytes_hash.into());
+
         let IdentityCreateTransitionV0 {
             asset_lock_proof,
             user_fee_increase,
@@ -41,6 +47,7 @@ impl PartiallyUseAssetLockActionV0 {
         Ok(PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint: Bytes36::new(asset_lock_outpoint.into()),
             initial_credit_value: asset_lock_initial_balance_amount,
+            previous_transaction_hashes,
             asset_lock_script: asset_lock_output_script,
             remaining_credit_value: remaining_balance_after_used_credits_are_deducted,
             used_credits,
@@ -51,11 +58,16 @@ impl PartiallyUseAssetLockActionV0 {
     /// try from borrowed identity create transition
     pub fn try_from_borrowed_identity_create_transition(
         value: &IdentityCreateTransitionV0,
+        signable_bytes: Vec<u8>,
         asset_lock_initial_balance_amount: Credits,
         asset_lock_output_script: Vec<u8>,
         asset_lock_remaining_balance_amount: Credits,
+        mut previous_transaction_hashes: Vec<Bytes32>,
         desired_used_credits: Credits,
     ) -> Result<Self, ConsensusError> {
+        let signable_bytes_hash = hash_double(signable_bytes);
+        previous_transaction_hashes.push(signable_bytes_hash.into());
+
         let IdentityCreateTransitionV0 {
             asset_lock_proof,
             user_fee_increase,
@@ -80,6 +92,7 @@ impl PartiallyUseAssetLockActionV0 {
         Ok(PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint: Bytes36::new(asset_lock_outpoint.into()),
             initial_credit_value: asset_lock_initial_balance_amount,
+            previous_transaction_hashes,
             asset_lock_script: asset_lock_output_script,
             remaining_credit_value: remaining_balance_after_used_credits_are_deducted,
             used_credits,
@@ -93,6 +106,7 @@ impl PartiallyUseAssetLockActionV0 {
         desired_used_credits: Credits,
     ) -> Self {
         let IdentityCreateTransitionActionV0 {
+            signable_bytes_hash,
             asset_lock_outpoint,
             asset_lock_value_to_be_consumed,
             user_fee_increase,
@@ -108,9 +122,15 @@ impl PartiallyUseAssetLockActionV0 {
             desired_used_credits,
         );
 
+        //todo: remove clone
+        let mut used_tags = asset_lock_value_to_be_consumed.used_tags_ref().clone();
+
+        used_tags.push(signable_bytes_hash);
+
         PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint,
             initial_credit_value: asset_lock_value_to_be_consumed.initial_credit_value(),
+            previous_transaction_hashes: used_tags,
             asset_lock_script: asset_lock_value_to_be_consumed.tx_out_script_owned(),
             remaining_credit_value: remaining_balance_after_used_credits_are_deducted,
             used_credits,
@@ -124,6 +144,7 @@ impl PartiallyUseAssetLockActionV0 {
         desired_used_credits: Credits,
     ) -> Self {
         let IdentityCreateTransitionActionV0 {
+            signable_bytes_hash,
             asset_lock_outpoint,
             asset_lock_value_to_be_consumed,
             user_fee_increase,
@@ -139,9 +160,14 @@ impl PartiallyUseAssetLockActionV0 {
             desired_used_credits,
         );
 
+        let mut used_tags = asset_lock_value_to_be_consumed.used_tags_ref().clone();
+
+        used_tags.push(signable_bytes_hash.clone());
+
         PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint: *asset_lock_outpoint,
             initial_credit_value: asset_lock_value_to_be_consumed.initial_credit_value(),
+            previous_transaction_hashes: used_tags,
             asset_lock_script: asset_lock_value_to_be_consumed.tx_out_script().clone(),
             remaining_credit_value: remaining_balance_after_used_credits_are_deducted,
             used_credits,
@@ -152,11 +178,16 @@ impl PartiallyUseAssetLockActionV0 {
     /// try from identity top up transition
     pub fn try_from_identity_top_up_transition(
         value: IdentityTopUpTransitionV0,
+        signable_bytes: Vec<u8>,
         asset_lock_initial_balance_amount: Credits,
         asset_lock_output_script: Vec<u8>,
         asset_lock_remaining_balance_amount: Credits,
+        mut previous_transaction_hashes: Vec<Bytes32>,
         desired_used_credits: Credits,
     ) -> Result<Self, ConsensusError> {
+        let signable_bytes_hash = hash_double(signable_bytes);
+        previous_transaction_hashes.push(signable_bytes_hash.into());
+
         let IdentityTopUpTransitionV0 {
             asset_lock_proof,
             user_fee_increase,
@@ -180,6 +211,7 @@ impl PartiallyUseAssetLockActionV0 {
         Ok(PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint: Bytes36::new(asset_lock_outpoint.into()),
             initial_credit_value: asset_lock_initial_balance_amount,
+            previous_transaction_hashes,
             asset_lock_script: asset_lock_output_script,
             remaining_credit_value: remaining_balance_after_used_credits_are_deducted,
             used_credits,
@@ -190,11 +222,16 @@ impl PartiallyUseAssetLockActionV0 {
     /// try from borrowed identity top up transition
     pub fn try_from_borrowed_identity_top_up_transition(
         value: &IdentityTopUpTransitionV0,
+        signable_bytes: Vec<u8>,
         asset_lock_initial_balance_amount: Credits,
         asset_lock_output_script: Vec<u8>,
         asset_lock_remaining_balance_amount: Credits,
+        mut previous_transaction_hashes: Vec<Bytes32>,
         desired_used_credits: Credits,
     ) -> Result<Self, ConsensusError> {
+        let signable_bytes_hash = hash_double(signable_bytes);
+        previous_transaction_hashes.push(signable_bytes_hash.into());
+
         let IdentityTopUpTransitionV0 {
             asset_lock_proof,
             user_fee_increase,
@@ -218,6 +255,7 @@ impl PartiallyUseAssetLockActionV0 {
         Ok(PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint: Bytes36::new(asset_lock_outpoint.into()),
             initial_credit_value: asset_lock_initial_balance_amount,
+            previous_transaction_hashes,
             asset_lock_script: asset_lock_output_script,
             remaining_credit_value: remaining_balance_after_used_credits_are_deducted,
             used_credits,
@@ -231,6 +269,7 @@ impl PartiallyUseAssetLockActionV0 {
         desired_used_credits: Credits,
     ) -> Self {
         let IdentityTopUpTransitionActionV0 {
+            signable_bytes_hash,
             asset_lock_outpoint,
             top_up_asset_lock_value,
             user_fee_increase,
@@ -246,9 +285,14 @@ impl PartiallyUseAssetLockActionV0 {
             desired_used_credits,
         );
 
+        let mut used_tags = top_up_asset_lock_value.used_tags_ref().clone();
+
+        used_tags.push(signable_bytes_hash.clone());
+
         PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint,
             initial_credit_value: top_up_asset_lock_value.initial_credit_value(),
+            previous_transaction_hashes: used_tags,
             asset_lock_script: top_up_asset_lock_value.tx_out_script_owned(),
             remaining_credit_value: remaining_balance_after_used_credits_are_deducted,
             used_credits,
@@ -262,6 +306,7 @@ impl PartiallyUseAssetLockActionV0 {
         desired_used_credits: Credits,
     ) -> Self {
         let IdentityTopUpTransitionActionV0 {
+            signable_bytes_hash,
             asset_lock_outpoint,
             top_up_asset_lock_value,
             user_fee_increase,
@@ -277,9 +322,14 @@ impl PartiallyUseAssetLockActionV0 {
             desired_used_credits,
         );
 
+        let mut used_tags = top_up_asset_lock_value.used_tags_ref().clone();
+
+        used_tags.push(signable_bytes_hash.clone());
+
         PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint: *asset_lock_outpoint,
             initial_credit_value: top_up_asset_lock_value.initial_credit_value(),
+            previous_transaction_hashes: used_tags,
             asset_lock_script: top_up_asset_lock_value.tx_out_script().clone(),
             remaining_credit_value: remaining_balance_after_used_credits_are_deducted,
             used_credits,

--- a/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/v0/transformer.rs
@@ -106,7 +106,7 @@ impl PartiallyUseAssetLockActionV0 {
         desired_used_credits: Credits,
     ) -> Self {
         let IdentityCreateTransitionActionV0 {
-            signable_bytes_hash,
+            signable_bytes_hasher,
             asset_lock_outpoint,
             asset_lock_value_to_be_consumed,
             user_fee_increase,
@@ -125,7 +125,7 @@ impl PartiallyUseAssetLockActionV0 {
         //todo: remove clone
         let mut used_tags = asset_lock_value_to_be_consumed.used_tags_ref().clone();
 
-        used_tags.push(signable_bytes_hash);
+        used_tags.push(signable_bytes_hasher.into_hashed_bytes());
 
         PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint,
@@ -144,7 +144,7 @@ impl PartiallyUseAssetLockActionV0 {
         desired_used_credits: Credits,
     ) -> Self {
         let IdentityCreateTransitionActionV0 {
-            signable_bytes_hash,
+            signable_bytes_hasher,
             asset_lock_outpoint,
             asset_lock_value_to_be_consumed,
             user_fee_increase,
@@ -162,7 +162,7 @@ impl PartiallyUseAssetLockActionV0 {
 
         let mut used_tags = asset_lock_value_to_be_consumed.used_tags_ref().clone();
 
-        used_tags.push(signable_bytes_hash.clone());
+        used_tags.push(signable_bytes_hasher.to_hashed_bytes());
 
         PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint: *asset_lock_outpoint,
@@ -269,7 +269,7 @@ impl PartiallyUseAssetLockActionV0 {
         desired_used_credits: Credits,
     ) -> Self {
         let IdentityTopUpTransitionActionV0 {
-            signable_bytes_hash,
+            signable_bytes_hasher,
             asset_lock_outpoint,
             top_up_asset_lock_value,
             user_fee_increase,
@@ -287,7 +287,7 @@ impl PartiallyUseAssetLockActionV0 {
 
         let mut used_tags = top_up_asset_lock_value.used_tags_ref().clone();
 
-        used_tags.push(signable_bytes_hash.clone());
+        used_tags.push(signable_bytes_hasher.into_hashed_bytes());
 
         PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint,
@@ -306,7 +306,7 @@ impl PartiallyUseAssetLockActionV0 {
         desired_used_credits: Credits,
     ) -> Self {
         let IdentityTopUpTransitionActionV0 {
-            signable_bytes_hash,
+            signable_bytes_hasher,
             asset_lock_outpoint,
             top_up_asset_lock_value,
             user_fee_increase,
@@ -324,7 +324,7 @@ impl PartiallyUseAssetLockActionV0 {
 
         let mut used_tags = top_up_asset_lock_value.used_tags_ref().clone();
 
-        used_tags.push(signable_bytes_hash.clone());
+        used_tags.push(signable_bytes_hasher.to_hashed_bytes());
 
         PartiallyUseAssetLockActionV0 {
             asset_lock_outpoint: *asset_lock_outpoint,

--- a/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/system/partially_use_asset_lock_action/v0/transformer.rs
@@ -1,7 +1,7 @@
 use crate::state_transition_action::identity::identity_create::v0::IdentityCreateTransitionActionV0;
 use crate::state_transition_action::identity::identity_topup::v0::IdentityTopUpTransitionActionV0;
 use crate::state_transition_action::system::partially_use_asset_lock_action::v0::PartiallyUseAssetLockActionV0;
-use dpp::asset_lock::reduced_asset_lock_value::{AssetLockValueGettersV0, AssetLockValueSettersV0};
+use dpp::asset_lock::reduced_asset_lock_value::AssetLockValueGettersV0;
 use dpp::consensus::basic::identity::IdentityAssetLockTransactionOutputNotFoundError;
 use dpp::consensus::ConsensusError;
 use dpp::fee::Credits;

--- a/packages/rs-platform-version/src/version/drive_abci_versions.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions.rs
@@ -143,6 +143,7 @@ pub struct DriveAbciStateTransitionValidationVersion {
 #[derive(Clone, Debug, Default)]
 pub struct DriveAbciStateTransitionValidationVersions {
     pub common_validation_methods: DriveAbciStateTransitionCommonValidationVersions,
+    pub max_asset_lock_usage_attempts: u16,
     pub identity_create_state_transition: DriveAbciStateTransitionValidationVersion,
     pub identity_update_state_transition: DriveAbciStateTransitionValidationVersion,
     pub identity_top_up_state_transition: DriveAbciStateTransitionValidationVersion,

--- a/packages/rs-platform-version/src/version/drive_abci_versions.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions.rs
@@ -85,6 +85,7 @@ pub struct DriveAbciValidationVersions {
 #[derive(Clone, Debug, Default)]
 pub struct PenaltyAmounts {
     pub identity_id_not_correct: u64,
+    pub unique_key_already_present: u64,
     pub validation_of_added_keys_structure_failure: u64,
     pub validation_of_added_keys_proof_of_possession_failure: u64,
 }

--- a/packages/rs-platform-version/src/version/mocks/v2_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v2_test.rs
@@ -600,6 +600,7 @@ pub const TEST_PLATFORM_V2: PlatformVersion = PlatformVersion {
                     validate_master_key_uniqueness: 0,
                     validate_simple_pre_check_balance: 0,
                 },
+                max_asset_lock_usage_attempts: 16,
                 identity_create_state_transition: DriveAbciStateTransitionValidationVersion {
                     basic_structure: Some(0),
                     advanced_structure: Some(0),

--- a/packages/rs-platform-version/src/version/mocks/v2_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v2_test.rs
@@ -695,9 +695,10 @@ pub const TEST_PLATFORM_V2: PlatformVersion = PlatformVersion {
             process_state_transition: 0,
             state_transition_to_execution_event_for_check_tx: 0,
             penalties: PenaltyAmounts {
-                identity_id_not_correct: 5000000,
-                validation_of_added_keys_structure_failure: 1000000,
-                validation_of_added_keys_proof_of_possession_failure: 5000000,
+                identity_id_not_correct: 50000000,
+                unique_key_already_present: 10000000,
+                validation_of_added_keys_structure_failure: 10000000,
+                validation_of_added_keys_proof_of_possession_failure: 50000000,
             },
         },
         query: DriveAbciQueryVersions {

--- a/packages/rs-platform-version/src/version/mocks/v3_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v3_test.rs
@@ -695,9 +695,10 @@ pub const TEST_PLATFORM_V3: PlatformVersion = PlatformVersion {
             process_state_transition: 0,
             state_transition_to_execution_event_for_check_tx: 0,
             penalties: PenaltyAmounts {
-                identity_id_not_correct: 5000000,
-                validation_of_added_keys_structure_failure: 1000000,
-                validation_of_added_keys_proof_of_possession_failure: 5000000,
+                identity_id_not_correct: 50000000,
+                unique_key_already_present: 10000000,
+                validation_of_added_keys_structure_failure: 10000000,
+                validation_of_added_keys_proof_of_possession_failure: 50000000,
             },
         },
         query: DriveAbciQueryVersions {

--- a/packages/rs-platform-version/src/version/mocks/v3_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v3_test.rs
@@ -600,6 +600,7 @@ pub const TEST_PLATFORM_V3: PlatformVersion = PlatformVersion {
                     validate_master_key_uniqueness: 0,
                     validate_simple_pre_check_balance: 0,
                 },
+                max_asset_lock_usage_attempts: 16,
                 identity_create_state_transition: DriveAbciStateTransitionValidationVersion {
                     basic_structure: Some(0),
                     advanced_structure: Some(0),

--- a/packages/rs-platform-version/src/version/v1.rs
+++ b/packages/rs-platform-version/src/version/v1.rs
@@ -599,6 +599,7 @@ pub const PLATFORM_V1: PlatformVersion = PlatformVersion {
                     validate_master_key_uniqueness: 0,
                     validate_simple_pre_check_balance: 0,
                 },
+                max_asset_lock_usage_attempts: 16,
                 identity_create_state_transition: DriveAbciStateTransitionValidationVersion {
                     basic_structure: Some(0),
                     advanced_structure: Some(0),

--- a/packages/rs-platform-version/src/version/v1.rs
+++ b/packages/rs-platform-version/src/version/v1.rs
@@ -694,9 +694,10 @@ pub const PLATFORM_V1: PlatformVersion = PlatformVersion {
             process_state_transition: 0,
             state_transition_to_execution_event_for_check_tx: 0,
             penalties: PenaltyAmounts {
-                identity_id_not_correct: 5000000,
-                validation_of_added_keys_structure_failure: 1000000,
-                validation_of_added_keys_proof_of_possession_failure: 5000000,
+                identity_id_not_correct: 50000000,
+                unique_key_already_present: 10000000,
+                validation_of_added_keys_structure_failure: 10000000,
+                validation_of_added_keys_proof_of_possession_failure: 50000000,
             },
         },
         query: DriveAbciQueryVersions {

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2021"
 dpp = { path = "../rs-dpp", default-features = false, features = [
   "dash-sdk-features",
 ] }
-dapi-grpc = { path = "../dapi-grpc", default-features = false, features = [
-  "client",
-] }
+dapi-grpc = { path = "../dapi-grpc" }
 rs-dapi-client = { path = "../rs-dapi-client", default-features = false }
 drive = { path = "../rs-drive", default-features = false, features = [
   "verify",

--- a/packages/rs-sdk/src/platform/transition/broadcast_identity.rs
+++ b/packages/rs-sdk/src/platform/transition/broadcast_identity.rs
@@ -110,6 +110,7 @@ impl<S: Signer> BroadcastRequestForNewIdentity<proto::BroadcastStateTransitionRe
             asset_lock_proof_private_key.inner.as_ref(),
             signer,
             &NativeBlsModule,
+            0,
             platform_version,
         )?;
         let request = identity_create_transition.broadcast_request_for_state_transition()?;

--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -75,7 +75,7 @@ pub type KeyMaps = BTreeMap<Purpose, BTreeMap<SecurityLevel, Vec<KeyType>>>;
 ///
 /// # Fields
 /// - `start_identities`: Specifies identities to be established at the simulation's outset, including their initial attributes and balances. This setup allows for immediate participation of these identities in the blockchain's simulated activities.
-/// 
+///
 /// - `start_contracts`: Maps each created data contract to potential updates, enabling the simulation of contract evolution. Each tuple consists of a `CreatedDataContract` and an optional mapping of block heights to subsequent contract versions, facilitating time-sensitive contract transformations.
 ///
 /// - `operations`: Enumerates discrete operations to be executed within the strategy. These operations represent individual actions or sequences of actions, such as document manipulations, identity updates, or contract interactions, each contributing to the overarching simulation narrative.
@@ -1442,7 +1442,7 @@ impl Strategy {
                 )
                 .expect("Expected to get identity public key in initial_contract_state_transitions");
                 let key_id = identity_public_key.id();
-                
+
                 let partial_identity = identity.clone().into_partial_identity_info();
                 let partial_identity_public_key = partial_identity.loaded_public_keys.values()
                     .find(|&public_key| public_key.id() == key_id)

--- a/packages/strategy-tests/src/transitions.rs
+++ b/packages/strategy-tests/src/transitions.rs
@@ -711,6 +711,7 @@ pub fn create_identities_state_transitions(
                     &pk,
                     signer,
                     &NativeBlsModule,
+                    0,
                     platform_version,
                 ) {
                     Ok(identity_create_transition) => {
@@ -788,6 +789,7 @@ pub fn create_state_transitions_for_identities(
                     pk.as_slice(),
                     signer,
                     &NativeBlsModule,
+                    0,
                     platform_version,
                 )
                 .expect("expected to transform identity into identity create transition");

--- a/packages/wasm-dpp/src/errors/consensus/basic/identity/identity_asset_lock_state_transition_replay_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/basic/identity/identity_asset_lock_state_transition_replay_error.rs
@@ -1,0 +1,47 @@
+use dpp::consensus::basic::identity::IdentityAssetLockStateTransitionReplayError;
+use dpp::consensus::codes::ErrorWithCode;
+use dpp::consensus::ConsensusError;
+
+use dpp::dashcore::hashes::Hash;
+use wasm_bindgen::prelude::*;
+
+use crate::buffer::Buffer;
+
+#[wasm_bindgen(js_name=IdentityAssetLockTransactionReplayError)]
+pub struct IdentityAssetLockStateTransitionReplayErrorWasm {
+    inner: IdentityAssetLockStateTransitionReplayError,
+}
+
+impl From<&IdentityAssetLockStateTransitionReplayError>
+    for IdentityAssetLockStateTransitionReplayErrorWasm
+{
+    fn from(e: &IdentityAssetLockStateTransitionReplayError) -> Self {
+        Self { inner: e.clone() }
+    }
+}
+
+#[wasm_bindgen(js_class=IdentityAssetLockTransactionReplayError)]
+impl IdentityAssetLockStateTransitionReplayErrorWasm {
+    #[wasm_bindgen(js_name=getTransactionId)]
+    pub fn transaction_id(&self) -> Buffer {
+        let tx_id = self.inner.transaction_id();
+        let mut tx_id_bytes = tx_id.to_byte_array();
+        tx_id_bytes.reverse();
+        Buffer::from_bytes(&tx_id_bytes)
+    }
+
+    #[wasm_bindgen(js_name=getCode)]
+    pub fn code(&self) -> u32 {
+        ConsensusError::from(self.inner.clone()).code()
+    }
+    #[wasm_bindgen(js_name=getStateTransitionId)]
+    pub fn state_transition_id(&self) -> Buffer {
+        let state_transition_id = self.inner.state_transition_id();
+        let state_transition_id_bytes = state_transition_id.to_buffer();
+        Buffer::from_bytes(&state_transition_id_bytes)
+    }
+    #[wasm_bindgen(js_name=getOutputIndex)]
+    pub fn output_index(&self) -> usize {
+        self.inner.output_index()
+    }
+}

--- a/packages/wasm-dpp/src/errors/consensus/basic/identity/mod.rs
+++ b/packages/wasm-dpp/src/errors/consensus/basic/identity/mod.rs
@@ -1,6 +1,7 @@
 mod duplicated_identity_public_key_error;
 mod duplicated_identity_public_key_id_error;
 mod identity_asset_lock_proof_locked_transaction_mismatch_error;
+mod identity_asset_lock_state_transition_replay_error;
 mod identity_asset_lock_transaction_is_not_found_error;
 mod identity_asset_lock_transaction_out_point_already_exists_error;
 mod identity_asset_lock_transaction_output_not_found_error;
@@ -29,6 +30,7 @@ mod missing_public_key_error;
 pub use duplicated_identity_public_key_error::*;
 pub use duplicated_identity_public_key_id_error::*;
 pub use identity_asset_lock_proof_locked_transaction_mismatch_error::*;
+pub use identity_asset_lock_state_transition_replay_error::*;
 pub use identity_asset_lock_transaction_is_not_found_error::*;
 pub use identity_asset_lock_transaction_out_point_already_exists_error::*;
 pub use identity_asset_lock_transaction_output_not_found_error::*;

--- a/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
@@ -8,6 +8,7 @@ use dpp::consensus::ConsensusError as DPPConsensusError;
 use crate::errors::consensus::basic::identity::{
     DuplicatedIdentityPublicKeyErrorWasm, DuplicatedIdentityPublicKeyIdErrorWasm,
     IdentityAssetLockProofLockedTransactionMismatchErrorWasm,
+    IdentityAssetLockStateTransitionReplayErrorWasm,
     IdentityAssetLockTransactionIsNotFoundErrorWasm,
     IdentityAssetLockTransactionOutPointAlreadyExistsErrorWasm,
     IdentityAssetLockTransactionOutPointNotEnoughBalanceErrorWasm,
@@ -36,7 +37,7 @@ use dpp::consensus::basic::BasicError;
 use dpp::consensus::basic::BasicError::{
     DuplicatedIdentityPublicKeyBasicError, DuplicatedIdentityPublicKeyIdBasicError,
     IdentityAssetLockProofLockedTransactionMismatchError,
-    IdentityAssetLockTransactionIsNotFoundError,
+    IdentityAssetLockStateTransitionReplayError, IdentityAssetLockTransactionIsNotFoundError,
     IdentityAssetLockTransactionOutPointAlreadyConsumedError,
     IdentityAssetLockTransactionOutPointNotEnoughBalanceError,
     IdentityAssetLockTransactionOutputNotFoundError, IncompatibleProtocolVersionError,
@@ -368,6 +369,9 @@ fn from_basic_error(basic_error: &BasicError) -> JsValue {
         }
         InvalidIdentityAssetLockTransactionOutputError(e) => {
             InvalidIdentityAssetLockTransactionOutputErrorWasm::from(e).into()
+        }
+        IdentityAssetLockStateTransitionReplayError(e) => {
+            IdentityAssetLockStateTransitionReplayErrorWasm::from(e).into()
         }
         InvalidAssetLockTransactionOutputReturnSizeError(e) => {
             InvalidAssetLockTransactionOutputReturnSizeErrorWasm::from(e).into()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
There were still issues with replay attacks on identity create state transitions, this should now fix them.


## What was done?
We added a list of state transition hashes to the asset lock, so that if a state transition fails the state transition signable bytes hash is added, so that replaying the state transition would immediately fail.

## How Has This Been Tested?
Added multiple tests.


## Breaking Changes
This is a breaking change.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [X] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
