### PR TITLE
refactor: rename `validate` to `full_validation`

### DIFF
--- a/packages/rs-dpp/src/data_contract/conversion/cbor/mod.rs
+++ b/packages/rs-dpp/src/data_contract/conversion/cbor/mod.rs
@@ -12,7 +12,7 @@ impl DataContractCborConversionMethodsV0 for DataContract {
     fn from_cbor_with_id(
         cbor_bytes: impl AsRef<[u8]>,
         contract_id: Option<Identifier>,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         match platform_version
@@ -23,7 +23,7 @@ impl DataContractCborConversionMethodsV0 for DataContract {
             0 => Ok(DataContractV0::from_cbor_with_id(
                 cbor_bytes,
                 contract_id,
-                validate,
+                full_validation,
                 platform_version,
             )?
             .into()),
@@ -37,7 +37,7 @@ impl DataContractCborConversionMethodsV0 for DataContract {
 
     fn from_cbor(
         cbor_bytes: impl AsRef<[u8]>,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         match platform_version
@@ -45,7 +45,9 @@ impl DataContractCborConversionMethodsV0 for DataContract {
             .contract_versions
             .contract_structure_version
         {
-            0 => Ok(DataContractV0::from_cbor(cbor_bytes, validate, platform_version)?.into()),
+            0 => Ok(
+                DataContractV0::from_cbor(cbor_bytes, full_validation, platform_version)?.into(),
+            ),
             version => Err(ProtocolError::UnknownVersionMismatch {
                 method: "DataContract::from_cbor".to_string(),
                 known_versions: vec![0],

--- a/packages/rs-dpp/src/data_contract/conversion/cbor/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/conversion/cbor/v0/mod.rs
@@ -7,14 +7,14 @@ pub trait DataContractCborConversionMethodsV0 {
     fn from_cbor_with_id(
         cbor_bytes: impl AsRef<[u8]>,
         contract_id: Option<Identifier>,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where
         Self: Sized;
     fn from_cbor(
         cbor_bytes: impl AsRef<[u8]>,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where

--- a/packages/rs-dpp/src/data_contract/conversion/json/mod.rs
+++ b/packages/rs-dpp/src/data_contract/conversion/json/mod.rs
@@ -10,7 +10,7 @@ use serde_json::Value as JsonValue;
 impl DataContractJsonConversionMethodsV0 for DataContract {
     fn from_json(
         json_value: JsonValue,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where
@@ -21,7 +21,9 @@ impl DataContractJsonConversionMethodsV0 for DataContract {
             .contract_versions
             .contract_structure_version
         {
-            0 => Ok(DataContractV0::from_json(json_value, validate, platform_version)?.into()),
+            0 => Ok(
+                DataContractV0::from_json(json_value, full_validation, platform_version)?.into(),
+            ),
             version => Err(ProtocolError::UnknownVersionMismatch {
                 method: "DataContract::from_json_object".to_string(),
                 known_versions: vec![0],

--- a/packages/rs-dpp/src/data_contract/conversion/json/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/conversion/json/v0/mod.rs
@@ -5,7 +5,7 @@ use serde_json::Value as JsonValue;
 pub trait DataContractJsonConversionMethodsV0 {
     fn from_json(
         json_value: JsonValue,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where

--- a/packages/rs-dpp/src/data_contract/conversion/value/mod.rs
+++ b/packages/rs-dpp/src/data_contract/conversion/value/mod.rs
@@ -10,7 +10,7 @@ use platform_value::Value;
 impl DataContractValueConversionMethodsV0 for DataContract {
     fn from_value(
         raw_object: Value,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         match platform_version
@@ -18,7 +18,9 @@ impl DataContractValueConversionMethodsV0 for DataContract {
             .contract_versions
             .contract_structure_version
         {
-            0 => Ok(DataContractV0::from_value(raw_object, validate, platform_version)?.into()),
+            0 => Ok(
+                DataContractV0::from_value(raw_object, full_validation, platform_version)?.into(),
+            ),
             version => Err(ProtocolError::UnknownVersionMismatch {
                 method: "DataContract::from_object".to_string(),
                 known_versions: vec![0],

--- a/packages/rs-dpp/src/data_contract/conversion/value/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/conversion/value/v0/mod.rs
@@ -5,7 +5,7 @@ use platform_value::Value;
 pub trait DataContractValueConversionMethodsV0 {
     fn from_value(
         raw_object: Value,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where

--- a/packages/rs-dpp/src/data_contract/created_data_contract/mod.rs
+++ b/packages/rs-dpp/src/data_contract/created_data_contract/mod.rs
@@ -82,7 +82,7 @@ impl PlatformSerializableWithPlatformVersion for CreatedDataContract {
 impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for CreatedDataContract {
     fn versioned_deserialize(
         data: &[u8],
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where
@@ -104,7 +104,7 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Cre
             created_data_contract_in_serialization_format.data_contract_and_identity_nonce_owned();
         let data_contract = DataContract::try_from_platform_versioned(
             data_contract_in_serialization_format,
-            validate,
+            full_validation,
             &mut vec![],
             platform_version,
         )?;
@@ -198,7 +198,7 @@ impl CreatedDataContract {
     #[cfg(feature = "data-contract-value-conversion")]
     pub fn from_object(
         raw_object: Value,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         match platform_version
@@ -206,9 +206,12 @@ impl CreatedDataContract {
             .contract_versions
             .created_data_contract_structure
         {
-            0 => Ok(
-                CreatedDataContractV0::from_object(raw_object, validate, platform_version)?.into(),
-            ),
+            0 => Ok(CreatedDataContractV0::from_object(
+                raw_object,
+                full_validation,
+                platform_version,
+            )?
+            .into()),
             version => Err(ProtocolError::UnknownVersionMismatch {
                 method: "CreatedDataContract::from_object".to_string(),
                 known_versions: vec![0],

--- a/packages/rs-dpp/src/data_contract/created_data_contract/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/created_data_contract/v0/mod.rs
@@ -32,7 +32,7 @@ impl CreatedDataContractV0 {
     #[cfg(feature = "data-contract-value-conversion")]
     pub fn from_object(
         raw_object: Value,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         let mut raw_map = raw_object
@@ -48,7 +48,7 @@ impl CreatedDataContractV0 {
             .map_err(ProtocolError::ValueError)?;
 
         let data_contract =
-            DataContract::from_value(raw_data_contract, validate, platform_version)?;
+            DataContract::from_value(raw_data_contract, full_validation, platform_version)?;
 
         Ok(Self {
             data_contract,

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/create_document_types_from_document_schemas/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/create_document_types_from_document_schemas/mod.rs
@@ -40,7 +40,7 @@ impl DocumentType {
         documents_keep_history_contract_default: bool,
         documents_mutable_contract_default: bool,
         documents_can_be_deleted_contract_default: bool,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<BTreeMap<String, DocumentType>, ProtocolError> {
@@ -58,7 +58,7 @@ impl DocumentType {
                 documents_keep_history_contract_default,
                 documents_mutable_contract_default,
                 documents_can_be_deleted_contract_default,
-                validate,
+                full_validation,
                 validation_operations,
                 platform_version,
             ),

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/create_document_types_from_document_schemas/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/create_document_types_from_document_schemas/v0/mod.rs
@@ -16,7 +16,7 @@ impl DocumentTypeV0 {
         documents_keep_history_contract_default: bool,
         documents_mutable_contract_default: bool,
         documents_can_be_deleted_contract_default: bool,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<BTreeMap<String, DocumentType>, ProtocolError> {
@@ -43,7 +43,7 @@ impl DocumentTypeV0 {
                     documents_keep_history_contract_default,
                     documents_mutable_contract_default,
                     documents_can_be_deleted_contract_default,
-                    validate,
+                    full_validation,
                     validation_operations,
                     platform_version,
                 )?,

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/mod.rs
@@ -17,7 +17,7 @@ impl DocumentType {
         default_keeps_history: bool,
         default_mutability: bool,
         default_can_be_deleted: bool,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
@@ -36,7 +36,7 @@ impl DocumentType {
                 default_keeps_history,
                 default_mutability,
                 default_can_be_deleted,
-                validate,
+                full_validation,
                 validation_operations,
                 platform_version,
             )

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v0/mod.rs
@@ -111,7 +111,7 @@ impl DocumentTypeV0 {
         default_keeps_history: bool,
         default_mutability: bool,
         default_can_be_deleted: bool,
-        validate: bool, // we don't need to validate if loaded from state
+        full_validation: bool, // we don't need to validate if loaded from state
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
@@ -123,7 +123,7 @@ impl DocumentTypeV0 {
         )?;
 
         #[cfg(not(feature = "validation"))]
-        if validate {
+        if full_validation {
             // TODO we are silently dropping this error when we shouldn't be
             // but returning this error causes tests to fail; investigate more.
             ProtocolError::CorruptedCodeExecution(
@@ -135,7 +135,7 @@ impl DocumentTypeV0 {
         let json_schema_validator = StatelessJsonSchemaLazyValidator::new();
 
         #[cfg(feature = "validation")]
-        if validate {
+        if full_validation {
             // Make sure a document type name is compliant
             if !name
                 .chars()
@@ -265,7 +265,7 @@ impl DocumentTypeV0 {
         .unwrap_or_default();
 
         #[cfg(feature = "validation")]
-        if validate {
+        if full_validation {
             validation_operations.push(
                 ProtocolValidationOperation::DocumentTypeSchemaPropertyValidation(
                     property_values.values().len() as u64,
@@ -347,7 +347,7 @@ impl DocumentTypeV0 {
                             .map_err(consensus_or_protocol_data_contract_error)?;
 
                         #[cfg(feature = "validation")]
-                        if validate {
+                        if full_validation {
                             validation_operations.push(
                                 ProtocolValidationOperation::DocumentTypeSchemaIndexValidation(
                                     index.properties.len() as u64,
@@ -500,7 +500,7 @@ impl DocumentTypeV0 {
             .unwrap_or(SecurityLevel::HIGH);
 
         #[cfg(feature = "validation")]
-        if validate && security_level_requirement == SecurityLevel::MASTER {
+        if full_validation && security_level_requirement == SecurityLevel::MASTER {
             return Err(ConsensusError::BasicError(
                 BasicError::InvalidDocumentTypeRequiredSecurityLevelError(
                     InvalidDocumentTypeRequiredSecurityLevelError::new(

--- a/packages/rs-dpp/src/data_contract/factory/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/factory/v0/mod.rs
@@ -103,7 +103,7 @@ impl DataContractFactoryV0 {
     pub fn create_from_object(
         &self,
         data_contract_object: Value,
-        validate: bool,
+        full_validation: bool,
     ) -> Result<DataContract, ProtocolError> {
         let platform_version = PlatformVersion::get(self.protocol_version)?;
         match platform_version
@@ -111,10 +111,12 @@ impl DataContractFactoryV0 {
             .contract_versions
             .contract_structure_version
         {
-            0 => Ok(
-                DataContractV0::from_value(data_contract_object, validate, platform_version)?
-                    .into(),
-            ),
+            0 => Ok(DataContractV0::from_value(
+                data_contract_object,
+                full_validation,
+                platform_version,
+            )?
+            .into()),
             version => Err(ProtocolError::UnknownVersionMismatch {
                 method: "DataContractFactoryV0::create_from_object".to_string(),
                 known_versions: vec![0],

--- a/packages/rs-dpp/src/data_contract/methods/schema/mod.rs
+++ b/packages/rs-dpp/src/data_contract/methods/schema/mod.rs
@@ -14,7 +14,7 @@ impl DataContractSchemaMethodsV0 for DataContract {
         &mut self,
         schemas: BTreeMap<DocumentName, Value>,
         defs: Option<BTreeMap<DefinitionName, Value>>,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<(), ProtocolError> {
@@ -22,7 +22,7 @@ impl DataContractSchemaMethodsV0 for DataContract {
             DataContract::V0(v0) => v0.set_document_schemas(
                 schemas,
                 defs,
-                validate,
+                full_validation,
                 validation_operations,
                 platform_version,
             ),
@@ -33,7 +33,7 @@ impl DataContractSchemaMethodsV0 for DataContract {
         &mut self,
         name: &str,
         schema: Value,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<(), ProtocolError> {
@@ -41,7 +41,7 @@ impl DataContractSchemaMethodsV0 for DataContract {
             DataContract::V0(v0) => v0.set_document_schema(
                 name,
                 schema,
-                validate,
+                full_validation,
                 validation_operations,
                 platform_version,
             ),
@@ -63,14 +63,17 @@ impl DataContractSchemaMethodsV0 for DataContract {
     fn set_schema_defs(
         &mut self,
         defs: Option<BTreeMap<DefinitionName, Value>>,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<(), ProtocolError> {
         match self {
-            DataContract::V0(v0) => {
-                v0.set_schema_defs(defs, validate, validation_operations, platform_version)
-            }
+            DataContract::V0(v0) => v0.set_schema_defs(
+                defs,
+                full_validation,
+                validation_operations,
+                platform_version,
+            ),
         }
     }
 }

--- a/packages/rs-dpp/src/data_contract/methods/schema/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/methods/schema/v0/mod.rs
@@ -10,7 +10,7 @@ pub trait DataContractSchemaMethodsV0 {
         &mut self,
         schemas: BTreeMap<DocumentName, Value>,
         defs: Option<BTreeMap<DefinitionName, Value>>,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<(), ProtocolError>;
@@ -19,7 +19,7 @@ pub trait DataContractSchemaMethodsV0 {
         &mut self,
         name: &str,
         schema: Value,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<(), ProtocolError>;
@@ -29,7 +29,7 @@ pub trait DataContractSchemaMethodsV0 {
     fn set_schema_defs(
         &mut self,
         defs: Option<BTreeMap<DefinitionName, Value>>,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<(), ProtocolError>;

--- a/packages/rs-dpp/src/data_contract/mod.rs
+++ b/packages/rs-dpp/src/data_contract/mod.rs
@@ -120,7 +120,7 @@ impl PlatformSerializableWithPlatformVersion for DataContract {
 impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for DataContract {
     fn versioned_deserialize(
         data: &[u8],
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where
@@ -140,7 +140,7 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Dat
                 .0;
         DataContract::try_from_platform_versioned(
             data_contract_in_serialization_format,
-            validate,
+            full_validation,
             &mut vec![],
             platform_version,
         )
@@ -150,7 +150,7 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Dat
 impl PlatformDeserializableWithBytesLenFromVersionedStructure for DataContract {
     fn versioned_deserialize_with_bytes_len(
         data: &[u8],
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<(Self, usize), ProtocolError>
     where
@@ -169,7 +169,7 @@ impl PlatformDeserializableWithBytesLenFromVersionedStructure for DataContract {
         Ok((
             DataContract::try_from_platform_versioned(
                 data_contract_in_serialization_format,
-                validate,
+                full_validation,
                 &mut vec![],
                 platform_version,
             )?,

--- a/packages/rs-dpp/src/data_contract/serialized_version/mod.rs
+++ b/packages/rs-dpp/src/data_contract/serialized_version/mod.rs
@@ -165,7 +165,7 @@ impl TryFromPlatformVersioned<DataContract> for DataContractInSerializationForma
 impl DataContract {
     pub fn try_from_platform_versioned(
         value: DataContractInSerializationFormat,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
@@ -179,7 +179,7 @@ impl DataContract {
                     0 => {
                         let data_contract = DataContractV0::try_from_platform_versioned_v0(
                             serialization_format_v0,
-                            validate,
+                            full_validation,
                             validation_operations,
                             platform_version,
                         )?;

--- a/packages/rs-dpp/src/data_contract/v0/conversion/cbor.rs
+++ b/packages/rs-dpp/src/data_contract/v0/conversion/cbor.rs
@@ -14,10 +14,10 @@ impl DataContractCborConversionMethodsV0 for DataContractV0 {
     fn from_cbor_with_id(
         cbor_bytes: impl AsRef<[u8]>,
         contract_id: Option<Identifier>,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
-        let mut data_contract = Self::from_cbor(cbor_bytes, validate, platform_version)?;
+        let mut data_contract = Self::from_cbor(cbor_bytes, full_validation, platform_version)?;
         if let Some(id) = contract_id {
             data_contract.id = id;
         }
@@ -26,7 +26,7 @@ impl DataContractCborConversionMethodsV0 for DataContractV0 {
 
     fn from_cbor(
         cbor_bytes: impl AsRef<[u8]>,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         let data_contract_cbor_value: CborValue = ciborium::de::from_reader(cbor_bytes.as_ref())
@@ -37,7 +37,7 @@ impl DataContractCborConversionMethodsV0 for DataContractV0 {
         let data_contract_value: Value =
             Value::try_from(data_contract_cbor_value).map_err(ProtocolError::ValueError)?;
 
-        Self::from_value(data_contract_value, validate, platform_version)
+        Self::from_value(data_contract_value, full_validation, platform_version)
     }
 
     fn to_cbor(&self, platform_version: &PlatformVersion) -> Result<Vec<u8>, ProtocolError> {

--- a/packages/rs-dpp/src/data_contract/v0/conversion/json.rs
+++ b/packages/rs-dpp/src/data_contract/v0/conversion/json.rs
@@ -11,10 +11,10 @@ use std::convert::TryInto;
 impl DataContractJsonConversionMethodsV0 for DataContractV0 {
     fn from_json(
         json_value: JsonValue,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
-        Self::from_value(json_value.into(), validate, platform_version)
+        Self::from_value(json_value.into(), full_validation, platform_version)
     }
 
     /// Returns Data Contract as a JSON Value

--- a/packages/rs-dpp/src/data_contract/v0/conversion/value.rs
+++ b/packages/rs-dpp/src/data_contract/v0/conversion/value.rs
@@ -15,7 +15,7 @@ pub const DATA_CONTRACT_IDENTIFIER_FIELDS_V0: [&str; 2] =
 impl DataContractValueConversionMethodsV0 for DataContractV0 {
     fn from_value(
         mut value: Value,
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         value.replace_at_paths(
@@ -30,7 +30,7 @@ impl DataContractValueConversionMethodsV0 for DataContractV0 {
 
                 DataContractV0::try_from_platform_versioned(
                     data_contract_data.into(),
-                    validate,
+                    full_validation,
                     &mut vec![], // this is not used in consensus code
                     platform_version,
                 )

--- a/packages/rs-dpp/src/data_contract/v0/methods/schema.rs
+++ b/packages/rs-dpp/src/data_contract/v0/methods/schema.rs
@@ -15,7 +15,7 @@ impl DataContractSchemaMethodsV0 for DataContractV0 {
         &mut self,
         schemas: BTreeMap<DocumentName, Value>,
         defs: Option<BTreeMap<DefinitionName, Value>>,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<(), ProtocolError> {
@@ -26,7 +26,7 @@ impl DataContractSchemaMethodsV0 for DataContractV0 {
             self.config.documents_keep_history_contract_default(),
             self.config.documents_mutable_contract_default(),
             self.config.documents_can_be_deleted_contract_default(),
-            validate,
+            full_validation,
             validation_operations,
             platform_version,
         )?;
@@ -38,7 +38,7 @@ impl DataContractSchemaMethodsV0 for DataContractV0 {
         &mut self,
         name: &str,
         schema: Value,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<(), ProtocolError> {
@@ -50,7 +50,7 @@ impl DataContractSchemaMethodsV0 for DataContractV0 {
             self.config.documents_keep_history_contract_default(),
             self.config.documents_mutable_contract_default(),
             self.config.documents_mutable_contract_default(),
-            validate,
+            full_validation,
             validation_operations,
             platform_version,
         )?;
@@ -75,7 +75,7 @@ impl DataContractSchemaMethodsV0 for DataContractV0 {
     fn set_schema_defs(
         &mut self,
         defs: Option<BTreeMap<DefinitionName, Value>>,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<(), ProtocolError> {
@@ -88,7 +88,7 @@ impl DataContractSchemaMethodsV0 for DataContractV0 {
         self.set_document_schemas(
             document_schemas,
             defs.clone(),
-            validate,
+            full_validation,
             validation_operations,
             platform_version,
         )?;

--- a/packages/rs-dpp/src/data_contract/v0/serialization/mod.rs
+++ b/packages/rs-dpp/src/data_contract/v0/serialization/mod.rs
@@ -45,7 +45,7 @@ impl<'de> Deserialize<'de> for DataContractV0 {
 impl DataContractV0 {
     pub(in crate::data_contract) fn try_from_platform_versioned(
         value: DataContractInSerializationFormat,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
@@ -59,7 +59,7 @@ impl DataContractV0 {
                     0 => {
                         let data_contract = DataContractV0::try_from_platform_versioned_v0(
                             serialization_format_v0,
-                            validate,
+                            full_validation,
                             validation_operations,
                             platform_version,
                         )?;
@@ -78,7 +78,7 @@ impl DataContractV0 {
 
     pub(in crate::data_contract) fn try_from_platform_versioned_v0(
         data_contract_data: DataContractInSerializationFormatV0,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
@@ -98,7 +98,7 @@ impl DataContractV0 {
             config.documents_keep_history_contract_default(),
             config.documents_mutable_contract_default(),
             config.documents_can_be_deleted_contract_default(),
-            validate,
+            full_validation,
             validation_operations,
             platform_version,
         )?;

--- a/packages/rs-dpp/src/serialization/serialization_traits.rs
+++ b/packages/rs-dpp/src/serialization/serialization_traits.rs
@@ -100,7 +100,7 @@ pub trait PlatformDeserializableWithPotentialValidationFromVersionedStructure {
     /// DataContractV1 (if system version is 1)
     fn versioned_deserialize(
         data: &[u8],
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where
@@ -119,7 +119,7 @@ pub trait PlatformDeserializableWithBytesLenFromVersionedStructure {
     /// DataContractV1 (if system version is 1)
     fn versioned_deserialize_with_bytes_len(
         data: &[u8],
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<(Self, usize), ProtocolError>
     where

--- a/packages/rs-dpp/src/tests/json_document.rs
+++ b/packages/rs-dpp/src/tests/json_document.rs
@@ -65,12 +65,12 @@ pub fn json_document_to_cbor(
 #[cfg(feature = "data-contract-json-conversion")]
 pub fn json_document_to_contract(
     path: impl AsRef<Path>,
-    validate: bool,
+    full_validation: bool,
     platform_version: &PlatformVersion,
 ) -> Result<DataContract, ProtocolError> {
     let value = json_document_to_json_value(path)?;
 
-    DataContract::from_json(value, validate, platform_version)
+    DataContract::from_json(value, full_validation, platform_version)
 }
 
 #[cfg(all(
@@ -81,10 +81,10 @@ pub fn json_document_to_contract(
 pub fn json_document_to_created_contract(
     path: impl AsRef<Path>,
     identity_nonce: IdentityNonce,
-    validate: bool,
+    full_validation: bool,
     platform_version: &PlatformVersion,
 ) -> Result<CreatedDataContract, ProtocolError> {
-    let data_contract = json_document_to_contract(path, validate, platform_version)?;
+    let data_contract = json_document_to_contract(path, full_validation, platform_version)?;
 
     Ok(CreatedDataContractV0 {
         data_contract,
@@ -99,12 +99,12 @@ pub fn json_document_to_contract_with_ids(
     path: impl AsRef<Path>,
     id: Option<Identifier>,
     owner_id: Option<Identifier>,
-    validate: bool,
+    full_validation: bool,
     platform_version: &PlatformVersion,
 ) -> Result<DataContract, ProtocolError> {
     let value = json_document_to_json_value(path)?;
 
-    let mut contract = DataContract::from_json(value, validate, platform_version)?;
+    let mut contract = DataContract::from_json(value, full_validation, platform_version)?;
 
     if let Some(id) = id {
         contract.set_id(id);

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
@@ -29,7 +29,7 @@ use crate::execution::validation::state_transition::ValidationMode;
 
 impl ValidationMode {
     /// Returns if we should validate the contract when we transform it from its serialized form
-    pub fn should_validate_contract_on_transform_into_action(&self) -> bool {
+    pub fn should_fully_validate_contract_on_transform_into_action(&self) -> bool {
         match self {
             ValidationMode::CheckTx => false,
             ValidationMode::RecheckTx => false,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/state/v0/mod.rs
@@ -98,7 +98,7 @@ impl DataContractCreateStateTransitionStateValidationV0 for DataContractCreateTr
         // The contract in serialized form into it's execution form
         let result = DataContractCreateTransitionAction::try_from_borrowed_transition(
             self,
-            validation_mode.should_validate_contract_on_transform_into_action(),
+            validation_mode.should_fully_validate_contract_on_transform_into_action(),
             &mut validation_operations,
             platform_version,
         );

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/state/v0/mod.rs
@@ -428,7 +428,7 @@ impl DataContractUpdateStateTransitionStateValidationV0 for DataContractUpdateTr
 
         let result = DataContractUpdateTransitionAction::try_from_borrowed_transition(
             self,
-            validation_mode.should_validate_contract_on_transform_into_action(),
+            validation_mode.should_fully_validate_contract_on_transform_into_action(),
             &mut validation_operations,
             platform_version,
         );

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/transformer/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/transformer/v0/mod.rs
@@ -58,7 +58,7 @@ pub(in crate::execution::validation::state_transition::state_transitions::docume
         &self,
         platform: &PlatformStateRef,
         block_info: &BlockInfo,
-        validate: bool,
+        full_validation: bool,
         transaction: TransactionArg,
         execution_context: &mut StateTransitionExecutionContext,
     ) -> Result<ConsensusValidationResult<DocumentsBatchTransitionAction>, Error>;
@@ -68,7 +68,7 @@ trait DocumentsBatchTransitionInternalTransformerV0 {
     fn transform_document_transitions_within_contract_v0(
         platform: &PlatformStateRef,
         block_info: &BlockInfo,
-        validate: bool,
+        full_validation: bool,
         data_contract_id: &Identifier,
         owner_id: Identifier,
         document_transitions: &BTreeMap<&String, Vec<&DocumentTransition>>,
@@ -79,7 +79,7 @@ trait DocumentsBatchTransitionInternalTransformerV0 {
     fn transform_document_transitions_within_document_type_v0(
         platform: &PlatformStateRef,
         block_info: &BlockInfo,
-        validate: bool,
+        full_validation: bool,
         data_contract_fetch_info: Arc<DataContractFetchInfo>,
         document_type_name: &str,
         owner_id: Identifier,
@@ -90,7 +90,7 @@ trait DocumentsBatchTransitionInternalTransformerV0 {
     ) -> Result<ConsensusValidationResult<Vec<DocumentTransitionAction>>, Error>;
     /// The data contract can be of multiple difference versions
     fn transform_transition_v0(
-        validate: bool,
+        full_validation: bool,
         block_info: &BlockInfo,
         data_contract_fetch_info: Arc<DataContractFetchInfo>,
         transition: &DocumentTransition,

--- a/packages/rs-drive/src/state_transition_action/contract/data_contract_create/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/contract/data_contract_create/transformer.rs
@@ -11,7 +11,7 @@ impl DataContractCreateTransitionAction {
     /// if validation is false, the data contract base structure is created regardless of if it is valid
     pub fn try_from_transition(
         value: DataContractCreateTransition,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
@@ -19,7 +19,7 @@ impl DataContractCreateTransitionAction {
             DataContractCreateTransition::V0(v0) => {
                 Ok(DataContractCreateTransitionActionV0::try_from_transition(
                     v0,
-                    validate,
+                    full_validation,
                     validation_operations,
                     platform_version,
                 )?
@@ -34,7 +34,7 @@ impl DataContractCreateTransitionAction {
 
     pub fn try_from_borrowed_transition(
         value: &DataContractCreateTransition,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
@@ -42,7 +42,7 @@ impl DataContractCreateTransitionAction {
             DataContractCreateTransition::V0(v0) => Ok(
                 DataContractCreateTransitionActionV0::try_from_borrowed_transition(
                     v0,
-                    validate,
+                    full_validation,
                     validation_operations,
                     platform_version,
                 )?

--- a/packages/rs-drive/src/state_transition_action/contract/data_contract_create/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/contract/data_contract_create/v0/transformer.rs
@@ -8,14 +8,14 @@ use platform_version::version::PlatformVersion;
 impl DataContractCreateTransitionActionV0 {
     pub(in crate::state_transition_action::contract::data_contract_create) fn try_from_transition(
         value: DataContractCreateTransitionV0,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         Ok(DataContractCreateTransitionActionV0 {
             data_contract: DataContract::try_from_platform_versioned(
                 value.data_contract,
-                validate,
+                full_validation,
                 validation_operations,
                 platform_version,
             )?,
@@ -26,14 +26,14 @@ impl DataContractCreateTransitionActionV0 {
 
     pub(in crate::state_transition_action::contract::data_contract_create) fn try_from_borrowed_transition(
         value: &DataContractCreateTransitionV0,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         Ok(DataContractCreateTransitionActionV0 {
             data_contract: DataContract::try_from_platform_versioned(
                 value.data_contract.clone(),
-                validate,
+                full_validation,
                 validation_operations,
                 platform_version,
             )?,

--- a/packages/rs-drive/src/state_transition_action/contract/data_contract_update/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/contract/data_contract_update/transformer.rs
@@ -11,7 +11,7 @@ impl DataContractUpdateTransitionAction {
     /// if validation is false, the data contract base structure is created regardless of if it is valid
     pub fn try_from_transition(
         value: DataContractUpdateTransition,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
@@ -19,7 +19,7 @@ impl DataContractUpdateTransitionAction {
             DataContractUpdateTransition::V0(v0) => {
                 Ok(DataContractUpdateTransitionActionV0::try_from_transition(
                     v0,
-                    validate,
+                    full_validation,
                     validation_operations,
                     platform_version,
                 )?
@@ -34,7 +34,7 @@ impl DataContractUpdateTransitionAction {
 
     pub fn try_from_borrowed_transition(
         value: &DataContractUpdateTransition,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
@@ -42,7 +42,7 @@ impl DataContractUpdateTransitionAction {
             DataContractUpdateTransition::V0(v0) => Ok(
                 DataContractUpdateTransitionActionV0::try_from_borrowed_transition(
                     v0,
-                    validate,
+                    full_validation,
                     validation_operations,
                     platform_version,
                 )?

--- a/packages/rs-drive/src/state_transition_action/contract/data_contract_update/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/contract/data_contract_update/v0/transformer.rs
@@ -8,14 +8,14 @@ use platform_version::version::PlatformVersion;
 impl DataContractUpdateTransitionActionV0 {
     pub(in crate::state_transition_action::contract::data_contract_update) fn try_from_transition(
         value: DataContractUpdateTransitionV0,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         Ok(DataContractUpdateTransitionActionV0 {
             data_contract: DataContract::try_from_platform_versioned(
                 value.data_contract,
-                validate,
+                full_validation,
                 validation_operations,
                 platform_version,
             )?,
@@ -26,14 +26,14 @@ impl DataContractUpdateTransitionActionV0 {
 
     pub(in crate::state_transition_action::contract::data_contract_update) fn try_from_borrowed_transition(
         value: &DataContractUpdateTransitionV0,
-        validate: bool,
+        full_validation: bool,
         validation_operations: &mut Vec<ProtocolValidationOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError> {
         Ok(DataContractUpdateTransitionActionV0 {
             data_contract: DataContract::try_from_platform_versioned(
                 value.data_contract.clone(),
-                validate,
+                full_validation,
                 validation_operations,
                 platform_version,
             )?,

--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -243,7 +243,7 @@ impl PlatformSerializableWithPlatformVersion for Strategy {
 impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Strategy {
     fn versioned_deserialize(
         data: &[u8],
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where
@@ -273,7 +273,7 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Str
             .map(|(serialized_contract, maybe_updates)| {
                 let contract = CreatedDataContract::versioned_deserialize(
                     serialized_contract.as_slice(),
-                    validate,
+                    full_validation,
                     platform_version,
                 )?;
                 let maybe_updates = maybe_updates
@@ -283,7 +283,7 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Str
                             .map(|(key, serialized_contract_update)| {
                                 let update = CreatedDataContract::versioned_deserialize(
                                     serialized_contract_update.as_slice(),
-                                    validate,
+                                    full_validation,
                                     platform_version,
                                 )?;
                                 Ok((key, update))
@@ -304,7 +304,11 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Str
         let operations = operations
             .into_iter()
             .map(|operation| {
-                Operation::versioned_deserialize(operation.as_slice(), validate, platform_version)
+                Operation::versioned_deserialize(
+                    operation.as_slice(),
+                    full_validation,
+                    platform_version,
+                )
             })
             .collect::<Result<Vec<Operation>, ProtocolError>>()?;
 

--- a/packages/strategy-tests/src/operations.rs
+++ b/packages/strategy-tests/src/operations.rs
@@ -94,7 +94,7 @@ impl PlatformSerializableWithPlatformVersion for DocumentOp {
 impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for DocumentOp {
     fn versioned_deserialize(
         data: &[u8],
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where
@@ -116,7 +116,7 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Doc
         } = document_op_in_serialization_format;
         let data_contract = DataContract::try_from_platform_versioned(
             contract,
-            validate,
+            full_validation,
             &mut vec![],
             platform_version,
         )?;
@@ -177,7 +177,7 @@ impl PlatformSerializableWithPlatformVersion for Operation {
 impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Operation {
     fn versioned_deserialize(
         data: &[u8],
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where
@@ -194,8 +194,11 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Ope
                 .0;
         let OperationInSerializationFormat { op_type, frequency } =
             operation_in_serialization_format;
-        let op_type =
-            OperationType::versioned_deserialize(op_type.as_slice(), validate, platform_version)?;
+        let op_type = OperationType::versioned_deserialize(
+            op_type.as_slice(),
+            full_validation,
+            platform_version,
+        )?;
         Ok(Operation { op_type, frequency })
     }
 }
@@ -278,7 +281,7 @@ impl PlatformSerializableWithPlatformVersion for DataContractUpdateOp {
 impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for DataContractUpdateOp {
     fn versioned_deserialize(
         data: &[u8],
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where
@@ -299,7 +302,7 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Dat
 
         let contract = DataContract::try_from_platform_versioned(
             deserialized.contract,
-            validate,
+            full_validation,
             &mut vec![],
             platform_version,
         )?;
@@ -324,7 +327,7 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Dat
                                 true,
                                 true,
                                 true,
-                                validate,
+                                full_validation,
                                 &mut vec![],
                                 platform_version,
                             )
@@ -420,7 +423,7 @@ impl PlatformSerializableWithPlatformVersion for OperationType {
 impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for OperationType {
     fn versioned_deserialize(
         data: &[u8],
-        validate: bool,
+        full_validation: bool,
         platform_version: &PlatformVersion,
     ) -> Result<Self, ProtocolError>
     where
@@ -439,7 +442,7 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Ope
             OperationTypeInSerializationFormat::Document(serialized_op) => {
                 let document_op = DocumentOp::versioned_deserialize(
                     serialized_op.as_slice(),
-                    validate,
+                    full_validation,
                     platform_version,
                 )?;
                 OperationType::Document(document_op)
@@ -457,7 +460,7 @@ impl PlatformDeserializableWithPotentialValidationFromVersionedStructure for Ope
             OperationTypeInSerializationFormat::ContractUpdate(serialized_op) => {
                 let update_op = DataContractUpdateOp::versioned_deserialize(
                     serialized_op.as_slice(),
-                    validate,
+                    full_validation,
                     platform_version,
                 )?;
                 OperationType::ContractUpdate(update_op)

--- a/packages/wasm-dpp/src/data_contract/data_contract.rs
+++ b/packages/wasm-dpp/src/data_contract/data_contract.rs
@@ -435,13 +435,18 @@ impl DataContractWasm {
 
     pub(crate) fn try_from_serialization_format(
         value: DataContractInSerializationFormat,
-        validate: bool,
+        full_validation: bool,
     ) -> Result<Self, JsValue> {
         let platform_version = PlatformVersion::first();
 
-        DataContract::try_from_platform_versioned(value, validate, &mut vec![], platform_version)
-            .with_js_error()
-            .map(Into::into)
+        DataContract::try_from_platform_versioned(
+            value,
+            full_validation,
+            &mut vec![],
+            platform_version,
+        )
+        .with_js_error()
+        .map(Into::into)
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For Data Contract validation we use confusing `validate` flag. It actually doesn't disable/enable validation but enable additional validation rules.


## What was done?
<!--- Describe your changes in detail -->
- Renamed the `validate` flag to `full_validation`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
