### PR TITLE
refactor(sdk)!: don't return Arc in SdkBuilder

### DIFF
--- a/packages/rs-dapi-client/src/dapi_client.rs
+++ b/packages/rs-dapi-client/src/dapi_client.rs
@@ -3,7 +3,7 @@
 use backon::{ExponentialBuilder, Retryable};
 use dapi_grpc::mock::Mockable;
 use dapi_grpc::tonic::async_trait;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tracing::Instrument;
 
@@ -61,9 +61,9 @@ pub trait DapiRequestExecutor {
 }
 
 /// Access point to DAPI.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DapiClient {
-    address_list: RwLock<AddressList>,
+    address_list: Arc<RwLock<AddressList>>,
     settings: RequestSettings,
     pool: ConnectionPool,
     #[cfg(feature = "dump")]
@@ -77,7 +77,7 @@ impl DapiClient {
         let address_count = 3 * address_list.len();
 
         Self {
-            address_list: RwLock::new(address_list),
+            address_list: Arc::new(RwLock::new(address_list)),
             settings,
             pool: ConnectionPool::new(address_count),
             #[cfg(feature = "dump")]

--- a/packages/rs-sdk/examples/read_contract.rs
+++ b/packages/rs-sdk/examples/read_contract.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroUsize, str::FromStr, sync::Arc};
+use std::{num::NonZeroUsize, str::FromStr};
 
 use clap::Parser;
 use dash_sdk::{mock::provider::GrpcContextProvider, platform::Fetch, Sdk, SdkBuilder};
@@ -58,7 +58,7 @@ async fn main() {
 }
 
 /// Setup Rust SDK
-fn setup_sdk(config: &Config) -> Arc<Sdk> {
+fn setup_sdk(config: &Config) -> Sdk {
     // We need to implement a ContextProvider.
     // Here, we will just use a mock implementation.
     // Tricky thing here is that this implementation requires SDK, so we have a
@@ -66,7 +66,7 @@ fn setup_sdk(config: &Config) -> Arc<Sdk> {
     // We'll first provide `None` Sdk, and then update it later.
     //
     // To modify context provider, we need locks and Arc to overcome ownership rules.
-    let context_provider = GrpcContextProvider::new(
+    let mut context_provider = GrpcContextProvider::new(
         None,
         &config.server_address,
         config.core_port,
@@ -76,7 +76,6 @@ fn setup_sdk(config: &Config) -> Arc<Sdk> {
         NonZeroUsize::new(100).expect("quorum public keys cache size"),
     )
     .expect("context provider");
-    let context_provider = Arc::new(std::sync::Mutex::new(context_provider));
 
     // Let's build the Sdk.
     // First, we need an URI of some Dash Platform DAPI host to connect to and use as seed.
@@ -87,16 +86,13 @@ fn setup_sdk(config: &Config) -> Arc<Sdk> {
     .expect("parse uri");
 
     // Now, we create the Sdk with the wallet and context provider.
-    let sdk = SdkBuilder::new(AddressList::from_iter([uri]))
-        .with_context_provider(Arc::clone(&context_provider))
+    let mut sdk = SdkBuilder::new(AddressList::from_iter([uri]))
         .build()
         .expect("cannot build sdk");
 
     // Reconfigure context provider with Sdk
-    let mut guard = context_provider.lock().expect("lock context provider");
-    guard.set_sdk(Some(Arc::clone(&sdk)));
-    drop(guard);
-
+    context_provider.set_sdk(Some(sdk.clone()));
+    sdk.set_context_provider(context_provider);
     // Return the SDK we created
     sdk
 }

--- a/packages/rs-sdk/src/mock.rs
+++ b/packages/rs-sdk/src/mock.rs
@@ -12,7 +12,7 @@
 //! ## Example
 //!
 //! ```no_run
-//! let sdk = dash_sdk::Sdk::new_mock();
+//! let mut sdk = dash_sdk::Sdk::new_mock();
 //! let query = dash_sdk::platform::Identifier::random();
 //! sdk.mock().expect_fetch(query, None as Option<dash_sdk::platform::Identity>);
 //! ```

--- a/packages/rs-sdk/src/mock/provider.rs
+++ b/packages/rs-sdk/src/mock/provider.rs
@@ -24,7 +24,7 @@ pub struct GrpcContextProvider {
     /// values set by the user in the caches: `data_contracts_cache`, `quorum_public_keys_cache`.
     ///
     /// We use [Arc] as we have circular dependencies between Sdk and ContextProvider.
-    sdk: Option<Arc<Sdk>>,
+    sdk: Option<Sdk>,
 
     /// Data contracts cache.
     ///
@@ -53,7 +53,7 @@ impl GrpcContextProvider {
     ///
     /// Sdk can be set later with [`GrpcContextProvider::set_sdk`].
     pub fn new(
-        sdk: Option<Arc<Sdk>>,
+        sdk: Option<Sdk>,
         core_ip: &str,
         core_port: u16,
         core_user: &str,
@@ -78,7 +78,7 @@ impl GrpcContextProvider {
     ///
     /// Note that if the `sdk` is `None`, the context provider will not be able to fetch data itself and will rely on
     /// values set by the user in the caches: `data_contracts_cache`, `quorum_public_keys_cache`.
-    pub fn set_sdk(&mut self, sdk: Option<Arc<Sdk>>) {
+    pub fn set_sdk(&mut self, sdk: Option<Sdk>) {
         self.sdk = sdk;
     }
     /// Set the directory where to store dumped data.

--- a/packages/rs-sdk/src/mock/sdk.rs
+++ b/packages/rs-sdk/src/mock/sdk.rs
@@ -34,13 +34,13 @@ use super::MockResponse;
 /// ## Panics
 ///
 /// Can panic on errors.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MockDashPlatformSdk {
     from_proof_expectations: BTreeMap<Key, Vec<u8>>,
     platform_version: &'static PlatformVersion,
     dapi: Arc<Mutex<MockDapiClient>>,
     prove: bool,
-    quorum_provider: Option<MockContextProvider>,
+    quorum_provider: Option<Arc<MockContextProvider>>,
 }
 
 impl MockDashPlatformSdk {
@@ -68,7 +68,7 @@ impl MockDashPlatformSdk {
     pub fn quorum_info_dir<P: AsRef<std::path::Path>>(&mut self, dir: P) -> &mut Self {
         let mut provider = MockContextProvider::new();
         provider.quorum_keys_dir(Some(dir.as_ref().to_path_buf()));
-        self.quorum_provider = Some(provider);
+        self.quorum_provider = Some(Arc::new(provider));
 
         self
     }

--- a/packages/rs-sdk/src/platform/fetch.rs
+++ b/packages/rs-sdk/src/platform/fetch.rs
@@ -124,7 +124,7 @@ where
         tracing::trace!(request = ?request, response = ?response, object_type, "fetched object from platform");
 
         let (object, response_metadata): (Option<Self>, ResponseMetadata) =
-            sdk.parse_proof_with_metadata(request, response)?;
+            sdk.parse_proof_with_metadata(request, response).await?;
 
         match object {
             Some(item) => Ok((item.into(), response_metadata)),
@@ -165,7 +165,7 @@ where
         let object_type = std::any::type_name::<Self>().to_string();
         tracing::trace!(request = ?request, response = ?response, object_type, "fetched object from platform");
 
-        let object: Option<Self> = sdk.parse_proof(request, response)?;
+        let object: Option<Self> = sdk.parse_proof(request, response).await?;
 
         match object {
             Some(item) => Ok(item.into()),

--- a/packages/rs-sdk/src/platform/fetch_many.rs
+++ b/packages/rs-sdk/src/platform/fetch_many.rs
@@ -142,7 +142,8 @@ where
         let object: BTreeMap<K, Option<Self>> = sdk
             .parse_proof::<<Self as FetchMany<K>>::Request, BTreeMap<K, Option<Self>>>(
                 request, response,
-            )?
+            )
+            .await?
             .unwrap_or_default();
 
         Ok(object)
@@ -227,7 +228,8 @@ impl FetchMany<Identifier> for Document {
 
         // let object: Option<BTreeMap<K,Document>> = sdk
         let documents: BTreeMap<Identifier, Option<Document>> = sdk
-            .parse_proof::<DocumentQuery, Documents>(document_query, response)?
+            .parse_proof::<DocumentQuery, Documents>(document_query, response)
+            .await?
             .unwrap_or_default();
 
         Ok(documents)

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -2,7 +2,7 @@
 
 use std::collections::btree_map::Entry;
 use std::sync::Arc;
-use std::{fmt::Debug, num::NonZeroUsize, ops::DerefMut};
+use std::{fmt::Debug, num::NonZeroUsize};
 
 use crate::error::Error;
 use crate::internal_cache::InternalSdkCache;
@@ -33,7 +33,7 @@ use rs_dapi_client::{
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(feature = "mocks")]
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, MutexGuard};
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 
 /// How many data contracts fit in the cache.
@@ -69,9 +69,12 @@ pub type LastQueryTimestamp = u64;
 /// Sdk is thread safe and can be shared between threads.
 /// It uses internal locking when needed.
 ///
+/// It is also safe to clone the Sdk.
+///
 /// ## Examples
 ///
 /// See tests/ for examples of using the SDK.
+#[derive(Clone)]
 pub struct Sdk {
     inner: SdkInstance,
     /// Use proofs when retrieving data from the platform.
@@ -80,14 +83,14 @@ pub struct Sdk {
     proofs: bool,
 
     /// An internal SDK cache managed exclusively by the SDK
-    internal_cache: InternalSdkCache,
+    internal_cache: Arc<InternalSdkCache>,
 
     /// Context provider used by the SDK.
     ///
     /// ## Panics
     ///
     /// Note that setting this to None can panic.
-    context_provider: std::sync::Mutex<Option<Box<dyn ContextProvider>>>,
+    context_provider: Option<Arc<Box<dyn ContextProvider>>>,
 
     /// Cancellation token; once cancelled, all pending requests should be aborted.
     pub(crate) cancel_token: CancellationToken,
@@ -118,7 +121,7 @@ impl Debug for Sdk {
 ///
 /// This is used to store the actual Sdk instance, which can be either a real Sdk or a mock Sdk.
 /// We use it to avoid exposing internals defined below to the public.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum SdkInstance {
     /// Real Sdk, using DAPI with gRPC transport
     Dapi {
@@ -136,7 +139,10 @@ enum SdkInstance {
         /// Dapi client is wrapped in a tokio [Mutex](tokio::sync::Mutex) as it's used in async context.
         dapi: Arc<Mutex<MockDapiClient>>,
         /// Mock SDK implementation processing mock expectations and responses.
-        mock: std::sync::Mutex<MockDashPlatformSdk>,
+        mock: Arc<Mutex<MockDashPlatformSdk>>,
+
+        /// Platform version configured for this Sdk
+        version: &'static PlatformVersion,
     },
 }
 
@@ -146,7 +152,7 @@ impl Sdk {
     /// This is a helper method that uses [`SdkBuilder`] to initialize the SDK in mock mode.
     ///
     /// See also [`SdkBuilder`].
-    pub fn new_mock() -> Arc<Self> {
+    pub fn new_mock() -> Self {
         SdkBuilder::default()
             .build()
             .expect("mock should be created")
@@ -160,7 +166,7 @@ impl Sdk {
     ///
     /// - `R`: Type of the request that was used to fetch the proof.
     /// - `O`: Type of the object to be retrieved from the proof.
-    pub(crate) fn parse_proof<R, O: FromProof<R> + MockResponse>(
+    pub(crate) async fn parse_proof<R, O: FromProof<R> + MockResponse>(
         &self,
         request: O::Request,
         response: O::Response,
@@ -169,6 +175,7 @@ impl Sdk {
         O::Request: Mockable,
     {
         self.parse_proof_with_metadata(request, response)
+            .await
             .map(|result| result.0)
     }
 
@@ -180,7 +187,7 @@ impl Sdk {
     ///
     /// - `R`: Type of the request that was used to fetch the proof.
     /// - `O`: Type of the object to be retrieved from the proof.
-    pub(crate) fn parse_proof_with_metadata<R, O: FromProof<R> + MockResponse>(
+    pub(crate) async fn parse_proof_with_metadata<R, O: FromProof<R> + MockResponse>(
         &self,
         request: O::Request,
         response: O::Response,
@@ -188,11 +195,8 @@ impl Sdk {
     where
         O::Request: Mockable,
     {
-        let guard = self
+        let provider = self
             .context_provider
-            .lock()
-            .expect("context provider lock poisoned");
-        let provider = guard
             .as_ref()
             .ok_or(drive_proof_verifier::Error::ContextProviderNotSet)?;
 
@@ -201,7 +205,10 @@ impl Sdk {
                 O::maybe_from_proof_with_metadata(request, response, self.version(), &provider)
             }
             #[cfg(feature = "mocks")]
-            SdkInstance::Mock { .. } => self.mock().parse_proof_with_metadata(request, response),
+            SdkInstance::Mock { ref mock, .. } => {
+                let guard = mock.lock().await;
+                guard.parse_proof_with_metadata(request, response)
+            }
         }
     }
 
@@ -211,15 +218,19 @@ impl Sdk {
     ///
     /// # Panics
     ///
-    /// Panics if the `self` instance is not a `Mock` variant.
+    /// Panics when:
+    ///
+    /// * the `self` instance is not a `Mock` variant,
+    /// * the `self` instance is in use by another thread.
     #[cfg(feature = "mocks")]
-    pub fn mock(&self) -> std::sync::MutexGuard<MockDashPlatformSdk> {
+    pub fn mock(&mut self) -> MutexGuard<MockDashPlatformSdk> {
         if let Sdk {
             inner: SdkInstance::Mock { ref mock, .. },
             ..
         } = self
         {
-            mock.lock().expect("mock lock poisoned")
+            mock.try_lock()
+                .expect("mock sdk is in use by another thread and connot be reconfigured")
         } else {
             panic!("not a mock")
         }
@@ -414,7 +425,7 @@ impl Sdk {
         match &self.inner {
             SdkInstance::Dapi { version, .. } => version,
             #[cfg(feature = "mocks")]
-            SdkInstance::Mock { .. } => self.mock().version(),
+            SdkInstance::Mock { version, .. } => version,
         }
     }
 
@@ -428,13 +439,9 @@ impl Sdk {
     /// [ContextProvider] is used to access state information, like data contracts and quorum public keys.
     ///
     /// Note that this will overwrite any previous context provider.
-    pub fn set_context_provider<C: ContextProvider + 'static>(&self, context_provider: C) {
-        let mut guard = self
-            .context_provider
-            .lock()
-            .expect("context provider lock poisoned");
-
-        guard.deref_mut().replace(Box::new(context_provider));
+    pub fn set_context_provider<C: ContextProvider + 'static>(&mut self, context_provider: C) {
+        self.context_provider
+            .replace(Arc::new(Box::new(context_provider)));
     }
 
     /// Returns a future that resolves when the Sdk is cancelled (eg. shutdown was requested).
@@ -545,6 +552,7 @@ impl Default for SdkBuilder {
             cancel_token: CancellationToken::new(),
 
             version: PlatformVersion::latest(),
+
             #[cfg(feature = "mocks")]
             dump_dir: None,
         }
@@ -673,36 +681,33 @@ impl SdkBuilder {
     /// # Errors
     ///
     /// This method will return an error if the Sdk cannot be created.
-    pub fn build(self) -> Result<Arc<Sdk>, Error> {
+    pub fn build(self) -> Result<Sdk, Error> {
         PlatformVersion::set_current(self.version);
 
-        let  sdk=  match self.addresses {
+        let sdk=     match self.addresses {
             // non-mock mode
             Some(addresses) => {
                 let dapi = DapiClient::new(addresses, self.settings);
                 #[cfg(feature = "mocks")]
                 let dapi = dapi.dump_dir(self.dump_dir.clone());
 
-                let sdk= Sdk{
+                let mut sdk= Sdk{
                     inner:SdkInstance::Dapi { dapi,  version:self.version },
                     proofs:self.proofs,
-                    context_provider: std::sync:: Mutex::new(self.context_provider),
+                    context_provider: self.context_provider.map(Arc::new),
                     cancel_token: self.cancel_token,
                     #[cfg(feature = "mocks")]
                     dump_dir: self.dump_dir,
                     internal_cache: Default::default(),
                 };
-                let sdk = Arc::new(sdk);
-
                 // if context provider is not set correctly (is None), it means we need to fallback to core wallet
-                let mut ctx_guard = sdk.context_provider.lock().expect("lock poisoned");
-                if  ctx_guard.is_none() {
+                if  sdk.context_provider.is_none() {
                     #[cfg(feature = "mocks")]
                     if !self.core_ip.is_empty() {
                         tracing::warn!("ContextProvider not set; mocking with Dash Core. \
                         Please provide your own ContextProvider with SdkBuilder::with_context_provider().");
 
-                        let mut context_provider = GrpcContextProvider::new(Some(Arc::clone(&sdk)),
+                        let mut context_provider = GrpcContextProvider::new(Some(sdk.clone()),
                         &self.core_ip, self.core_port, &self.core_user, &self.core_password,
                         self.data_contract_cache_size, self.quorum_public_keys_cache_size)?;
                         #[cfg(feature = "mocks")]
@@ -710,7 +715,7 @@ impl SdkBuilder {
                             context_provider.set_dump_dir(sdk.dump_dir.clone());
                         }
 
-                        ctx_guard.replace(Box::new(context_provider));
+                        sdk.context_provider.replace(Arc::new(Box::new(context_provider)));
                     } else{
                         tracing::warn!(
                             "Configure ContextProvider with Sdk::with_context_provider(); otherwise Sdk will fail");
@@ -719,9 +724,8 @@ impl SdkBuilder {
                     tracing::warn!(
                         "Configure ContextProvider with Sdk::with_context_provider(); otherwise Sdk will fail");
                 };
-                drop(ctx_guard);
 
-                Ok(sdk)
+                sdk
             },
             #[cfg(feature = "mocks")]
             // mock mode
@@ -730,23 +734,23 @@ impl SdkBuilder {
                 // We create mock context provider that will use the mock DAPI client to retrieve data contracts.
                 let  context_provider = self.context_provider.unwrap_or(Box::new(MockContextProvider::new()));
 
-                let sdk = Sdk {
+                Sdk {
                     inner:SdkInstance::Mock {
-                        mock: std::sync::Mutex::new( MockDashPlatformSdk::new(self.version, Arc::clone(&dapi), self.proofs)),
+                        mock:Arc::new(Mutex::new( MockDashPlatformSdk::new(self.version, Arc::clone(&dapi), self.proofs))),
                         dapi,
+                        version:self.version,
                     },
                     dump_dir: self.dump_dir,
                     proofs:self.proofs,
                     internal_cache: Default::default(),
-                    context_provider:  std::sync:: Mutex::new( Some(context_provider)),
+                    context_provider:Some(Arc::new(context_provider)),
                     cancel_token: self.cancel_token,
-                };
-                Ok(Arc::new(sdk))
+                }
             },
             #[cfg(not(feature = "mocks"))]
-            None => Err(Error::Config("Mock mode is not available. Please enable `mocks` feature or provide address list.".to_string())),
+            None => return Err(Error::Config("Mock mode is not available. Please enable `mocks` feature or provide address list.".to_string())),
         };
 
-        sdk
+        Ok(sdk)
     }
 }

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -684,7 +684,7 @@ impl SdkBuilder {
     pub fn build(self) -> Result<Sdk, Error> {
         PlatformVersion::set_current(self.version);
 
-        let sdk=     match self.addresses {
+        let sdk= match self.addresses {
             // non-mock mode
             Some(addresses) => {
                 let dapi = DapiClient::new(addresses, self.settings);

--- a/packages/rs-sdk/tests/fetch/broadcast.rs
+++ b/packages/rs-sdk/tests/fetch/broadcast.rs
@@ -20,7 +20,6 @@ mod online {
 
         let cfg = Config::new();
         let sdk = cfg.setup_api("test_wait_timeout").await;
-        let sdk_ref: &Sdk = sdk.as_ref();
 
         let request: WaitForStateTransitionResultRequest = WaitForStateTransitionResultRequestV0 {
             prove: false,
@@ -36,7 +35,7 @@ mod online {
         // we add few millis to duration to give chance to the server to time out before we kill request
         let response = tokio::time::timeout(
             TIMEOUT + Duration::from_millis(100),
-            request.execute(sdk_ref, settings),
+            request.execute(&sdk, settings),
         )
         .await
         .expect("expected request timeout, got tokio timeout");

--- a/packages/rs-sdk/tests/fetch/config.rs
+++ b/packages/rs-sdk/tests/fetch/config.rs
@@ -6,7 +6,7 @@
 use dpp::prelude::Identifier;
 use rs_dapi_client::AddressList;
 use serde::Deserialize;
-use std::{path::PathBuf, str::FromStr, sync::Arc};
+use std::{path::PathBuf, str::FromStr};
 
 /// Existing document ID
 ///
@@ -144,7 +144,7 @@ impl Config {
     /// expectations from different tests.
     ///
     /// When empty string is provided, expectations are stored in the root of the dump directory.
-    pub async fn setup_api(&self, namespace: &str) -> Arc<dash_sdk::Sdk> {
+    pub async fn setup_api(&self, namespace: &str) -> dash_sdk::Sdk {
         let dump_dir = match namespace.is_empty() {
             true => self.dump_dir.clone(),
             false => self.dump_dir.join(sanitize_filename::sanitize(namespace)),
@@ -194,7 +194,7 @@ impl Config {
         // offline testing takes precedence over network testing
         #[cfg(feature = "offline-testing")]
         let sdk = {
-            let mock_sdk = dash_sdk::SdkBuilder::new_mock()
+            let mut mock_sdk = dash_sdk::SdkBuilder::new_mock()
                 .build()
                 .expect("initialize api");
 

--- a/packages/rs-sdk/tests/fetch/mock_fetch.rs
+++ b/packages/rs-sdk/tests/fetch/mock_fetch.rs
@@ -22,7 +22,7 @@ use dpp::{
 #[tokio::test]
 /// Given some identity, when I fetch it using mock API, then I get the same identity
 async fn test_mock_fetch_identity() {
-    let sdk = Sdk::new_mock();
+    let mut sdk = Sdk::new_mock();
 
     let expected: Identity = Identity::from(IdentityV0::default());
     let query = expected.id();
@@ -43,7 +43,7 @@ async fn test_mock_fetch_identity() {
 #[tokio::test]
 /// When I define mock expectation twice for the same request, second call ends with error
 async fn test_mock_fetch_duplicate_expectation() {
-    let sdk = Sdk::new_mock();
+    let mut sdk = Sdk::new_mock();
 
     let expected: Identity = Identity::from(IdentityV0::default());
     let expected2 =
@@ -72,7 +72,7 @@ async fn test_mock_fetch_duplicate_expectation() {
 #[tokio::test]
 /// Given some random identity ID, when I fetch it using mock API, then I get None
 async fn test_mock_fetch_identity_not_found() {
-    let sdk = Sdk::new_mock();
+    let mut sdk = Sdk::new_mock();
 
     let id = Identifier::random();
 
@@ -91,7 +91,7 @@ async fn test_mock_fetch_identity_not_found() {
 /// Given some data contract, when I fetch it by ID, I get it.
 #[tokio::test]
 async fn test_mock_fetch_data_contract() {
-    let sdk = Sdk::new_mock();
+    let mut sdk = Sdk::new_mock();
 
     let document_type: DocumentType = mock_document_type();
     let expected = mock_data_contract(Some(&document_type));
@@ -114,7 +114,7 @@ async fn test_mock_fetch_data_contract() {
 async fn test_mock_fetch_document() {
     use dpp::document::DocumentV0Getters;
 
-    let sdk = Sdk::new_mock();
+    let mut sdk = Sdk::new_mock();
     let document_type: DocumentType = mock_document_type();
     let data_contract = mock_data_contract(Some(&document_type));
 

--- a/packages/rs-sdk/tests/fetch/mock_fetch_many.rs
+++ b/packages/rs-sdk/tests/fetch/mock_fetch_many.rs
@@ -19,7 +19,7 @@ use dpp::{
 /// document.
 #[tokio::test]
 async fn test_mock_document_fetch_many() {
-    let sdk = Sdk::new_mock();
+    let mut sdk = Sdk::new_mock();
     let document_type: DocumentType = mock_document_type();
     let data_contract = mock_data_contract(Some(&document_type));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Based on team's feedback, it's not a good idea to return Arc<Sdk> from SdkBuilder::build().

## What was done?

Refactored the code to:

* return Sdk from SdkBuilder::build()
* implement `Clone` on `Sdk` and make Sdk internally thread-safe

Accompanying PR: https://github.com/dashpay/rs-platform-explorer/pull/48

## How Has This Been Tested?

GHA

## Breaking Changes

SdkBuilder::build() now returns Sdk instead of Arc<Sdk>.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
