### PR TITLE
feat: implement mempool document counter in strategy tests

### DIFF
--- a/packages/rs-dpp/src/data_contract/document_type/random_document.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/random_document.rs
@@ -307,7 +307,7 @@ impl CreateRandomDocument for DocumentType {
                 document_field_fill_size,
                 rng,
                 platform_version,
-            ), // Add more cases as necessary for other variants
+            ),
         }
     }
 }

--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -569,8 +569,8 @@ impl Strategy {
                         document_type,
                         contract,
                     }) => {
-                        // Get the first 3 identities who are eligible to submit documents for this contract
-                        let first_3_eligible_identities: Vec<Identity> = current_identities
+                        // Get the first 10 identities who are eligible to submit documents for this contract
+                        let first_10_eligible_identities: Vec<Identity> = current_identities
                             .iter()
                             .filter(|identity| {
                                 mempool_document_counter
@@ -578,15 +578,22 @@ impl Strategy {
                                     .unwrap_or(&0)
                                     < &24u64
                             })
-                            .take(3)
+                            .take(10)
                             .cloned()
                             .collect();
+
+                        if first_10_eligible_identities.len() == 0 {
+                            tracing::warn!(
+                                "No eligible identities to submit a document to contract {}",
+                                contract.id().to_string(Encoding::Base64)
+                            );
+                        }
 
                         // TO-DO: these documents should be created according to the data contract's validation rules
                         let documents = document_type
                             .random_documents_with_params(
                                 count as u32,
-                                &first_3_eligible_identities,
+                                &first_10_eligible_identities,
                                 Some(block_info.time_ms),
                                 Some(block_info.height),
                                 Some(block_info.core_height),

--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -394,6 +394,7 @@ impl Strategy {
         signer: &mut SimpleSigner,
         identity_nonce_counter: &mut BTreeMap<Identifier, u64>,
         contract_nonce_counter: &mut BTreeMap<(Identifier, Identifier), u64>,
+        mempool_document_counter: BTreeMap<(Identifier, Identifier), u64>,
         rng: &mut StdRng,
         config: &StrategyConfig,
         platform_version: &PlatformVersion,
@@ -449,6 +450,7 @@ impl Strategy {
                     signer,
                     identity_nonce_counter,
                     contract_nonce_counter,
+                    mempool_document_counter,
                     rng,
                     platform_version,
                 );
@@ -541,6 +543,7 @@ impl Strategy {
         signer: &mut SimpleSigner,
         identity_nonce_counter: &mut BTreeMap<Identifier, u64>,
         contract_nonce_counter: &mut BTreeMap<(Identifier, Identifier), u64>,
+        mempool_document_counter: BTreeMap<(Identifier, Identifier), u64>,
         rng: &mut StdRng,
         platform_version: &PlatformVersion,
     ) -> (Vec<StateTransition>, Vec<FinalizeBlockOperation>) {
@@ -566,11 +569,24 @@ impl Strategy {
                         document_type,
                         contract,
                     }) => {
+                        // Get the first 3 identities who are eligible to submit documents for this contract
+                        let first_3_eligible_identities: Vec<Identity> = current_identities
+                            .iter()
+                            .filter(|identity| {
+                                mempool_document_counter
+                                    .get(&(identity.id(), contract.id()))
+                                    .unwrap_or(&0)
+                                    < &24u64
+                            })
+                            .take(3)
+                            .cloned()
+                            .collect();
+
                         // TO-DO: these documents should be created according to the data contract's validation rules
                         let documents = document_type
                             .random_documents_with_params(
                                 count as u32,
-                                current_identities,
+                                &first_3_eligible_identities,
                                 Some(block_info.time_ms),
                                 Some(block_info.height),
                                 Some(block_info.core_height),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Identities would broadcast documents into the mempool successfully but the transitions would potentially fail while in the mempool if the identity put more than 24 documents for a contract in, due to nonce errors.

## What was done?
<!--- Describe your changes in detail -->
Pass a BTreeMap of (IdentityID, ContractID) to u64 which acts as a counter for how many documents an identity has put into the mempool for a contract. If the number is 24 or greater, we don't use that identity.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
