### PR TITLE
refactor(dpp): change String and ByteArray DocumentPropertyType sizes to structs

### DIFF
--- a/packages/rs-dpp/src/data_contract/document_type/schema/find_identifier_and_binary_paths/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/schema/find_identifier_and_binary_paths/v0/mod.rs
@@ -32,7 +32,7 @@ impl DocumentTypeV0 {
                 DocumentPropertyType::Identifier => {
                     identifier_paths.insert(new_path);
                 }
-                DocumentPropertyType::ByteArray(_, _) => {
+                DocumentPropertyType::ByteArray(_) => {
                     binary_paths.insert(new_path);
                 }
                 DocumentPropertyType::Object(inner_properties) => {

--- a/packages/rs-dpp/src/data_contract/errors/contract.rs
+++ b/packages/rs-dpp/src/data_contract/errors/contract.rs
@@ -3,7 +3,6 @@ use crate::consensus::basic::decode::DecodingError;
 use crate::consensus::basic::BasicError;
 use bincode::{Decode, Encode};
 use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
-use platform_value::Identifier;
 use thiserror::Error;
 
 use crate::consensus::basic::document::InvalidDocumentTypeError;

--- a/packages/rs-dpp/src/tests/fixtures/identity_fixture.rs
+++ b/packages/rs-dpp/src/tests/fixtures/identity_fixture.rs
@@ -1,10 +1,9 @@
 use crate::identity::identity_public_key::v0::IdentityPublicKeyV0;
-use crate::identity::{IdentityPublicKey, IdentityV0, KeyType, Purpose, SecurityLevel};
+use crate::identity::{IdentityV0, KeyType, Purpose, SecurityLevel};
 use platform_value::platform_value;
 use platform_value::string_encoding::Encoding;
 use platform_value::BinaryData;
 use serde_json::json;
-use std::collections::BTreeMap;
 
 use crate::prelude::{Identifier, Identity};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was a TODO to create structs for the lengths and sizes of String and ByteArray DocumentPropertyTypes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
