### PR TITLE
refactor(platform)!: document creation/update/deletion does not refetch contract

### DIFF
--- a/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/v0/mod.rs
@@ -49,7 +49,9 @@ use drive::drive::batch::{
     DataContractOperationType, DocumentOperationType, DriveOperation, IdentityOperationType,
 };
 
-use drive::drive::object_size_info::{DocumentAndContractInfo, DocumentInfo, OwnedDocumentInfo};
+use drive::drive::object_size_info::{
+    DataContractInfo, DocumentInfo, DocumentTypeInfo, OwnedDocumentInfo,
+};
 use drive::query::TransactionArg;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -267,18 +269,15 @@ impl<C> Platform<C> {
 
         let document_type = contract.document_type_for_name("domain")?;
 
-        let operation =
-            DriveOperation::DocumentOperation(DocumentOperationType::AddDocumentForContract {
-                document_and_contract_info: DocumentAndContractInfo {
-                    owned_document_info: OwnedDocumentInfo {
-                        document_info: DocumentInfo::DocumentOwnedInfo((document, None)),
-                        owner_id: None,
-                    },
-                    contract,
-                    document_type,
-                },
-                override_document: false,
-            });
+        let operation = DriveOperation::DocumentOperation(DocumentOperationType::AddDocument {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentInfo::DocumentOwnedInfo((document, None)),
+                owner_id: None,
+            },
+            contract_info: DataContractInfo::BorrowedDataContract(contract),
+            document_type_info: DocumentTypeInfo::DocumentTypeRef(document_type),
+            override_document: false,
+        });
 
         operations.push(operation);
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
@@ -732,7 +732,7 @@ mod tests {
 
             assert_eq!(processing_result.valid_count(), 1);
 
-            assert_eq!(processing_result.aggregated_fees().processing_fee, 5081030);
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 3810570);
         }
 
         #[test]
@@ -2014,7 +2014,7 @@ mod tests {
 
             assert_eq!(processing_result.aggregated_fees().storage_fee, 0); // There is no storage fee, as there are no indexes that will change
 
-            assert_eq!(processing_result.aggregated_fees().processing_fee, 5609930);
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 4926670);
         }
 
         #[test]
@@ -2205,7 +2205,7 @@ mod tests {
                 Some(14992395)
             );
 
-            assert_eq!(processing_result.aggregated_fees().processing_fee, 9357180);
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 8622720);
 
             let query_sender_results = platform
                 .drive
@@ -2742,7 +2742,7 @@ mod tests {
 
             assert_eq!(processing_result.valid_count(), 1);
 
-            assert_eq!(processing_result.aggregated_fees().processing_fee, 10283900);
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 9549440);
 
             let query_sender_results = platform
                 .drive
@@ -3145,7 +3145,7 @@ mod tests {
 
             assert_eq!(processing_result.valid_count(), 1);
 
-            assert_eq!(processing_result.aggregated_fees().processing_fee, 6814950);
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 6075290);
 
             let query_sender_results = platform
                 .drive
@@ -3266,11 +3266,11 @@ mod tests {
                     .change(),
                 &BalanceChange::RemoveFromBalance {
                     required_removed_balance: 123579000,
-                    desired_removed_balance: 128673220,
+                    desired_removed_balance: 127933560,
                 }
             );
 
-            let original_creation_cost = 128673220;
+            let original_creation_cost = 127933560;
 
             platform
                 .drive
@@ -3397,7 +3397,7 @@ mod tests {
                 None
             );
 
-            assert_eq!(processing_result.aggregated_fees().processing_fee, 6814950);
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 6075290);
 
             let seller_balance = platform
                 .drive
@@ -3408,7 +3408,7 @@ mod tests {
             // the seller should have received 0.1 and already had 0.1 minus the processing fee and storage fee
             assert_eq!(
                 seller_balance,
-                dash_to_credits!(0.1) - 6814950 - 216000 - original_creation_cost
+                dash_to_credits!(0.1) - 6075290 - 216000 - original_creation_cost
             );
 
             let query_sender_results = platform
@@ -3503,7 +3503,7 @@ mod tests {
 
             assert_eq!(processing_result.aggregated_fees().storage_fee, 64611000);
 
-            assert_eq!(processing_result.aggregated_fees().processing_fee, 10873700);
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 10134040);
 
             assert_eq!(
                 processing_result
@@ -3537,7 +3537,7 @@ mod tests {
             // the seller should have received 0.1 and already had 0.1 minus the processing fee and storage fee
             assert_eq!(
                 seller_balance,
-                dash_to_credits!(0.2) - 6814950 - 216000 - original_creation_cost + 22704503
+                dash_to_credits!(0.2) - 6075290 - 216000 - original_creation_cost + 22704503
             );
 
             let buyers_balance = platform
@@ -3547,7 +3547,7 @@ mod tests {
                 .expect("expected that purchaser exists");
 
             // the buyer payed 0.1, but also storage and processing fees
-            assert_eq!(buyers_balance, dash_to_credits!(0.9) - 10873700 - 64611000);
+            assert_eq!(buyers_balance, dash_to_credits!(0.9) - 10134040 - 64611000);
         }
 
         #[test]
@@ -4413,7 +4413,7 @@ mod tests {
 
             assert_eq!(processing_result.valid_count(), 1);
 
-            assert_eq!(processing_result.aggregated_fees().processing_fee, 6814950);
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 6075290);
 
             let query_sender_results = platform
                 .drive

--- a/packages/rs-drive-abci/tests/strategy_tests/main.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/main.rs
@@ -1778,7 +1778,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
             ),
-            "c0c1f59b535f358448a33c20b419b93bcfa12b05b221f77a7347892f48ca2f16".to_string()
+            "10fbe38850d752b491305b2587468788acbd6dd130272c5a8844d0da05e3a9cf".to_string()
         )
     }
 
@@ -1903,7 +1903,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
             ),
-            "a7be306dcdf58930dc14befa2b78c839d66699cf9d454942ac9c595161ffe99e".to_string()
+            "9ed86b1ed5d0f7a981cb0ff2f3943603a095a031c463b3389bce8a6f60e2b21e".to_string()
         )
     }
 

--- a/packages/rs-drive-abci/tests/strategy_tests/query.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/query.rs
@@ -20,7 +20,7 @@ use drive_abci::rpc::core::MockCoreRPCLike;
 use rand::prelude::SliceRandom;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use strategy_tests::frequency::Frequency;
 use tenderdash_abci::proto::google::protobuf::Timestamp;
 use tenderdash_abci::proto::serializers::timestamp::ToMilis;

--- a/packages/rs-drive/src/drive/batch/drive_op_batch/document.rs
+++ b/packages/rs-drive/src/drive/batch/drive_op_batch/document.rs
@@ -1,7 +1,10 @@
 use crate::drive::batch::drive_op_batch::DriveLowLevelOperationConverter;
 use crate::drive::flags::StorageFlags;
 use crate::drive::object_size_info::DocumentInfo::{DocumentRefAndSerialization, DocumentRefInfo};
-use crate::drive::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
+use crate::drive::object_size_info::{
+    DataContractInfo, DataContractResolvedInfo, DocumentAndContractInfo, DocumentTypeInfo,
+    OwnedDocumentInfo,
+};
 use crate::drive::Drive;
 use crate::error::document::DocumentError;
 use crate::error::Error;
@@ -51,75 +54,35 @@ pub struct DocumentOperationsForContractDocumentType<'a> {
 /// Operations on Documents
 #[derive(Clone, Debug)]
 pub enum DocumentOperationType<'a> {
-    /// Deserializes a document and adds it to a contract.
-    AddSerializedDocumentForContract {
-        /// The serialized document
-        serialized_document: &'a [u8],
-        /// The contract
-        contract: &'a DataContract,
-        /// The name of the document type
-        document_type_name: &'a str,
-        /// The owner id, if none is specified will try to recover from serialized document
-        owner_id: Option<[u8; 32]>,
-        /// Should we override the document if one already exists?
-        override_document: bool,
-        /// Add storage flags (like epoch, owner id, etc)
-        storage_flags: Option<Cow<'a, StorageFlags>>,
-    },
     /// Adds a document to a contract matching the desired info.
     AddDocument {
         /// The document and contract info, also may contain the owner_id
         owned_document_info: OwnedDocumentInfo<'a>,
-        ///DataContract
-        contract_id: Identifier,
+        /// DataContract
+        contract_info: DataContractInfo<'a>,
         /// Document type
-        document_type_name: Cow<'a, String>,
+        document_type_info: DocumentTypeInfo<'a>,
         /// Should we override the document if one already exists?
         override_document: bool,
     },
-    /// Adds a withdrawal document.
+    /// Convenience method to add a withdrawal document.
     AddWithdrawalDocument {
         /// The document and contract info, also may contain the owner_id
         owned_document_info: OwnedDocumentInfo<'a>,
-    },
-    /// Adds a document to a contract.
-    AddDocumentForContract {
-        /// The document and contract info, also may contain the owner_id
-        document_and_contract_info: DocumentAndContractInfo<'a>,
-        /// Should we override the document if one already exists?
-        override_document: bool,
     },
     /// Adds a document to a contract.
     MultipleDocumentOperationsForSameContractDocumentType {
         /// The document operations
         document_operations: DocumentOperationsForContractDocumentType<'a>,
     },
-    /// Deletes a document and returns the associated fee.
-    DeleteDocumentOfNamedTypeForContractId {
+    /// Deletes a document
+    DeleteDocument {
         /// The document id
-        document_id: [u8; 32],
-        /// The contract id
-        contract_id: [u8; 32],
-        /// The name of the document type
-        document_type_name: Cow<'a, String>,
-    },
-    /// Deletes a document and returns the associated fee.
-    DeleteDocumentOfNamedTypeForContract {
-        /// The document id
-        document_id: [u8; 32],
-        /// The contract
-        contract: &'a DataContract,
-        /// The name of the document type
-        document_type_name: &'a str,
-    },
-    /// Deletes a document and returns the associated fee.
-    DeleteDocumentForContract {
-        /// The document id
-        document_id: [u8; 32],
-        /// The contract
-        contract: &'a DataContract,
-        /// The name of the document type
-        document_type: DocumentTypeRef<'a>,
+        document_id: Identifier,
+        /// Data Contract info
+        contract_info: DataContractInfo<'a>,
+        /// Document type
+        document_type_info: DocumentTypeInfo<'a>,
     },
     /// Updates a serialized document and returns the associated fee.
     UpdateSerializedDocumentForContract {
@@ -172,65 +135,49 @@ impl DriveLowLevelOperationConverter for DocumentOperationType<'_> {
         platform_version: &PlatformVersion,
     ) -> Result<Vec<LowLevelDriveOperation>, Error> {
         match self {
-            DocumentOperationType::AddSerializedDocumentForContract {
-                serialized_document,
-                contract,
-                document_type_name,
-                owner_id,
-                override_document,
-                storage_flags,
-            } => {
-                let document_type = contract
-                    .document_type_for_name(document_type_name)
-                    .map_err(ProtocolError::DataContractError)?;
-
-                let document =
-                    Document::from_bytes(serialized_document, document_type, platform_version)?;
-
-                let document_info =
-                    DocumentRefAndSerialization((&document, serialized_document, storage_flags));
-
-                let document_and_contract_info = DocumentAndContractInfo {
-                    owned_document_info: OwnedDocumentInfo {
-                        document_info,
-                        owner_id,
-                    },
-                    contract,
-                    document_type,
-                };
-                drive.add_document_for_contract_operations(
-                    document_and_contract_info,
-                    override_document,
-                    block_info,
-                    &mut None,
-                    estimated_costs_only_with_layer_info,
-                    transaction,
-                    platform_version,
-                )
-            }
             DocumentOperationType::AddDocument {
                 owned_document_info,
-                contract_id,
-                document_type_name,
+                contract_info,
+                document_type_info,
                 override_document,
             } => {
                 let mut drive_operations: Vec<LowLevelDriveOperation> = vec![];
-                let contract_fetch_info = drive
-                    .get_contract_with_fetch_info_and_add_to_operations(
-                        contract_id.into_buffer(),
-                        Some(&block_info.epoch),
-                        true,
-                        transaction,
-                        &mut drive_operations,
-                        platform_version,
-                    )?
-                    .ok_or(Error::Document(DocumentError::DataContractNotFound))?;
+                let contract_resolved_info = match contract_info {
+                    DataContractInfo::DataContractId(contract_id) => {
+                        let contract_fetch_info = drive
+                            .get_contract_with_fetch_info_and_add_to_operations(
+                                contract_id.into_buffer(),
+                                Some(&block_info.epoch),
+                                true,
+                                transaction,
+                                &mut drive_operations,
+                                platform_version,
+                            )?
+                            .ok_or(Error::Document(DocumentError::DataContractNotFound))?;
+                        DataContractResolvedInfo::DataContractFetchInfo(contract_fetch_info)
+                    }
+                    DataContractInfo::DataContractFetchInfo(contract_fetch_info) => {
+                        DataContractResolvedInfo::DataContractFetchInfo(contract_fetch_info)
+                    }
+                    DataContractInfo::BorrowedDataContract(contract) => {
+                        DataContractResolvedInfo::BorrowedDataContract(contract)
+                    }
+                    DataContractInfo::OwnedDataContract(contract) => {
+                        DataContractResolvedInfo::OwnedDataContract(contract)
+                    }
+                };
 
-                let contract = &contract_fetch_info.contract;
+                let contract = contract_resolved_info.as_ref();
 
-                let document_type = contract
-                    .document_type_for_name(document_type_name.as_str())
-                    .map_err(ProtocolError::DataContractError)?;
+                let document_type = match document_type_info {
+                    DocumentTypeInfo::DocumentTypeName(document_type_name) => contract
+                        .document_type_for_name(document_type_name.as_str())
+                        .map_err(ProtocolError::DataContractError)?,
+                    DocumentTypeInfo::DocumentTypeNameAsStr(document_type_name) => contract
+                        .document_type_for_name(document_type_name)
+                        .map_err(ProtocolError::DataContractError)?,
+                    DocumentTypeInfo::DocumentTypeRef(document_type_ref) => document_type_ref,
+                };
 
                 let document_and_contract_info = DocumentAndContractInfo {
                     owned_document_info,
@@ -273,58 +220,59 @@ impl DriveLowLevelOperationConverter for DocumentOperationType<'_> {
                     platform_version,
                 )
             }
-            DocumentOperationType::AddDocumentForContract {
-                document_and_contract_info,
-                override_document,
-            } => drive.add_document_for_contract_operations(
-                document_and_contract_info,
-                override_document,
-                block_info,
-                &mut None,
-                estimated_costs_only_with_layer_info,
-                transaction,
-                platform_version,
-            ),
-            DocumentOperationType::DeleteDocumentForContract {
+            DocumentOperationType::DeleteDocument {
                 document_id,
-                contract,
-                document_type,
-            } => drive.delete_document_for_contract_operations(
-                document_id,
-                contract,
-                document_type,
-                None,
-                estimated_costs_only_with_layer_info,
-                transaction,
-                platform_version,
-            ),
-            DocumentOperationType::DeleteDocumentOfNamedTypeForContractId {
-                document_id,
-                contract_id,
-                document_type_name,
-            } => drive.delete_document_for_contract_id_with_named_type_operations(
-                document_id,
-                contract_id,
-                document_type_name.as_str(),
-                &block_info.epoch,
-                None,
-                estimated_costs_only_with_layer_info,
-                transaction,
-                platform_version,
-            ),
-            DocumentOperationType::DeleteDocumentOfNamedTypeForContract {
-                document_id,
-                contract,
-                document_type_name,
-            } => drive.delete_document_for_contract_with_named_type_operations(
-                document_id,
-                contract,
-                document_type_name,
-                None,
-                estimated_costs_only_with_layer_info,
-                transaction,
-                platform_version,
-            ),
+                contract_info,
+                document_type_info,
+            } => {
+                let mut drive_operations: Vec<LowLevelDriveOperation> = vec![];
+                let contract_resolved_info = match contract_info {
+                    DataContractInfo::DataContractId(contract_id) => {
+                        let contract_fetch_info = drive
+                            .get_contract_with_fetch_info_and_add_to_operations(
+                                contract_id.into_buffer(),
+                                Some(&block_info.epoch),
+                                true,
+                                transaction,
+                                &mut drive_operations,
+                                platform_version,
+                            )?
+                            .ok_or(Error::Document(DocumentError::DataContractNotFound))?;
+                        DataContractResolvedInfo::DataContractFetchInfo(contract_fetch_info)
+                    }
+                    DataContractInfo::DataContractFetchInfo(contract_fetch_info) => {
+                        DataContractResolvedInfo::DataContractFetchInfo(contract_fetch_info)
+                    }
+                    DataContractInfo::BorrowedDataContract(contract) => {
+                        DataContractResolvedInfo::BorrowedDataContract(contract)
+                    }
+                    DataContractInfo::OwnedDataContract(contract) => {
+                        DataContractResolvedInfo::OwnedDataContract(contract)
+                    }
+                };
+
+                let contract = contract_resolved_info.as_ref();
+
+                let document_type = match document_type_info {
+                    DocumentTypeInfo::DocumentTypeName(document_type_name) => contract
+                        .document_type_for_name(document_type_name.as_str())
+                        .map_err(ProtocolError::DataContractError)?,
+                    DocumentTypeInfo::DocumentTypeNameAsStr(document_type_name) => contract
+                        .document_type_for_name(document_type_name)
+                        .map_err(ProtocolError::DataContractError)?,
+                    DocumentTypeInfo::DocumentTypeRef(document_type_ref) => document_type_ref,
+                };
+
+                drive.delete_document_for_contract_operations(
+                    document_id,
+                    contract,
+                    document_type,
+                    None,
+                    estimated_costs_only_with_layer_info,
+                    transaction,
+                    platform_version,
+                )
+            }
             DocumentOperationType::UpdateSerializedDocumentForContract {
                 serialized_document,
                 contract,

--- a/packages/rs-drive/src/drive/batch/drive_op_batch/document.rs
+++ b/packages/rs-drive/src/drive/batch/drive_op_batch/document.rs
@@ -2,18 +2,15 @@ use crate::drive::batch::drive_op_batch::DriveLowLevelOperationConverter;
 use crate::drive::flags::StorageFlags;
 use crate::drive::object_size_info::DocumentInfo::{DocumentRefAndSerialization, DocumentRefInfo};
 use crate::drive::object_size_info::{
-    DataContractInfo, DataContractResolvedInfo, DocumentAndContractInfo, DocumentTypeInfo,
-    OwnedDocumentInfo,
+    DataContractInfo, DocumentAndContractInfo, DocumentTypeInfo, OwnedDocumentInfo,
 };
 use crate::drive::Drive;
-use crate::error::document::DocumentError;
 use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 use dpp::block::block_info::BlockInfo;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::document_type::DocumentTypeRef;
 use dpp::data_contract::DataContract;
-use dpp::document::serialization_traits::DocumentPlatformConversionMethodsV0;
 use dpp::document::Document;
 use dpp::prelude::Identifier;
 
@@ -58,12 +55,30 @@ pub enum DocumentOperationType<'a> {
     AddDocument {
         /// The document and contract info, also may contain the owner_id
         owned_document_info: OwnedDocumentInfo<'a>,
-        /// DataContract
+        /// Data Contract info to potentially be resolved if needed
         contract_info: DataContractInfo<'a>,
         /// Document type
         document_type_info: DocumentTypeInfo<'a>,
         /// Should we override the document if one already exists?
         override_document: bool,
+    },
+    /// Updates a document and returns the associated fee.
+    UpdateDocument {
+        /// The document and contract info, also may contain the owner_id
+        owned_document_info: OwnedDocumentInfo<'a>,
+        /// Data Contract info to potentially be resolved if needed
+        contract_info: DataContractInfo<'a>,
+        /// Document type
+        document_type_info: DocumentTypeInfo<'a>,
+    },
+    /// Deletes a document
+    DeleteDocument {
+        /// The document id
+        document_id: Identifier,
+        /// Data Contract info to potentially be resolved if needed
+        contract_info: DataContractInfo<'a>,
+        /// Document type
+        document_type_info: DocumentTypeInfo<'a>,
     },
     /// Convenience method to add a withdrawal document.
     AddWithdrawalDocument {
@@ -74,52 +89,6 @@ pub enum DocumentOperationType<'a> {
     MultipleDocumentOperationsForSameContractDocumentType {
         /// The document operations
         document_operations: DocumentOperationsForContractDocumentType<'a>,
-    },
-    /// Deletes a document
-    DeleteDocument {
-        /// The document id
-        document_id: Identifier,
-        /// Data Contract info
-        contract_info: DataContractInfo<'a>,
-        /// Document type
-        document_type_info: DocumentTypeInfo<'a>,
-    },
-    /// Updates a serialized document and returns the associated fee.
-    UpdateSerializedDocumentForContract {
-        /// The serialized document
-        serialized_document: &'a [u8],
-        /// The contract
-        contract: &'a DataContract,
-        /// The name of the document type
-        document_type_name: &'a str,
-        /// The owner id, if none is specified will try to recover from serialized document
-        owner_id: Option<[u8; 32]>,
-        /// Add storage flags (like epoch, owner id, etc)
-        storage_flags: Option<Cow<'a, StorageFlags>>,
-    },
-    /// Updates a document and returns the associated fee.
-    UpdateDocument {
-        /// The document and contract info, also may contain the owner_id
-        owned_document_info: OwnedDocumentInfo<'a>,
-        /// DataContract
-        contract_id: Identifier,
-        /// Document type
-        document_type_name: Cow<'a, String>,
-    },
-    /// Updates a document and returns the associated fee.
-    UpdateDocumentForContract {
-        /// The document to update
-        document: &'a Document,
-        /// The document in pre-serialized form
-        serialized_document: &'a [u8],
-        /// The contract
-        contract: &'a DataContract,
-        /// The name of the document type
-        document_type_name: &'a str,
-        /// The owner id, if none is specified will try to recover from serialized document
-        owner_id: Option<[u8; 32]>,
-        /// Add storage flags (like epoch, owner id, etc)
-        storage_flags: Option<Cow<'a, StorageFlags>>,
     },
 }
 
@@ -142,42 +111,15 @@ impl DriveLowLevelOperationConverter for DocumentOperationType<'_> {
                 override_document,
             } => {
                 let mut drive_operations: Vec<LowLevelDriveOperation> = vec![];
-                let contract_resolved_info = match contract_info {
-                    DataContractInfo::DataContractId(contract_id) => {
-                        let contract_fetch_info = drive
-                            .get_contract_with_fetch_info_and_add_to_operations(
-                                contract_id.into_buffer(),
-                                Some(&block_info.epoch),
-                                true,
-                                transaction,
-                                &mut drive_operations,
-                                platform_version,
-                            )?
-                            .ok_or(Error::Document(DocumentError::DataContractNotFound))?;
-                        DataContractResolvedInfo::DataContractFetchInfo(contract_fetch_info)
-                    }
-                    DataContractInfo::DataContractFetchInfo(contract_fetch_info) => {
-                        DataContractResolvedInfo::DataContractFetchInfo(contract_fetch_info)
-                    }
-                    DataContractInfo::BorrowedDataContract(contract) => {
-                        DataContractResolvedInfo::BorrowedDataContract(contract)
-                    }
-                    DataContractInfo::OwnedDataContract(contract) => {
-                        DataContractResolvedInfo::OwnedDataContract(contract)
-                    }
-                };
-
+                let contract_resolved_info = contract_info.resolve(
+                    drive,
+                    block_info,
+                    transaction,
+                    &mut drive_operations,
+                    platform_version,
+                )?;
                 let contract = contract_resolved_info.as_ref();
-
-                let document_type = match document_type_info {
-                    DocumentTypeInfo::DocumentTypeName(document_type_name) => contract
-                        .document_type_for_name(document_type_name.as_str())
-                        .map_err(ProtocolError::DataContractError)?,
-                    DocumentTypeInfo::DocumentTypeNameAsStr(document_type_name) => contract
-                        .document_type_for_name(document_type_name)
-                        .map_err(ProtocolError::DataContractError)?,
-                    DocumentTypeInfo::DocumentTypeRef(document_type_ref) => document_type_ref,
-                };
+                let document_type = document_type_info.resolve(contract)?;
 
                 let document_and_contract_info = DocumentAndContractInfo {
                     owned_document_info,
@@ -220,120 +162,59 @@ impl DriveLowLevelOperationConverter for DocumentOperationType<'_> {
                     platform_version,
                 )
             }
+            DocumentOperationType::UpdateDocument {
+                owned_document_info,
+                contract_info,
+                document_type_info,
+            } => {
+                let mut drive_operations = vec![];
+                let contract_resolved_info = contract_info.resolve(
+                    drive,
+                    block_info,
+                    transaction,
+                    &mut drive_operations,
+                    platform_version,
+                )?;
+                let contract = contract_resolved_info.as_ref();
+                let document_type = document_type_info.resolve(contract)?;
+
+                let document_and_contract_info = DocumentAndContractInfo {
+                    owned_document_info,
+                    contract,
+                    document_type,
+                };
+                let mut operations = drive.update_document_for_contract_operations(
+                    document_and_contract_info,
+                    block_info,
+                    &mut None,
+                    estimated_costs_only_with_layer_info,
+                    transaction,
+                    platform_version,
+                )?;
+                drive_operations.append(&mut operations);
+                Ok(drive_operations)
+            }
             DocumentOperationType::DeleteDocument {
                 document_id,
                 contract_info,
                 document_type_info,
             } => {
                 let mut drive_operations: Vec<LowLevelDriveOperation> = vec![];
-                let contract_resolved_info = match contract_info {
-                    DataContractInfo::DataContractId(contract_id) => {
-                        let contract_fetch_info = drive
-                            .get_contract_with_fetch_info_and_add_to_operations(
-                                contract_id.into_buffer(),
-                                Some(&block_info.epoch),
-                                true,
-                                transaction,
-                                &mut drive_operations,
-                                platform_version,
-                            )?
-                            .ok_or(Error::Document(DocumentError::DataContractNotFound))?;
-                        DataContractResolvedInfo::DataContractFetchInfo(contract_fetch_info)
-                    }
-                    DataContractInfo::DataContractFetchInfo(contract_fetch_info) => {
-                        DataContractResolvedInfo::DataContractFetchInfo(contract_fetch_info)
-                    }
-                    DataContractInfo::BorrowedDataContract(contract) => {
-                        DataContractResolvedInfo::BorrowedDataContract(contract)
-                    }
-                    DataContractInfo::OwnedDataContract(contract) => {
-                        DataContractResolvedInfo::OwnedDataContract(contract)
-                    }
-                };
-
+                let contract_resolved_info = contract_info.resolve(
+                    drive,
+                    block_info,
+                    transaction,
+                    &mut drive_operations,
+                    platform_version,
+                )?;
                 let contract = contract_resolved_info.as_ref();
-
-                let document_type = match document_type_info {
-                    DocumentTypeInfo::DocumentTypeName(document_type_name) => contract
-                        .document_type_for_name(document_type_name.as_str())
-                        .map_err(ProtocolError::DataContractError)?,
-                    DocumentTypeInfo::DocumentTypeNameAsStr(document_type_name) => contract
-                        .document_type_for_name(document_type_name)
-                        .map_err(ProtocolError::DataContractError)?,
-                    DocumentTypeInfo::DocumentTypeRef(document_type_ref) => document_type_ref,
-                };
+                let document_type = document_type_info.resolve(contract)?;
 
                 drive.delete_document_for_contract_operations(
                     document_id,
                     contract,
                     document_type,
                     None,
-                    estimated_costs_only_with_layer_info,
-                    transaction,
-                    platform_version,
-                )
-            }
-            DocumentOperationType::UpdateSerializedDocumentForContract {
-                serialized_document,
-                contract,
-                document_type_name,
-                owner_id,
-                storage_flags,
-            } => {
-                let document_type = contract
-                    .document_type_for_name(document_type_name)
-                    .map_err(ProtocolError::DataContractError)?;
-
-                let document =
-                    Document::from_bytes(serialized_document, document_type, platform_version)?;
-
-                let document_info =
-                    DocumentRefAndSerialization((&document, serialized_document, storage_flags));
-
-                let document_and_contract_info = DocumentAndContractInfo {
-                    owned_document_info: OwnedDocumentInfo {
-                        document_info,
-                        owner_id,
-                    },
-                    contract,
-                    document_type,
-                };
-                drive.update_document_for_contract_operations(
-                    document_and_contract_info,
-                    block_info,
-                    &mut None,
-                    estimated_costs_only_with_layer_info,
-                    transaction,
-                    platform_version,
-                )
-            }
-            DocumentOperationType::UpdateDocumentForContract {
-                document,
-                serialized_document,
-                contract,
-                document_type_name,
-                owner_id,
-                storage_flags,
-            } => {
-                let document_info =
-                    DocumentRefAndSerialization((document, serialized_document, storage_flags));
-
-                let document_type = contract
-                    .document_type_for_name(document_type_name)
-                    .map_err(ProtocolError::DataContractError)?;
-
-                let document_and_contract_info = DocumentAndContractInfo {
-                    owned_document_info: OwnedDocumentInfo {
-                        document_info,
-                        owner_id,
-                    },
-                    contract,
-                    document_type,
-                };
-                drive.update_document_for_contract_operations(
-                    document_and_contract_info,
-                    block_info,
-                    &mut None,
                     estimated_costs_only_with_layer_info,
                     transaction,
                     platform_version,
@@ -409,45 +290,6 @@ impl DriveLowLevelOperationConverter for DocumentOperationType<'_> {
                         }
                     }
                 }
-                Ok(drive_operations)
-            }
-            DocumentOperationType::UpdateDocument {
-                owned_document_info,
-                contract_id,
-                document_type_name,
-            } => {
-                let mut drive_operations = vec![];
-                let contract_fetch_info = drive
-                    .get_contract_with_fetch_info_and_add_to_operations(
-                        contract_id.into_buffer(),
-                        Some(&block_info.epoch),
-                        true,
-                        transaction,
-                        &mut drive_operations,
-                        platform_version,
-                    )?
-                    .ok_or(Error::Document(DocumentError::DataContractNotFound))?;
-
-                let contract = &contract_fetch_info.contract;
-
-                let document_type = contract
-                    .document_type_for_name(document_type_name.as_str())
-                    .map_err(ProtocolError::DataContractError)?;
-
-                let document_and_contract_info = DocumentAndContractInfo {
-                    owned_document_info,
-                    contract,
-                    document_type,
-                };
-                let mut operations = drive.update_document_for_contract_operations(
-                    document_and_contract_info,
-                    block_info,
-                    &mut None,
-                    estimated_costs_only_with_layer_info,
-                    transaction,
-                    platform_version,
-                )?;
-                drive_operations.append(&mut operations);
                 Ok(drive_operations)
             }
         }

--- a/packages/rs-drive/src/drive/batch/drive_op_batch/mod.rs
+++ b/packages/rs-drive/src/drive/batch/drive_op_batch/mod.rs
@@ -203,13 +203,13 @@ mod tests {
         DocumentOperationsForContractDocumentType, UpdateOperationInfo,
     };
     use crate::drive::batch::DataContractOperationType::ApplyContract;
-    use crate::drive::batch::DocumentOperationType::AddDocumentForContract;
+    use crate::drive::batch::DocumentOperationType::AddDocument;
     use crate::drive::batch::DriveOperation::{DataContractOperation, DocumentOperation};
 
     use crate::drive::contract::paths::contract_root_path;
     use crate::drive::flags::StorageFlags;
     use crate::drive::object_size_info::DocumentInfo::DocumentRefInfo;
-    use crate::drive::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
+    use crate::drive::object_size_info::{DataContractInfo, DocumentTypeInfo, OwnedDocumentInfo};
     use crate::drive::Drive;
     use crate::tests::helpers::setup::setup_drive_with_initial_state_structure;
 
@@ -251,18 +251,16 @@ mod tests {
         )
         .expect("expected to get document");
 
-        drive_operations.push(DocumentOperation(AddDocumentForContract {
-            document_and_contract_info: DocumentAndContractInfo {
-                owned_document_info: OwnedDocumentInfo {
-                    document_info: DocumentRefInfo((
-                        &dashpay_cr_document,
-                        StorageFlags::optional_default_as_cow(),
-                    )),
-                    owner_id: None,
-                },
-                contract: &contract,
-                document_type,
+        drive_operations.push(DocumentOperation(AddDocument {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((
+                    &dashpay_cr_document,
+                    StorageFlags::optional_default_as_cow(),
+                )),
+                owner_id: None,
             },
+            contract_info: DataContractInfo::BorrowedDataContract(&contract),
+            document_type_info: DocumentTypeInfo::DocumentTypeRef(document_type),
             override_document: false,
         }));
 
@@ -354,17 +352,13 @@ mod tests {
         )
         .expect("expected to get contract");
 
-        drive_operations.push(DocumentOperation(AddDocumentForContract {
-            document_and_contract_info: DocumentAndContractInfo {
-                owned_document_info: OwnedDocumentInfo {
-                    document_info: DocumentRefInfo((&dashpay_cr_document, None)),
-                    owner_id: None,
-                },
-                contract: &contract,
-                document_type: contract
-                    .document_type_for_name("contactRequest")
-                    .expect("expected to get document type"),
+        drive_operations.push(DocumentOperation(AddDocument {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((&dashpay_cr_document, None)),
+                owner_id: None,
             },
+            contract_info: DataContractInfo::BorrowedDataContract(&contract),
+            document_type_info: DocumentTypeInfo::DocumentTypeNameAsStr("contactRequest"),
             override_document: false,
         }));
 
@@ -378,17 +372,13 @@ mod tests {
         )
         .expect("expected to get contract");
 
-        drive_operations.push(DocumentOperation(AddDocumentForContract {
-            document_and_contract_info: DocumentAndContractInfo {
-                owned_document_info: OwnedDocumentInfo {
-                    document_info: DocumentRefInfo((&dashpay_cr_1_document, None)),
-                    owner_id: None,
-                },
-                contract: &contract,
-                document_type: contract
-                    .document_type_for_name("contactRequest")
-                    .expect("expected to get document type"),
+        drive_operations.push(DocumentOperation(AddDocument {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((&dashpay_cr_1_document, None)),
+                owner_id: None,
             },
+            contract_info: DataContractInfo::BorrowedDataContract(&contract),
+            document_type_info: DocumentTypeInfo::DocumentTypeNameAsStr("contactRequest"),
             override_document: false,
         }));
 

--- a/packages/rs-drive/src/drive/batch/transitions/document/document_create_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/document/document_create_transition.rs
@@ -3,7 +3,7 @@ use crate::drive::batch::DriveOperation::{DocumentOperation, IdentityOperation};
 use crate::drive::batch::{DocumentOperationType, DriveOperation, IdentityOperationType};
 use crate::drive::flags::StorageFlags;
 use crate::drive::object_size_info::DocumentInfo::DocumentOwnedInfo;
-use crate::drive::object_size_info::OwnedDocumentInfo;
+use crate::drive::object_size_info::{DocumentTypeInfo, OwnedDocumentInfo};
 use crate::error::Error;
 use dpp::block::epoch::Epoch;
 
@@ -13,6 +13,7 @@ use std::borrow::Cow;
 use crate::state_transition_action::document::documents_batch::document_transition::document_base_transition_action::DocumentBaseTransitionActionAccessorsV0;
 use crate::state_transition_action::document::documents_batch::document_transition::document_create_transition_action::{DocumentCreateTransitionAction, DocumentCreateTransitionActionAccessorsV0, DocumentFromCreateTransitionAction};
 use dpp::version::PlatformVersion;
+use crate::drive::object_size_info::DataContractInfo::DataContractFetchInfo;
 
 impl DriveHighLevelDocumentOperationConverter for DocumentCreateTransitionAction {
     fn into_high_level_document_drive_operations<'b>(
@@ -22,6 +23,8 @@ impl DriveHighLevelDocumentOperationConverter for DocumentCreateTransitionAction
         platform_version: &PlatformVersion,
     ) -> Result<Vec<DriveOperation<'b>>, Error> {
         let data_contract_id = self.base().data_contract_id();
+
+        let contract_fetch_info = self.base().data_contract_fetch_info();
 
         let document_type_name = self.base().document_type_name().clone();
 
@@ -43,8 +46,8 @@ impl DriveHighLevelDocumentOperationConverter for DocumentCreateTransitionAction
                     document_info: DocumentOwnedInfo((document, Some(Cow::Owned(storage_flags)))),
                     owner_id: Some(owner_id.into_buffer()),
                 },
-                contract_id: data_contract_id,
-                document_type_name: Cow::Owned(document_type_name),
+                contract_info: DataContractFetchInfo(contract_fetch_info),
+                document_type_info: DocumentTypeInfo::DocumentTypeName(document_type_name),
                 override_document: false,
             }),
         ])

--- a/packages/rs-drive/src/drive/batch/transitions/document/document_delete_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/document/document_delete_transition.rs
@@ -7,11 +7,11 @@ use crate::error::Error;
 use dpp::block::epoch::Epoch;
 
 use dpp::identifier::Identifier;
-use std::borrow::Cow;
 use crate::state_transition_action::document::documents_batch::document_transition::document_base_transition_action::DocumentBaseTransitionActionAccessorsV0;
 use crate::state_transition_action::document::documents_batch::document_transition::document_delete_transition_action::DocumentDeleteTransitionAction;
 use crate::state_transition_action::document::documents_batch::document_transition::document_delete_transition_action::v0::DocumentDeleteTransitionActionAccessorsV0;
 use dpp::version::PlatformVersion;
+use crate::drive::object_size_info::{DataContractInfo, DocumentTypeInfo};
 
 impl DriveHighLevelDocumentOperationConverter for DocumentDeleteTransitionAction {
     fn into_high_level_document_drive_operations<'b>(
@@ -32,13 +32,15 @@ impl DriveHighLevelDocumentOperationConverter for DocumentDeleteTransitionAction
                 contract_id: data_contract_id.into_buffer(),
                 nonce: identity_contract_nonce,
             }),
-            DocumentOperation(
-                DocumentOperationType::DeleteDocumentOfNamedTypeForContractId {
-                    document_id: base.id().to_buffer(),
-                    contract_id: base.data_contract_id().to_buffer(),
-                    document_type_name: Cow::Owned(base.document_type_name_owned()),
-                },
-            ),
+            DocumentOperation(DocumentOperationType::DeleteDocument {
+                document_id: base.id(),
+                contract_info: DataContractInfo::DataContractFetchInfo(
+                    base.data_contract_fetch_info(),
+                ),
+                document_type_info: DocumentTypeInfo::DocumentTypeName(
+                    base.document_type_name_owned(),
+                ),
+            }),
         ])
     }
 }

--- a/packages/rs-drive/src/drive/batch/transitions/document/document_purchase_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/document/document_purchase_transition.rs
@@ -3,7 +3,7 @@ use crate::drive::batch::DriveOperation::{DocumentOperation, IdentityOperation};
 use crate::drive::batch::{DocumentOperationType, DriveOperation, IdentityOperationType};
 use crate::drive::flags::StorageFlags;
 use crate::drive::object_size_info::DocumentInfo::DocumentOwnedInfo;
-use crate::drive::object_size_info::OwnedDocumentInfo;
+use crate::drive::object_size_info::{DataContractInfo, DocumentTypeInfo, OwnedDocumentInfo};
 use crate::error::Error;
 use dpp::block::epoch::Epoch;
 
@@ -25,6 +25,7 @@ impl DriveHighLevelDocumentOperationConverter for DocumentPurchaseTransitionActi
         let identity_contract_nonce = self.base().identity_contract_nonce();
         let original_owner_id = self.original_owner_id();
         let purchase_amount = self.price();
+        let contract_fetch_info = self.base().data_contract_fetch_info();
         let document = self.document_owned();
 
         // we are purchasing the document so the new storage flags should be on the new owner
@@ -45,8 +46,8 @@ impl DriveHighLevelDocumentOperationConverter for DocumentPurchaseTransitionActi
                     document_info: DocumentOwnedInfo((document, Some(Cow::Owned(storage_flags)))),
                     owner_id: Some(new_document_owner_id.into_buffer()),
                 },
-                contract_id: data_contract_id,
-                document_type_name: Cow::Owned(document_type_name),
+                contract_info: DataContractInfo::DataContractFetchInfo(contract_fetch_info),
+                document_type_info: DocumentTypeInfo::DocumentTypeName(document_type_name),
             }),
             IdentityOperation(IdentityOperationType::RemoveFromIdentityBalance {
                 identity_id: owner_id.to_buffer(),

--- a/packages/rs-drive/src/drive/batch/transitions/document/document_replace_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/document/document_replace_transition.rs
@@ -3,7 +3,7 @@ use crate::drive::batch::DriveOperation::{DocumentOperation, IdentityOperation};
 use crate::drive::batch::{DocumentOperationType, DriveOperation, IdentityOperationType};
 use crate::drive::flags::StorageFlags;
 use crate::drive::object_size_info::DocumentInfo::DocumentOwnedInfo;
-use crate::drive::object_size_info::OwnedDocumentInfo;
+use crate::drive::object_size_info::{DataContractInfo, DocumentTypeInfo, OwnedDocumentInfo};
 use crate::error::Error;
 use dpp::block::epoch::Epoch;
 
@@ -24,6 +24,7 @@ impl DriveHighLevelDocumentOperationConverter for DocumentReplaceTransitionActio
         let data_contract_id = self.base().data_contract_id();
         let document_type_name = self.base().document_type_name().clone();
         let identity_contract_nonce = self.base().identity_contract_nonce();
+        let contract_fetch_info = self.base().data_contract_fetch_info();
         let document =
             Document::try_from_owned_replace_transition_action(self, owner_id, platform_version)?;
 
@@ -40,8 +41,8 @@ impl DriveHighLevelDocumentOperationConverter for DocumentReplaceTransitionActio
                     document_info: DocumentOwnedInfo((document, Some(Cow::Owned(storage_flags)))),
                     owner_id: Some(owner_id.into_buffer()),
                 },
-                contract_id: data_contract_id,
-                document_type_name: Cow::Owned(document_type_name),
+                contract_info: DataContractInfo::DataContractFetchInfo(contract_fetch_info),
+                document_type_info: DocumentTypeInfo::DocumentTypeName(document_type_name),
             }),
         ])
     }

--- a/packages/rs-drive/src/drive/batch/transitions/document/document_transfer_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/document/document_transfer_transition.rs
@@ -3,7 +3,7 @@ use crate::drive::batch::DriveOperation::{DocumentOperation, IdentityOperation};
 use crate::drive::batch::{DocumentOperationType, DriveOperation, IdentityOperationType};
 use crate::drive::flags::StorageFlags;
 use crate::drive::object_size_info::DocumentInfo::DocumentOwnedInfo;
-use crate::drive::object_size_info::OwnedDocumentInfo;
+use crate::drive::object_size_info::{DataContractInfo, DocumentTypeInfo, OwnedDocumentInfo};
 use crate::error::Error;
 use dpp::block::epoch::Epoch;
 
@@ -24,6 +24,7 @@ impl DriveHighLevelDocumentOperationConverter for DocumentTransferTransitionActi
         let data_contract_id = self.base().data_contract_id();
         let document_type_name = self.base().document_type_name().clone();
         let identity_contract_nonce = self.base().identity_contract_nonce();
+        let contract_fetch_info = self.base().data_contract_fetch_info();
         let document = self.document_owned();
 
         // we are transferring the document so the new storage flags should be on the new owner
@@ -44,8 +45,8 @@ impl DriveHighLevelDocumentOperationConverter for DocumentTransferTransitionActi
                     document_info: DocumentOwnedInfo((document, Some(Cow::Owned(storage_flags)))),
                     owner_id: Some(new_document_owner_id.into_buffer()),
                 },
-                contract_id: data_contract_id,
-                document_type_name: Cow::Owned(document_type_name),
+                contract_info: DataContractInfo::DataContractFetchInfo(contract_fetch_info),
+                document_type_info: DocumentTypeInfo::DocumentTypeName(document_type_name),
             }),
         ])
     }

--- a/packages/rs-drive/src/drive/batch/transitions/document/document_update_price_transition.rs
+++ b/packages/rs-drive/src/drive/batch/transitions/document/document_update_price_transition.rs
@@ -3,7 +3,7 @@ use crate::drive::batch::DriveOperation::{DocumentOperation, IdentityOperation};
 use crate::drive::batch::{DocumentOperationType, DriveOperation, IdentityOperationType};
 use crate::drive::flags::StorageFlags;
 use crate::drive::object_size_info::DocumentInfo::DocumentOwnedInfo;
-use crate::drive::object_size_info::OwnedDocumentInfo;
+use crate::drive::object_size_info::{DataContractInfo, DocumentTypeInfo, OwnedDocumentInfo};
 use crate::error::Error;
 use dpp::block::epoch::Epoch;
 
@@ -23,6 +23,7 @@ impl DriveHighLevelDocumentOperationConverter for DocumentUpdatePriceTransitionA
         let data_contract_id = self.base().data_contract_id();
         let document_type_name = self.base().document_type_name().clone();
         let identity_contract_nonce = self.base().identity_contract_nonce();
+        let fetch_info = self.base().data_contract_fetch_info();
         let document = self.document_owned();
 
         let storage_flags = StorageFlags::new_single_epoch(epoch.index, Some(owner_id.to_buffer()));
@@ -38,8 +39,8 @@ impl DriveHighLevelDocumentOperationConverter for DocumentUpdatePriceTransitionA
                     document_info: DocumentOwnedInfo((document, Some(Cow::Owned(storage_flags)))),
                     owner_id: Some(owner_id.into_buffer()),
                 },
-                contract_id: data_contract_id,
-                document_type_name: Cow::Owned(document_type_name),
+                contract_info: DataContractInfo::DataContractFetchInfo(fetch_info),
+                document_type_info: DocumentTypeInfo::DocumentTypeName(document_type_name),
             }),
         ])
     }

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract/mod.rs
@@ -10,6 +10,7 @@ use dpp::fee::fee_result::FeeResult;
 
 use dpp::version::PlatformVersion;
 
+use dpp::identifier::Identifier;
 use grovedb::TransactionArg;
 
 impl Drive {
@@ -30,7 +31,7 @@ impl Drive {
     /// * `Err(DriveError::UnknownVersionMismatch)` if the drive version does not match known versions.
     pub fn delete_document_for_contract(
         &self,
-        document_id: [u8; 32],
+        document_id: Identifier,
         contract: &DataContract,
         document_type_name: &str,
         block_info: BlockInfo,

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract/v0/mod.rs
@@ -5,6 +5,7 @@ use dpp::block::block_info::BlockInfo;
 use dpp::data_contract::DataContract;
 use dpp::fee::fee_result::FeeResult;
 
+use dpp::identifier::Identifier;
 use dpp::version::PlatformVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -15,7 +16,7 @@ impl Drive {
     #[inline(always)]
     pub(super) fn delete_document_for_contract_v0(
         &self,
-        document_id: [u8; 32],
+        document_id: Identifier,
         contract: &DataContract,
         document_type_name: &str,
         block_info: BlockInfo,

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_apply_and_add_to_operations/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_apply_and_add_to_operations/mod.rs
@@ -6,6 +6,7 @@ use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 use dpp::data_contract::DataContract;
 
+use dpp::identifier::Identifier;
 use dpp::version::PlatformVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -29,7 +30,7 @@ impl Drive {
     /// * `Err(DriveError::UnknownVersionMismatch)` if the drive version does not match known versions.
     pub fn delete_document_for_contract_apply_and_add_to_operations(
         &self,
-        document_id: [u8; 32],
+        document_id: Identifier,
         contract: &DataContract,
         document_type_name: &str,
         estimated_costs_only_with_layer_info: Option<

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_apply_and_add_to_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_apply_and_add_to_operations/v0/mod.rs
@@ -3,6 +3,7 @@ use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 use dpp::data_contract::DataContract;
 
+use dpp::identifier::Identifier;
 use dpp::version::PlatformVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -13,7 +14,7 @@ impl Drive {
     #[inline(always)]
     pub(super) fn delete_document_for_contract_apply_and_add_to_operations_v0(
         &self,
-        document_id: [u8; 32],
+        document_id: Identifier,
         contract: &DataContract,
         document_type_name: &str,
         mut estimated_costs_only_with_layer_info: Option<

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_id/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_id/mod.rs
@@ -11,6 +11,7 @@ use crate::error::drive::DriveError;
 use crate::error::Error;
 
 use dpp::fee::fee_result::FeeResult;
+use dpp::identifier::Identifier;
 
 use dpp::version::PlatformVersion;
 
@@ -33,8 +34,8 @@ impl Drive {
     /// * `Err(DriveError::UnknownVersionMismatch)` if the drive version does not match known versions.
     pub fn delete_document_for_contract_id(
         &self,
-        document_id: [u8; 32],
-        contract_id: [u8; 32],
+        document_id: Identifier,
+        contract_id: Identifier,
         document_type_name: &str,
         block_info: BlockInfo,
         apply: bool,

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_id/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_id/v0/mod.rs
@@ -13,6 +13,7 @@ use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 
 use dpp::fee::fee_result::FeeResult;
+use dpp::identifier::Identifier;
 
 use dpp::version::PlatformVersion;
 
@@ -22,8 +23,8 @@ impl Drive {
     #[inline(always)]
     pub(super) fn delete_document_for_contract_id_v0(
         &self,
-        document_id: [u8; 32],
-        contract_id: [u8; 32],
+        document_id: Identifier,
+        contract_id: Identifier,
         document_type_name: &str,
         block_info: BlockInfo,
         apply: bool,
@@ -39,7 +40,7 @@ impl Drive {
 
         let contract_fetch_info = self
             .get_contract_with_fetch_info_and_add_to_operations(
-                contract_id,
+                contract_id.to_buffer(),
                 Some(&block_info.epoch),
                 true,
                 transaction,

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_id_with_named_type_operations/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_id_with_named_type_operations/mod.rs
@@ -6,6 +6,7 @@ use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 use dpp::block::epoch::Epoch;
 
+use dpp::identifier::Identifier;
 use dpp::version::PlatformVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -30,8 +31,8 @@ impl Drive {
     /// * `Err(DriveError::UnknownVersionMismatch)` if the drive version does not match known versions.
     pub fn delete_document_for_contract_id_with_named_type_operations(
         &self,
-        document_id: [u8; 32],
-        contract_id: [u8; 32],
+        document_id: Identifier,
+        contract_id: Identifier,
         document_type_name: &str,
         epoch: &Epoch,
         previous_batch_operations: Option<&mut Vec<LowLevelDriveOperation>>,

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_id_with_named_type_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_id_with_named_type_operations/v0/mod.rs
@@ -12,6 +12,7 @@ use crate::fee::op::LowLevelDriveOperation;
 
 use dpp::block::epoch::Epoch;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::identifier::Identifier;
 
 use dpp::version::PlatformVersion;
 
@@ -20,8 +21,8 @@ impl Drive {
     #[inline(always)]
     pub(super) fn delete_document_for_contract_id_with_named_type_operations_v0(
         &self,
-        document_id: [u8; 32],
-        contract_id: [u8; 32],
+        document_id: Identifier,
+        contract_id: Identifier,
         document_type_name: &str,
         epoch: &Epoch,
         previous_batch_operations: Option<&mut Vec<LowLevelDriveOperation>>,
@@ -33,7 +34,7 @@ impl Drive {
     ) -> Result<Vec<LowLevelDriveOperation>, Error> {
         let mut operations = vec![];
         let Some(contract_fetch_info) = self.get_contract_with_fetch_info_and_add_to_operations(
-            contract_id,
+            contract_id.to_buffer(),
             Some(epoch),
             true,
             transaction,

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_operations/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_operations/mod.rs
@@ -8,6 +8,7 @@ use crate::fee::op::LowLevelDriveOperation;
 use dpp::data_contract::document_type::DocumentTypeRef;
 use dpp::data_contract::DataContract;
 
+use dpp::identifier::Identifier;
 use dpp::version::PlatformVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -30,7 +31,7 @@ impl Drive {
     /// * `Err(DriveError::UnknownVersionMismatch)` if the drive version does not match known versions.
     pub(crate) fn delete_document_for_contract_operations(
         &self,
-        document_id: [u8; 32],
+        document_id: Identifier,
         contract: &DataContract,
         document_type: DocumentTypeRef,
         previous_batch_operations: Option<&mut Vec<LowLevelDriveOperation>>,

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_operations/v0/mod.rs
@@ -29,6 +29,7 @@ use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
 use dpp::document::serialization_traits::DocumentPlatformConversionMethodsV0;
+use dpp::identifier::Identifier;
 
 use dpp::version::PlatformVersion;
 
@@ -37,7 +38,7 @@ impl Drive {
     #[inline(always)]
     pub(super) fn delete_document_for_contract_operations_v0(
         &self,
-        document_id: [u8; 32],
+        document_id: Identifier,
         contract: &DataContract,
         document_type: DocumentTypeRef,
         previous_batch_operations: Option<&mut Vec<LowLevelDriveOperation>>,

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_with_named_type_operations/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_with_named_type_operations/mod.rs
@@ -7,6 +7,7 @@ use crate::fee::op::LowLevelDriveOperation;
 
 use dpp::data_contract::DataContract;
 
+use dpp::identifier::Identifier;
 use dpp::version::PlatformVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -29,7 +30,7 @@ impl Drive {
     /// * `Err(DriveError::UnknownVersionMismatch)` if the drive version does not match known versions.
     pub(crate) fn delete_document_for_contract_with_named_type_operations(
         &self,
-        document_id: [u8; 32],
+        document_id: Identifier,
         contract: &DataContract,
         document_type_name: &str,
         previous_batch_operations: Option<&mut Vec<LowLevelDriveOperation>>,

--- a/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_with_named_type_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/delete_document_for_contract_with_named_type_operations/v0/mod.rs
@@ -12,6 +12,7 @@ use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::identifier::Identifier;
 
 use dpp::version::PlatformVersion;
 
@@ -20,7 +21,7 @@ impl Drive {
     #[inline(always)]
     pub(super) fn delete_document_for_contract_with_named_type_operations_v0(
         &self,
-        document_id: [u8; 32],
+        document_id: Identifier,
         contract: &DataContract,
         document_type_name: &str,
         previous_batch_operations: Option<&mut Vec<LowLevelDriveOperation>>,

--- a/packages/rs-drive/src/drive/document/delete/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/mod.rs
@@ -1,32 +1,3 @@
-// MIT LICENSE
-//
-// Copyright (c) 2021 Dash Core Group
-//
-// Permission is hereby granted, free of charge, to any
-// person obtaining a copy of this software and associated
-// documentation files (the "Software"), to deal in the
-// Software without restriction, including without
-// limitation the rights to use, copy, modify, merge,
-// publish, distribute, sublicense, and/or sell copies of
-// the Software, and to permit persons to whom the Software
-// is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice
-// shall be included in all copies or substantial portions
-// of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-// DEALINGS IN THE SOFTWARE.
-//
-
 //! Delete Documents.
 //!
 //! This module implements functions in Drive for deleting documents.

--- a/packages/rs-drive/src/drive/document/delete/remove_document_from_primary_storage/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/remove_document_from_primary_storage/mod.rs
@@ -6,6 +6,7 @@ use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 use dpp::data_contract::document_type::DocumentTypeRef;
 
+use dpp::identifier::Identifier;
 use dpp::version::PlatformVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -28,7 +29,7 @@ impl Drive {
     /// * `Err(DriveError::UnknownVersionMismatch)` if the drive version does not match known versions.
     pub(in crate::drive::document) fn remove_document_from_primary_storage(
         &self,
-        document_id: [u8; 32],
+        document_id: Identifier,
         document_type: DocumentTypeRef,
         contract_documents_primary_key_path: [&[u8]; 5],
         estimated_costs_only_with_layer_info: &mut Option<

--- a/packages/rs-drive/src/drive/document/delete/remove_document_from_primary_storage/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/remove_document_from_primary_storage/v0/mod.rs
@@ -16,6 +16,7 @@ use crate::error::Error;
 use crate::fee::op::LowLevelDriveOperation;
 
 use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
+use dpp::identifier::Identifier;
 
 use dpp::version::PlatformVersion;
 
@@ -24,7 +25,7 @@ impl Drive {
     #[inline(always)]
     pub(super) fn remove_document_from_primary_storage_v0(
         &self,
-        document_id: [u8; 32],
+        document_id: Identifier,
         document_type: DocumentTypeRef,
         contract_documents_primary_key_path: [&[u8]; 5],
         estimated_costs_only_with_layer_info: &mut Option<

--- a/packages/rs-drive/src/drive/document/update/mod.rs
+++ b/packages/rs-drive/src/drive/document/update/mod.rs
@@ -456,7 +456,7 @@ mod tests {
 
         drive
             .delete_document_for_contract(
-                document.id().to_buffer(),
+                document.id(),
                 &contract,
                 "profile",
                 BlockInfo::default(),
@@ -1641,7 +1641,7 @@ mod tests {
     ) -> FeeResult {
         drive
             .delete_document_for_contract(
-                person.id.to_buffer(),
+                person.id,
                 contract,
                 "person",
                 block_info,

--- a/packages/rs-drive/src/drive/object_size_info/contract_info.rs
+++ b/packages/rs-drive/src/drive/object_size_info/contract_info.rs
@@ -1,0 +1,70 @@
+use crate::drive::contract::DataContractFetchInfo;
+use dpp::data_contract::document_type::DocumentTypeRef;
+use dpp::data_contract::DataContract;
+use dpp::identifier::Identifier;
+use std::sync::Arc;
+
+/// Represents various forms of accessing or representing a data contract.
+/// This enum is used to handle different scenarios in which data contracts
+/// might be needed, providing a unified interface to access their data.
+#[derive(Clone, Debug)]
+pub enum DataContractInfo<'a> {
+    /// A unique identifier for a data contract. This variant is typically used
+    /// when only the identity of the data contract is required without needing
+    /// to access the full contract itself.
+    DataContractId(Identifier),
+
+    /// Information necessary for fetching a data contract, encapsulated in an
+    /// `Arc` for thread-safe shared ownership. This variant is used when the
+    /// data needs to be fetched or is not immediately available.
+    DataContractFetchInfo(Arc<DataContractFetchInfo>),
+
+    /// A borrowed reference to a data contract. This variant is used for temporary,
+    /// read-only access to a data contract, avoiding ownership transfer.
+    BorrowedDataContract(&'a DataContract),
+
+    /// An owned version of a data contract. This variant is used when full ownership
+    /// and possibly mutability of the data contract is necessary.
+    OwnedDataContract(DataContract),
+}
+
+/// Contains resolved data contract information, typically used after initial
+/// fetching or retrieval steps have been completed. This enum simplifies handling
+/// of data contract states post-retrieval.
+#[derive(Clone, Debug)]
+pub(crate) enum DataContractResolvedInfo<'a> {
+    /// Information necessary for fetched data contracts, encapsulated in an
+    /// `Arc` to ensure thread-safe shared ownership and access.
+    DataContractFetchInfo(Arc<DataContractFetchInfo>),
+
+    /// A borrowed reference to a resolved data contract. This variant is suitable
+    /// for scenarios where temporary, read-only access to a data contract is required.
+    BorrowedDataContract(&'a DataContract),
+
+    /// An owned instance of a data contract. This variant provides full control
+    /// and mutability over the data contract, suitable for scenarios requiring
+    /// modifications or extended operations on the data contract.
+    OwnedDataContract(DataContract),
+}
+impl<'a> AsRef<DataContract> for DataContractResolvedInfo<'a> {
+    fn as_ref(&self) -> &DataContract {
+        match self {
+            DataContractResolvedInfo::DataContractFetchInfo(fetch_info) => &fetch_info.contract,
+            DataContractResolvedInfo::BorrowedDataContract(borrowed) => borrowed,
+            DataContractResolvedInfo::OwnedDataContract(owned) => owned,
+        }
+    }
+}
+
+/// Enumerates methods for identifying or referencing document types, accommodating various application needs.
+#[derive(Clone, Debug)]
+pub enum DocumentTypeInfo<'a> {
+    /// Contains the document type name as an owned `String`, suitable for dynamic or mutable scenarios.
+    DocumentTypeName(String),
+
+    /// References the document type name via a borrowed `&'a str`, ideal for static or temporary usage.
+    DocumentTypeNameAsStr(&'a str),
+
+    /// References a document type that has already been resolved through `DocumentTypeRef`.
+    DocumentTypeRef(DocumentTypeRef<'a>),
+}

--- a/packages/rs-drive/src/drive/object_size_info/mod.rs
+++ b/packages/rs-drive/src/drive/object_size_info/mod.rs
@@ -1,37 +1,9 @@
-// MIT LICENSE
-//
-// Copyright (c) 2021 Dash Core Group
-//
-// Permission is hereby granted, free of charge, to any
-// person obtaining a copy of this software and associated
-// documentation files (the "Software"), to deal in the
-// Software without restriction, including without
-// limitation the rights to use, copy, modify, merge,
-// publish, distribute, sublicense, and/or sell copies of
-// the Software, and to permit persons to whom the Software
-// is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice
-// shall be included in all copies or substantial portions
-// of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-// DEALINGS IN THE SOFTWARE.
-//
-
 //! Object Size Info
 //!
 //! This module defines enums and implements functions relevant to the sizes of objects.
 //!
 
+mod contract_info;
 mod deletion_info;
 mod document_and_contract_info;
 mod document_info;
@@ -44,6 +16,7 @@ mod path_info;
 mod path_key_element_info;
 mod path_key_info;
 
+pub use contract_info::*;
 pub use deletion_info::*;
 pub use document_and_contract_info::*;
 pub use document_info::*;

--- a/packages/rs-sdk/src/platform/fetch_many.rs
+++ b/packages/rs-sdk/src/platform/fetch_many.rs
@@ -21,7 +21,7 @@ use dpp::block::epoch::EpochIndex;
 use dpp::block::extended_epoch_info::ExtendedEpochInfo;
 use dpp::data_contract::DataContract;
 use dpp::document::Document;
-use dpp::identity::{KeyID, Purpose};
+use dpp::identity::KeyID;
 use dpp::prelude::{Identifier, IdentityPublicKey};
 use dpp::util::deserializer::ProtocolVersion;
 use dpp::version::ProtocolVersionVoteCount;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Document creation, update and deletion all told drive about the contract by setting the contract id. Drive would then refetch the contract from disk.

Even though most of the time it would fetch it from cache, this still was not ideal, because the processing cost of a fetch from cache is the same as a fetch from disk.

## What was done?
A new type was created that encapsulates all types on data contract info, and we made the document operations in drive more straightforward hiding away most of the complexity. Now there are just a single operation allowed for adding, updating, or deleting.

## How Has This Been Tested?
Tests continue to pass.


## Breaking Changes
Since we no longer fetch the contract in drive, drive will report less processing costs, this means that this is a breaking change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [X] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
