### PR TITLE
test(sdk): disable failing tests for bugs scheduled for future

### DIFF
--- a/packages/rs-sdk/tests/fetch/contested_resource.rs
+++ b/packages/rs-sdk/tests/fetch/contested_resource.rs
@@ -149,6 +149,7 @@ async fn contested_resources_start_at_value() {
     ignore = "requires manual DPNS names setup for masternode voting tests; see fn check_mn_voting_prerequisities()"
 )]
 #[allow(non_snake_case)]
+#[ignore = "disabled due to bug PLAN-656"]
 async fn contested_resources_limit_PLAN_656() {
     // TODO: fails due to PLAN-656, not tested enough so it can be faulty
     setup_logs();
@@ -236,7 +237,8 @@ async fn contested_resources_limit_PLAN_656() {
 #[test_case::test_case(|q| q.document_type_name = "some random non-existing name".to_string(), Err(r#"code: InvalidArgument, message: "document type some random non-existing name not found"#); "non existing document type returns InvalidArgument")]
 #[test_case::test_case(|q| q.index_name = "nx index".to_string(), Err(r#"code: InvalidArgument, message: "index with name nx index is not the contested index"#); "non existing index returns InvalidArgument")]
 #[test_case::test_case(|q| q.index_name = "dashIdentityId".to_string(), Err(r#"code: InvalidArgument, message: "index with name dashIdentityId is not the contested index"#); "existing non-contested index returns InvalidArgument")]
-#[test_case::test_case(|q| q.start_at_value = Some((Value::Array(vec![]), true)), Err(r#"code: InvalidArgument"#); "start_at_value wrong index type returns InvalidArgument PLAN-653")]
+// Disabled due to bug PLAN-653
+// #[test_case::test_case(|q| q.start_at_value = Some((Value::Array(vec![]), true)), Err(r#"code: InvalidArgument"#); "start_at_value wrong index type returns InvalidArgument PLAN-653")]
 #[test_case::test_case(|q| q.start_index_values = vec![], Ok(r#"ContestedResources([Value(Text("dash"))])"#.into()); "start_index_values empty vec returns top-level keys")]
 #[test_case::test_case(|q| q.start_index_values = vec![Value::Text("".to_string())], Ok(r#"ContestedResources([])"#.into()); "start_index_values empty string returns zero results")]
 #[test_case::test_case(|q| {
@@ -278,11 +280,12 @@ async fn contested_resources_limit_PLAN_656() {
 #[test_case::test_case(|q| q.end_index_values = vec![Value::Array(vec![0.into(), 1.into()])], Err("incorrect index values error: too many end index values were provided"); "wrong type of end_index_values should return InvalidArgument")]
 #[test_case::test_case(|q| q.limit = Some(0), Err(r#"code: InvalidArgument"#); "limit 0 returns InvalidArgument")]
 #[test_case::test_case(|q| q.limit = Some(std::u16::MAX), Err(r#"code: InvalidArgument"#); "limit std::u16::MAX returns InvalidArgument")]
-#[test_case::test_case(|q| {
-    q.start_index_values = vec![Value::Text("dash".to_string())];
-    q.start_at_value = Some((Value::Text(TEST_DPNS_NAME.to_string()), true));
-    q.limit = Some(1);
-}, Ok(format!(r#"ContestedResources([Value(Text({}))])"#, TEST_DPNS_NAME)); "exact match query returns one object PLAN-656")]
+// Disabled due to bug PLAN-656
+// #[test_case::test_case(|q| {
+//     q.start_index_values = vec![Value::Text("dash".to_string())];
+//     q.start_at_value = Some((Value::Text(TEST_DPNS_NAME.to_string()), true));
+//     q.limit = Some(1);
+// }, Ok(format!(r#"ContestedResources([Value(Text({}))])"#, TEST_DPNS_NAME)); "exact match query returns one object PLAN-656")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[cfg_attr(
     not(feature = "offline-testing"),

--- a/packages/rs-sdk/tests/fetch/contested_resource_vote_state.rs
+++ b/packages/rs-sdk/tests/fetch/contested_resource_vote_state.rs
@@ -207,6 +207,7 @@ fn base_query(cfg: &Config) -> ContestedDocumentVotePollDriveQuery {
     not(feature = "offline-testing"),
     ignore = "equires manual DPNS names setup for masternode voting tests; see fn check_mn_voting_prerequisities()"
 )]
+#[ignore = "disabled due to bug PLAN-674"]
 #[allow(non_snake_case)]
 async fn contested_resource_vote_states_with_limit_PLAN_674() {
     setup_logs();

--- a/packages/rs-sdk/tests/fetch/document.rs
+++ b/packages/rs-sdk/tests/fetch/document.rs
@@ -189,6 +189,7 @@ async fn document_list_document_query() {
 ///     `query: storage: protocol: value error: structure error: value was a string, but could not be decoded from base 58`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[allow(non_snake_case)]
+#[ignore = "disabled due to bug PLAN-653"]
 async fn document_list_bug_value_text_decode_base58_PLAN_653() {
     setup_logs();
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

The following tests fail, and we decided they will be fixed in separate PRs:

*    fetch::contested_resource::contested_resources_fields::exact_match_query_returns_one_object_plan_656
*    fetch::contested_resource::contested_resources_fields::start_at_value_wrong_index_type_returns_invalidargument_plan_653
*    fetch::contested_resource::contested_resources_limit_PLAN_656
*    fetch::contested_resource_vote_state::contested_resource_vote_states_with_limit_PLAN_674
*    fetch::document::document_list_bug_value_text_decode_base58_PLAN_653

## What was done?

Disabled tests with comment `disabled due to bug...`

## How Has This Been Tested?

GHA: https://github.com/dashpay/platform/actions/runs/9810199925

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
