### PR TITLE
fix(dpp): document factory wouldn't allow delete transitions for immutable document types

### DIFF
--- a/packages/rs-dpp/src/document/errors.rs
+++ b/packages/rs-dpp/src/document/errors.rs
@@ -44,8 +44,8 @@ pub enum DocumentError {
     #[error("Trying To Replace Immutable Document")]
     TryingToReplaceImmutableDocument { document: Box<Document> },
 
-    #[error("Trying To Delete Immutable Document")]
-    TryingToDeleteImmutableDocument { document: Box<Document> },
+    #[error("Trying to delete indelible document")]
+    TryingToDeleteIndelibleDocument { document: Box<Document> },
 
     #[error("Documents have mixed owner ids")]
     MismatchOwnerIdsError { documents: Vec<Document> },

--- a/packages/rs-dpp/src/document/specialized_document_factory/v0/mod.rs
+++ b/packages/rs-dpp/src/document/specialized_document_factory/v0/mod.rs
@@ -525,8 +525,8 @@ impl SpecializedDocumentFactoryV0 {
         documents
             .into_iter()
             .map(|(document, document_type)| {
-                if !document_type.documents_mutable() {
-                    return Err(DocumentError::TryingToDeleteImmutableDocument {
+                if !document_type.documents_can_be_deleted() {
+                    return Err(DocumentError::TryingToDeleteIndelibleDocument {
                         document: Box::new(document),
                     }
                     .into());

--- a/packages/wasm-dpp/src/document/errors/mod.rs
+++ b/packages/wasm-dpp/src/document/errors/mod.rs
@@ -75,7 +75,7 @@ pub fn from_document_to_js_error(e: DocumentError) -> JsValue {
             TryingToReplaceImmutableDocumentError::new((*document).into()).into()
         }
         DocumentError::InvalidActionError(action) => InvalidActionError::new(action.into()).into(),
-        DocumentError::TryingToDeleteImmutableDocument { document } => {
+        DocumentError::TryingToDeleteIndelibleDocument { document } => {
             TryingToDeleteImmutableDocumentError::new((*document).into()).into()
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`DocumentFactoryV0` and `SpecializedDocumentFactoryV0` were not allowing to create delete transitions if not `document_type.documents_mutable()`, but it should have been checking `document_type.documents_can_be_deleted()`.

## What was done?
<!--- Describe your changes in detail -->
Changed the check and wrote a test. Also renamed the error message about not being able to delete immutable documents.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Wrote a test for deleting immutable but deletable document types.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
