### PR TITLE
fix(sdk): invalid order of items returned by VotePollsByEndDateDriveQuery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,7 +418,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -469,9 +480,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
@@ -495,7 +506,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.3.0",
 ]
 
 [[package]]
@@ -614,6 +625,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
 ]
 
 [[package]]
@@ -808,6 +829,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +967,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -1491,6 +1528,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2195,7 +2233,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "grovedb"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#8664b723330cc3850edbebd5f336b982f29ed23c"
+source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#d77bbf5bf6ab0eb48cca226fadc3764ca5c80d0f"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "bitvec",
@@ -2213,12 +2251,13 @@ dependencies = [
  "nohash-hasher",
  "tempfile",
  "thiserror",
+ "zip-extensions",
 ]
 
 [[package]]
 name = "grovedb-costs"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#8664b723330cc3850edbebd5f336b982f29ed23c"
+source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#d77bbf5bf6ab0eb48cca226fadc3764ca5c80d0f"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -2228,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#8664b723330cc3850edbebd5f336b982f29ed23c"
+source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#d77bbf5bf6ab0eb48cca226fadc3764ca5c80d0f"
 dependencies = [
  "blake3",
  "byteorder",
@@ -2251,12 +2290,12 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#8664b723330cc3850edbebd5f336b982f29ed23c"
+source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#d77bbf5bf6ab0eb48cca226fadc3764ca5c80d0f"
 
 [[package]]
 name = "grovedb-storage"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#8664b723330cc3850edbebd5f336b982f29ed23c"
+source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#d77bbf5bf6ab0eb48cca226fadc3764ca5c80d0f"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -2275,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "1.0.0-rc.2"
-source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#8664b723330cc3850edbebd5f336b982f29ed23c"
+source = "git+https://github.com/dashpay/grovedb?branch=feat/QuerySumTree#d77bbf5bf6ab0eb48cca226fadc3764ca5c80d0f"
 dependencies = [
  "hex",
  "itertools 0.12.1",
@@ -2407,6 +2446,15 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -2643,6 +2691,15 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
  "serde",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2907,7 +2964,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -3421,7 +3478,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3495,10 +3552,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -3955,7 +4035,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "memchr",
  "unicase",
 ]
@@ -4051,7 +4131,7 @@ version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -4080,7 +4160,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -4318,7 +4398,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "itoa",
  "libc",
@@ -4469,7 +4549,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4516,9 +4596,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
@@ -4546,9 +4626,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -4630,6 +4710,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.68",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4940,7 +5031,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0682e006dd35771e392a6623ac180999a9a854b1d4a6c12fb2e804941c2b1f58"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
@@ -5156,9 +5247,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5621,9 +5712,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea73390fe27785838dcbf75b91b1d84799e28f1ce71e6f372a5dc2200c80de5"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
  "rand",
@@ -5720,7 +5811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d888b611fee7d273dd057dc009d2dd3132736f36710ffd65657ac83628d1e3b"
 dependencies = [
  "anyhow",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cap-rand",
  "cap-std",
  "io-extras",
@@ -6108,7 +6199,7 @@ checksum = "0afb26cd3269289bb314a361ff0a6685e5ce793b62181a9fe3f81ace15051697"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -6345,7 +6436,7 @@ version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9643b83820c0cd246ecabe5fa454dd04ba4fa67996369466d0747472d337346"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "windows-sys 0.52.0",
 ]
 
@@ -6421,10 +6512,46 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
+ "aes",
  "byteorder",
+ "bzip2",
+ "constant_time_eq 0.1.5",
  "crc32fast",
  "crossbeam-utils",
  "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zip-extensions"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecf62554c4ff96bce01a7ef123d160c3ffe9180638820f8b4d545c65b221b8c"
+dependencies = [
+ "zip",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/packages/rs-drive-proof-verifier/src/lib.rs
+++ b/packages/rs-drive-proof-verifier/src/lib.rs
@@ -3,6 +3,7 @@
 
 /// Errors that can occur during proof verification
 pub mod error;
+pub mod ordered_btreemap;
 /// Implementation of proof verification
 mod proof;
 mod provider;

--- a/packages/rs-drive-proof-verifier/src/ordered_btreemap.rs
+++ b/packages/rs-drive-proof-verifier/src/ordered_btreemap.rs
@@ -13,6 +13,17 @@ pub enum OrderedIterator<I: DoubleEndedIterator> {
     Descending(Rev<I>),
 }
 
+impl<I: DoubleEndedIterator> Iterator for OrderedIterator<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            OrderedIterator::Ascending(iter) => iter.next(),
+            OrderedIterator::Descending(iter) => iter.next(),
+        }
+    }
+}
+
 /// BTreeMap that can be ordered in either ascending or descending order.
 #[derive(Clone, Debug, Default, derive_more::From)]
 #[cfg_attr(feature = "mocks", derive(Encode, Decode))]
@@ -20,7 +31,8 @@ pub enum OrderedIterator<I: DoubleEndedIterator> {
 pub struct OrderedBTreeMap<K: Ord, V> {
     /// The inner map.
     inner: BTreeMap<K, V>,
-    /// When set to true, the map will be ordered in ascending order.
+    /// When set to true, the map will be iterated in ascending order. Otherwise, it will be
+    /// iterated in descending order.
     order_ascending: bool,
 }
 
@@ -114,17 +126,6 @@ impl<K: Ord, V> IntoIterator for OrderedBTreeMap<K, V> {
             OrderedIterator::Ascending(iter)
         } else {
             OrderedIterator::Descending(iter.rev())
-        }
-    }
-}
-
-impl<I: DoubleEndedIterator> Iterator for OrderedIterator<I> {
-    type Item = I::Item;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            OrderedIterator::Ascending(iter) => iter.next(),
-            OrderedIterator::Descending(iter) => iter.next(),
         }
     }
 }

--- a/packages/rs-drive-proof-verifier/src/ordered_btreemap.rs
+++ b/packages/rs-drive-proof-verifier/src/ordered_btreemap.rs
@@ -1,0 +1,130 @@
+//! [BTreeMap] that can be ordered in either ascending or descending order.
+use bincode::{Decode, Encode};
+use std::collections::btree_map::{Iter, Keys};
+use std::{collections::BTreeMap, iter::Rev};
+
+/// Iterator that can be either forward or reverse.
+///
+/// Used to iterate over items in a map in either ascending or descending order.
+pub enum OrderedIterator<I: DoubleEndedIterator> {
+    /// Items are iterated in ascending order.
+    Ascending(I),
+    /// Items are iterated in descending order.
+    Descending(Rev<I>),
+}
+
+/// BTreeMap that can be ordered in either ascending or descending order.
+#[derive(Clone, Debug, Default, derive_more::From)]
+#[cfg_attr(feature = "mocks", derive(Encode, Decode))]
+
+pub struct OrderedBTreeMap<K: Ord, V> {
+    /// The inner map.
+    inner: BTreeMap<K, V>,
+    /// When set to true, the map will be ordered in ascending order.
+    order_ascending: bool,
+}
+
+impl<K: Ord, V> OrderedBTreeMap<K, V> {
+    /// Create a new OrderedBTreeMap with provided ordering.
+    pub fn new(order_ascending: bool) -> Self {
+        Self {
+            inner: BTreeMap::new(),
+            order_ascending,
+        }
+    }
+
+    /// Creates a new OrderedBTreeMap from a BTreeMap with the provided ordering.
+    ///
+    /// This function consumes the provided map to avoid cloning it, thus it is more efficient than
+    /// creating a new OrderedBTreeMap and then extending it with the provided map.
+    pub fn from_btreemap(map: BTreeMap<K, V>, order_ascending: bool) -> Self {
+        Self {
+            inner: map,
+            order_ascending,
+        }
+    }
+
+    /// Returns an iterator over the map.
+    ///
+    /// See [BTreemap::iter()] for more information.
+    pub fn iter(&self) -> OrderedIterator<Iter<'_, K, V>> {
+        if self.order_ascending {
+            OrderedIterator::Ascending(self.inner.iter())
+        } else {
+            OrderedIterator::Descending(self.inner.iter().rev())
+        }
+    }
+
+    /// Returns true if the map is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns the number of elements in the map.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Gets an iterator over the keys of the map, in sorted order.
+    pub fn keys(&self) -> OrderedIterator<Keys<'_, K, V>> {
+        if self.order_ascending {
+            OrderedIterator::Ascending(self.inner.keys())
+        } else {
+            OrderedIterator::Descending(self.inner.keys().rev())
+        }
+    }
+
+    /// Gets all values in the map as a vector, ordered by key.
+    pub fn values_vec(&self) -> Vec<&V> {
+        self.iter().map(|(_k, v)| v).collect()
+    }
+}
+
+impl<K: Ord, V> From<OrderedBTreeMap<K, V>> for BTreeMap<K, V> {
+    fn from(value: OrderedBTreeMap<K, V>) -> Self {
+        value.inner
+    }
+}
+
+impl<K: Ord, V> Extend<(K, V)> for OrderedBTreeMap<K, V> {
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = (K, V)>,
+    {
+        self.inner.extend(iter)
+    }
+}
+
+impl<K: Ord, V> From<BTreeMap<K, V>> for OrderedBTreeMap<K, V> {
+    fn from(value: BTreeMap<K, V>) -> Self {
+        Self {
+            inner: value,
+            order_ascending: true, // btreemap is always ordered in ascending order
+        }
+    }
+}
+
+impl<K: Ord, V> IntoIterator for OrderedBTreeMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = OrderedIterator<<BTreeMap<K, V> as IntoIterator>::IntoIter>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let iter = self.inner.into_iter();
+        if self.order_ascending {
+            OrderedIterator::Ascending(iter)
+        } else {
+            OrderedIterator::Descending(iter.rev())
+        }
+    }
+}
+
+impl<I: DoubleEndedIterator> Iterator for OrderedIterator<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            OrderedIterator::Ascending(iter) => iter.next(),
+            OrderedIterator::Descending(iter) => iter.next(),
+        }
+    }
+}

--- a/packages/rs-drive-proof-verifier/src/proof.rs
+++ b/packages/rs-drive-proof-verifier/src/proof.rs
@@ -1,4 +1,5 @@
 use crate::from_request::TryFromRequest;
+use crate::ordered_btreemap::OrderedBTreeMap;
 use crate::{types, types::*, ContextProvider, Error};
 use dapi_grpc::platform::v0::get_identities_contract_keys_request::GetIdentitiesContractKeysRequestV0;
 use dapi_grpc::platform::v0::get_path_elements_request::GetPathElementsRequestV0;
@@ -13,10 +14,11 @@ use dapi_grpc::platform::v0::{
     get_identity_balance_request, get_identity_by_public_key_hash_request,
     get_identity_contract_nonce_request, get_identity_keys_request, get_identity_nonce_request,
     get_identity_request, get_path_elements_request, get_prefunded_specialized_balance_request,
-    GetContestedResourceVotersForIdentityRequest, GetContestedResourceVotersForIdentityResponse,
-    GetPathElementsRequest, GetPathElementsResponse, GetProtocolVersionUpgradeStateRequest,
-    GetProtocolVersionUpgradeStateResponse, GetProtocolVersionUpgradeVoteStatusRequest,
-    GetProtocolVersionUpgradeVoteStatusResponse, ResponseMetadata,
+    get_vote_polls_by_end_date_request, GetContestedResourceVotersForIdentityRequest,
+    GetContestedResourceVotersForIdentityResponse, GetPathElementsRequest, GetPathElementsResponse,
+    GetProtocolVersionUpgradeStateRequest, GetProtocolVersionUpgradeStateResponse,
+    GetProtocolVersionUpgradeVoteStatusRequest, GetProtocolVersionUpgradeVoteStatusResponse,
+    ResponseMetadata,
 };
 use dapi_grpc::platform::{
     v0::{self as platform, key_request_type, KeyRequestType as GrpcKeyType},
@@ -1452,6 +1454,13 @@ impl FromProof<platform::GetVotePollsByEndDateRequest> for VotePollsGroupedByTim
         let request: Self::Request = request.into();
         let response: Self::Response = response.into();
 
+        let order_ascending =
+            if let Some(get_vote_polls_by_end_date_request::Version::V0(ref v)) = request.version {
+                v.ascending
+            } else {
+                return Err(Error::EmptyVersion);
+            };
+
         // Decode request to get drive query
         let drive_query = VotePollsByEndDateDriveQuery::try_from_request(request)?;
 
@@ -1467,7 +1476,10 @@ impl FromProof<platform::GetVotePollsByEndDateRequest> for VotePollsGroupedByTim
 
         verify_tenderdash_proof(proof, mtd, &root_hash, provider)?;
 
-        let response = VotePollsGroupedByTimestamp::from_iter(vote_polls);
+        let response = VotePollsGroupedByTimestamp(OrderedBTreeMap::from_btreemap(
+            vote_polls,
+            order_ascending,
+        ));
 
         Ok((response.into_option(), mtd.clone()))
     }

--- a/packages/rs-drive-proof-verifier/src/proof.rs
+++ b/packages/rs-drive-proof-verifier/src/proof.rs
@@ -1665,7 +1665,7 @@ define_length!(Contenders, |x: &Contenders| x.contenders.len());
 define_length!(Voters, |x: &Voters| x.0.len());
 define_length!(
     VotePollsGroupedByTimestamp,
-    |x: &VotePollsGroupedByTimestamp| x.0.values().map(|v| v.len()).sum()
+    |x: &VotePollsGroupedByTimestamp| x.0.values_vec().into_iter().map(|v| v.len()).sum()
 );
 trait IntoOption
 where

--- a/packages/rs-sdk/tests/fetch/prefunded_specialized_balance.rs
+++ b/packages/rs-sdk/tests/fetch/prefunded_specialized_balance.rs
@@ -49,7 +49,8 @@ async fn test_prefunded_specialized_balance_ok() {
 
     let poll = polls
         .0
-        .first_key_value()
+        .iter()
+        .next()
         .expect("need at least one vote poll timestamp")
         .1
         .first()


### PR DESCRIPTION
## Issue being fixed or feature implemented

VotePollsByEndDateDriveQuery supports `order_ascending` field for the requests.
Unfortunately, internally we use BTreeMap that always orders items in ascending order.

There is a `rev()` method to reverse iteration, but it's not intuitive - as user requested reversed objects, standard iter() should return them in reverse order.

## What was done?

Implemented OrderedBTreeMap that allows iterating over items in reverse order and used it in VotePollsGroupedByTimestamp.

Note: this only fixes Sdk-side of the issue. Drive still returns items in invalid order.
## How Has This Been Tested?

Test `fetch::contested_resource_polls_by_ts::vote_polls_by_ts_order` is green.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
