### PR TITLE
perf(dapi): use cached core height in streaming endpoints

### DIFF
--- a/packages/dapi/lib/chainDataProvider/ChainDataProvider.js
+++ b/packages/dapi/lib/chainDataProvider/ChainDataProvider.js
@@ -11,9 +11,9 @@ const REORG_SAFE_DEPTH = 6;
 class ChainDataProvider extends EventEmitter {
   /**
    *
-   * @param coreRpcClient {CoreRpcClient}
-   * @param zmqClient {ZmqClient}
-   * @param blockHeadersCache {BlockHeadersCache}
+   * @param {CoreRpcClient} coreRpcClient
+   * @param {ZmqClient} zmqClient
+   * @param {BlockHeadersCache} blockHeadersCache
    */
   constructor(coreRpcClient, zmqClient, blockHeadersCache) {
     super();
@@ -23,7 +23,7 @@ class ChainDataProvider extends EventEmitter {
     this.blockHeadersCache = blockHeadersCache;
 
     this.chainLock = null;
-    this.chainHeight = -1;
+    this.chainHeight = 0;
   }
 
   /**
@@ -52,7 +52,7 @@ class ChainDataProvider extends EventEmitter {
   }
 
   /**
-   *
+   * @private
    * @param {Buffer} rawChainLockSigBuffer
    */
   rawChainLockSigHandler(rawChainLockSigBuffer) {
@@ -215,6 +215,15 @@ class ChainDataProvider extends EventEmitter {
    */
   getBestChainLock() {
     return this.chainLock;
+  }
+
+  /**
+   * Return chain height
+   *
+   * @return {number}
+   */
+  getChainHeight() {
+    return this.chainHeight;
   }
 }
 

--- a/packages/dapi/lib/grpcServer/handlers/blockheaders-stream/subscribeToBlockHeadersWithChainLocksHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/blockheaders-stream/subscribeToBlockHeadersWithChainLocksHandlerFactory.js
@@ -121,7 +121,7 @@ function subscribeToBlockHeadersWithChainLocksHandlerFactory(
       throw e;
     }
 
-    const bestBlockHeight = await coreAPI.getBestBlockHeight();
+    const bestBlockHeight = chainDataProvider.getChainHeight();
 
     const historicalCount = count === 0 ? bestBlockHeight - fromBlock.height + 1 : count;
 

--- a/packages/dapi/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.js
@@ -83,6 +83,7 @@ async function sendInstantLockResponse(call, instantLock) {
  * @param {testFunction} testTransactionAgainstFilter
  * @param {CoreRpcClient} coreAPI
  * @param {getMemPoolTransactions} getMemPoolTransactions
+ * @param {ChainDataProvider} chainDataProvider
  * @return {subscribeToTransactionsWithProofsHandler}
  */
 function subscribeToTransactionsWithProofsHandlerFactory(
@@ -92,6 +93,7 @@ function subscribeToTransactionsWithProofsHandlerFactory(
   testTransactionAgainstFilter,
   coreAPI,
   getMemPoolTransactions,
+  chainDataProvider,
 ) {
   /**
    * @typedef subscribeToTransactionsWithProofsHandler
@@ -208,7 +210,7 @@ function subscribeToTransactionsWithProofsHandlerFactory(
       throw e;
     }
 
-    const bestBlockHeight = await coreAPI.getBestBlockHeight();
+    const bestBlockHeight = chainDataProvider.getChainHeight();
 
     let historicalCount = count;
 

--- a/packages/dapi/scripts/core-streams.js
+++ b/packages/dapi/scripts/core-streams.js
@@ -152,6 +152,7 @@ async function main() {
     testTransactionsAgainstFilter,
     dashCoreRpcClient,
     getMemPoolTransactions,
+    chainDataProvider,
   );
 
   const wrappedSubscribeToTransactionsWithProofs = jsonToProtobufHandlerWrapper(

--- a/packages/dapi/test/unit/grpcServer/handlers/blockheaders-stream/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/blockheaders-stream/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
@@ -43,7 +43,6 @@ describe('subscribeToBlockHeadersWithChainLocksHandlerFactory', () => {
       getBlock: this.sinon.stub(),
       getBlockStats: this.sinon.stub(),
       getBlockHeaders: this.sinon.stub(),
-      getBestBlockHeight: this.sinon.stub(),
       getBlockHash: this.sinon.stub(),
       getBestChainLock: this.sinon.stub(),
     };
@@ -113,6 +112,7 @@ describe('subscribeToBlockHeadersWithChainLocksHandlerFactory', () => {
     });
 
     coreAPIMock.getBlockStats.resolves({ height: 1 });
+    chainDataProvider.chainHeight = 10;
 
     await subscribeToBlockHeadersWithChainLocksHandler(call);
 
@@ -165,6 +165,7 @@ describe('subscribeToBlockHeadersWithChainLocksHandlerFactory', () => {
     });
 
     coreAPIMock.getBlockStats.resolves({ height: 1 });
+    chainDataProvider.chainHeight = 10;
 
     await subscribeToBlockHeadersWithChainLocksHandler(call);
 
@@ -213,7 +214,7 @@ describe('subscribeToBlockHeadersWithChainLocksHandlerFactory', () => {
 
       coreAPIMock.getBlockStats.resolves({ height: 10 });
 
-      coreAPIMock.getBestBlockHeight.resolves(11);
+      chainDataProvider.chainHeight = 11;
 
       await subscribeToBlockHeadersWithChainLocksHandler(call);
 

--- a/packages/dapi/test/unit/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.spec.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.spec.js
@@ -34,7 +34,7 @@ const subscribeToTransactionsWithProofsHandlerFactory = require(
 );
 
 const ProcessMediator = require('../../../../../lib/transactionsFilter/ProcessMediator');
-const ChainDataProvider = require("../../../../../lib/chainDataProvider/ChainDataProvider");
+const ChainDataProvider = require('../../../../../lib/chainDataProvider/ChainDataProvider');
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -63,6 +63,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', () => {
   let coreAPIMock;
   let getMemPoolTransactionsMock;
   let chainDataProvider;
+  let zmqClientMock;
 
   beforeEach(function beforeEach() {
     const bloomFilterMessage = new BloomFilter();
@@ -111,7 +112,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', () => {
       testTransactionAgainstFilterMock,
       coreAPIMock,
       getMemPoolTransactionsMock,
-      chainDataProvider
+      chainDataProvider,
     );
 
     this.sinon.spy(ProcessMediator.prototype, 'emit');

--- a/packages/dapi/test/unit/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.spec.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/tx-filter-stream/subscribeToTransactionsWithProofsHandlerFactory.spec.js
@@ -34,6 +34,7 @@ const subscribeToTransactionsWithProofsHandlerFactory = require(
 );
 
 const ProcessMediator = require('../../../../../lib/transactionsFilter/ProcessMediator');
+const ChainDataProvider = require("../../../../../lib/chainDataProvider/ChainDataProvider");
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -61,6 +62,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', () => {
   let testTransactionAgainstFilterMock;
   let coreAPIMock;
   let getMemPoolTransactionsMock;
+  let chainDataProvider;
 
   beforeEach(function beforeEach() {
     const bloomFilterMessage = new BloomFilter();
@@ -93,11 +95,14 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', () => {
     coreAPIMock = {
       getBlock: this.sinon.stub(),
       getBlockStats: this.sinon.stub(),
-      getBestBlockHeight: this.sinon.stub(),
       getBlockHash: this.sinon.stub(),
     };
 
     getMemPoolTransactionsMock = this.sinon.stub().returns([]);
+
+    zmqClientMock = { on: this.sinon.stub(), topics: { hashblock: 'fake' } };
+
+    chainDataProvider = new ChainDataProvider(coreAPIMock, zmqClientMock);
 
     subscribeToTransactionsWithProofsHandler = subscribeToTransactionsWithProofsHandlerFactory(
       getHistoricalTransactionsIteratorMock,
@@ -106,6 +111,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', () => {
       testTransactionAgainstFilterMock,
       coreAPIMock,
       getMemPoolTransactionsMock,
+      chainDataProvider
     );
 
     this.sinon.spy(ProcessMediator.prototype, 'emit');
@@ -151,7 +157,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', () => {
     call.request = TransactionsWithProofsRequest.deserializeBinary(call.request.serializeBinary());
 
     coreAPIMock.getBlockStats.resolves({ height: 1 });
-    coreAPIMock.getBestBlockHeight.resolves(10);
+    chainDataProvider.chainHeight = 10;
 
     try {
       await subscribeToTransactionsWithProofsHandler(call);
@@ -184,7 +190,7 @@ describe('subscribeToTransactionsWithProofsHandlerFactory', () => {
     call = new GrpcCallMock(this.sinon, call.request);
 
     coreAPIMock.getBlockStats.resolves({ height: 1 });
-    coreAPIMock.getBestBlockHeight.resolves(10);
+    chainDataProvider.chainHeight = 10;
 
     historicalTxData.push({
       merkleBlock: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to reduce amount of Core RPC calls (which is slow), we should use already available chain height.

## What was done?
<!--- Describe your changes in detail -->
- Use height from `ChainDataProvider` instead of calling `getBestBlockHeight` every request in `subscribeToTransactionsWithProofs` and `subscribeToBlockHeadersWithChainLocks`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
