### PR TITLE
fix(sdk): invalid error returned when identity create fails

### DIFF
--- a/packages/rs-sdk/src/platform/transition/put_identity.rs
+++ b/packages/rs-sdk/src/platform/transition/put_identity.rs
@@ -90,6 +90,8 @@ impl<S: Signer> PutIdentity<S> for Identity {
                         "identity was proved to not exist but was said to exist".to_string(),
                     ));
                 }
+
+                return Err(e.into());
             }
         }
 

--- a/packages/rs-sdk/src/platform/transition/put_identity.rs
+++ b/packages/rs-sdk/src/platform/transition/put_identity.rs
@@ -4,6 +4,7 @@ use crate::platform::Fetch;
 use crate::{Error, Sdk};
 
 use dapi_grpc::platform::VersionedGrpcResponse;
+use dapi_grpc::tonic::Code;
 use dpp::dashcore::PrivateKey;
 use dpp::identity::signer::Signer;
 use dpp::prelude::{AssetLockProof, Identity};
@@ -11,7 +12,7 @@ use dpp::prelude::{AssetLockProof, Identity};
 use crate::platform::block_info_from_metadata::block_info_from_metadata;
 use dpp::state_transition::proof_result::StateTransitionProofResult;
 use drive::drive::Drive;
-use rs_dapi_client::{DapiRequest, RequestSettings};
+use rs_dapi_client::{DapiClientError, DapiRequest, RequestSettings};
 
 #[async_trait::async_trait]
 /// A trait for putting an identity to platform
@@ -83,16 +84,17 @@ impl<S: Signer> PutIdentity<S> for Identity {
         match response_result {
             Ok(_) => {}
             //todo make this more reliable
-            Err(e) => {
-                if e.to_string().contains("already exists") {
-                    let identity = Identity::fetch(sdk, identity_id).await?;
-                    return identity.ok_or(Error::DapiClientError(
-                        "identity was proved to not exist but was said to exist".to_string(),
-                    ));
-                }
-
-                return Err(e.into());
+            Err(DapiClientError::Transport(te, _)) if te.code() == Code::AlreadyExists => {
+                tracing::debug!(
+                    ?identity_id,
+                    "attempt to create identity that already exists"
+                );
+                let identity = Identity::fetch(sdk, identity_id).await?;
+                return identity.ok_or(Error::DapiClientError(
+                    "identity was proved to not exist but was said to exist".to_string(),
+                ));
             }
+            Err(e) => return Err(e.into()),
         }
 
         let request = state_transition.wait_for_state_transition_result_request()?;


### PR DESCRIPTION
## Issue being fixed or feature implemented

put_to_platform_and_wait_for_response() doesn't return correct error when `broadcast_request_for_new_identity` fails, but it waits until timeout.

## What was done?

Added return when error occurs

## How Has This Been Tested?

Using rs-platform explorer, patched to use invalid asset lock private key when creating identity in `Wallet > Register identity`.

BEFORE the fix, `Wallet > Register identity` waits until timeout and then errors with:

```
 |>SDK error: Dapi client error: Transport(Status { code: Cancelled, message: "Timeout expired", source:           │
│ Some(tonic::transport::Error(Transport, TimeoutExpired(()))) }, Address { ban_count: 0, banned_until: None,     │
│ uri: http://127.0.0.1:2643/ })                                                                                  │
│                                     
```

AFTER the fix `Wallet > Register identity` immediately errors with:

```
│>SDK error: Dapi client error: Transport(Status { code: Unauthenticated, message: "ecdsa signing                 │
│ error the signature isn't valid", metadata: MetadataMap { headers: {"drive-error-data-bin":                     │
│ "oW9zZXJpYWxpemVkRXJyb3KYHAMKGBkYdBhoGGUYIBhzGGkYZxhuGGEYdBh1GHIYZRggGGkYcxhuGCcYdBggGHYYYRhsGGkYZA==",         │
│ "code": "20009", "grpc-accept-encoding": "identity", "grpc-encoding": "identity", "content-type": "application/ │
│ grpc+proto", "date": "Fri, 24 May 2024 11:01:15 GMT", "x-envoy-upstream-service-time": "16", "server":          │
│ "envoy"} }, source: None }, Address { ban_count: 0, banned_until: None, uri: http://127.0.0.1:2543/ })          │
│                                                                                                          
```

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
