### PR TITLE
feat(drive): added config for grovedb verify on startup

### DIFF
--- a/packages/rs-drive-abci/src/main.rs
+++ b/packages/rs-drive-abci/src/main.rs
@@ -98,8 +98,6 @@ impl Cli {
     ) -> Result<(), String> {
         match self.command {
             Commands::Start => {
-                verify_grovedb(&config.db_path, false)?;
-
                 let core_rpc = DefaultCoreRPC::open(
                     config.core.consensus_rpc.url().as_str(),
                     config.core.consensus_rpc.username.clone(),

--- a/packages/rs-drive-abci/src/main.rs
+++ b/packages/rs-drive-abci/src/main.rs
@@ -98,6 +98,9 @@ impl Cli {
     ) -> Result<(), String> {
         match self.command {
             Commands::Start => {
+                if config.drive.grovedb_verify_on_startup {
+                    verify_grovedb(&config.db_path, false)?;
+                }
                 let core_rpc = DefaultCoreRPC::open(
                     config.core.consensus_rpc.url().as_str(),
                     config.core.consensus_rpc.username.clone(),

--- a/packages/rs-drive/src/config.rs
+++ b/packages/rs-drive/src/config.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_GROVE_BATCHING_CONSISTENCY_VERIFICATION_ENABLED: bool = false;
 /// Boolean if GroveDB has_raw in enabled by default
 pub const DEFAULT_GROVE_HAS_RAW_ENABLED: bool = true;
+/// Boolean if verification of GroveDB should be run on startup
+pub const DEFAULT_VERIFY_GROVE_ON_STARTUP: bool = true;
 /// The default default query limit
 pub const DEFAULT_QUERY_LIMIT: u16 = 100;
 /// The default max query limit
@@ -30,6 +32,10 @@ pub struct DriveConfig {
     /// Boolean if has_raw is enabled
     #[cfg_attr(feature = "serde", serde(default = "default_has_raw_enabled"))]
     pub has_raw_enabled: bool,
+
+    /// Boolean if GroveDB verification should happen on startup
+    #[cfg_attr(feature = "serde", serde(default = "default_grove_verify_on_startup_enabled"))]
+    pub grovedb_verify_on_startup: bool,
 
     /// The default returned count if no limit is set
     #[cfg_attr(
@@ -146,6 +152,10 @@ fn default_has_raw_enabled() -> bool {
     DEFAULT_GROVE_HAS_RAW_ENABLED
 }
 
+fn default_grove_verify_on_startup_enabled() -> bool {
+    DEFAULT_VERIFY_GROVE_ON_STARTUP
+}
+
 fn default_default_query_limit() -> u16 {
     DEFAULT_QUERY_LIMIT
 }
@@ -172,6 +182,7 @@ impl Default for DriveConfig {
             batching_consistency_verification:
                 DEFAULT_GROVE_BATCHING_CONSISTENCY_VERIFICATION_ENABLED,
             has_raw_enabled: DEFAULT_GROVE_HAS_RAW_ENABLED,
+            grovedb_verify_on_startup: DEFAULT_VERIFY_GROVE_ON_STARTUP,
             default_query_limit: DEFAULT_QUERY_LIMIT,
             epochs_per_era: DEFAULT_EPOCHS_PER_ERA,
             max_query_limit: DEFAULT_MAX_QUERY_LIMIT,

--- a/packages/rs-drive/src/config.rs
+++ b/packages/rs-drive/src/config.rs
@@ -34,7 +34,10 @@ pub struct DriveConfig {
     pub has_raw_enabled: bool,
 
     /// Boolean if GroveDB verification should happen on startup
-    #[cfg_attr(feature = "serde", serde(default = "default_grove_verify_on_startup_enabled"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default = "default_grove_verify_on_startup_enabled")
+    )]
     pub grovedb_verify_on_startup: bool,
 
     /// The default returned count if no limit is set

--- a/packages/rs-drive/src/config.rs
+++ b/packages/rs-drive/src/config.rs
@@ -10,7 +10,7 @@ pub const DEFAULT_GROVE_BATCHING_CONSISTENCY_VERIFICATION_ENABLED: bool = false;
 /// Boolean if GroveDB has_raw in enabled by default
 pub const DEFAULT_GROVE_HAS_RAW_ENABLED: bool = true;
 /// Boolean if verification of GroveDB should be run on startup
-pub const DEFAULT_VERIFY_GROVE_ON_STARTUP: bool = true;
+pub const DEFAULT_VERIFY_GROVE_ON_STARTUP: bool = false;
 /// The default default query limit
 pub const DEFAULT_QUERY_LIMIT: u16 = 100;
 /// The default max query limit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We shouldn't verify grovedb on every start since verification could take a long time on big database

## What was done?
<!--- Describe your changes in detail -->
- Added a flag in `DriveConfig` which enables/disables grovedb verification on startup. 
- This flag will be disabled by default.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
