### PR TITLE
fix: set data contract versions in strategy tests

### DIFF
--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -1565,7 +1565,11 @@ impl Strategy {
                     DataContract::generate_data_contract_id_v0(partial_identity.id, *identity_nonce);
                 contract.set_id(new_id);
 
-                id_mapping.insert(old_id, new_id); // Store the mapping
+                // Set version to 1
+                contract.set_version(1);
+
+                // Store the mapping
+                id_mapping.insert(old_id, new_id);
 
                 // If there are contract updates, use the mapping to update their ID and owner ID too
                 if let Some(contract_updates) = contract_updates {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## What was done?
<!--- Describe your changes in detail -->
Just set initial data contract versions to 1 when they are being registered in strategy tests. The hardcoded strategy tests use data contracts that have version 0, but Platform was updated so that they must be 1, so this fixes errors that arose from that, but also will be helpful in general.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Platform TUI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
