### PR TITLE
fix(dashmate): increase tenderdash tx gossip rate limit

### DIFF
--- a/packages/dashmate/configs/defaults/getTestnetConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getTestnetConfigFactory.js
@@ -82,8 +82,8 @@ export default function getTestnetConfigFactory(homeDir, getBaseConfig) {
             mempool: {
               timeoutCheckTx: '1s',
               txEnqueueTimeout: '10ms',
-              txSendRateLimit: 10,
-              txRecvRateLimit: 12,
+              txSendRateLimit: 100,
+              txRecvRateLimit: 120,
             },
             rpc: {
               port: 36657,

--- a/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
+++ b/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
@@ -374,12 +374,6 @@ tx-send-rate-limit = {{=it.platform.drive.tenderdash.mempool.txSendRateLimit}}
 # Default: 0
 tx-recv-rate-limit = {{=it.platform.drive.tenderdash.mempool.txRecvRateLimit}}
 
-# tx-recv-rate-punish-peer set to true means that when tx-recv-rate-limit is reached, the peer will be punished
-# (disconnected). If set to false, the peer will be throttled (messages will be dropped).
-#
-# Default: false
-tx-recv-rate-punish-peer = false
-
 # Maximum size of a single transaction.
 # NOTE: the max size of a tx transmitted over the network is {max-tx-bytes}.
 max-tx-bytes = 50000


### PR DESCRIPTION
## Issue being fixed or feature implemented

Current limit of transaction gossip in Tenderdash is set to 10 txs/sec (outgoing) and 12 txs/sec (incoming).
This is too low, as this limit is shared between all connected peers.

As a result, mempool on non-validators is processed very very slowly, and validators that don't receive txs directly thourgh REST interface produce very small blocks. 

This can be seen also as the network producing blocks within very small interval after end of load tests, giving a (false) impression that `create-empty-blocks-interval` config option is ignored.

## What was done?

In this PR, we change this limit to 100 txs/sec (outgoing) and 120 txs/sec (incoming).

## How Has This Been Tested?

Did the change manually on testnet and checked that it works.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
