### PR TITLE
feat(sdk): support mocking of error responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2524,6 +2524,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-serde"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
+dependencies = [
+ "http 0.2.12",
+ "serde",
+]
+
+[[package]]
 name = "httparse"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4310,12 +4320,15 @@ name = "rs-dapi-client"
 version = "1.0.0-dev.15"
 dependencies = [
  "backon",
+ "chrono",
  "dapi-grpc",
  "futures",
  "hex",
- "http 0.2.12",
+ "http-serde",
  "lru",
  "rand",
+ "serde",
+ "serde_json",
  "sha2",
  "thiserror",
  "tokio",

--- a/packages/dapi-grpc/src/mock.rs
+++ b/packages/dapi-grpc/src/mock.rs
@@ -4,6 +4,9 @@
 //!
 //! Note that this trait is defined even if mocks are not supported, but it should always return `None` on serialization.
 
+#[cfg(feature = "mocks")]
+pub mod serde_mockable;
+
 use tonic::Streaming;
 
 /// Mocking support for messages.
@@ -37,12 +40,12 @@ where
         None
     }
 }
-
 #[cfg(feature = "mocks")]
-const RESULT_OK: u8 = 0;
-#[cfg(feature = "mocks")]
-const RESULT_ERR: u8 = 1;
-
+#[derive(serde::Serialize, serde::Deserialize)]
+enum SerializableResult {
+    Ok(Vec<u8>),
+    Err(Vec<u8>),
+}
 impl<T, E> Mockable for Result<T, E>
 where
     T: Mockable,
@@ -50,28 +53,23 @@ where
 {
     #[cfg(feature = "mocks")]
     fn mock_serialize(&self) -> Option<Vec<u8>> {
-        let (typ, mut buf) = match self {
-            Ok(value) => (RESULT_OK, value.mock_serialize()?),
-            Err(error) => (RESULT_ERR, error.mock_serialize()?),
+        let serializable = match self {
+            Ok(value) => SerializableResult::Ok(value.mock_serialize()?),
+            Err(error) => SerializableResult::Err(error.mock_serialize()?),
         };
-
-        let mut result = vec![typ];
-        result.append(&mut buf);
-        Some(result)
+        serde_json::to_vec(&serializable).ok()
     }
 
     #[cfg(feature = "mocks")]
     fn mock_deserialize(data: &[u8]) -> Option<Self> {
-        use core::panic;
-
         if data.is_empty() {
             return None;
         }
-
-        Some(match data[0] {
-            RESULT_OK => Ok(T::mock_deserialize(&data[1..])?),
-            RESULT_ERR => Err(E::mock_deserialize(&data[1..])?),
-            d => panic!("cannot deserialize mock result: invalid result type {}", d),
+        let deser: SerializableResult =
+            serde_json::from_slice(data).expect("unable to deserialize mock data");
+        Some(match deser {
+            SerializableResult::Ok(data) => Ok(T::mock_deserialize(&data)?),
+            SerializableResult::Err(data) => Err(E::mock_deserialize(&data)?),
         })
     }
 }
@@ -99,25 +97,28 @@ impl Mockable for Vec<u8> {
         serde_json::from_slice(data).ok()
     }
 }
-
+#[cfg(feature = "mocks")]
+#[derive(serde::Serialize, serde::Deserialize)]
+struct MockableStatus {
+    code: i32,
+    message: Vec<u8>,
+}
 impl Mockable for crate::tonic::Status {
     #[cfg(feature = "mocks")]
     fn mock_serialize(&self) -> Option<Vec<u8>> {
-        let code: i32 = self.code().into();
-        let message = self.message();
+        let mockable = MockableStatus {
+            code: self.code().into(),
+            message: self.message().as_bytes().to_vec(),
+        };
 
-        let mut buf = Vec::new();
-        buf.extend(&code.to_be_bytes());
-        buf.extend(message.as_bytes());
-
-        Some(buf)
+        Some(serde_json::to_vec(&mockable).expect("unable to serialize tonic::Status"))
     }
 
     #[cfg(feature = "mocks")]
     fn mock_deserialize(data: &[u8]) -> Option<Self> {
-        let code = i32::from_be_bytes(data[0..4].try_into().expect("invalid code"));
-        let message = String::from_utf8_lossy(&data[2..]).to_string();
-
+        let MockableStatus { code, message } =
+            serde_json::from_slice(data).expect("unable to deserialize tonic::Status");
+        let message = std::str::from_utf8(&message).expect("invalid utf8 message in tonic::Status");
         Some(Self::new(code.into(), message))
     }
 }

--- a/packages/dapi-grpc/src/mock/serde_mockable.rs
+++ b/packages/dapi-grpc/src/mock/serde_mockable.rs
@@ -1,0 +1,86 @@
+//! Serde serialization and deserialization for Mockable objects.
+//!
+//! This module provides a custom serialization and deserialization implementation for Mockable objects.
+//!
+//! /// ## Example
+///
+/// ```rust
+///
+/// #[derive(serde::Serialize,serde::Deserialize)]
+/// struct TestStruct {
+///     #[serde(with="dapi_grpc::mock::serde_mockable")]
+///     field: u32,
+/// }
+/// ```
+use super::Mockable;
+
+use serde::{
+    de::{self, Visitor},
+    Deserializer, Serializer,
+};
+use serde_bytes::Deserialize;
+use std::fmt;
+use std::marker::PhantomData;
+
+/// Serialize any Mockable object to bytes.
+///
+/// ## Example
+///
+/// `#[serde(with="dapi_grpc::mock::serde_mockable")]`
+pub fn serialize<T: Mockable, S>(data: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match data.mock_serialize() {
+        Some(bytes) => serializer.serialize_bytes(bytes.as_slice()),
+        None => Err(serde::ser::Error::custom(
+            "Mockable object is not serializable",
+        )),
+    }
+}
+
+struct MockableVisitor<T> {
+    marker: PhantomData<T>,
+}
+
+impl<'de, T> Visitor<'de> for MockableVisitor<T>
+where
+    T: Mockable,
+{
+    type Value = T;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a byte array")
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        T::mock_deserialize(v).ok_or_else(|| E::custom("Failed to deserialize Mockable object"))
+    }
+
+    fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let bytes = <Vec<u8>>::deserialize(de::value::SeqAccessDeserializer::new(seq))?;
+        T::mock_deserialize(&bytes).ok_or_else(|| {
+            serde::de::Error::custom("Failed to deserialize Mockable object from seq")
+        })
+    }
+}
+
+/// Deserialize any Mockable object from bytes.
+///
+/// ## Example
+///
+/// `#[serde(with="dapi_grpc::mock::serde_mockable")]`
+pub fn deserialize<'de, T: Mockable, D>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_bytes(MockableVisitor {
+        marker: PhantomData,
+    })
+}

--- a/packages/rs-dapi-client/Cargo.toml
+++ b/packages/rs-dapi-client/Cargo.toml
@@ -5,7 +5,14 @@ edition = "2021"
 
 [features]
 default = ["mocks", "offline-testing"]
-mocks = ["dep:sha2", "dep:hex", "dapi-grpc/mocks"]
+mocks = [
+    "dep:sha2",
+    "dep:hex",
+    "dapi-grpc/mocks",
+    "dep:serde",
+    "dep:http-serde",
+    "dep:serde_json",
+]
 # dump requests and responses to file
 dump = ["mocks"]
 # skip tests that require connection to the platform; enabled by default
@@ -16,7 +23,7 @@ offline-testing = []
 backon = "0.4.1"
 dapi-grpc = { path = "../dapi-grpc" }
 futures = "0.3.28"
-http = "0.2.9"
+http-serde = { version = "1.1.3", optional = true }
 rand = { version = "0.8.5", features = ["small_rng"] }
 thiserror = "1.0.58"
 tracing = "0.1.40"
@@ -24,6 +31,8 @@ tokio = { version = "1.32.0", default-features = false }
 sha2 = { version = "0.10", optional = true }
 hex = { version = "0.4.3", optional = true }
 lru = { version = "0.12.3" }
-
+serde = { version = "1.0.197", optional = true, features = ["derive"] }
+serde_json = { version = "1.0.120", optional = true }
+chrono = { version = "0.4.38", features = ["serde"] }
 [dev-dependencies]
 tokio = { version = "1.32.0", features = ["macros"] }

--- a/packages/rs-dapi-client/src/connection_pool.rs
+++ b/packages/rs-dapi-client/src/connection_pool.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use http::Uri;
+use dapi_grpc::tonic::transport::Uri;
 use lru::LruCache;
 
 use crate::{

--- a/packages/rs-dapi-client/src/lib.rs
+++ b/packages/rs-dapi-client/src/lib.rs
@@ -12,15 +12,14 @@ pub mod mock;
 mod request_settings;
 pub mod transport;
 
-pub use dapi_client::DapiRequestExecutor;
-use futures::{future::BoxFuture, FutureExt};
-pub use http::Uri;
-
 pub use address_list::Address;
 pub use address_list::AddressList;
+pub use dapi_client::DapiRequestExecutor;
 pub use dapi_client::{DapiClient, DapiClientError};
+use dapi_grpc::mock::Mockable;
 #[cfg(feature = "dump")]
 pub use dump::DumpData;
+use futures::{future::BoxFuture, FutureExt};
 pub use request_settings::RequestSettings;
 
 /// A DAPI request could be executed with an initialized [DapiClient].
@@ -41,7 +40,7 @@ pub trait DapiRequest {
     /// Response from DAPI for this specific request.
     type Response;
     /// An error type for the transport this request uses.
-    type TransportError;
+    type TransportError: Mockable;
 
     /// Executes the request.
     fn execute<'c, D: DapiRequestExecutor>(

--- a/packages/rs-dapi-client/src/mock.rs
+++ b/packages/rs-dapi-client/src/mock.rs
@@ -177,6 +177,7 @@ impl Display for Key {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[cfg_attr(feature = "mocks", derive(serde::Serialize, serde::Deserialize))]
 /// Mock errors
 pub enum MockError {
     #[error("mock expectation not found for request: {0}")]

--- a/packages/rs-dapi-client/src/mock.rs
+++ b/packages/rs-dapi-client/src/mock.rs
@@ -34,6 +34,11 @@ use std::{
 pub struct MockDapiClient {
     expectations: Expectations,
 }
+/// Result of executing a mock request
+pub type MockResult<T> = Result<
+    <T as TransportRequest>::Response,
+    DapiClientError<<<T as TransportRequest>::Client as TransportClient>::Error>,
+>;
 
 impl MockDapiClient {
     /// Create a new mock client
@@ -42,7 +47,11 @@ impl MockDapiClient {
     }
 
     /// Add a new expectation for a request
-    pub fn expect<R>(&mut self, request: &R, response: &R::Response) -> Result<&mut Self, MockError>
+    pub fn expect<R>(
+        &mut self,
+        request: &R,
+        response: &MockResult<R>,
+    ) -> Result<&mut Self, MockError>
     where
         R: TransportRequest + Mockable,
         R::Response: Mockable,
@@ -52,7 +61,7 @@ impl MockDapiClient {
         tracing::trace!(
             %key,
             request_type = std::any::type_name::<R>(),
-            response_typr = std::any::type_name::<R::Response>(),
+            response_type = std::any::type_name::<R::Response>(),
             "mock added expectation"
         );
 
@@ -71,7 +80,7 @@ impl MockDapiClient {
     pub fn load<T: TransportRequest, P: AsRef<std::path::Path>>(
         &mut self,
         file: P,
-    ) -> Result<(T, T::Response), std::io::Error>
+    ) -> Result<(T, MockResult<T>), std::io::Error>
     where
         T: Mockable,
         T::Response: Mockable,
@@ -100,7 +109,7 @@ impl DapiRequestExecutor for MockDapiClient {
         &self,
         request: R,
         _settings: RequestSettings,
-    ) -> Result<R::Response, DapiClientError<<R::Client as TransportClient>::Error>>
+    ) -> MockResult<R>
     where
         R: Mockable,
         R::Response: Mockable,
@@ -116,7 +125,7 @@ impl DapiRequestExecutor for MockDapiClient {
         );
 
         return if let Some(response) = response {
-            Ok(response)
+            response
         } else {
             Err(MockError::MockExpectationNotFound(format!(
                 "unexpected mock request with key {}, use MockDapiClient::expect(): {:?}",

--- a/packages/rs-dapi-client/src/transport.rs
+++ b/packages/rs-dapi-client/src/transport.rs
@@ -6,9 +6,9 @@ use crate::connection_pool::ConnectionPool;
 pub use crate::request_settings::AppliedRequestSettings;
 use crate::{CanRetry, RequestSettings};
 use dapi_grpc::mock::Mockable;
+use dapi_grpc::tonic::transport::Uri;
 pub use futures::future::BoxFuture;
 pub use grpc::{CoreGrpcClient, PlatformGrpcClient};
-use http::Uri;
 use std::any;
 use std::fmt::Debug;
 
@@ -48,7 +48,7 @@ pub trait TransportRequest: Clone + Send + Sync + Debug + Mockable {
 /// Generic way to create a transport client from provided [Uri].
 pub trait TransportClient: Send + Sized {
     /// Error type for the specific client.
-    type Error: CanRetry + Send + Debug;
+    type Error: CanRetry + Send + Debug + Mockable;
 
     /// Build client using node's url.
     fn with_uri(uri: Uri, pool: &ConnectionPool) -> Self;

--- a/packages/rs-dapi-client/src/transport/grpc.rs
+++ b/packages/rs-dapi-client/src/transport/grpc.rs
@@ -8,10 +8,10 @@ use crate::{request_settings::AppliedRequestSettings, RequestSettings};
 use dapi_grpc::core::v0::core_client::CoreClient;
 use dapi_grpc::core::v0::{self as core_proto};
 use dapi_grpc::platform::v0::{self as platform_proto, platform_client::PlatformClient};
+use dapi_grpc::tonic::transport::Uri;
 use dapi_grpc::tonic::Streaming;
 use dapi_grpc::tonic::{transport::Channel, IntoRequest};
 use futures::{future::BoxFuture, FutureExt, TryFutureExt};
-use http::Uri;
 
 /// Platform Client using gRPC transport.
 pub type PlatformGrpcClient = PlatformClient<Channel>;

--- a/packages/rs-dapi-client/tests/mock_dapi_client.rs
+++ b/packages/rs-dapi-client/tests/mock_dapi_client.rs
@@ -19,7 +19,8 @@ async fn test_mock_get_identity_dapi_client() {
         }))
     };
 
-    dapi.expect(&request, &response).expect("expectation added");
+    dapi.expect(&request, &Ok(response.clone()))
+        .expect("expectation added");
 
     let settings = RequestSettings::default();
 

--- a/packages/rs-dapi-grpc-macros/src/lib.rs
+++ b/packages/rs-dapi-grpc-macros/src/lib.rs
@@ -209,12 +209,12 @@ pub fn mockable_derive(input: TokenStream) -> TokenStream {
         impl crate::mock::Mockable for #name {
             #[cfg(feature = "mocks")]
             fn mock_serialize(&self) -> Option<Vec<u8>> {
-                Some(serde_json::to_vec_pretty(self).expect("unable to serialize"))
+                Some(serde_json::to_vec_pretty(self).expect("unable to serialize mock data"))
             }
 
             #[cfg(feature = "mocks")]
             fn mock_deserialize(data: &[u8]) -> Option<Self> {
-                Some(serde_json::from_slice(data).expect("unable to deserialize"))
+                Some(serde_json::from_slice(data).expect("unable to deserialize mock data"))
             }
         }
     };

--- a/packages/rs-sdk/src/error.rs
+++ b/packages/rs-sdk/src/error.rs
@@ -2,6 +2,7 @@
 use std::fmt::Debug;
 use std::time::Duration;
 
+use dapi_grpc::mock::Mockable;
 use dpp::version::PlatformVersionError;
 use dpp::ProtocolError;
 use rs_dapi_client::DapiClientError;
@@ -65,7 +66,7 @@ pub enum Error {
     Cancelled(String),
 }
 
-impl<T: Debug> From<DapiClientError<T>> for Error {
+impl<T: Debug + Mockable> From<DapiClientError<T>> for Error {
     fn from(value: DapiClientError<T>) -> Self {
         Self::DapiClientError(format!("{:?}", value))
     }

--- a/packages/rs-sdk/src/mock/sdk.rs
+++ b/packages/rs-sdk/src/mock/sdk.rs
@@ -359,7 +359,7 @@ impl MockDashPlatformSdk {
         // This expectation will work for execute
         let mut dapi_guard = self.dapi.lock().await;
         // We don't really care about the response, as it will be mocked by from_proof, so we provide default()
-        dapi_guard.expect(&grpc_request, &Default::default())?;
+        dapi_guard.expect(&grpc_request, &Ok(Default::default()))?;
 
         Ok(())
     }

--- a/packages/rs-sdk/tests/fetch/contested_resource_polls_by_ts.rs
+++ b/packages/rs-sdk/tests/fetch/contested_resource_polls_by_ts.rs
@@ -119,8 +119,6 @@ async fn vote_polls_by_ts_order_PLAN_661() {
     feature = "network-testing",
     ignore = "requires manual DPNS names setup for masternode voting tests; see fn check_mn_voting_prerequisities()"
 )]
-
-// fails due to PLAN-659
 async fn vote_polls_by_ts_limit() {
     setup_logs();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

We are not able to run offline tests (without network connectivity, eg. errors) as we don't support serialization of errors.

## What was done?

Implemented Mockable for Result<T,E> and for DapiClientError. 


## How Has This Been Tested?

Locally, generated test vectors.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
