### PR TITLE
test: fix documentTransition.hasPrefundedBalance is not a function

### DIFF
--- a/packages/dapi/test/unit/externalApis/drive/fetchProofForStateTransitionFactory.spec.js
+++ b/packages/dapi/test/unit/externalApis/drive/fetchProofForStateTransitionFactory.spec.js
@@ -86,6 +86,7 @@ describe('fetchProofForStateTransition', () => {
         getDataContractId: this.sinon.stub().returns(await generateRandomIdentifierAsync()),
         getType: this.sinon.stub().returns('niceDocument'),
         getId: this.sinon.stub().returns(await generateRandomIdentifierAsync()),
+        hasPrefundedBalance: this.sinon.stub().returns(true),
       },
     ]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
  1) fetchProofForStateTransition
       should fetch documents proofs:
     TypeError: documentTransition.hasPrefundedBalance is not a function
      at /home/runner/work/platform/platform/packages/dapi/lib/externalApis/drive/fetchProofForStateTransitionFactory.js:9:1016
      at Array.map (<anonymous>)
      at fetchProofForStateTransition (lib/externalApis/drive/fetchProofForStateTransitionFactory.js:9:553)
      at Context.it (test/unit/externalApis/drive/fetchProofForStateTransitionFactory.spec.js:92:26)

```

## What was done?
<!--- Describe your changes in detail -->
- Added `hasPrefundedBalance` to the state transition mock

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
