### PR TITLE
ci: install javy and npm for json-schema-faker-rs dependency

### DIFF
--- a/.github/actions/javy/action.yaml
+++ b/.github/actions/javy/action.yaml
@@ -1,6 +1,11 @@
 ---
 name: "Setup Javy"
 description: "Setup Javy binaries"
+inputs:
+  version:
+    description: Javy version to use
+    required: false
+    default: "1.4.0"
 runs:
   using: composite
   steps:
@@ -8,11 +13,22 @@ runs:
       shell: bash
       run: |
         set -e
-        if [ "${{ runner.arch }}" == "ARM64" ]; then
-          curl -Ls https://github.com/bytecodealliance/javy/releases/download/v1.4.0/javy-arm-linux-v1.4.0.gz | gunzip > javy
-        else
-          curl -Ls https://github.com/bytecodealliance/javy/releases/download/v1.4.0/javy-x86_64-linux-v1.4.0.gz | gunzip > javy
-        fi
+
+        case "${{ runner.arch }}" in
+          "ARM64")
+            JAVY_ARCH="arm-linux"
+            ;;
+          "X64")
+            JAVY_ARCH="x86_64-linux"            
+            ;;
+          *)
+            echo "Unsupported architecture: ${{ runner.arch }}"
+            exit 1
+            ;;
+        esac
+
+        curl -Ls "https://github.com/bytecodealliance/javy/releases/download/v${{ inputs.version }}/javy-${JAVY_ARCH}-v${{ inputs.version }}.gz" | gunzip > javy
+
         chmod +x javy
         sudo mv javy /usr/local/bin/javy
 

--- a/.github/actions/javy/action.yaml
+++ b/.github/actions/javy/action.yaml
@@ -1,0 +1,21 @@
+---
+name: "Setup Javy"
+description: "Setup Javy binaries"
+runs:
+  using: composite
+  steps:
+    - name: Install Javy
+      shell: bash
+      run: |
+        set -e
+        if [ "${{ runner.arch }}" == "ARM64" ]; then
+          curl -Ls https://github.com/bytecodealliance/javy/releases/download/v1.4.0/javy-arm-linux-v1.4.0.gz | gunzip > javy
+        else
+          curl -Ls https://github.com/bytecodealliance/javy/releases/download/v1.4.0/javy-x86_64-linux-v1.4.0.gz | gunzip > javy
+        fi
+        chmod +x javy
+        sudo mv javy /usr/local/bin/javy
+
+    - name: Verify Javy installation
+      shell: bash
+      run: javy --version

--- a/.github/workflows/tests-rs-package.yml
+++ b/.github/workflows/tests-rs-package.yml
@@ -205,7 +205,23 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/rust
 
-      - name: Get crate ${{ inputs.package }} info
+      - name: Setup Node.JS, required by json-schema-faker-rs
+        if: inputs.package == 'dpp'
+        uses: ./.github/actions/nodejs
+
+      - name: Setup Javy, required by json-schema-faker-rs
+        if: inputs.package == 'dpp'
+        run: |
+          set -e
+          if [ "${{ runner.arch }}" == "ARM64" ]; then 
+            curl -Ls https://github.com/bytecodealliance/javy/releases/download/v1.4.0/javy-arm-linux-v1.4.0.gz | gunzip > javy
+          else
+            curl -Ls https://github.com/bytecodealliance/javy/releases/download/v1.4.0/javy-x86_64-linux-v1.4.0.gz | gunzip > javy
+          fi
+          chmod +x javy
+          sudo mv javy /usr/local/bin/javy
+          javy --version
+      - name: Get crate ${{ runner.arch }} info
         id: crate_info
         uses: ./.github/actions/crate_info
         with:

--- a/.github/workflows/tests-rs-package.yml
+++ b/.github/workflows/tests-rs-package.yml
@@ -41,6 +41,14 @@ jobs:
         with:
           components: clippy
 
+      - name: Setup Node.JS, required by json-schema-faker-rs
+        if: inputs.package == 'dpp'
+        uses: ./.github/actions/nodejs
+
+      - name: Setup Javy, required by json-schema-faker-rs
+        if: inputs.package == 'dpp'
+        uses: ./.github/actions/javy
+
       - uses: clechasseur/rs-clippy-check@v3
         with:
           args: --package ${{ inputs.package }} --all-features --locked -- --no-deps
@@ -180,6 +188,14 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/rust
 
+      - name: Setup Node.JS, required by json-schema-faker-rs
+        if: inputs.package == 'dpp'
+        uses: ./.github/actions/nodejs
+
+      - name: Setup Javy, required by json-schema-faker-rs
+        if: inputs.package == 'dpp'
+        uses: ./.github/actions/javy
+
       - name: Run tests
         run: cargo test --package=${{ inputs.package }} --all-features --locked
         env:
@@ -211,16 +227,8 @@ jobs:
 
       - name: Setup Javy, required by json-schema-faker-rs
         if: inputs.package == 'dpp'
-        run: |
-          set -e
-          if [ "${{ runner.arch }}" == "ARM64" ]; then 
-            curl -Ls https://github.com/bytecodealliance/javy/releases/download/v1.4.0/javy-arm-linux-v1.4.0.gz | gunzip > javy
-          else
-            curl -Ls https://github.com/bytecodealliance/javy/releases/download/v1.4.0/javy-x86_64-linux-v1.4.0.gz | gunzip > javy
-          fi
-          chmod +x javy
-          sudo mv javy /usr/local/bin/javy
-          javy --version
+        uses: ./.github/actions/javy
+
       - name: Get crate ${{ runner.arch }} info
         id: crate_info
         uses: ./.github/actions/crate_info

--- a/packages/rs-dpp/src/data_contract/document_type/v0/random_document.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/v0/random_document.rs
@@ -3,6 +3,7 @@
 //! This module defines the CreateRandomDocument trait and its functions, which
 //! create various types of random documents.
 //!
+//!
 
 #[cfg(feature = "documents-faker")]
 use std::collections::BTreeMap;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

`json-schema-faker-rs` dependency of dpp, introduced in #1710 , requires `javy` and npm to build.
As our tests test each individual dependency, we need to install it whenever using that dep.

## What was done?

Install `javy` and `nodejs` dependency when testing/linting/checking features of `dpp`.

## How Has This Been Tested?

1. In [lint](https://github.com/dashpay/platform/actions/runs/9189663301/job/25272219164?pr=1853), [test](https://github.com/dashpay/platform/actions/runs/9189663301/job/25272219790?pr=1853) and [check each feature](https://github.com/dashpay/platform/actions/runs/9189663301/job/25272219375?pr=1853) of DPP, nodejs and javy are installed correctly:  
2. When testing other packages, nodejs and javy are skipped: https://github.com/dashpay/platform/actions/runs/9189663301/job/25272216994?pr=1853 
3. GHA pipeline is green

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
