### PR TITLE
chore(dashmate): limit concurrent state transition checks

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -241,6 +241,7 @@ export default function getBaseConfigFactory(homeDir) {
               txEnqueueTimeout: '0',
               txSendRateLimit: 0,
               txRecvRateLimit: 0,
+              maxConcurrentCheckTx: 500,
             },
             consensus: {
               createEmptyBlocks: true,

--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -241,7 +241,7 @@ export default function getBaseConfigFactory(homeDir) {
               txEnqueueTimeout: '0',
               txSendRateLimit: 0,
               txRecvRateLimit: 0,
-              maxConcurrentCheckTx: 500,
+              maxConcurrentCheckTx: 250,
             },
             consensus: {
               createEmptyBlocks: true,

--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -206,7 +206,7 @@ export default function getBaseConfigFactory(homeDir) {
           tenderdash: {
             mode: 'full',
             docker: {
-              image: 'dashpay/tenderdash:feat-grpc-client-conn-limit',
+              image: 'dashpay/tenderdash:0.14.0-dev.6',
             },
             p2p: {
               host: '0.0.0.0',

--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -206,7 +206,7 @@ export default function getBaseConfigFactory(homeDir) {
           tenderdash: {
             mode: 'full',
             docker: {
-              image: 'dashpay/tenderdash:0.14.0-dev.5',
+              image: 'dashpay/tenderdash:feat-grpc-client-conn-limit',
             },
             p2p: {
               host: '0.0.0.0',

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -521,6 +521,14 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
 
         return configFile;
       },
+      '1.0.0-dev.12': (configFile) => {
+        Object.entries(configFile.configs)
+          .forEach(([, options]) => {
+            options.platform.drive.tenderdash.docker.image = base.get('platform.drive.tenderdash.docker.image');
+          });
+
+        return configFile;
+      },
     };
   }
 

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -525,6 +525,7 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
         Object.entries(configFile.configs)
           .forEach(([, options]) => {
             options.platform.drive.tenderdash.docker.image = base.get('platform.drive.tenderdash.docker.image');
+            options.platform.drive.tenderdash.mempool.maxConcurrentCheckTx = base.get('platform.drive.tenderdash.mempool.maxConcurrentCheckTx');
           });
 
         return configFile;

--- a/packages/dashmate/src/config/configJsonSchema.js
+++ b/packages/dashmate/src/config/configJsonSchema.js
@@ -656,9 +656,13 @@ export default {
                       type: 'integer',
                       minimum: 0,
                     },
+                    maxConcurrentCheckTx: {
+                      type: 'integer',
+                      minimum: 0,
+                    },
                   },
                   additionalProperties: false,
-                  required: ['size', 'maxTxsBytes', 'cacheSize', 'timeoutCheckTx', 'txEnqueueTimeout', 'txSendRateLimit', 'txRecvRateLimit'],
+                  required: ['size', 'maxTxsBytes', 'cacheSize', 'timeoutCheckTx', 'txEnqueueTimeout', 'txSendRateLimit', 'txRecvRateLimit', 'maxConcurrentCheckTx'],
                 },
                 consensus: {
                   type: 'object',

--- a/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
+++ b/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
@@ -96,7 +96,7 @@ transport = "routed"
 #	{ "info" = 2 },
 #]
 grpc-concurrency = [
-  { "check_tx" = 100 },
+  { "check_tx" = {{= it.platform.drive.tenderdash.mempool.maxConcurrentCheckTx }} },
 ]
 
 

--- a/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
+++ b/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
@@ -10,11 +10,6 @@
 ###                   Main Base Config Options                      ###
 #######################################################################
 
-# TCP or UNIX socket address of the ABCI application,
-# or the name of an ABCI application compiled in with the Tendermint binary
-#proxy-app = "tcp://drive_abci:26658"
-proxy-app = "CheckTx:grpc:drive_abci:26670,*:socket:tcp://drive_abci:26658"
-
 # A custom human readable name for this node
 {{?it.platform.drive.tenderdash.moniker}}moniker = "{{=it.platform.drive.tenderdash.moniker}}"{{?}}
 
@@ -72,12 +67,37 @@ genesis-file = "config/genesis.json"
 # Path to the JSON file containing the private key to use for node authentication in the p2p protocol
 node-key-file = "config/node_key.json"
 
-# Mechanism to connect to the ABCI application: socket | grpc
-abci = "routed"
-
 # If true, query the ABCI app on connecting to a new peer
 # so the app can decide if we should keep the connection or not
 filter-peers = false
+
+#######################################################
+###       ABCI App Connection Options               ###
+#######################################################
+[abci]
+# TCP or UNIX socket address of the ABCI application,
+# or routing rules for routed multi-app setup,
+# or the name of an ABCI application compiled in with the Tendermint binary
+# Example for routed multi-app setup:
+#   abci = "routed"
+#   address = "Info:socket:unix:///tmp/socket.1,Info:socket:unix:///tmp/socket.2,CheckTx:socket:unix:///tmp/socket.1,*:socket:unix:///tmp/socket.3"
+address = "CheckTx:grpc:drive_abci:26670,*:socket:tcp://drive_abci:26658"
+# Transport mechanism to connect to the ABCI application: socket | grpc | routed
+transport = "routed"
+# Maximum number of simultaneous connections to the ABCI application
+# per each method. Map of a gRPC method name,like "echo", to the number of concurrent connections.
+# Special value "*" can be used to set the default limit for methods not explicitly listed.
+#
+# Example:
+#
+# grpc-concurrency = [
+#	{ "*" = 10 },
+#	{ "echo" = 2 },
+#	{ "info" = 2 },
+#]
+grpc-concurrency = [
+  { "check_tx" = 100 },
+]
 
 
 #######################################################


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To protect Drive from overwhelming number of check tx ABCI calls in case of stress testing or an attack, we need limit max concurrent check tx calls in Tenderdash https://github.com/dashpay/tenderdash/pull/775

## What was done?
<!--- Describe your changes in detail -->
- Update tenderdash to a version that supports check tx concurrency limiting
- Add `platform.drive.tenderdash.mempool.maxConcurrentCheckTx` option to dashmate

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Broadcasting transactions to local network

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
