### PR TITLE
fix!: removal of already required system fields

### DIFF
--- a/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
@@ -246,7 +246,7 @@ mod tests {
     use dpp::state_transition::identity_update_transition::IdentityUpdateTransition;
     use dpp::state_transition::public_key_in_creation::v0::IdentityPublicKeyInCreationV0;
     use dpp::state_transition::public_key_in_creation::IdentityPublicKeyInCreation;
-    use dpp::state_transition::{StateTransition, StateTransitionLike};
+    use dpp::state_transition::{documents_batch_transition, StateTransition, StateTransitionLike};
     use dpp::tests::fixtures::{
         get_dashpay_contract_fixture, get_dpns_data_contract_fixture,
         instant_asset_lock_proof_fixture,
@@ -255,21 +255,25 @@ mod tests {
 
     use crate::execution::check_tx::CheckTxLevel::{FirstTimeCheck, Recheck};
     use dpp::consensus::state::state_error::StateError;
+    use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
     use dpp::data_contract::document_type::v0::random_document_type::{
         FieldMinMaxBounds, FieldTypeWeights, RandomDocumentTypeParameters,
     };
     use dpp::data_contract::document_type::v0::DocumentTypeV0;
     use dpp::data_contract::document_type::DocumentType;
+    use dpp::data_contract::{DataContract, DataContractFactory, DataContractV0};
     use dpp::identity::contract_bounds::ContractBounds::SingleContractDocumentType;
-    use dpp::platform_value::Bytes32;
+    use dpp::platform_value::{platform_value, Bytes32};
     use dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
     use dpp::state_transition::identity_create_transition::accessors::IdentityCreateTransitionAccessorsV0;
     use dpp::state_transition::public_key_in_creation::accessors::IdentityPublicKeyInCreationV0Setters;
     use dpp::system_data_contracts::dashpay_contract;
     use dpp::system_data_contracts::SystemDataContract::Dashpay;
+    use drive::drive::document::query::QueryDocumentsOutcomeV0Methods;
+    use drive::query::DriveQuery;
     use platform_version::{TryFromPlatformVersioned, TryIntoPlatformVersioned};
     use rand::rngs::StdRng;
-    use rand::SeedableRng;
+    use rand::{random, SeedableRng};
     use std::collections::BTreeMap;
 
     // This test needs to be redone with new contract bytes, but is still useful for debugging
@@ -1154,6 +1158,383 @@ mod tests {
             check_result.errors.first().expect("expected an error"),
             ConsensusError::StateError(StateError::InvalidIdentityNonceError(_))
         ));
+    }
+
+    #[test]
+    fn data_contract_update_with_system_fields_changed() {
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(PlatformConfig::default())
+            .build_with_mock_rpc();
+
+        platform
+            .core_rpc
+            .expect_verify_instant_lock()
+            .returning(|_, _| Ok(true));
+
+        let platform_state = platform.state.load();
+        let protocol_version = platform_state.current_protocol_version_in_consensus();
+        let platform_version = PlatformVersion::get(protocol_version).unwrap();
+
+        let (key, private_key) = IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+            1,
+            Some(1),
+            platform_version,
+        )
+        .expect("expected to get key pair");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        platform
+            .drive
+            .create_initial_state_structure(Some(&transaction), platform_version)
+            .expect("expected to create state structure");
+
+        // Create identity
+
+        let identity: Identity = IdentityV0 {
+            id: Identifier::new([
+                158, 113, 180, 126, 91, 83, 62, 44, 83, 54, 97, 88, 240, 215, 84, 139, 167, 156,
+                166, 203, 222, 4, 64, 31, 215, 199, 149, 151, 190, 246, 251, 44,
+            ]),
+            public_keys: BTreeMap::from([(1, key.clone())]),
+            balance: 100000000000,
+            revision: 0,
+        }
+        .into();
+
+        platform
+            .drive
+            .add_new_identity(
+                identity.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to insert identity");
+
+        // Create original contract with required system fields
+
+        let factory = DataContractFactory::new(protocol_version).expect("failed to create factory");
+
+        let indices = platform_value!([
+            {
+                "name": "$createdAt",
+                "properties": [{"$createdAt": "asc"}],
+            },
+            {
+                "name": "$updatedAt",
+                "properties": [{"$updatedAt": "asc"}],
+            },
+            {
+                "name": "$transferredAt",
+                "properties": [{"$transferredAt": "asc"}],
+            },
+            {
+                "name": "$createdAtBlockHeight",
+                "properties": [{"$createdAtBlockHeight": "asc"}],
+            },
+            {
+                "name": "$updatedAtBlockHeight",
+                "properties": [{"$updatedAtBlockHeight": "asc"}],
+            },
+            {
+                "name": "$transferredAtBlockHeight",
+                "properties": [{"$transferredAtBlockHeight": "asc"}],
+            },
+            {
+                "name": "$createdAtCoreBlockHeight",
+                "properties": [{"$createdAtCoreBlockHeight": "asc"}],
+            },
+            {
+                "name": "$updatedAtCoreBlockHeight",
+                "properties": [{"$updatedAtCoreBlockHeight": "asc"}]
+            },
+            {
+                "name": "$transferredAtCoreBlockHeight",
+                "properties": [{"$transferredAtCoreBlockHeight": "asc"}]
+            }
+        ]);
+
+        let schema = platform_value!({
+            "test": {
+                "type": "object",
+                "indices": indices.clone(),
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "position": 0,
+                    },
+                },
+                "required": ["$createdAt", "$updatedAt", "$transferredAt", "$createdAtBlockHeight", "$updatedAtBlockHeight", "$transferredAtBlockHeight", "$createdAtCoreBlockHeight", "$updatedAtCoreBlockHeight", "$transferredAtCoreBlockHeight"],
+                "additionalProperties": false,
+            }
+        });
+
+        let created_contract = factory
+            .create(identity.id(), 1, schema, None, None)
+            .expect("failed to create data contract");
+
+        let contract = created_contract.data_contract().clone();
+        let mut create_contract_state_transition: StateTransition = created_contract
+            .try_into_platform_versioned(platform_version)
+            .expect("expected a state transition");
+        create_contract_state_transition
+            .sign(&key, private_key.as_slice(), &NativeBlsModule)
+            .expect("expected to sign transition");
+        let serialized = create_contract_state_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![serialized.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.valid_count(), 1);
+
+        // Create a document
+
+        let block = BlockInfo {
+            time_ms: 100,
+            height: 1,
+            core_height: 1,
+            epoch: Default::default(),
+        };
+
+        let document_data = platform_value!({
+            "name": "test1",
+        });
+
+        let document_type = contract
+            .document_type_for_name("test")
+            .expect("test document type must be present");
+
+        let entropy = random();
+
+        let original_document = document_type
+            .create_document_from_data(
+                document_data,
+                identity.id(),
+                block.height,
+                block.core_height,
+                entropy,
+                platform_version,
+            )
+            .expect("failed to create document");
+
+        let mut signer = SimpleSigner::default();
+        signer.add_key(key.clone(), private_key.clone());
+
+        let documents_batch_transition =
+            DocumentsBatchTransition::new_document_creation_transition_from_document(
+                original_document.clone(),
+                document_type,
+                entropy,
+                &key,
+                2,
+                0,
+                &signer,
+                platform_version,
+                None,
+                None,
+                None,
+            )
+            .expect("expected a document batch transition");
+
+        let serialized_documents_batch_transition = documents_batch_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let document_processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![serialized_documents_batch_transition],
+                &platform_state,
+                &block,
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(document_processing_result.valid_count(), 1);
+
+        // Fetch document and compare
+
+        let mut fetched_documents = platform
+            .platform
+            .drive
+            .query_documents(
+                DriveQuery::any_item_query(&contract, document_type),
+                None,
+                false,
+                Some(&transaction),
+                Some(platform_version.protocol_version),
+            )
+            .expect("expected to fetch document")
+            .documents_owned();
+
+        assert_eq!(fetched_documents.len(), 1);
+
+        let fetched_document = fetched_documents.remove(0);
+
+        assert_eq!(fetched_document, original_document);
+
+        // Update contract to make system fields optional
+
+        let mut updated_contract = contract.clone();
+
+        updated_contract.set_version(2);
+
+        let schema = platform_value!({
+            "type": "object",
+            "indices": indices,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "position": 0,
+                },
+            },
+            "additionalProperties": false,
+        });
+
+        let updated_test_document_type = DocumentType::try_from_schema(
+            contract.id(),
+            "test",
+            schema,
+            None,
+            false,
+            false,
+            false,
+            false,
+            &mut Vec::new(),
+            platform_version,
+        )
+        .expect("failed to create document type");
+
+        updated_contract
+            .document_types_mut()
+            .insert("test".to_string(), updated_test_document_type.clone())
+            .expect("test document type must be present");
+
+        let mut update_contract_state_transition: StateTransition =
+            DataContractUpdateTransition::try_from_platform_versioned(
+                (updated_contract.clone(), 3),
+                platform_version,
+            )
+            .expect("expected a state transition")
+            .into();
+
+        update_contract_state_transition
+            .sign(&key, private_key.as_slice(), &NativeBlsModule)
+            .expect("expected to sign transition");
+        let serialized_update = update_contract_state_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let update_processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![serialized_update],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(update_processing_result.valid_count(), 1);
+
+        // Fetch and update existing document
+
+        let mut fetched_documents = platform
+            .platform
+            .drive
+            .query_documents(
+                DriveQuery::any_item_query(&updated_contract, updated_test_document_type.as_ref()),
+                None,
+                false,
+                Some(&transaction),
+                Some(platform_version.protocol_version),
+            )
+            .expect("expected to fetch document")
+            .documents_owned();
+
+        assert_eq!(fetched_documents.len(), 1);
+
+        let fetched_document = fetched_documents.remove(0);
+
+        assert_eq!(fetched_document, original_document);
+
+        // Create one more document for updated contract
+
+        let block = BlockInfo {
+            time_ms: 200,
+            height: 2,
+            core_height: 2,
+            epoch: Default::default(),
+        };
+
+        let document_data = platform_value!({
+            "name": "test1",
+        });
+
+        let document_type = updated_contract
+            .document_type_for_name("test")
+            .expect("test document type must be present");
+
+        let entropy = random();
+
+        let document = document_type
+            .create_document_from_data(
+                document_data,
+                identity.id(),
+                block.height,
+                block.core_height,
+                entropy,
+                platform_version,
+            )
+            .expect("failed to create document");
+
+        let documents_batch_transition =
+            DocumentsBatchTransition::new_document_creation_transition_from_document(
+                document.clone(),
+                document_type,
+                entropy,
+                &key,
+                4,
+                0,
+                &signer,
+                platform_version,
+                None,
+                None,
+                None,
+            )
+            .expect("expected a document batch transition");
+
+        let serialized_documents_batch_transition = documents_batch_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let document_processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![serialized_documents_batch_transition],
+                &platform_state,
+                &block,
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(document_processing_result.valid_count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, we do not support making optional already required document system fields such as `$createdAt`, `$createdAtHeight`, etc. This will break the state and ST processing logic. 

## What was done?
<!--- Describe your changes in detail -->
- Do not allow to remove fields started from `$` on from `required` list on data contract update.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test that expects an error on removal.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Data contract update validation rules are changed. Previous blockchain data might not be valid.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
