### PR TITLE
chore(dapi): enable logger for reconnectable stream

### DIFF
--- a/packages/js-dapi-client/lib/DAPIClient.js
+++ b/packages/js-dapi-client/lib/DAPIClient.js
@@ -39,7 +39,15 @@ class DAPIClient extends EventEmitter {
       ...options,
     };
 
-    this.dapiAddressProvider = createDAPIAddressProviderFromOptions(this.options);
+    this.logger = logger.getForId(
+      this.options.loggerOptions.identifier,
+      this.options.loggerOptions.level,
+    );
+
+    this.dapiAddressProvider = createDAPIAddressProviderFromOptions({
+      ...this.options,
+      logger: this.logger,
+    });
 
     const grpcTransport = new GrpcTransport(
       createDAPIAddressProviderFromOptions,
@@ -58,10 +66,6 @@ class DAPIClient extends EventEmitter {
 
     this.core = new CoreMethodsFacade(jsonRpcTransport, grpcTransport);
     this.platform = new PlatformMethodsFacade(grpcTransport);
-    this.logger = logger.getForId(
-      this.options.loggerOptions.identifier,
-      this.options.loggerOptions.level,
-    );
 
     this.initBlockHeadersProvider();
   }

--- a/packages/js-dapi-client/lib/SimplifiedMasternodeListProvider/createMasternodeListStreamFactory.js
+++ b/packages/js-dapi-client/lib/SimplifiedMasternodeListProvider/createMasternodeListStreamFactory.js
@@ -42,6 +42,7 @@ function createMasternodeListStreamFactory(
       ),
       {
         maxRetriesOnError: -1,
+        logger: options.logger,
       },
     );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to see why subscribe to masternode list stream is reconnecting all the time

## What was done?
<!--- Describe your changes in detail -->
- Enable logging in reconnectable stream

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally, running test suite

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
