### PR TITLE
fix(sdk): panic GrpcContextProvider on async call inside sync code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,6 +1307,7 @@ dependencies = [
 name = "dash-sdk"
 version = "1.0.0-dev.15"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "base64 0.22.0",
  "bincode 2.0.0-rc.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,7 @@ dependencies = [
  "hex",
  "http 0.2.12",
  "lru",
+ "pollster",
  "rs-dapi-client",
  "sanitize-filename",
  "serde",
@@ -3657,6 +3658,12 @@ dependencies = [
  "pin-project-lite",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
 name = "portable-atomic"

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.0-dev.15"
 edition = "2021"
 
 [dependencies]
+arc-swap = { version = "1.7.1" }
 dpp = { path = "../rs-dpp", default-features = false, features = [
   "dash-sdk-features",
 ] }

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -35,7 +35,7 @@ derive_more = { version = "0.99.17" }
 dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.2" }
 lru = { version = "0.12.3", optional = true }
 bip37-bloom-filter = { git = "https://github.com/dashpay/rs-bip37-bloom-filter", branch = "develop" }
-
+pollster = { version = "0.3.0" }
 
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }

--- a/packages/rs-sdk/src/mock/provider.rs
+++ b/packages/rs-sdk/src/mock/provider.rs
@@ -3,6 +3,7 @@
 use crate::core_client::CoreClient;
 use crate::platform::Fetch;
 use crate::{Error, Sdk};
+use arc_swap::ArcSwapAny;
 use dpp::prelude::{DataContract, Identifier};
 use drive_proof_verifier::error::ContextProviderError;
 use drive_proof_verifier::ContextProvider;
@@ -11,7 +12,6 @@ use futures::FutureExt;
 use std::future::Future;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
-use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
@@ -27,7 +27,7 @@ pub struct GrpcContextProvider {
     /// values set by the user in the caches: `data_contracts_cache`, `quorum_public_keys_cache`.
     ///
     /// We use [Arc] as we have circular dependencies between Sdk and ContextProvider.
-    sdk: std::sync::RwLock<Option<Sdk>>,
+    sdk: ArcSwapAny<Arc<Option<Sdk>>>,
 
     /// Data contracts cache.
     ///
@@ -68,7 +68,7 @@ impl GrpcContextProvider {
         let core_client = CoreClient::new(core_ip, core_port, core_user, core_password)?;
         Ok(Self {
             core: core_client,
-            sdk: std::sync::RwLock::new(sdk),
+            sdk: ArcSwapAny::new(Arc::new(sdk)),
             data_contracts_cache: Cache::new(data_contracts_cache_size),
             quorum_public_keys_cache: Cache::new(quorum_public_keys_cache_size),
             #[cfg(feature = "mocks")]
@@ -82,9 +82,7 @@ impl GrpcContextProvider {
     /// Note that if the `sdk` is `None`, the context provider will not be able to fetch data itself and will rely on
     /// values set by the user in the caches: `data_contracts_cache`, `quorum_public_keys_cache`.
     pub fn set_sdk(&self, sdk: Option<Sdk>) {
-        let mut guard = self.sdk.write().expect("lock poisoned");
-        let item = guard.deref_mut();
-        *item = sdk;
+        self.sdk.store(Arc::new(sdk));
     }
     /// Set the directory where to store dumped data.
     ///
@@ -162,8 +160,10 @@ impl ContextProvider for GrpcContextProvider {
         if let Some(contract) = self.data_contracts_cache.get(data_contract_id) {
             return Ok(Some(contract));
         };
-        let sdk_guard = self.sdk.read().expect("lock poisoned");
-        let sdk = match &sdk_guard.deref() {
+        // let sdk_guard = self.sdk.read().expect("lock poisoned");
+        let sdk_guard = self.sdk.load();
+
+        let sdk = match sdk_guard.as_ref() {
             Some(sdk) => sdk,
             None => {
                 tracing::warn!("data contract cache miss and no sdk provided, skipping fetch");

--- a/packages/rs-sdk/src/mock/provider.rs
+++ b/packages/rs-sdk/src/mock/provider.rs
@@ -1,12 +1,17 @@
 //! Example ContextProvider that uses the Core gRPC API to fetch data from the platform.
 
+use std::fmt::Debug;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
+use std::thread::sleep;
 
 use dpp::prelude::{DataContract, Identifier};
 use drive_proof_verifier::error::ContextProviderError;
 use drive_proof_verifier::ContextProvider;
+use std::future::Future;
+use tokio::sync::oneshot::error::TryRecvError;
 
 use crate::core_client::CoreClient;
 use crate::platform::Fetch;
@@ -24,7 +29,7 @@ pub struct GrpcContextProvider {
     /// values set by the user in the caches: `data_contracts_cache`, `quorum_public_keys_cache`.
     ///
     /// We use [Arc] as we have circular dependencies between Sdk and ContextProvider.
-    sdk: Option<Sdk>,
+    sdk: std::sync::RwLock<Option<Sdk>>,
 
     /// Data contracts cache.
     ///
@@ -65,7 +70,7 @@ impl GrpcContextProvider {
         let core_client = CoreClient::new(core_ip, core_port, core_user, core_password)?;
         Ok(Self {
             core: core_client,
-            sdk,
+            sdk: std::sync::RwLock::new(sdk),
             data_contracts_cache: Cache::new(data_contracts_cache_size),
             quorum_public_keys_cache: Cache::new(quorum_public_keys_cache_size),
             #[cfg(feature = "mocks")]
@@ -78,8 +83,10 @@ impl GrpcContextProvider {
     ///
     /// Note that if the `sdk` is `None`, the context provider will not be able to fetch data itself and will rely on
     /// values set by the user in the caches: `data_contracts_cache`, `quorum_public_keys_cache`.
-    pub fn set_sdk(&mut self, sdk: Option<Sdk>) {
-        self.sdk = sdk;
+    pub fn set_sdk(&self, sdk: Option<Sdk>) {
+        let mut guard = self.sdk.write().expect("lock poisoned");
+        let item = guard.deref_mut();
+        *item = sdk;
     }
     /// Set the directory where to store dumped data.
     ///
@@ -157,8 +164,8 @@ impl ContextProvider for GrpcContextProvider {
         if let Some(contract) = self.data_contracts_cache.get(data_contract_id) {
             return Ok(Some(contract));
         };
-
-        let sdk = match &self.sdk {
+        let sdk_guard = self.sdk.read().expect("lock poisoned");
+        let sdk = match &sdk_guard.deref() {
             Some(sdk) => sdk,
             None => {
                 tracing::warn!("data contract cache miss and no sdk provided, skipping fetch");
@@ -166,20 +173,14 @@ impl ContextProvider for GrpcContextProvider {
             }
         };
 
-        let handle = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => handle,
-            // not an error, we rely on the caller to provide a data contract using
-            Err(e) => {
-                tracing::warn!(
-                    error = e.to_string(),
-                    "data contract cache miss and no tokio runtime detected, skipping fetch"
-                );
-                return Ok(None);
-            }
-        };
+        let contract_id = *data_contract_id;
+        let sdk_cloned = sdk.clone();
 
-        let data_contract = handle
-            .block_on(DataContract::fetch(sdk, *data_contract_id))
+        let data_contract: Option<DataContract> =
+            spawn_async::<Result<Option<DataContract>, crate::error::Error>, _, _>(
+                move || async move { DataContract::fetch(&sdk_cloned, contract_id).await },
+            )
+            .map_err(|e| ContextProviderError::InvalidDataContract(e.to_string()))?
             .map_err(|e| ContextProviderError::InvalidDataContract(e.to_string()))?;
 
         if let Some(ref dc) = data_contract {
@@ -187,6 +188,53 @@ impl ContextProvider for GrpcContextProvider {
         };
 
         Ok(data_contract.map(Arc::new))
+    }
+}
+
+// spawn_async is a workaorund to connect sync and async code, as block_on() panics when in async context
+fn spawn_async<R, F, Fut>(f: F) -> Result<R, Error>
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = R> + Send + 'static,
+    R: Send + Sync + 'static + Debug,
+{
+    let tokio_rt = match tokio::runtime::Handle::try_current() {
+        Ok(handle) => handle,
+        // not an error, we rely on the caller to provide a data contract using
+        Err(e) => {
+            tracing::warn!(
+                error = e.to_string(),
+                "data contract cache miss and no tokio runtime detected, skipping fetch"
+            );
+            return Err(Error::ContextProviderError(ContextProviderError::Generic(
+                e.to_string(),
+            )));
+        }
+    };
+
+    let (send, mut recv) = tokio::sync::oneshot::channel();
+
+    let _join_handle = tokio_rt.spawn(async move {
+        let result = f().await;
+        send.send(result).expect("send result");
+    });
+
+    loop {
+        match recv.try_recv() {
+            Ok(result) => return Ok(result),
+            Err(TryRecvError::Empty) => {
+                tracing::trace!("waiting for data contract to be fetched");
+                // FIXME this is just a workaround to connect sync and async code
+                sleep(std::time::Duration::from_millis(10));
+
+                continue;
+            }
+            Err(e) => {
+                return Err(Error::ContextProviderError(
+                    ContextProviderError::InvalidDataContract(e.to_string()),
+                ));
+            }
+        }
     }
 }
 

--- a/packages/rs-sdk/src/mock/provider.rs
+++ b/packages/rs-sdk/src/mock/provider.rs
@@ -1,21 +1,19 @@
 //! Example ContextProvider that uses the Core gRPC API to fetch data from the platform.
 
-use std::fmt::Debug;
+use crate::core_client::CoreClient;
+use crate::platform::Fetch;
+use crate::{Error, Sdk};
+use dpp::prelude::{DataContract, Identifier};
+use drive_proof_verifier::error::ContextProviderError;
+use drive_proof_verifier::ContextProvider;
+use futures::task::ArcWake;
+use futures::FutureExt;
+use std::future::Future;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
-use std::thread::sleep;
-
-use dpp::prelude::{DataContract, Identifier};
-use drive_proof_verifier::error::ContextProviderError;
-use drive_proof_verifier::ContextProvider;
-use std::future::Future;
-use tokio::sync::oneshot::error::TryRecvError;
-
-use crate::core_client::CoreClient;
-use crate::platform::Fetch;
-use crate::{Error, Sdk};
+use std::task::{Context, Poll};
 
 /// Context provider that uses the Core gRPC API to fetch data from the platform.
 ///
@@ -177,11 +175,8 @@ impl ContextProvider for GrpcContextProvider {
         let sdk_cloned = sdk.clone();
 
         let data_contract: Option<DataContract> =
-            spawn_async::<Result<Option<DataContract>, crate::error::Error>, _, _>(
-                move || async move { DataContract::fetch(&sdk_cloned, contract_id).await },
-            )
-            .map_err(|e| ContextProviderError::InvalidDataContract(e.to_string()))?
-            .map_err(|e| ContextProviderError::InvalidDataContract(e.to_string()))?;
+            poll_future(DataContract::fetch(&sdk_cloned, contract_id))
+                .map_err(|e| ContextProviderError::InvalidDataContract(e.to_string()))?;
 
         if let Some(ref dc) = data_contract {
             self.data_contracts_cache.put(*data_contract_id, dc.clone());
@@ -191,49 +186,55 @@ impl ContextProvider for GrpcContextProvider {
     }
 }
 
-// spawn_async is a workaorund to connect sync and async code, as block_on() panics when in async context
-fn spawn_async<R, F, Fut>(f: F) -> Result<R, Error>
-where
-    F: FnOnce() -> Fut + Send + 'static,
-    Fut: Future<Output = R> + Send + 'static,
-    R: Send + Sync + 'static + Debug,
-{
-    let tokio_rt = match tokio::runtime::Handle::try_current() {
-        Ok(handle) => handle,
-        // not an error, we rely on the caller to provide a data contract using
-        Err(e) => {
-            tracing::warn!(
-                error = e.to_string(),
-                "data contract cache miss and no tokio runtime detected, skipping fetch"
-            );
-            return Err(Error::ContextProviderError(ContextProviderError::Generic(
-                e.to_string(),
-            )));
+struct MtxWaker {
+    mtx: std::sync::Mutex<bool>,
+    cvar: std::sync::Condvar,
+}
+
+impl MtxWaker {
+    fn new() -> Self {
+        Self {
+            mtx: std::sync::Mutex::new(false),
+            cvar: std::sync::Condvar::new(),
         }
-    };
+    }
 
-    let (send, mut recv) = tokio::sync::oneshot::channel();
+    fn wait(&self) {
+        let mut started = self.mtx.lock().expect("lock poisoned");
+        while !*started {
+            started = self.cvar.wait(started).expect("wait failed");
+        }
+    }
+}
 
-    let _join_handle = tokio_rt.spawn(async move {
-        let result = f().await;
-        send.send(result).expect("send result");
-    });
+impl ArcWake for MtxWaker {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        let mut started = arc_self.mtx.lock().expect("lock poisoned");
+        *started = true;
+        arc_self.cvar.notify_one();
+    }
+}
+
+/// Execute an async function in a sync context, when block_on() is not available.
+///
+/// When async code runs some sync code inside a thread used to drive asynchronous tasks,
+/// that sync code cannot call block_on(). This function is a workaround for this that allows to run async code in a
+/// sync context.
+///
+/// Note it uses a busy loop to poll the future, so it's not efficient and should be used only for testing purposes.
+fn poll_future<F: Future>(future: F) -> F::Output {
+    let mtx_waker = Arc::new(MtxWaker::new());
+    let waker = futures::task::waker(mtx_waker.clone());
+    // let waker = futures::task::noop_waker();
+
+    let mut context = Context::from_waker(&waker);
+
+    let mut future = Box::pin(future).fuse();
 
     loop {
-        match recv.try_recv() {
-            Ok(result) => return Ok(result),
-            Err(TryRecvError::Empty) => {
-                tracing::trace!("waiting for data contract to be fetched");
-                // FIXME this is just a workaround to connect sync and async code
-                sleep(std::time::Duration::from_millis(10));
-
-                continue;
-            }
-            Err(e) => {
-                return Err(Error::ContextProviderError(
-                    ContextProviderError::InvalidDataContract(e.to_string()),
-                ));
-            }
+        match Future::poll(std::pin::Pin::new(&mut future), &mut context) {
+            Poll::Ready(value) => return value,
+            Poll::Pending => mtx_waker.wait(),
         }
     }
 }

--- a/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
@@ -149,6 +149,12 @@ pub fn from_consensus_error_ref(e: &DPPConsensusError) -> JsValue {
         DPPConsensusError::StateError(state_error) => from_state_error(state_error),
         DPPConsensusError::BasicError(basic_error) => from_basic_error(basic_error),
         DPPConsensusError::DefaultError => JsError::new("DefaultError").into(),
+        #[cfg(test)]
+        e => todo!(
+            "ConsensusError {} not implemented: {}",
+            std::any::type_name_of_val(e),
+            e
+        ),
     }
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two related issues fixed:

1. Tokio::block_on() panics in sync fn in async context:

```
thread 'main' panicked at 'Cannot start a runtime from within a runtime. This 
happens because a function (like `block_on`) attempted to block the current 
thread while the thread is being used to drive asynchronous tasks.'
```

2. Proof verification cannot fetch contracts

```
"proof: the contract could not be retrieved during verification: cannot get data contract: Proof verification error: context provider is not set"
```

This is caused because we have cyclical dependencies: Sdk uses GrpcContextProvider, and GrpcContextProvider uses Sdk.
Unfortunately, due to the way we initialize GrpcContextProvider, it uses an invalid, not complete copy of Sdk. This issue was introduced in #1838 . 

## What was done?

Issue 1: Implemented a workaround to safely call async code within sync context. This is done in new `spawn_async` fn that uses oneshot channel to synchronize with async thread.

Issue 2: Refactored `GrpcContextProvider` to allow setting sdk without need of `&mut`. This allows the use of `Arc<>` when referring to `GrpcContextProvider`, and helps ensure that it uses correct version of Sdk.

## How Has This Been Tested?

GHA

Run dash-sdk tests against local network.


## Breaking Changes

None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
