### PR TITLE
fix(strategy-tests): transfer keys were being disabled

### DIFF
--- a/packages/strategy-tests/src/transitions.rs
+++ b/packages/strategy-tests/src/transitions.rs
@@ -13,7 +13,7 @@ use dpp::identity::identity_public_key::accessors::v0::{
 };
 use dpp::identity::state_transition::asset_lock_proof::InstantAssetLockProof;
 use dpp::identity::KeyType::ECDSA_SECP256K1;
-use dpp::identity::Purpose::AUTHENTICATION;
+use dpp::identity::Purpose::{AUTHENTICATION, TRANSFER};
 use dpp::identity::SecurityLevel::{CRITICAL, MASTER};
 use dpp::identity::{Identity, IdentityPublicKey, KeyID, KeyType, Purpose, SecurityLevel};
 use dpp::prelude::AssetLockProof;
@@ -398,6 +398,7 @@ pub fn create_identity_update_transition_disable_keys(
                     && !(key.security_level() == CRITICAL
                         && key.purpose() == AUTHENTICATION
                         && key.key_type() == ECDSA_SECP256K1))
+                && key.purpose() != TRANSFER
         })
         .map(|(key_id, _)| *key_id)
         .collect::<Vec<_>>();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When we did IdentityUpdate(DisableKeys) transitions in strategies, we were sometimes disabling transfer keys, but we don't want to do that.

## What was done?
<!--- Describe your changes in detail -->
Prevent IdentityUpdate(DisableKeys) transitions from disabling transfer keys in strategy tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TUI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
