### PR TITLE
fix: contested unique indexes can only be on non mutable document types

### DIFF
--- a/packages/rs-dpp/src/errors/consensus/basic/basic_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/basic_error.rs
@@ -7,11 +7,12 @@ use crate::consensus::basic::data_contract::data_contract_max_depth_exceed_error
 #[cfg(feature = "json-schema-validation")]
 use crate::consensus::basic::data_contract::InvalidJsonSchemaRefError;
 use crate::consensus::basic::data_contract::{
-    DataContractHaveNewUniqueIndexError, DataContractImmutablePropertiesUpdateError,
-    DataContractInvalidIndexDefinitionUpdateError, DataContractUniqueIndicesChangedError,
-    DuplicateIndexError, DuplicateIndexNameError, IncompatibleDataContractSchemaError,
-    IncompatibleDocumentTypeSchemaError, IncompatibleRe2PatternError, InvalidCompoundIndexError,
-    InvalidDataContractIdError, InvalidDataContractVersionError, InvalidDocumentTypeNameError,
+    ContestedUniqueIndexOnMutableDocumentTypeError, DataContractHaveNewUniqueIndexError,
+    DataContractImmutablePropertiesUpdateError, DataContractInvalidIndexDefinitionUpdateError,
+    DataContractUniqueIndicesChangedError, DuplicateIndexError, DuplicateIndexNameError,
+    IncompatibleDataContractSchemaError, IncompatibleDocumentTypeSchemaError,
+    IncompatibleRe2PatternError, InvalidCompoundIndexError, InvalidDataContractIdError,
+    InvalidDataContractVersionError, InvalidDocumentTypeNameError,
     InvalidDocumentTypeRequiredSecurityLevelError, InvalidIndexPropertyTypeError,
     InvalidIndexedPropertyConstraintError, SystemPropertyIndexAlreadyPresentError,
     UndefinedIndexPropertyError, UniqueIndicesLimitReachedError,
@@ -375,6 +376,9 @@ pub enum BasicError {
 
     #[error(transparent)]
     IncompatibleDocumentTypeSchemaError(IncompatibleDocumentTypeSchemaError),
+
+    #[error(transparent)]
+    ContestedUniqueIndexOnMutableDocumentTypeError(ContestedUniqueIndexOnMutableDocumentTypeError),
 
     #[error(transparent)]
     OverflowError(OverflowError),

--- a/packages/rs-dpp/src/errors/consensus/basic/data_contract/contested_unique_index_on_mutable_document_type_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/data_contract/contested_unique_index_on_mutable_document_type_error.rs
@@ -1,0 +1,48 @@
+use crate::consensus::basic::BasicError;
+use crate::consensus::ConsensusError;
+use crate::errors::ProtocolError;
+use bincode::{Decode, Encode};
+use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
+use thiserror::Error;
+
+#[derive(
+    Error, Debug, Clone, PartialEq, Eq, Encode, Decode, PlatformSerialize, PlatformDeserialize,
+)]
+#[error(
+    "Document type '{document_type}' has a contested unique index '{contested_unique_index_name}'"
+)]
+#[platform_serialize(unversioned)]
+pub struct ContestedUniqueIndexOnMutableDocumentTypeError {
+    /*
+
+    DO NOT CHANGE ORDER OF FIELDS WITHOUT INTRODUCING OF NEW VERSION
+
+    */
+    document_type: String,
+    contested_unique_index_name: String,
+}
+
+impl ContestedUniqueIndexOnMutableDocumentTypeError {
+    pub fn new(document_type: String, contested_unique_index_name: String) -> Self {
+        Self {
+            document_type,
+            contested_unique_index_name,
+        }
+    }
+
+    pub fn document_type(&self) -> &str {
+        &self.document_type
+    }
+
+    pub fn contested_unique_index_name(&self) -> &str {
+        &self.contested_unique_index_name
+    }
+}
+
+impl From<ContestedUniqueIndexOnMutableDocumentTypeError> for ConsensusError {
+    fn from(err: ContestedUniqueIndexOnMutableDocumentTypeError) -> Self {
+        Self::BasicError(BasicError::ContestedUniqueIndexOnMutableDocumentTypeError(
+            err,
+        ))
+    }
+}

--- a/packages/rs-dpp/src/errors/consensus/basic/data_contract/mod.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/data_contract/mod.rs
@@ -1,3 +1,4 @@
+mod contested_unique_index_on_mutable_document_type_error;
 mod data_contract_have_new_unique_index_error;
 mod data_contract_immutable_properties_update_error;
 mod data_contract_invalid_index_definition_update_error;
@@ -49,6 +50,7 @@ pub use system_property_index_already_present_error::*;
 pub use undefined_index_property_error::*;
 pub use unique_indices_limit_reached_error::*;
 
+pub use contested_unique_index_on_mutable_document_type_error::*;
 pub use incompatible_document_type_schema_error::*;
 pub use invalid_document_type_name_error::*;
 pub use unknown_document_creation_restriction_mode_error::*;

--- a/packages/rs-dpp/src/errors/consensus/basic/data_contract/unique_indices_limit_reached_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/data_contract/unique_indices_limit_reached_error.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 #[derive(
     Error, Debug, Clone, PartialEq, Eq, Encode, Decode, PlatformSerialize, PlatformDeserialize,
 )]
-#[error("'{document_type}' document has more than '{index_limit}' unique indexes")]
+#[error("'{document_type}' document has more than '{index_limit}' unique indexes (contested is {is_contested_limit})")]
 #[platform_serialize(unversioned)]
 pub struct UniqueIndicesLimitReachedError {
     /*
@@ -17,22 +17,28 @@ pub struct UniqueIndicesLimitReachedError {
 
     */
     document_type: String,
-    index_limit: usize,
+    index_limit: u16,
+    is_contested_limit: bool,
 }
 
 impl UniqueIndicesLimitReachedError {
-    pub fn new(document_type: String, index_limit: usize) -> Self {
+    pub fn new(document_type: String, index_limit: u16, is_contested_limit: bool) -> Self {
         Self {
             document_type,
             index_limit,
+            is_contested_limit,
         }
     }
 
     pub fn document_type(&self) -> &str {
         &self.document_type
     }
-    pub fn index_limit(&self) -> usize {
+    pub fn index_limit(&self) -> u16 {
         self.index_limit
+    }
+
+    pub fn is_contested_limit(&self) -> bool {
+        self.is_contested_limit
     }
 }
 

--- a/packages/rs-platform-version/src/version/dpp_versions.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions.rs
@@ -88,6 +88,8 @@ pub struct VotingValidationVersions {
 #[derive(Clone, Debug, Default)]
 pub struct DocumentTypeValidationVersions {
     pub validate_update: FeatureVersion,
+    pub unique_index_limit: u16,
+    pub contested_index_limit: u16,
 }
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Extra validation that there can only be one contested unique index, and that we can only have a contested unique index when the document type is non mutable.


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [X] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
