### PR TITLE
chore(dashmate): enable Core RPC whitelists

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -124,7 +124,7 @@ export default function getBaseConfigFactory(homeDir) {
             tenderdash: {
               password: 'rpcpassword',
               whitelist: [
-                'quoruminfo', 'quorumverify', 'quorumplatformsign', 'masternodestatus', 'masternodelist',
+                'quoruminfo', 'quorumverify', 'quorumsign', 'masternodestatus', 'masternodelist',
                 'ping', 'getnetworkinfo',
               ],
               lowPriority: false,

--- a/packages/dashmate/configs/defaults/getLocalConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getLocalConfigFactory.js
@@ -25,7 +25,7 @@ export default function getLocalConfigFactory(getBaseConfig) {
       },
       core: {
         docker: {
-          image: 'dashpay/dashd:21.0.0-rc.1',
+          image: 'dashpay/dashd:21.0.0-devpr6115.db828177',
           commandArgs: [],
         },
         p2p: {

--- a/packages/dashmate/configs/defaults/getTestnetConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getTestnetConfigFactory.js
@@ -25,7 +25,7 @@ export default function getTestnetConfigFactory(homeDir, getBaseConfig) {
       },
       core: {
         docker: {
-          image: 'dashpay/dashd:21.0.0-rc.1',
+          image: 'dashpay/dashd:21.0.0-devpr6115.db828177',
           commandArgs: [],
         },
         p2p: {

--- a/packages/dashmate/templates/core/dash.conf.dot
+++ b/packages/dashmate/templates/core/dash.conf.dot
@@ -18,14 +18,14 @@ rpcwallet=main
 deprecatedrpc=hpmn
 rpcworkqueue=64
 rpcthreads=16
-#rpcwhitelistdefault=0
+rpcwhitelistdefault=0
 rpcexternaluser={{= Object.entries(it.core.rpc.users).filter(([username, options]) => options.lowPriority).map(([username, options]) => username).join(',') }}
 {{~ Object.keys(it.core.rpc.users) :user}}
 {{ salt = it.crypto.randomBytes(16).toString('hex'); }}
 {{ hmac = it.crypto.createHmac('sha256', salt).update(it.core.rpc.users[user].password); }}
 rpcauth={{=user}}:{{=salt}}${{=hmac.digest('hex') }}
 {{? it.core.rpc.users[user].whitelist !== null }}
-#rpcwhitelist={{=user}}:{{=it.core.rpc.users[user].whitelist.join(',')}}
+rpcwhitelist={{=user}}:{{=it.core.rpc.users[user].whitelist.join(',')}}
 {{?}}
 {{~}}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since #1883 whitelists were disabled since Core 21 rc.1 didn't support them for complex commands. Core rc2 is released so we can enable whitelists.

## What was done?
<!--- Describe your changes in detail -->
- Enabled whitelists in dash.conf
- Changed `quorumplatformsign` to `quorumsign` since we do not support in in Tenderdash v1 yet
- Updated Core to v21.0.0-devpr6115.db828177 which is basically Core rc2

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
