### PR TITLE
fix(drive): unknown mn_rr fork height

### DIFF
--- a/packages/rs-drive-abci/src/error/execution.rs
+++ b/packages/rs-drive-abci/src/error/execution.rs
@@ -60,14 +60,12 @@ pub enum ExecutionError {
     InitializationForkNotActive(String),
 
     /// Invalid core chain locked height
-    #[error("core chain locked height {requested} is invalid: {mn_rr_fork} <=  {requested} <= {best} is not true")]
-    InitializationBadCoreLockedHeight {
-        /// mn_rr fork height
-        mn_rr_fork: u32,
-        /// requested core height
-        requested: u32,
+    #[error("initial height {initial_height} is not chain locked. latest chainlocked height is {chain_lock_height}")]
+    InitializationHeightIsNotLocked {
+        /// initial height (requested or fork)
+        initial_height: u32,
         /// best core lock height
-        best: u32,
+        chain_lock_height: u32,
     },
 
     /// An error occurred during initialization.

--- a/packages/rs-drive-abci/src/execution/engine/initialization/init_chain/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/initialization/init_chain/v0/mod.rs
@@ -37,7 +37,7 @@ where
                 Ok(height) => break height,
                 Err(e) => match e {
                     Error::Execution(ExecutionError::InitializationForkNotActive(_))
-                    | Error::Execution(ExecutionError::InitializationBadCoreLockedHeight {
+                    | Error::Execution(ExecutionError::InitializationHeightIsNotLocked {
                         ..
                     }) => {
                         tracing::warn!(

--- a/packages/rs-drive-abci/src/execution/platform_events/initialization/initial_core_height/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/initialization/initial_core_height/v0/mod.rs
@@ -43,48 +43,38 @@ where
         // We expect height to present if the fork is active
         let mn_rr_fork_height = fork_info.height.unwrap();
 
-        let best = self.core_rpc.get_best_chain_lock()?.block_height;
-
-        if let Some(requested) = requested {
-            tracing::trace!(
+        let initial_height = if let Some(requested) = requested {
+            tracing::debug!(
                 requested,
                 mn_rr_fork_height,
-                best,
-                "selecting initial core lock height"
-            );
-            // TODO in my opinion, the condition should be:
-            //
-            // `mn_rr_fork <= requested && requested <= best`
-            //
-            // but it results in 1440 <=  1243 <= 1545
-            //
-            // So, fork_info.since differs? is it non-deterministic?
-            if requested <= best {
-                Ok(requested)
-            } else {
-                Err(ExecutionError::InitializationBadCoreLockedHeight {
-                    requested,
-                    best,
-                    mn_rr_fork: mn_rr_fork_height,
-                }
-                .into())
-            }
-        } else {
-            tracing::trace!(
-                mn_rr_fork_height,
-                "used fork height as initial core lock height"
+                "initial core lock height is set in genesis"
             );
 
-            if mn_rr_fork_height <= best {
-                Ok(mn_rr_fork_height)
-            } else {
-                Err(ExecutionError::InitializationBadCoreLockedHeight {
-                    requested: 0,
-                    best,
-                    mn_rr_fork: mn_rr_fork_height,
-                }
-                .into())
+            requested
+        } else {
+            tracing::debug!(mn_rr_fork_height, "used fork height as initial core height");
+
+            mn_rr_fork_height
+        };
+
+        // Make sure initial height is chain locked
+        let chain_lock_height = self.core_rpc.get_best_chain_lock()?.block_height;
+
+        // TODO (Lukazs) in my opinion, the condition should be:
+        //
+        // `mn_rr_fork <= requested && requested <= best`
+        //
+        // but it results in 1440 <=  1243 <= 1545
+        //
+        // So, fork_info.since differs? is it non-deterministic?
+        if initial_height <= chain_lock_height {
+            Ok(initial_height)
+        } else {
+            Err(ExecutionError::InitializationHeightIsNotLocked {
+                initial_height,
+                chain_lock_height,
             }
+            .into())
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
 2024-07-23T18:58:32.717312Z DEBUG dashcore_rpc: JSON-RPC request: protx ["listdiff",1,5400]
    at /root/.cargo/git/checkouts/rust-dashcore-rpc-474497c1dcebe04a/9e59614/client/src/client.rs:1646 on main ThreadId(1)
    in tenderdash_abci::tracing_span::abci with endpoint: "InitChain", request_id: "e994bea4-b338-47b3-91cb-2721b3553294"

  2024-07-23T18:58:32.717754Z DEBUG dashcore_rpc: JSON-RPC error for protx: RpcError { code: -1, message: "block must be a chain height and not 5400", data: None }
    at /root/.cargo/git/checkouts/rust-dashcore-rpc-474497c1dcebe04a/9e59614/client/src/client.rs:1666 on main ThreadId(1)
    in tenderdash_abci::tracing_span::abci with endpoint: "InitChain", request_id: "e994bea4-b338-47b3-91cb-2721b3553294"
```
It means the fork is active but Core doesn't have blocks for this height yet.

## What was done?
<!--- Describe your changes in detail -->
- Return an error (to retry) if the mn_rr fork height is not chain locked yet

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
