### PR TITLE
fix(strategy-tests): key ids for new identities with extra keys were not calculated properly

### DIFF
--- a/packages/strategy-tests/src/transitions.rs
+++ b/packages/strategy-tests/src/transitions.rs
@@ -671,7 +671,6 @@ pub fn create_identities_state_transitions(
                     )?;
                     identity.add_public_key(key.clone());
                     let key_num = key_count as usize * (i + 1) + i;
-                    tracing::info!("key num: {key_num}");
                     keys.insert(key_num, (key, private_key))
                 }
             }

--- a/packages/strategy-tests/src/transitions.rs
+++ b/packages/strategy-tests/src/transitions.rs
@@ -649,8 +649,15 @@ pub fn create_identities_state_transitions(
         )
         .expect("Expected to create identities and keys");
 
-    for identity in identities.iter_mut() {
-        for (purpose, security_to_key_type_map) in extra_keys {
+    let starting_id_num = signer
+        .private_keys
+        .keys()
+        .max()
+        .map_or(0, |max_key| max_key.id() + 1);
+
+    for (i, identity) in identities.iter_mut().enumerate() {
+        // TODO: deal with the case where there's more than one extra key
+        for (_, (purpose, security_to_key_type_map)) in extra_keys.iter().enumerate() {
             for (security_level, key_types) in security_to_key_type_map {
                 for key_type in key_types {
                     let (key, private_key) = IdentityPublicKey::random_key_with_known_attributes(
@@ -663,17 +670,13 @@ pub fn create_identities_state_transitions(
                         platform_version,
                     )?;
                     identity.add_public_key(key.clone());
-                    keys.push((key, private_key));
+                    let key_num = key_count as usize * (i + 1) + i;
+                    tracing::info!("key num: {key_num}");
+                    keys.insert(key_num, (key, private_key))
                 }
             }
         }
     }
-
-    let starting_id_num = signer
-        .private_keys
-        .keys()
-        .max()
-        .map_or(0, |max_key| max_key.id() + 1);
 
     // Update keys with new KeyIDs and add them to signer
     let mut current_id_num = starting_id_num;
@@ -690,7 +693,8 @@ pub fn create_identities_state_transitions(
         .enumerate()
         .map(|(index, mut identity)| {
             // Calculate the starting KeyID for this identity
-            let identity_starting_id = starting_id_num + (index as u32) * key_count;
+            let identity_starting_id =
+                starting_id_num + index as u32 * (key_count + extra_keys.len() as u32);
 
             // Update the identity with the new KeyIDs
             let public_keys_map = identity.public_keys_mut();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If extra keys were defined for identities being created in a strategy, the key ids were not being calculated correctly when inputting them into the signer in the case where there was more than one identity per block.

## What was done?
<!--- Describe your changes in detail -->
Fixed the calculation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TUI strategy tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
