### PR TITLE
feat(dashmate): import existing Core data

### DIFF
--- a/packages/dashmate/src/createDIContainer.js
+++ b/packages/dashmate/src/createDIContainer.js
@@ -109,6 +109,7 @@ import createIpAndPortsFormFactory from './listr/prompts/createIpAndPortsForm.js
 import registerMasternodeWithCoreWalletFactory from './listr/tasks/setup/regular/registerMasternode/registerMasternodeWithCoreWallet.js';
 import registerMasternodeWithDMTFactory from './listr/tasks/setup/regular/registerMasternode/registerMasternodeWithDMT.js';
 import writeConfigTemplatesFactory from './templates/writeConfigTemplatesFactory.js';
+import importCoreDataTaskFactory from './listr/tasks/setup/regular/importCoreDataTaskFactory.js';
 
 /**
  * @param {Object} [options]
@@ -298,6 +299,7 @@ export default async function createDIContainer(options = {}) {
       .singleton(),
     registerMasternodeWithDMT: asFunction(registerMasternodeWithDMTFactory)
       .singleton(),
+    importCoreDataTask: asFunction(importCoreDataTaskFactory).singleton(),
   });
 
   /**

--- a/packages/dashmate/src/listr/tasks/setup/regular/configureNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/configureNodeTaskFactory.js
@@ -33,7 +33,7 @@ export default function configureNodeTaskFactory(createIpAndPortsForm) {
           task.title = `Configure ${ctx.nodeType}`;
 
           // Masternode Operator key
-          if (ctx.nodeType === NODE_TYPE_MASTERNODE) {
+          if (ctx.nodeType === NODE_TYPE_MASTERNODE && !ctx.config.get('core.masternode.operator.privateKey')) {
             const masternodeOperatorPrivateKey = await task.prompt({
               type: 'input',
               header: `  Please enter your Masternode Operator BLS Private key.

--- a/packages/dashmate/src/listr/tasks/setup/regular/configureNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/configureNodeTaskFactory.js
@@ -71,12 +71,23 @@ export default function configureNodeTaskFactory(createIpAndPortsForm) {
 
             let form;
             if (ctx.initialIpForm) {
+              // Using for testing
               form = ctx.initialIpForm;
             } else {
+              let initialIp = ctx.nodeType === NODE_TYPE_MASTERNODE ? '' : undefined;
+              if (ctx.importedExternalIp) {
+                initialIp = ctx.importedExternalIp;
+              }
+
+              let initialCoreP2PPort = showEmptyPort ? '' : undefined;
+              if (ctx.importedP2pPort) {
+                initialCoreP2PPort = ctx.importedP2pPort;
+              }
+
               form = await task.prompt(await createIpAndPortsForm(ctx.preset, {
                 isHPMN: ctx.isHP,
-                initialIp: ctx.nodeType === NODE_TYPE_MASTERNODE ? '' : undefined,
-                initialCoreP2PPort: showEmptyPort ? '' : undefined,
+                initialIp,
+                initialCoreP2PPort,
                 initialPlatformHTTPPort: showEmptyPort ? '' : undefined,
                 initialPlatformP2PPort: showEmptyPort ? '' : undefined,
               }));

--- a/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
@@ -1,0 +1,193 @@
+import { Listr } from 'listr2';
+import fs from 'fs';
+import path from 'path';
+import {
+  NETWORK_TESTNET,
+} from '../../../../constants.js';
+
+/**
+ * @param {Config} config
+ * @return {validateCoreDataDirectoryPath}
+ */
+function validateCoreDataDirectoryPathFactory(config) {
+  /**
+   * @typedef {function} validateCoreDataDirectoryPath
+   * @param {string} value
+   * @return {string|boolean}
+   */
+  function validateCoreDataDirectoryPath(value) {
+    if (value.length === 0) {
+      return 'should not be empty';
+    }
+
+    // Path must be absolute
+    if (!path.isAbsolute(value)) {
+      return 'path must be absolute';
+    }
+
+    // Should contain dashd.conf
+    const configFilePath = path.join(value, 'dash.conf');
+    try {
+      fs.accessSync(configFilePath, fs.constants.R_OK);
+    } catch (e) {
+      return 'directory must contain dash.conf and it must be readable by the current user';
+    }
+
+    let dataDirName = 'blocks';
+    if (config.get('network') === NETWORK_TESTNET) {
+      dataDirName = 'testnet3';
+    }
+
+    // Should contain data dir
+    try {
+      fs.accessSync(path.join(value, dataDirName), fs.constants.R_OK);
+    } catch (e) {
+      return 'directory must contain network data and it must be readable by the current user';
+    }
+
+    const configFileContent = fs.readFileSync(configFilePath, 'utf8');
+
+    // Config file should contain testnet=1 in case of testnet
+    // and shouldn't contain testnet=1, regtest=1 or devnet= in case of mainnet
+    if (config.get('network') === NETWORK_TESTNET) {
+      if (!configFileContent.includes('testnet=1')) {
+        return 'dash.conf should be configured for testnet';
+      }
+    } else if (configFileContent.includes('testnet=1')
+      || configFileContent.includes('regtest=1')
+      || configFileContent.includes('devnet=')) {
+      return 'dash.conf should be configured for mainnet';
+    }
+
+    // Config file should contain masternodeblsprivkey in case of masternode
+    if (config.get('core.masternode.enable')) {
+      if (!configFileContent.includes('masternodeblsprivkey=')) {
+        return 'dash.conf should contain masternodeblsprivkey';
+      }
+    }
+
+    return true;
+  }
+
+  return validateCoreDataDirectoryPath;
+}
+
+/**
+ *
+ * @param {Docker} docker
+ * @param {dockerPull} dockerPull
+ * @param {generateEnvs} generateEnvs
+ * @return {importCoreDataTask}
+ */
+export default function importCoreDataTaskFactory(docker, dockerPull, generateEnvs) {
+  /**
+   * @typedef {function} importCoreDataTask
+   * @returns {Listr}
+   */
+  async function importCoreDataTask() {
+    return new Listr([
+      {
+        title: 'Import existing Core data',
+        task: async (ctx, task) => {
+          const doImport = await task.prompt({
+            type: 'toggle',
+            header: `  If you run a masternode on the same machine, you can
+   import your existing data so you don't need to sync node from scratch.
+   You current user must have read access to this directory.`,
+            message: 'Try?',
+            enabled: 'Yes',
+            disabled: 'No',
+            initial: true,
+          });
+
+          if (!doImport) {
+            task.skip();
+            return;
+          }
+
+          // Masternode Operator key
+          const coreDataPath = await task.prompt({
+            type: 'input',
+            header: `  Please enter path to your existing Dash Core data directory.
+
+You current user must have read access to this directory.\n`,
+            message: 'Core data directory path',
+            validate: validateCoreDataDirectoryPathFactory(ctx.config),
+          });
+
+          // Read masternode operator private key from dashd.conf
+          const configPath = path.join(coreDataPath, 'dash.conf');
+          const configFileContent = fs.readFileSync(configPath, 'utf8');
+          const masternodeOperatorPrivateKey = configFileContent.match(/masternodeblsprivkey=(.*)/)[1];
+
+          ctx.config.set('core.masternode.operator.privateKey', masternodeOperatorPrivateKey);
+
+          // Copy data directory to docker a volume
+
+          // Create a volume
+          const { COMPOSE_PROJECT_NAME: composeProjectName } = generateEnvs(ctx.config);
+
+          const volumeName = `${composeProjectName}_core_data`;
+          await docker.createVolume(volumeName);
+
+          // Pull image
+          await dockerPull('alpine');
+
+          const hostConfig = {
+            AutoRemove: true,
+            Binds: [
+              `${coreDataPath}:/source:ro`,
+            ],
+            Mounts: [
+              {
+                Type: 'volume',
+                Source: volumeName,
+                Target: '/destination',
+              },
+            ],
+          };
+
+          // Copy data and set user dash
+          const writableStream = new WritableStream();
+
+          const [result] = await docker.run(
+            'alpine',
+            ['/bin/sh', '-c', 'cp -a /source/. /destination/ && chown -R 1000:1000 /destination/'],
+            writableStream,
+            {
+              HostConfig: hostConfig,
+            },
+          );
+
+          // TODO: Stream to output
+
+          const output = writableStream.toString();
+
+          if (result.StatusCode !== 0) {
+            throw new Error(`Cannot copy data dir: ${output.substring(0, 100)}`);
+          }
+
+          await task.prompt({
+            type: 'confirm',
+            header: `  You need to stop your existing master before your start a dashmate
+    node\n`,
+            message: 'Yes I understand...',
+            default: ' ',
+            separator: () => '',
+            format: () => '',
+            initial: true,
+            isTrue: () => true,
+          });
+
+          // eslint-disable-next-line no-param-reassign
+          task.output = `${coreDataPath} imported`;
+        },
+        options: {
+          persistentOutput: true,
+        },
+      },
+    ]);
+  }
+
+  return importCoreDataTask;
+}

--- a/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
@@ -156,13 +156,21 @@ export default function importCoreDataTaskFactory(docker, dockerPull, generateEn
           // Pull image
           await dockerPull('alpine');
 
+          const commands = [
+            `mkdir /${volumeName}/.dashcore/`,
+            'cd /source',
+            `cp -avL * /${volumeName}/.dashcore/`,
+            `chown -R 1000:1000 /${volumeName}/`,
+            `rm /${volumeName}/.dashcore/dash.conf`,
+          ];
+
           // Copy data and set user dash
           const [result] = await docker.run(
             'alpine',
             [
               '/bin/sh',
               '-c',
-              `mkdir /${volumeName}/.dashcore/ && cd /source && cp -avL * /${volumeName}/.dashcore/ && chown -R 1000:1000 /${volumeName}/`,
+              commands.join(' && '),
             ],
             task.stdout(),
             {

--- a/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
@@ -160,7 +160,7 @@ You current user must have read access to this directory.\n`,
             [
               '/bin/sh',
               '-c',
-              `mkdir /${volumeName}/.dashcore/ && cd /source && cp -av * /${volumeName}/.dashcore/ && chown -R 1000:1000 /${volumeName}/`,
+              `mkdir /${volumeName}/.dashcore/ && cd /source && cp -avL * /${volumeName}/.dashcore/ && chown -R 1000:1000 /${volumeName}/`,
             ],
             task.stdout(),
             {

--- a/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
@@ -198,7 +198,7 @@ export default function importCoreDataTaskFactory(docker, dockerPull, generateEn
           await task.prompt({
             type: 'confirm',
             header: `  Please stop your existing Dash Core node before starting the new dashmate-based
-    node ("dashmate start"). Also, disable any automatic startup services (e.g., cron, systemd) for the existing existing Dash Core installation.\n`,
+    node ("dashmate start"). Also, disable any automatic startup services (e.g., cron, systemd) for the existing Dash Core installation.\n`,
             message: 'Press any key to continue...',
             default: ' ',
             separator: () => '',

--- a/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
@@ -197,8 +197,8 @@ export default function importCoreDataTaskFactory(docker, dockerPull, generateEn
           // TODO: Wording needs to be updated
           await task.prompt({
             type: 'confirm',
-            header: `  You need to stop your existing node before your start a dashmate
-    node\n`,
+            header: `  Please stop your existing Dash Core node before starting the new dashmate-based
+    node ("dashmate start"). Also, disable any automatic startup services (e.g., cron, systemd) for the existing existing Dash Core installation.\n`,
             message: 'Press any key to continue...',
             default: ' ',
             separator: () => '',

--- a/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
@@ -106,9 +106,9 @@ export default function importCoreDataTaskFactory(docker, dockerPull, generateEn
             type: 'input',
             header: `  Please enter path to your existing Dash Core data directory.
 
-   - You current user must have read access to this directory.
-   - Data directory usually ends with .dashcore and contains dash.conf and data files (what files we expect)
-   - If dash.conf stored separately you should copy or link this file to data dire\n`,
+   - Your current user must have read access to this directory.
+   - The data directory usually ends with .dashcore and contains dash.conf and the data files to import
+   - If dash.conf is stored separately, you should copy or link to this file in the data directory\n`,
             message: 'Core data directory path',
             validate: validateCoreDataDirectoryPathFactory(ctx.config),
           });

--- a/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
@@ -86,9 +86,9 @@ export default function importCoreDataTaskFactory(docker, dockerPull, generateEn
         task: async (ctx, task) => {
           const doImport = await task.prompt({
             type: 'toggle',
-            header: `  If you run a masternode on the same machine, you can
-   import your existing data so you don't need to sync node from scratch.
-   You current user must have read access to this directory.\n`,
+            header: `  If you already run a masternode on this server, you can
+   import your existing Dash Core data instead of syncing a new dashmate node from scratch.
+   Your current user account must have read access to this directory.\n`,
             message: 'Import existing data?',
             enabled: 'Yes',
             disabled: 'No',

--- a/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
@@ -94,11 +94,12 @@ export default function importCoreDataTaskFactory(docker, dockerPull, generateEn
             header: `  If you run a masternode on the same machine, you can
    import your existing data so you don't need to sync node from scratch.
    You current user must have read access to this directory.`,
-            message: 'Try?',
+            message: 'Import existing data?',
             enabled: 'Yes',
             disabled: 'No',
             initial: true,
           });
+          // TODO: Wording needs to be updated
 
           if (!doImport) {
             task.skip();
@@ -179,6 +180,7 @@ You current user must have read access to this directory.\n`,
             throw new Error('Cannot copy data dir to volume');
           }
 
+          // TODO: Wording needs to be updated
           await task.prompt({
             type: 'confirm',
             header: `  You need to stop your existing node before your start a dashmate

--- a/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
@@ -106,7 +106,9 @@ export default function importCoreDataTaskFactory(docker, dockerPull, generateEn
             type: 'input',
             header: `  Please enter path to your existing Dash Core data directory.
 
-You current user must have read access to this directory.\n`,
+   - You current user must have read access to this directory.
+   - Data directory usually ends with .dashcore and contains dash.conf and data files (what files we expect)
+   - If dash.conf stored separately you should copy or link this file to data dire\n`,
             message: 'Core data directory path',
             validate: validateCoreDataDirectoryPathFactory(ctx.config),
           });

--- a/packages/dashmate/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
@@ -25,6 +25,7 @@ import generateRandomString from '../../../util/generateRandomString.js';
  * @param {configureNodeTask} configureNodeTask
  * @param {configureSSLCertificateTask} configureSSLCertificateTask
  * @param {DefaultConfigs} defaultConfigs
+ * @param {importCoreDataTask} importCoreDataTask
  */
 export default function setupRegularPresetTaskFactory(
   configFile,
@@ -35,6 +36,7 @@ export default function setupRegularPresetTaskFactory(
   configureNodeTask,
   configureSSLCertificateTask,
   defaultConfigs,
+  importCoreDataTask,
 ) {
   /**
    * @typedef {setupRegularPresetTask}
@@ -130,6 +132,10 @@ export default function setupRegularPresetTaskFactory(
       {
         enabled: (ctx) => !ctx.isMasternodeRegistered && ctx.nodeType === NODE_TYPE_MASTERNODE,
         task: () => registerMasternodeGuideTask(),
+      },
+      {
+        enabled: (ctx) => ctx.isMasternodeRegistered,
+        task: () => importCoreDataTask(),
       },
       {
         enabled: (ctx) => ctx.isMasternodeRegistered || ctx.nodeType === NODE_TYPE_FULLNODE,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, most evo masternode owners run an evo masternode using only Core. We need a convenient method to import existing data and configuration so they don't need to sync and configure the node from scratch.

## What was done?
<!--- Describe your changes in detail -->
- Added a step to import Core data to `dashmate setup` for already registered masternodes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running `dashmate setup` locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
