### PR TITLE
chore(drive)!: don't use `0.0.0.0` as default listen IP

### DIFF
--- a/packages/rs-drive-abci/.env.local
+++ b/packages/rs-drive-abci/.env.local
@@ -1,8 +1,8 @@
 # ABCI host and port to listen
-ABCI_CONSENSUS_BIND_ADDRESS="tcp://0.0.0.0:26658"
-GRPC_BIND_ADDRESS="0.0.0.0:26670"
+ABCI_CONSENSUS_BIND_ADDRESS="tcp://127.0.0.1:26658"
+GRPC_BIND_ADDRESS="127.0.0.1:26670"
 
-# Metrics are disabled when empty. Must be http://0.0.0.0:29090 for example to enable
+# Metrics are disabled when empty. Must be http://127.0.0.1:29090 for example to enable
 PROMETHEUS_BIND_ADDRESS=
 
 # stderr logging for humans
@@ -87,4 +87,4 @@ TOKIO_CONSOLE_ADDRESS=127.0.0.1:6669
 TOKIO_CONSOLE_RETENTION_SECS=180
 
 GROVEDB_VISUALIZER_ENABLED=false
-GROVEDB_VISUALIZER_ADDRESS=0.0.0.0:8083
+GROVEDB_VISUALIZER_ADDRESS=127.0.0.1:8083

--- a/packages/rs-drive-abci/.env.mainnet
+++ b/packages/rs-drive-abci/.env.mainnet
@@ -1,8 +1,8 @@
 # ABCI host and port to listen
-ABCI_CONSENSUS_BIND_ADDRESS="tcp://0.0.0.0:26658"
-GRPC_BIND_ADDRESS="0.0.0.0:26670"
+ABCI_CONSENSUS_BIND_ADDRESS="tcp://127.0.0.1:26658"
+GRPC_BIND_ADDRESS="127.0.0.1:26670"
 
-# Metrics are disabled when empty. Must be http://0.0.0.0:29090 for example to enable
+# Metrics are disabled when empty. Must be http://127.0.0.1:29090 for example to enable
 PROMETHEUS_BIND_ADDRESS=
 
 # stderr logging for humans

--- a/packages/rs-drive-abci/.env.testnet
+++ b/packages/rs-drive-abci/.env.testnet
@@ -1,8 +1,8 @@
 # ABCI host and port to listen
-ABCI_CONSENSUS_BIND_ADDRESS="tcp://0.0.0.0:26658"
-GRPC_BIND_ADDRESS="0.0.0.0:26670"
+ABCI_CONSENSUS_BIND_ADDRESS="tcp://127.0.0.1:26658"
+GRPC_BIND_ADDRESS="127.0.0.1:26670"
 
-# Metrics are disabled when empty. Must be http://0.0.0.0:29090 for example to enable
+# Metrics are disabled when empty. Must be http://127.0.0.1:29090 for example to enable
 PROMETHEUS_BIND_ADDRESS=
 
 # stderr logging for humans

--- a/packages/rs-drive-abci/src/config.rs
+++ b/packages/rs-drive-abci/src/config.rs
@@ -656,8 +656,7 @@ impl PlatformConfig {
             tokio_console_retention_secs: PlatformConfig::default_tokio_console_retention_secs(),
             initial_protocol_version: Self::default_initial_protocol_version(),
             prometheus_bind_address: None,
-            // TODO: This is dangerous. The default value must be 127.0.0.1
-            grpc_bind_address: "0.0.0.0:26670".to_string(),
+            grpc_bind_address: "127.0.0.1:26670".to_string(),
         }
     }
 
@@ -695,7 +694,7 @@ impl PlatformConfig {
             testing_configs: PlatformTestConfig::default(),
             initial_protocol_version: Self::default_initial_protocol_version(),
             prometheus_bind_address: None,
-            grpc_bind_address: "0.0.0.0:26670".to_string(),
+            grpc_bind_address: "127.0.0.1:26670".to_string(),
             tokio_console_enabled: false,
             tokio_console_address: PlatformConfig::default_tokio_console_address(),
             tokio_console_retention_secs: PlatformConfig::default_tokio_console_retention_secs(),
@@ -736,7 +735,7 @@ impl PlatformConfig {
             testing_configs: PlatformTestConfig::default(),
             initial_protocol_version: Self::default_initial_protocol_version(),
             prometheus_bind_address: None,
-            grpc_bind_address: "0.0.0.0:26670".to_string(),
+            grpc_bind_address: "127.0.0.1:26670".to_string(),
             tokio_console_enabled: false,
             tokio_console_address: PlatformConfig::default_tokio_console_address(),
             tokio_console_retention_secs: PlatformConfig::default_tokio_console_retention_secs(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Not a good idea to use services that bind to `0.0.0.0` by default

## What was done?
<!--- Describe your changes in detail -->
- Set `127.0.0.1` as a default interface for drive services

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Default bind interface for gRPC, tokio console, grovedb visualiser and others changed to `127.0.0.1`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
