### PR TITLE
build: use ubuntu-platform github runner hardware for all github actions

### DIFF
--- a/.github/workflows/tests-build-image.yml
+++ b/.github/workflows/tests-build-image.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build-image:
     name: Build ${{ inputs.name }} image
-    runs-on: [ "self-hosted", "linux", "arm64", "ubuntu-platform-4x" ]
+    runs-on: ["self-hosted", "linux", "arm64", "ubuntu-platform"]
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.github/workflows/tests-build-js.yml
+++ b/.github/workflows/tests-build-js.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   build-js:
     name: Build JS
-    runs-on: [ "self-hosted", "linux", "arm64", "ubuntu-platform-4x" ]
+    runs-on: ["self-hosted", "linux", "arm64", "ubuntu-platform"]
     steps:
       - name: Configure AWS credentials and bucket region
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
       # FIXME: Clippy fails on github hosted runners, most likely due to RAM usage. Using self-hosted runners for now.
       lint-runner: '[ "self-hosted", "linux", "arm64", "ubuntu-platform" ]'
       # Run drive tests on self-hosted 4x
-      test-runner: ${{ contains(fromJSON('["drive-abci"]'), matrix.rs-package) && '[ "self-hosted", "linux", "arm64", "ubuntu-platform-4x" ]' || '[ "self-hosted", "linux", "arm64", "ubuntu-platform" ]' }}
+      test-runner: '[ "self-hosted", "linux", "arm64", "ubuntu-platform" ]'
       check-each-feature: ${{ contains(fromJSON('["dash-sdk","rs-dapi-client","dapi-grpc","dpp","drive-abci"]'), matrix.rs-package) }}
 
   rs-crates-security:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Docker images and `drive-abci` tests are run using ubuntu-platform-4x instances that are configured to use [c7gd.4xlarge](https://instances.vantage.sh/aws/ec2/c7gd.4xlarge) aws instances. Others use [c7gd.2xlarge](https://instances.vantage.sh/aws/ec2/c7gd.2xlarge).This causes the following issues:

* pipelines don't even start for multiple hours due to low availability of c7gd.4xlarge instances on the region we use,
* 4x costs are higher than 2x

## What was done?

As a workaround, we use `ubuntu-platform` (c7gd.2xlarge) for all types of jobs.


## How Has This Been Tested?

Run GHA pipelines.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
