### PR TITLE
feat(drive-abci): configure dir to store rejected txs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -232,9 +232,11 @@ LABEL description="Drive ABCI Rust"
 RUN apk add --no-cache libgcc libstdc++
 
 ENV DB_PATH=/var/lib/dash/rs-drive-abci/db
+ENV REJECTIONS_PATH=/var/log/dash/rejected
 
 RUN mkdir -p /var/log/dash \
-    /var/lib/dash/rs-drive-abci/db
+    /var/lib/dash/rs-drive-abci/db \
+    ${REJECTIONS_PATH}
 
 COPY --from=build-drive-abci /artifacts/drive-abci /usr/bin/drive-abci
 COPY --from=build-drive-abci /platform/packages/rs-drive-abci/.env.mainnet /var/lib/dash/rs-drive-abci/.env

--- a/packages/rs-drive-abci/.env.local
+++ b/packages/rs-drive-abci/.env.local
@@ -10,6 +10,7 @@ ABCI_LOG_STDOUT_FORMAT=pretty
 ABCI_LOG_STDOUT_COLOR=true
 
 DB_PATH=/tmp/db
+REJECTIONS_PATH=/tmp/rejected
 
 # Cache size for Data Contracts
 DATA_CONTRACTS_GLOBAL_CACHE_SIZE=500

--- a/packages/rs-drive-abci/.env.mainnet
+++ b/packages/rs-drive-abci/.env.mainnet
@@ -10,6 +10,7 @@ ABCI_LOG_STDOUT_FORMAT=pretty
 ABCI_LOG_STDOUT_COLOR=true
 
 DB_PATH=/tmp/db
+REJECTIONS_PATH=/tmp/rejected
 
 # Cache size for Data Contracts
 DATA_CONTRACTS_GLOBAL_CACHE_SIZE=500

--- a/packages/rs-drive-abci/.env.testnet
+++ b/packages/rs-drive-abci/.env.testnet
@@ -10,6 +10,7 @@ ABCI_LOG_STDOUT_FORMAT=pretty
 ABCI_LOG_STDOUT_COLOR=true
 
 DB_PATH=/tmp/db
+REJECTIONS_PATH=/tmp/rejected
 
 # Cache size for Data Contracts
 DATA_CONTRACTS_GLOBAL_CACHE_SIZE=500

--- a/packages/rs-drive-abci/src/config.rs
+++ b/packages/rs-drive-abci/src/config.rs
@@ -202,6 +202,13 @@ pub struct PlatformConfig {
     /// Path to data storage
     pub db_path: PathBuf,
 
+    /// Path to store rejected / invalid items (like transactions).
+    /// Used mainly for debuggig.
+    ///
+    /// If not set, rejected and invalid items will not be stored.
+    #[serde(default)]
+    pub rejections_path: Option<PathBuf>,
+
     // todo: put this in tests like #[cfg(test)]
     /// This should be None, except in the case of Testing platform
     #[serde(skip)]
@@ -342,6 +349,7 @@ impl PlatformConfig {
             core: Default::default(),
             execution: Default::default(),
             db_path: PathBuf::from("/var/lib/dash-platform/data"),
+            rejections_path: Some(PathBuf::from("/var/log/dash/rejected")),
             testing_configs: PlatformTestConfig::default(),
             tokio_console_enabled: false,
             tokio_console_address: PlatformConfig::default_tokio_console_address(),
@@ -365,6 +373,7 @@ impl PlatformConfig {
             core: Default::default(),
             execution: Default::default(),
             db_path: PathBuf::from("/var/lib/dash-platform/data"),
+            rejections_path: Some(PathBuf::from("/var/log/dash/rejected")),
             testing_configs: PlatformTestConfig::default(),
             initial_protocol_version: Self::default_initial_protocol_version(),
             prometheus_bind_address: None,
@@ -388,6 +397,7 @@ impl PlatformConfig {
             core: Default::default(),
             execution: Default::default(),
             db_path: PathBuf::from("/var/lib/dash-platform/data"),
+            rejections_path: Some(PathBuf::from("/var/log/dash/rejected")),
             testing_configs: PlatformTestConfig::default(),
             initial_protocol_version: Self::default_initial_protocol_version(),
             prometheus_bind_address: None,
@@ -454,6 +464,7 @@ mod tests {
 
         dotenvy::from_path(envfile.as_path()).expect("cannot load .env file");
         assert_eq!("/tmp/db", env::var("DB_PATH").unwrap());
+        assert_eq!("/tmp/rejected", env::var("REJECTIONS_PATH").unwrap());
 
         let config = super::PlatformConfig::from_env().expect("expected config from env");
         assert!(config.execution.verify_sum_trees);

--- a/packages/rs-drive-abci/src/execution/platform_events/withdrawals/append_signatures_and_broadcast_withdrawal_transactions/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/withdrawals/append_signatures_and_broadcast_withdrawal_transactions/v0/mod.rs
@@ -110,6 +110,10 @@ fn store_transaction_failures(
     failures: Vec<(Txid, Vec<u8>)>,
     dir_path: &Path,
 ) -> std::io::Result<()> {
+    if failures.is_empty() {
+        return Ok(());
+    }
+
     // Ensure the directory exists
     fs::create_dir_all(dir_path).map_err(|e| {
         std::io::Error::new(


### PR DESCRIPTION
## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #1821, we store failed transactions on disk. However, the location should be configurable.

## What was done?

1. Added config variable, REJECTIONS_PATH, that points to directory where rejected transactions should be saved.
2. Using REJECTIONS_PATH in `store_transaction_failures()`
3. Set default `REJECTIONS_PATH=/var/log/dash/rejected` in Docker


## How Has This Been Tested?

Modified check_tx to dump every tx, then started local network and verified that files are stored in /var/log/dash/rejected

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
