### PR TITLE
refactor(drive): don't use private bound for public trait

### DIFF
--- a/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
@@ -201,14 +201,6 @@ impl TryFromPlatformVersioned<PlatformStateForSaving> for PlatformState {
 }
 
 impl PlatformStateV0PrivateMethods for PlatformState {
-    /// Patched platform version. Used to fix urgent bugs as not part of normal upgrade process.
-    /// The patched version returns from the public current_platform_version getter in case if present.
-    fn patched_platform_version(&self) -> Option<&'static PlatformVersion> {
-        match self {
-            PlatformState::V0(v0) => v0.patched_platform_version,
-        }
-    }
-
     /// Set patched platform version. It's using to fix urgent bugs as not a part of normal upgrade process
     /// The patched version returns from the public current_platform_version getter in case if present.
     fn set_patched_platform_version(&mut self, version: Option<&'static PlatformVersion>) {
@@ -306,6 +298,14 @@ impl PlatformStateV0Methods for PlatformState {
     fn current_protocol_version_in_consensus(&self) -> ProtocolVersion {
         match self {
             PlatformState::V0(v0) => v0.current_protocol_version_in_consensus(),
+        }
+    }
+
+    /// Patched platform version. Used to fix urgent bugs as not part of normal upgrade process.
+    /// The patched version returns from the public current_platform_version getter in case if present.
+    fn patched_platform_version(&self) -> Option<&'static PlatformVersion> {
+        match self {
+            PlatformState::V0(v0) => v0.patched_platform_version,
         }
     }
 

--- a/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
@@ -292,17 +292,13 @@ pub struct MasternodeListChanges {
 }
 
 pub(super) trait PlatformStateV0PrivateMethods {
-    /// Patched platform version. Used to fix urgent bugs as not part of normal upgrade process.
-    /// The patched version returns from the public current_platform_version getter in case if present.
-    fn patched_platform_version(&self) -> Option<&'static PlatformVersion>;
-
     /// Set patched platform version. It's using to fix urgent bugs as not a part of normal upgrade process
     /// The patched version returns from the public current_platform_version getter in case if present.
     fn set_patched_platform_version(&mut self, version: Option<&'static PlatformVersion>);
 }
 
 /// Platform state methods introduced in version 0 of Platform State Struct
-pub trait PlatformStateV0Methods: PlatformStateV0PrivateMethods {
+pub trait PlatformStateV0Methods {
     /// The last block height or 0 for genesis
     fn last_committed_block_height(&self) -> u64;
     /// The height of the platform, only committed blocks increase height
@@ -333,14 +329,14 @@ pub trait PlatformStateV0Methods: PlatformStateV0PrivateMethods {
     fn last_committed_block_info(&self) -> &Option<ExtendedBlockInfo>;
     /// Returns the current protocol version that is in consensus.
     fn current_protocol_version_in_consensus(&self) -> ProtocolVersion;
+    /// Patched platform version. Used to fix urgent bugs as not part of normal upgrade process.
+    /// The patched version returns from the public current_platform_version getter in case if present.
+    fn patched_platform_version(&self) -> Option<&'static PlatformVersion>;
     /// Get the current platform version or patched if present
     fn current_platform_version(&self) -> Result<&'static PlatformVersion, Error> {
-        self.patched_platform_version()
-            .map(|version| Ok(version))
-            .unwrap_or_else(|| {
-                PlatformVersion::get(self.current_protocol_version_in_consensus())
-                    .map_err(Error::from)
-            })
+        self.patched_platform_version().map(Ok).unwrap_or_else(|| {
+            PlatformVersion::get(self.current_protocol_version_in_consensus()).map_err(Error::from)
+        })
     }
     /// Returns the upcoming protocol version for the next epoch.
     fn next_epoch_protocol_version(&self) -> ProtocolVersion;
@@ -460,12 +456,6 @@ pub trait PlatformStateV0Methods: PlatformStateV0PrivateMethods {
 }
 
 impl PlatformStateV0PrivateMethods for PlatformStateV0 {
-    /// Patched platform version. Used to fix urgent bugs as not part of normal upgrade process.
-    /// The patched version returns from the public current_platform_version getter in case if present.
-    fn patched_platform_version(&self) -> Option<&'static PlatformVersion> {
-        self.patched_platform_version
-    }
-
     /// Set patched platform version. It's using to fix urgent bugs as not a part of normal upgrade process
     /// The patched version returns from the public current_platform_version getter in case if present.
     fn set_patched_platform_version(&mut self, version: Option<&'static PlatformVersion>) {
@@ -593,6 +583,12 @@ impl PlatformStateV0Methods for PlatformStateV0 {
     /// Get the current protocol version in consensus
     fn current_protocol_version_in_consensus(&self) -> ProtocolVersion {
         self.current_protocol_version_in_consensus
+    }
+
+    /// Patched platform version. Used to fix urgent bugs as not part of normal upgrade process.
+    /// The patched version returns from the public current_platform_version getter in case if present.
+    fn patched_platform_version(&self) -> Option<&'static PlatformVersion> {
+        self.patched_platform_version
     }
 
     /// Returns the upcoming protocol version for the next epoch.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using the private bound `PlatformStateV0PrivateMethods` for public the `PlatformStateV0Methods` trait is a bad idea. Not sure how it even compiles.

## What was done?
<!--- Describe your changes in detail -->
- Removed the `PlatformStateV0PrivateMethods` bound from the `PlatformStateV0Methods` trait 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compile the project

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
