### PR TITLE
feat(drive-abci)!: rotate quorums when all quorums members have had a chance to propose a block

### DIFF
--- a/packages/rs-dpp/src/block/extended_block_info/mod.rs
+++ b/packages/rs-dpp/src/block/extended_block_info/mod.rs
@@ -72,6 +72,12 @@ impl ExtendedBlockInfoV0Getters for ExtendedBlockInfo {
         }
     }
 
+    fn proposer_pro_tx_hash(&self) -> &[u8; 32] {
+        match self {
+            ExtendedBlockInfo::V0(v0) => &v0.proposer_pro_tx_hash,
+        }
+    }
+
     fn block_id_hash(&self) -> &[u8; 32] {
         match self {
             ExtendedBlockInfo::V0(v0) => &v0.block_id_hash,
@@ -146,6 +152,7 @@ mod tests {
             app_hash: [1; 32],
             quorum_hash: [2; 32],
             block_id_hash: [3; 32],
+            proposer_pro_tx_hash: [4; 32],
             signature: [3; 96],
             round: 1,
         }

--- a/packages/rs-dpp/src/block/extended_block_info/v0/mod.rs
+++ b/packages/rs-dpp/src/block/extended_block_info/v0/mod.rs
@@ -14,6 +14,8 @@ pub struct ExtendedBlockInfoV0 {
     pub quorum_hash: [u8; 32],
     /// The block id hash
     pub block_id_hash: [u8; 32],
+    /// The proposer pro_tx_hash
+    pub proposer_pro_tx_hash: [u8; 32],
     /// Signature
     #[serde(with = "signature_serializer")]
     pub signature: [u8; 96],
@@ -37,6 +39,9 @@ pub trait ExtendedBlockInfoV0Getters {
 
     /// Returns the quorum hash.
     fn quorum_hash(&self) -> &[u8; 32];
+    /// Proposer pro tx hash.
+    fn proposer_pro_tx_hash(&self) -> &[u8; 32];
+    /// The block id hash
     fn block_id_hash(&self) -> &[u8; 32];
 
     /// Returns the signature.
@@ -83,6 +88,10 @@ impl ExtendedBlockInfoV0Getters for ExtendedBlockInfoV0 {
 
     fn quorum_hash(&self) -> &[u8; 32] {
         &self.quorum_hash
+    }
+
+    fn proposer_pro_tx_hash(&self) -> &[u8; 32] {
+        &self.proposer_pro_tx_hash
     }
 
     fn block_id_hash(&self) -> &[u8; 32] {

--- a/packages/rs-drive-abci/src/config.rs
+++ b/packages/rs-drive-abci/src/config.rs
@@ -123,14 +123,6 @@ pub struct ExecutionConfig {
     #[serde(default = "ExecutionConfig::default_verify_sum_trees")]
     pub verify_sum_trees: bool,
 
-    // TODO: Move to ValidatorSetConfig
-    /// How often should quorums change?
-    #[serde(
-        default = "ExecutionConfig::default_validator_set_rotation_block_count",
-        deserialize_with = "from_str_or_number"
-    )]
-    pub validator_set_rotation_block_count: u32,
-
     /// How long in seconds should an epoch last
     /// It might last a lot longer if the chain is halted
     #[serde(
@@ -567,10 +559,6 @@ impl ExecutionConfig {
         true
     }
 
-    fn default_validator_set_rotation_block_count() -> u32 {
-        15
-    }
-
     fn default_epoch_time_length_s() -> u64 {
         788400
     }
@@ -618,8 +606,6 @@ impl Default for ExecutionConfig {
         Self {
             use_document_triggers: ExecutionConfig::default_use_document_triggers(),
             verify_sum_trees: ExecutionConfig::default_verify_sum_trees(),
-            validator_set_rotation_block_count:
-                ExecutionConfig::default_validator_set_rotation_block_count(),
             epoch_time_length_s: ExecutionConfig::default_epoch_time_length_s(),
         }
     }
@@ -763,6 +749,8 @@ impl PlatformConfig {
 pub struct PlatformTestConfig {
     /// Block signing
     pub block_signing: bool,
+    /// Storing of platform state
+    pub store_platform_state: bool,
     /// Block signature verification
     pub block_commit_signature_verification: bool,
     /// Disable instant lock signature verification
@@ -772,11 +760,12 @@ pub struct PlatformTestConfig {
 #[cfg(feature = "testing-config")]
 impl PlatformTestConfig {
     /// Much faster config for tests
-    pub fn default_with_no_block_signing() -> Self {
+    pub fn default_minimal_verifications() -> Self {
         Self {
             block_signing: false,
+            store_platform_state: false,
             block_commit_signature_verification: false,
-            disable_instant_lock_signature_verification: false,
+            disable_instant_lock_signature_verification: true,
         }
     }
 }
@@ -786,6 +775,7 @@ impl Default for PlatformTestConfig {
     fn default() -> Self {
         Self {
             block_signing: true,
+            store_platform_state: true,
             block_commit_signature_verification: true,
             disable_instant_lock_signature_verification: false,
         }

--- a/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
@@ -241,6 +241,7 @@ where
             app_hash: block_header.app_hash,
             quorum_hash: current_quorum_hash,
             block_id_hash,
+            proposer_pro_tx_hash: block_header.proposer_pro_tx_hash,
             signature: commit_info.block_signature,
             round,
         }

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
@@ -364,6 +364,7 @@ where
             .set_app_hash(Some(root_hash));
 
         let validator_set_update = self.validator_set_update(
+            block_proposal.proposer_pro_tx_hash,
             last_committed_platform_state,
             &mut block_execution_context,
             platform_version,

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/mod.rs
@@ -36,6 +36,7 @@ where
     ///
     pub fn validator_set_update(
         &self,
+        proposer_pro_tx_hash: [u8; 32],
         platform_state: &PlatformState,
         block_execution_context: &mut BlockExecutionContext,
         platform_version: &PlatformVersion,
@@ -46,7 +47,11 @@ where
             .block_end
             .validator_set_update
         {
-            0 => self.validator_set_update_v0(platform_state, block_execution_context),
+            0 => self.validator_set_update_v0(
+                proposer_pro_tx_hash,
+                platform_state,
+                block_execution_context,
+            ),
             version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
                 method: "validator_set_update".to_string(),
                 known_versions: vec![0],

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v0/mod.rs
@@ -64,34 +64,29 @@ where
             // and that the new proposer is on the same quorum and the last proposer but is before
             // them in the list of proposers.
             // This only works if Tenderdash goes through proposers properly
-            if &block_execution_context
-                .block_platform_state()
-                .last_committed_quorum_hash()
+            if &platform_state.last_committed_quorum_hash()
                 == platform_state
                     .current_validator_set_quorum_hash()
                     .as_byte_array()
+                && platform_state.last_committed_block_proposer_pro_tx_hash() > proposer_pro_tx_hash
+                && platform_state.validator_sets().len() > 1
             {
-                // we haven't changed quorums
-                if block_execution_context
-                    .block_platform_state()
-                    .last_committed_block_proposer_pro_tx_hash()
-                    > proposer_pro_tx_hash
-                {
-                    // The new proposer is before the old proposer
-                    tracing::debug!(
-                        method = "validator_set_update_v0",
-                    "rotation: quorum finished as we hit last an earlier member {} than last block proposer {} for quorum {}. All known quorums are: [{}]. quorum rotation expected",
-                    hex::encode(proposer_pro_tx_hash),
-                        hex::encode(block_execution_context.block_platform_state().last_committed_block_proposer_pro_tx_hash()),
-                        hex::encode(platform_state.current_validator_set_quorum_hash().as_byte_array()),
-                    block_execution_context
-                    .block_platform_state()
-                    .validator_sets()
-                    .keys()
-                    .map(hex::encode).collect::<Vec<_>>().join(" | "),
-                    );
-                    perform_rotation = true;
-                }
+                // 1 - We haven't changed quorums
+                // 2 - The new proposer is before the old proposer
+                // 3 - There are more than one quorum in the system
+                tracing::debug!(
+                    method = "validator_set_update_v0",
+                "rotation: quorum finished as we hit last an earlier member {} than last block proposer {} for quorum {}. All known quorums are: [{}]. quorum rotation expected",
+                hex::encode(proposer_pro_tx_hash),
+                    hex::encode(block_execution_context.block_platform_state().last_committed_block_proposer_pro_tx_hash()),
+                    hex::encode(platform_state.current_validator_set_quorum_hash().as_byte_array()),
+                block_execution_context
+                .block_platform_state()
+                .validator_sets()
+                .keys()
+                .map(hex::encode).collect::<Vec<_>>().join(" | "),
+                );
+                perform_rotation = true;
             }
         } else {
             // we also need to perform a rotation if the validator set is being removed
@@ -126,7 +121,7 @@ where
                 0 => Err(Error::Execution(ExecutionError::CorruptedCachedState(
                     "no current quorums".to_string(),
                 ))),
-                1 => Ok(None),
+                1 => Ok(None), // no rotation as we are the only quorum
                 count => {
                     let start_index = index;
                     index = (index + 1) % count;

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v0/mod.rs
@@ -4,7 +4,6 @@ use crate::execution::types::block_execution_context::v0::{
     BlockExecutionContextV0Getters, BlockExecutionContextV0MutableGetters,
 };
 use crate::execution::types::block_execution_context::BlockExecutionContext;
-use crate::execution::types::block_state_info::v0::BlockStateInfoV0Getters;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::v0::PlatformStateV0Methods;
 use crate::platform_types::platform_state::PlatformState;
@@ -12,6 +11,7 @@ use crate::platform_types::validator_set::v0::ValidatorSetV0Getters;
 use crate::rpc::core::CoreRPCLike;
 use itertools::Itertools;
 
+use dpp::dashcore::hashes::Hash;
 use tenderdash_abci::proto::abci::ValidatorSetUpdate;
 
 impl<C> Platform<C>
@@ -23,28 +23,78 @@ where
     #[inline(always)]
     pub(super) fn validator_set_update_v0(
         &self,
+        proposer_pro_tx_hash: [u8; 32],
         platform_state: &PlatformState,
         block_execution_context: &mut BlockExecutionContext,
     ) -> Result<Option<ValidatorSetUpdate>, Error> {
         let mut perform_rotation = false;
 
-        if block_execution_context.block_state_info().height()
-            % self.config.execution.validator_set_rotation_block_count as u64
-            == 0
-        {
-            tracing::debug!(
-                method = "validator_set_update_v0",
-                "rotation: previous quorum finished members. quorum rotation expected"
-            );
-            perform_rotation = true;
-        }
-        // we also need to perform a rotation if the validator set is being removed
-        if block_execution_context
+        if let Some(validator_set) = block_execution_context
             .block_platform_state()
             .validator_sets()
             .get(&platform_state.current_validator_set_quorum_hash())
-            .is_none()
         {
+            if let Some((last_member_pro_tx_hash, _)) = validator_set.members().last_key_value() {
+                // we should also perform a rotation if the validator set went through all quorum members
+                // this means we are at the last member of the quorum
+                if last_member_pro_tx_hash.as_byte_array() == &proposer_pro_tx_hash {
+                    tracing::debug!(
+                    method = "validator_set_update_v0",
+                    "rotation: quorum finished as we hit last member {} of quorum {}. All known quorums are: [{}]. quorum rotation expected",
+                    hex::encode(proposer_pro_tx_hash),
+                        hex::encode(platform_state.current_validator_set_quorum_hash().as_byte_array()),
+                    block_execution_context
+                    .block_platform_state()
+                    .validator_sets()
+                    .keys()
+                    .map(hex::encode).collect::<Vec<_>>().join(" | "),
+                );
+                    perform_rotation = true;
+                }
+            } else {
+                // the validator set has no members, very weird, but let's just perform a rotation
+                tracing::debug!(
+                    method = "validator_set_update_v0",
+                    "rotation: validator set has no members",
+                );
+                perform_rotation = true;
+            }
+
+            // We should also perform a rotation if there are more than one quorum in the system
+            // and that the new proposer is on the same quorum and the last proposer but is before
+            // them in the list of proposers.
+            // This only works if Tenderdash goes through proposers properly
+            if &block_execution_context
+                .block_platform_state()
+                .last_committed_quorum_hash()
+                == platform_state
+                    .current_validator_set_quorum_hash()
+                    .as_byte_array()
+            {
+                // we haven't changed quorums
+                if block_execution_context
+                    .block_platform_state()
+                    .last_committed_block_proposer_pro_tx_hash()
+                    > proposer_pro_tx_hash
+                {
+                    // The new proposer is before the old proposer
+                    tracing::debug!(
+                        method = "validator_set_update_v0",
+                    "rotation: quorum finished as we hit last an earlier member {} than last block proposer {} for quorum {}. All known quorums are: [{}]. quorum rotation expected",
+                    hex::encode(proposer_pro_tx_hash),
+                        hex::encode(block_execution_context.block_platform_state().last_committed_block_proposer_pro_tx_hash()),
+                        hex::encode(platform_state.current_validator_set_quorum_hash().as_byte_array()),
+                    block_execution_context
+                    .block_platform_state()
+                    .validator_sets()
+                    .keys()
+                    .map(hex::encode).collect::<Vec<_>>().join(" | "),
+                    );
+                    perform_rotation = true;
+                }
+            }
+        } else {
+            // we also need to perform a rotation if the validator set is being removed
             tracing::debug!(
                 method = "validator_set_update_v0",
                 "rotation: new quorums not containing current quorum current {:?}, {}. quorum rotation expected˚",
@@ -58,7 +108,7 @@ where
             perform_rotation = true;
         }
 
-        //todo: perform a rotation if quorum health is low
+        //todo: (maybe) perform a rotation if quorum health is low
 
         if perform_rotation {
             // get the index of the previous quorum

--- a/packages/rs-drive-abci/src/execution/storage/store_platform_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/storage/store_platform_state/v0/mod.rs
@@ -12,6 +12,19 @@ impl<C> Platform<C> {
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<(), Error> {
+        #[cfg(feature = "testing-config")]
+        {
+            if self.config.testing_configs.store_platform_state {
+                self.drive
+                    .store_platform_state_bytes(
+                        &state.serialize_to_bytes()?,
+                        transaction,
+                        platform_version,
+                    )
+                    .map_err(Error::Drive)?;
+            }
+        }
+        #[cfg(not(feature = "testing-config"))]
         self.drive
             .store_platform_state_bytes(&state.serialize_to_bytes()?, transaction, platform_version)
             .map_err(Error::Drive)?;

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/mod.rs
@@ -179,11 +179,11 @@ mod tests {
             },
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 300,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let platform = TestPlatformBuilder::new()

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/triggers/dashpay/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/data_triggers/triggers/dashpay/v0/mod.rs
@@ -227,6 +227,7 @@ mod test {
                 app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                 quorum_hash: [0u8; 32],
                 block_id_hash: [0u8; 32],
+                proposer_pro_tx_hash: [0u8; 32],
                 signature: [0u8; 96],
                 round: 0,
             }
@@ -345,6 +346,7 @@ mod test {
                 app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                 quorum_hash: [0u8; 32],
                 block_id_hash: [0u8; 32],
+                proposer_pro_tx_hash: [0u8; 32],
                 signature: [0u8; 96],
                 round: 0,
             }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/masternode_vote/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/masternode_vote/mod.rs
@@ -4090,6 +4090,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -4271,6 +4272,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -4415,6 +4417,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -4450,6 +4453,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -4659,6 +4663,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -4694,6 +4699,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -4805,6 +4811,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -4840,6 +4847,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -4947,6 +4955,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -4982,6 +4991,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -5106,6 +5116,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -5742,6 +5753,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -5949,6 +5961,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -6156,6 +6169,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -6358,6 +6372,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -6551,6 +6566,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -6758,6 +6774,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -6961,6 +6978,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -7144,6 +7162,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }
@@ -7610,6 +7629,7 @@ mod tests {
                         app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                         quorum_hash: [0u8; 32],
                         block_id_hash: [0u8; 32],
+                        proposer_pro_tx_hash: [0u8; 32],
                         signature: [0u8; 96],
                         round: 0,
                     }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
@@ -1435,6 +1435,7 @@ mod tests {
                 app_hash: platform.drive.grove.root_hash(None).unwrap().unwrap(),
                 quorum_hash: [0u8; 32],
                 block_id_hash: [0u8; 32],
+                proposer_pro_tx_hash: [0u8; 32],
                 signature: [0u8; 96],
                 round: 0,
             }

--- a/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
@@ -207,6 +207,12 @@ impl TryFromPlatformVersioned<PlatformStateForSaving> for PlatformState {
 }
 
 impl PlatformStateV0Methods for PlatformState {
+    fn last_committed_block_height(&self) -> u64 {
+        match self {
+            PlatformState::V0(v0) => v0.last_committed_block_height(),
+        }
+    }
+
     fn last_committed_known_block_height_or(&self, default: u64) -> u64 {
         match self {
             PlatformState::V0(v0) => v0.last_committed_known_block_height_or(default),
@@ -237,6 +243,12 @@ impl PlatformStateV0Methods for PlatformState {
         }
     }
 
+    fn last_committed_block_proposer_pro_tx_hash(&self) -> [u8; 32] {
+        match self {
+            PlatformState::V0(v0) => v0.last_committed_block_proposer_pro_tx_hash(),
+        }
+    }
+
     fn last_committed_block_signature(&self) -> [u8; 96] {
         match self {
             PlatformState::V0(v0) => v0.last_committed_block_signature(),
@@ -246,12 +258,6 @@ impl PlatformStateV0Methods for PlatformState {
     fn last_committed_block_app_hash(&self) -> Option<[u8; 32]> {
         match self {
             PlatformState::V0(v0) => v0.last_committed_block_app_hash(),
-        }
-    }
-
-    fn last_committed_block_height(&self) -> u64 {
-        match self {
-            PlatformState::V0(v0) => v0.last_committed_block_height(),
         }
     }
 
@@ -324,6 +330,12 @@ impl PlatformStateV0Methods for PlatformState {
     fn chain_lock_validating_quorums(&self) -> &SignatureVerificationQuorumSet {
         match self {
             PlatformState::V0(v0) => &v0.chain_lock_validating_quorums,
+        }
+    }
+
+    fn instant_lock_validating_quorums(&self) -> &SignatureVerificationQuorumSet {
+        match self {
+            PlatformState::V0(v0) => v0.instant_lock_validating_quorums(),
         }
     }
 
@@ -459,6 +471,12 @@ impl PlatformStateV0Methods for PlatformState {
         }
     }
 
+    fn instant_lock_validating_quorums_mut(&mut self) -> &mut SignatureVerificationQuorumSet {
+        match self {
+            PlatformState::V0(v0) => v0.instant_lock_validating_quorums_mut(),
+        }
+    }
+
     fn full_masternode_list_mut(&mut self) -> &mut BTreeMap<ProTxHash, MasternodeListItem> {
         match self {
             PlatformState::V0(v0) => v0.full_masternode_list_mut(),
@@ -496,18 +514,6 @@ impl PlatformStateV0Methods for PlatformState {
             (PlatformState::V0(v0), PlatformState::V0(v0_previous)) => {
                 v0.hpmn_masternode_list_changes(v0_previous)
             }
-        }
-    }
-
-    fn instant_lock_validating_quorums(&self) -> &SignatureVerificationQuorumSet {
-        match self {
-            PlatformState::V0(v0) => v0.instant_lock_validating_quorums(),
-        }
-    }
-
-    fn instant_lock_validating_quorums_mut(&mut self) -> &mut SignatureVerificationQuorumSet {
-        match self {
-            PlatformState::V0(v0) => v0.instant_lock_validating_quorums_mut(),
         }
     }
 }

--- a/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
@@ -289,6 +289,8 @@ pub trait PlatformStateV0Methods {
     fn last_committed_block_time_ms(&self) -> Option<u64>;
     /// The last quorum hash
     fn last_committed_quorum_hash(&self) -> [u8; 32];
+    /// The last block proposer pro tx hash
+    fn last_committed_block_proposer_pro_tx_hash(&self) -> [u8; 32];
     /// The last block signature
     fn last_committed_block_signature(&self) -> [u8; 96];
     /// The last block app hash
@@ -472,6 +474,14 @@ impl PlatformStateV0Methods for PlatformStateV0 {
         self.last_committed_block_info
             .as_ref()
             .map(|block_info| *block_info.quorum_hash())
+            .unwrap_or_default()
+    }
+
+    /// The last committed block proposer's pro tx hash
+    fn last_committed_block_proposer_pro_tx_hash(&self) -> [u8; 32] {
+        self.last_committed_block_info
+            .as_ref()
+            .map(|block_info| *block_info.proposer_pro_tx_hash())
             .unwrap_or_default()
     }
 

--- a/packages/rs-drive-abci/tests/strategy_tests/chain_lock_update.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/chain_lock_update.rs
@@ -64,12 +64,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },

--- a/packages/rs-drive-abci/tests/strategy_tests/core_update_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/core_update_tests.rs
@@ -72,11 +72,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -173,11 +173,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -265,11 +265,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()

--- a/packages/rs-drive-abci/tests/strategy_tests/execution.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/execution.rs
@@ -975,8 +975,9 @@ pub(crate) fn continue_chain_for_strategy(
         }
 
         let proposer = current_quorum_with_test_info
-            .validator_set
-            .get(i as usize)
+            .validator_map
+            .values()
+            .nth(i as usize)
             .unwrap();
         let (state_transitions, finalize_block_operations) = strategy.state_transitions_for_block(
             platform,

--- a/packages/rs-drive-abci/tests/strategy_tests/failures.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/failures.rs
@@ -83,12 +83,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -162,11 +163,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -218,7 +219,6 @@ mod tests {
     //         execution: ExecutionConfig {
     //             //we disable document triggers because we are using dpns and dpns needs a preorder
     //             use_document_triggers: false,
-    //             validator_set_rotation_block_count: 25,
     //             ..Default::default()
     //         },
     //         block_spacing_ms: 3000,

--- a/packages/rs-drive-abci/tests/strategy_tests/main.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/main.rs
@@ -121,11 +121,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..ExecutionConfig::default()
             },
             block_spacing_ms: 3000,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -166,7 +166,7 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..ExecutionConfig::default()
             },
             block_spacing_ms: 3000,
@@ -211,7 +211,7 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..ExecutionConfig::default()
             },
             block_spacing_ms: 3000,
@@ -353,7 +353,7 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..ExecutionConfig::default()
             },
             block_spacing_ms: 3000,
@@ -496,12 +496,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -562,11 +563,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -611,11 +612,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 ..Default::default()
             },
             block_spacing_ms: hour_in_ms,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
 
@@ -668,12 +669,12 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 epoch_time_length_s: hour_in_s,
                 ..Default::default()
             },
             block_spacing_ms: three_mins_in_ms,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
 
@@ -742,11 +743,11 @@ mod tests {
             },
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 300,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -838,11 +839,11 @@ mod tests {
             },
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 300,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -921,11 +922,11 @@ mod tests {
             },
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 300,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -999,11 +1000,11 @@ mod tests {
             },
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 300,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -1096,7 +1097,7 @@ mod tests {
             instant_lock: InstantLockConfig::default(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
@@ -1150,12 +1151,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -1185,7 +1187,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
             ),
-            "2c1628cbe2b7f67b48078045146890fb4ac5498a2826201ce01f5c290d8be0ac".to_string()
+            "3a1756d12483a31c585d741281d2f882857943f1f7eb02d9bb47bc406a391c33".to_string()
         )
     }
 
@@ -1235,12 +1237,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -1358,11 +1361,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -1445,12 +1448,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -1553,11 +1557,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -1634,12 +1638,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -1747,12 +1752,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -1860,12 +1866,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -1898,7 +1905,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
             ),
-            "f86815bbe9f0596b0ebe5c5e093efcd7e768f1fdb3701955918d9b20f2c7d9ae".to_string()
+            "4437143051f651e86e0c279ef0ccc0adf3d36a42f9db03b76829681ddbca3e4a".to_string()
         )
     }
 
@@ -1991,12 +1998,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -2028,7 +2036,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
             ),
-            "2a3c97f0c35ee026715121f1c21c076f0adadfd59ab9ee7672c28f56724f8df3".to_string()
+            "bba2902bc71ce45f72b46661458203334e9ffd347347b0ccb252955011d6b355".to_string()
         )
     }
 
@@ -2121,11 +2129,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
 
@@ -2236,11 +2244,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
 
@@ -2351,13 +2359,14 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 epoch_time_length_s: 1576800,
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -2485,13 +2494,14 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 epoch_time_length_s: 1576800,
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -2635,13 +2645,14 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 epoch_time_length_s: 1576800,
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -2710,11 +2721,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform = TestPlatformBuilder::new()
@@ -2790,12 +2801,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -2879,12 +2891,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -2980,12 +2993,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -3581,11 +3595,10 @@ mod tests {
             },
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 1,
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
 
@@ -3763,12 +3776,11 @@ mod tests {
             },
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 1,
                 epoch_time_length_s: 1576800,
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let mut platform_a = TestPlatformBuilder::new()
@@ -3921,12 +3933,12 @@ mod tests {
             },
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 1,
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -4021,8 +4033,8 @@ mod tests {
             .into_iter()
             .filter(|(_, balance)| *balance != 0)
             .count();
-        // we have a maximum 90 quorums, that could have been used, 6 were used twice
-        assert_eq!(balance_count, 84);
+        // we have a maximum 90 quorums, that could have been used, 7 were used twice
+        assert_eq!(balance_count, 83);
     }
 
     #[test]
@@ -4074,12 +4086,11 @@ mod tests {
             },
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 1,
                 epoch_time_length_s: 1576800,
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
         let TempPlatform {
@@ -4227,12 +4238,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -4287,12 +4299,13 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },

--- a/packages/rs-drive-abci/tests/strategy_tests/query.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/query.rs
@@ -377,11 +377,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 ..Default::default()
             },
             block_spacing_ms: hour_in_ms,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
 
@@ -391,11 +391,16 @@ mod tests {
 
         let outcome = run_chain_for_strategy(&mut platform, 1000, strategy, config, 15, &mut None);
         assert_eq!(outcome.masternode_identity_balances.len(), 100);
-        let all_have_balances = outcome
+        let nodes_with_no_balance = outcome
             .masternode_identity_balances
             .iter()
-            .all(|(_, balance)| *balance != 0);
-        assert!(all_have_balances, "all masternodes should have a balance");
+            .filter(|(_, balance)| *balance == &0)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            nodes_with_no_balance.len(),
+            0,
+            "all masternodes should have a balance"
+        );
 
         let request = GetEpochsInfoRequest {
             version: Some(Version::V0(GetEpochsInfoRequestV0 {
@@ -475,11 +480,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 ..Default::default()
             },
             block_spacing_ms: hour_in_ms,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
 
@@ -574,11 +579,11 @@ mod tests {
             instant_lock: InstantLockConfig::default_100_67(),
             execution: ExecutionConfig {
                 verify_sum_trees: true,
-                validator_set_rotation_block_count: 100,
+
                 ..Default::default()
             },
             block_spacing_ms: hour_in_ms,
-            testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
             ..Default::default()
         };
 

--- a/packages/rs-drive-abci/tests/strategy_tests/upgrade_fork_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/upgrade_fork_tests.rs
@@ -31,7 +31,7 @@ mod tests {
     #[test]
     fn run_chain_version_upgrade() {
         // Define the desired stack size
-        let stack_size = 4 * 1024 * 1024; //Lets set the stack size to be higher than the default 2MB
+        let stack_size = 4 * 1024 * 1024; //Let's set the stack size to be higher than the default 2MB
 
         let builder = std::thread::Builder::new()
             .stack_size(stack_size)
@@ -73,7 +73,6 @@ mod tests {
                     instant_lock: InstantLockConfig::default_100_67(),
                     execution: ExecutionConfig {
                         verify_sum_trees: true,
-                        validator_set_rotation_block_count: 125,
                         epoch_time_length_s: 1576800,
                         ..Default::default()
                     },
@@ -82,7 +81,7 @@ mod tests {
                         ..Default::default()
                     },
                     block_spacing_ms: twenty_minutes_in_ms,
-                    testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+                    testing_configs: PlatformTestConfig::default_minimal_verifications(),
 
                     ..Default::default()
                 };
@@ -145,7 +144,7 @@ mod tests {
                             counter.get(&1).unwrap(),
                             counter.get(&TEST_PROTOCOL_VERSION_2).unwrap()
                         ),
-                        (Some(&17), Some(&414))
+                        (Some(&11), Some(&435))
                     );
                     //most nodes were hit (63 were not)
                 }
@@ -213,7 +212,7 @@ mod tests {
                     assert_eq!(state.current_protocol_version_in_consensus(), 1);
                     assert_eq!(state.next_epoch_protocol_version(), TEST_PROTOCOL_VERSION_2);
                     assert_eq!(counter.get(&1).unwrap(), None); //no one has proposed 1 yet
-                    assert_eq!(counter.get(&TEST_PROTOCOL_VERSION_2).unwrap(), Some(&154));
+                    assert_eq!(counter.get(&TEST_PROTOCOL_VERSION_2).unwrap(), Some(&179));
                 }
 
                 // we locked in
@@ -269,7 +268,7 @@ mod tests {
                     );
                     assert_eq!(state.next_epoch_protocol_version(), TEST_PROTOCOL_VERSION_2);
                     assert_eq!(counter.get(&1).unwrap(), None); //no one has proposed 1 yet
-                    assert_eq!(counter.get(&TEST_PROTOCOL_VERSION_2).unwrap(), Some(&123));
+                    assert_eq!(counter.get(&TEST_PROTOCOL_VERSION_2).unwrap(), Some(&147));
                 }
             })
             .expect("Failed to create thread with custom stack size");
@@ -281,7 +280,7 @@ mod tests {
     #[test]
     fn run_chain_quick_version_upgrade() {
         // Define the desired stack size
-        let stack_size = 4 * 1024 * 1024; //Lets set the stack size to be higher than the default 2MB
+        let stack_size = 4 * 1024 * 1024; //Let's set the stack size to be higher than the default 2MB
 
         let builder = std::thread::Builder::new()
             .stack_size(stack_size)
@@ -326,12 +325,11 @@ mod tests {
                     instant_lock: InstantLockConfig::default_100_67(),
                     execution: ExecutionConfig {
                         verify_sum_trees: true,
-                        validator_set_rotation_block_count: 30,
                         epoch_time_length_s: one_hour_in_s,
                         ..Default::default()
                     },
                     block_spacing_ms: thirty_seconds_in_ms,
-                    testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+                    testing_configs: PlatformTestConfig::default_minimal_verifications(),
 
                     ..Default::default()
                 };
@@ -579,6 +577,7 @@ mod tests {
             block_spacing_ms: epoch_time_length_s * 1000,
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -702,7 +701,7 @@ mod tests {
     #[test]
     fn run_chain_version_upgrade_slow_upgrade() {
         // Define the desired stack size
-        let stack_size = 4 * 1024 * 1024; //Lets set the stack size to be higher than the default 2MB
+        let stack_size = 4 * 1024 * 1024; //Let's set the stack size to be higher than the default 2MB
 
         let builder = std::thread::Builder::new()
             .stack_size(stack_size)
@@ -746,7 +745,6 @@ mod tests {
                     instant_lock: InstantLockConfig::default_100_67(),
                     execution: ExecutionConfig {
                         verify_sum_trees: true,
-                        validator_set_rotation_block_count: 80,
                         epoch_time_length_s: 1576800,
                         ..Default::default()
                     },
@@ -756,7 +754,7 @@ mod tests {
                     },
                     block_spacing_ms: hour_in_ms,
 
-                    testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+                    testing_configs: PlatformTestConfig::default_minimal_verifications(),
                     ..Default::default()
                 };
                 let mut platform = TestPlatformBuilder::new()
@@ -813,7 +811,7 @@ mod tests {
                             counter.get(&1).unwrap(),
                             counter.get(&TEST_PROTOCOL_VERSION_2).unwrap()
                         ),
-                        (Some(&35), Some(&64))
+                        (Some(&39), Some(&78))
                     );
                 }
 
@@ -844,7 +842,7 @@ mod tests {
                     ChainExecutionParameters {
                         block_start,
                         core_height_start: 1,
-                        block_count: 2500,
+                        block_count: 1400,
                         proposers,
                         validator_quorums: quorums,
                         current_validator_quorum_hash: current_quorum_hash,
@@ -864,24 +862,20 @@ mod tests {
                 {
                     let counter = &platform.drive.cache.protocol_versions_counter.read();
                     assert_eq!(
-                        state
-                            .last_committed_block_info()
-                            .as_ref()
-                            .unwrap()
-                            .basic_info()
-                            .epoch
-                            .index,
-                        11
-                    );
-                    assert_eq!(state.current_protocol_version_in_consensus(), 1);
-                    assert_eq!(state.next_epoch_protocol_version(), TEST_PROTOCOL_VERSION_2);
-                    // the counter is for the current voting during that window
-                    assert_eq!(
                         (
+                            state
+                                .last_committed_block_info()
+                                .as_ref()
+                                .unwrap()
+                                .basic_info()
+                                .epoch
+                                .index,
+                            state.current_protocol_version_in_consensus(),
+                            state.next_epoch_protocol_version(),
                             counter.get(&1).unwrap(),
                             counter.get(&TEST_PROTOCOL_VERSION_2).unwrap()
                         ),
-                        (Some(&8), Some(&79))
+                        (8, 1, TEST_PROTOCOL_VERSION_2, Some(&19), Some(&98))
                     );
                 }
 
@@ -918,8 +912,8 @@ mod tests {
 
                 let state = platform.state.load();
 
-                {
-                    assert_eq!(
+                assert_eq!(
+                    (
                         state
                             .last_committed_block_info()
                             .as_ref()
@@ -927,14 +921,11 @@ mod tests {
                             .basic_info()
                             .epoch
                             .index,
-                        12
-                    );
-                    assert_eq!(
                         state.current_protocol_version_in_consensus(),
-                        TEST_PROTOCOL_VERSION_2
-                    );
-                    assert_eq!(state.next_epoch_protocol_version(), TEST_PROTOCOL_VERSION_2);
-                }
+                        state.next_epoch_protocol_version()
+                    ),
+                    (9, TEST_PROTOCOL_VERSION_2, TEST_PROTOCOL_VERSION_2)
+                );
             })
             .expect("Failed to create thread with custom stack size");
 
@@ -945,7 +936,7 @@ mod tests {
     #[test]
     fn run_chain_version_upgrade_slow_upgrade_quick_reversion_after_lock_in() {
         // Define the desired stack size
-        let stack_size = 4 * 1024 * 1024; //Lets set the stack size to be higher than the default 2MB
+        let stack_size = 4 * 1024 * 1024; //Let's set the stack size to be higher than the default 2MB
 
         let builder = std::thread::Builder::new()
             .stack_size(stack_size)
@@ -989,7 +980,6 @@ mod tests {
                     instant_lock: InstantLockConfig::default_100_67(),
                     execution: ExecutionConfig {
                         verify_sum_trees: true,
-                        validator_set_rotation_block_count: 50,
                         epoch_time_length_s: 1576800,
                         ..Default::default()
                     },
@@ -999,7 +989,7 @@ mod tests {
                     },
                     block_spacing_ms: hour_in_ms,
 
-                    testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+                    testing_configs: PlatformTestConfig::default_minimal_verifications(),
                     ..Default::default()
                 };
                 let mut platform = TestPlatformBuilder::new()
@@ -1114,7 +1104,7 @@ mod tests {
                             counter.get(&1).unwrap(),
                             counter.get(&TEST_PROTOCOL_VERSION_2).unwrap()
                         ),
-                        (Some(&18), Some(&112))
+                        (Some(&16), Some(&117))
                     );
                     //not all nodes have upgraded
                 }
@@ -1203,7 +1193,7 @@ mod tests {
                         ),
                         (Some(&172), Some(&24))
                     );
-                    //a lot nodes reverted to previous version, however this won't impact things
+                    //a lot of nodes reverted to previous version, however this won't impact things
                     assert_eq!(
                         state
                             .last_committed_block_info()
@@ -1283,7 +1273,7 @@ mod tests {
     #[test]
     fn run_chain_version_upgrade_multiple_versions() {
         // Define the desired stack size
-        let stack_size = 4 * 1024 * 1024; //Lets set the stack size to be higher than the default 2MB
+        let stack_size = 4 * 1024 * 1024; //Let's set the stack size to be higher than the default 2MB
 
         let builder = std::thread::Builder::new()
             .stack_size(stack_size)
@@ -1331,7 +1321,6 @@ mod tests {
                     instant_lock: InstantLockConfig::default_100_67(),
                     execution: ExecutionConfig {
                         verify_sum_trees: true,
-                        validator_set_rotation_block_count: 30,
                         epoch_time_length_s: 1576800,
                         ..Default::default()
                     },
@@ -1341,7 +1330,7 @@ mod tests {
                     },
                     block_spacing_ms: hour_in_ms,
 
-                    testing_configs: PlatformTestConfig::default_with_no_block_signing(),
+                    testing_configs: PlatformTestConfig::default_minimal_verifications(),
                     ..Default::default()
                 };
                 let mut platform = TestPlatformBuilder::new()
@@ -1369,7 +1358,7 @@ mod tests {
                     ..
                 } = run_chain_for_strategy(
                     &mut platform,
-                    1400,
+                    1200,
                     strategy,
                     config.clone(),
                     15,
@@ -1381,30 +1370,34 @@ mod tests {
                     let counter = &platform.drive.cache.protocol_versions_counter.read();
 
                     assert_eq!(
-                        state
-                            .last_committed_block_info()
-                            .as_ref()
-                            .unwrap()
-                            .basic_info()
-                            .epoch
-                            .index,
-                        3
-                    );
-                    assert_eq!(state.current_protocol_version_in_consensus(), 1);
-                    assert_eq!(state.next_epoch_protocol_version(), TEST_PROTOCOL_VERSION_2);
-                    assert_eq!(
                         (
+                            state
+                                .last_committed_block_info()
+                                .as_ref()
+                                .unwrap()
+                                .basic_info()
+                                .epoch
+                                .index,
+                            state.current_protocol_version_in_consensus(),
+                            state.next_epoch_protocol_version(),
                             counter.get(&1).unwrap(),
                             counter.get(&TEST_PROTOCOL_VERSION_2).unwrap(),
                             counter.get(&TEST_PROTOCOL_VERSION_3).unwrap()
                         ),
-                        (Some(&2), Some(&68), Some(&3))
+                        (
+                            2,
+                            1,
+                            TEST_PROTOCOL_VERSION_2,
+                            Some(&10),
+                            Some(&153),
+                            Some(&8)
+                        )
                     ); //some nodes reverted to previous version
 
                     let epochs = platform
                         .drive
                         .get_epochs_infos(
-                            2,
+                            1,
                             1,
                             true,
                             None,
@@ -1464,7 +1457,7 @@ mod tests {
                     ChainExecutionParameters {
                         block_start,
                         core_height_start: 1,
-                        block_count: 1100,
+                        block_count: 800,
                         proposers,
                         validator_quorums: quorums,
                         current_validator_quorum_hash: current_quorum_hash,
@@ -1484,33 +1477,34 @@ mod tests {
                 {
                     let counter = &platform.drive.cache.protocol_versions_counter.read();
                     assert_eq!(
-                        state
-                            .last_committed_block_info()
-                            .as_ref()
-                            .unwrap()
-                            .basic_info()
-                            .epoch
-                            .index,
-                        5
-                    );
-                    assert_eq!(
-                        state.current_protocol_version_in_consensus(),
-                        TEST_PROTOCOL_VERSION_2
-                    );
-                    assert_eq!(state.next_epoch_protocol_version(), TEST_PROTOCOL_VERSION_3);
-                    assert_eq!(
                         (
+                            state
+                                .last_committed_block_info()
+                                .as_ref()
+                                .unwrap()
+                                .basic_info()
+                                .epoch
+                                .index,
+                            state.current_protocol_version_in_consensus(),
+                            state.next_epoch_protocol_version(),
                             counter.get(&1).unwrap(),
                             counter.get(&TEST_PROTOCOL_VERSION_2).unwrap(),
                             counter.get(&TEST_PROTOCOL_VERSION_3).unwrap()
                         ),
-                        (None, Some(&3), Some(&143))
+                        (
+                            4,
+                            TEST_PROTOCOL_VERSION_2,
+                            TEST_PROTOCOL_VERSION_3,
+                            None,
+                            Some(&3),
+                            Some(&149)
+                        )
                     );
 
                     let epochs = platform
                         .drive
                         .get_epochs_infos(
-                            4,
+                            3,
                             1,
                             true,
                             None,

--- a/packages/rs-drive-abci/tests/strategy_tests/voting_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/voting_tests.rs
@@ -41,6 +41,7 @@ mod tests {
         let config = PlatformConfig {
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -49,7 +50,6 @@ mod tests {
             execution: ExecutionConfig {
                 //we disable document triggers because we are using dpns and dpns needs a preorder
                 use_document_triggers: false,
-                validator_set_rotation_block_count: 25,
                 ..Default::default()
             },
             block_spacing_ms: 3000,
@@ -343,6 +343,7 @@ mod tests {
         let config = PlatformConfig {
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -351,7 +352,6 @@ mod tests {
             execution: ExecutionConfig {
                 //we disable document triggers because we are using dpns and dpns needs a preorder
                 use_document_triggers: false,
-                validator_set_rotation_block_count: 25,
                 ..Default::default()
             },
             block_spacing_ms: 3000,
@@ -700,6 +700,7 @@ mod tests {
         let config = PlatformConfig {
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -708,7 +709,6 @@ mod tests {
             execution: ExecutionConfig {
                 //we disable document triggers because we are using dpns and dpns needs a preorder
                 use_document_triggers: false,
-                validator_set_rotation_block_count: 25,
                 ..Default::default()
             },
             block_spacing_ms: 3000,
@@ -1068,6 +1068,7 @@ mod tests {
         let config = PlatformConfig {
             testing_configs: PlatformTestConfig {
                 block_signing: false,
+                store_platform_state: false,
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
             },
@@ -1076,7 +1077,7 @@ mod tests {
             execution: ExecutionConfig {
                 //we disable document triggers because we are using dpns and dpns needs a preorder
                 use_document_triggers: false,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: 3000,
@@ -1280,7 +1281,7 @@ mod tests {
             execution: ExecutionConfig {
                 //we disable document triggers because we are using dpns and dpns needs a preorder
                 use_document_triggers: false,
-                validator_set_rotation_block_count: 25,
+
                 ..Default::default()
             },
             block_spacing_ms: day_in_ms,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
In the past we would rotate every 15 or 25 blocks. This caused later members of a quorum to never be paid. Now instead we rotate when all quorum members have had a chance to propose a block.

## What was done?
Got rid of old rotation strategy and introduced a new one. When the last proposer of a quorum proposes we rotate. If that member did not propose a block we rotate as soon as possible.

I noticed some tests were very slow, so I made state saving optional, this reduced the time needed to finish strategy tests by over 50%.

## How Has This Been Tested?
Verified that unit tests all passed.


## Breaking Changes
This is a breaking change.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [X] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
