### PR TITLE
fix: sdk should ignore transient fields when verifying proofs

### DIFF
--- a/packages/rs-dpp/src/document/document_methods/mod.rs
+++ b/packages/rs-dpp/src/document/document_methods/mod.rs
@@ -52,6 +52,7 @@ pub trait DocumentMethodsV0 {
     fn is_equal_ignoring_time_based_fields(
         &self,
         rhs: &Self,
+        also_ignore_fields: Option<Vec<&str>>,
         platform_version: &PlatformVersion,
     ) -> Result<bool, ProtocolError>;
 }

--- a/packages/rs-dpp/src/document/mod.rs
+++ b/packages/rs-dpp/src/document/mod.rs
@@ -183,6 +183,7 @@ impl DocumentMethodsV0 for Document {
     fn is_equal_ignoring_time_based_fields(
         &self,
         rhs: &Self,
+        also_ignore_fields: Option<Vec<&str>>,
         platform_version: &PlatformVersion,
     ) -> Result<bool, ProtocolError> {
         match (self, rhs) {
@@ -193,7 +194,8 @@ impl DocumentMethodsV0 for Document {
                     .document_method_versions
                     .is_equal_ignoring_timestamps
                 {
-                    0 => Ok(document_v0.is_equal_ignoring_time_based_fields_v0(rhs_v0)),
+                    0 => Ok(document_v0
+                        .is_equal_ignoring_time_based_fields_v0(rhs_v0, also_ignore_fields)),
                     version => Err(ProtocolError::UnknownVersionMismatch {
                         method: "DocumentMethodV0::is_equal_ignoring_time_based_fields".to_string(),
                         known_versions: vec![0],

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
@@ -5833,10 +5833,20 @@ mod tests {
                 .expect("expected to get back documents")
                 .documents_owned();
 
+            let transient_fields = domain
+                .transient_fields()
+                .iter()
+                .map(|a| a.as_str())
+                .collect();
+
             assert!(documents
                 .get(0)
                 .expect("expected a document")
-                .is_equal_ignoring_time_based_fields(&document_3, platform_version)
+                .is_equal_ignoring_time_based_fields(
+                    &document_3,
+                    Some(transient_fields),
+                    platform_version
+                )
                 .expect("expected to run is equal"));
 
             let drive_query = DriveDocumentQuery {

--- a/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
@@ -165,8 +165,15 @@ impl Drive {
                             platform_version,
                         )?;
 
+                        let transient_fields = document_type
+                            .transient_fields()
+                            .iter()
+                            .map(|a| a.as_str())
+                            .collect();
+
                         if !document.is_equal_ignoring_time_based_fields(
                             &expected_document,
+                            Some(transient_fields),
                             platform_version,
                         )? {
                             return Err(Error::Proof(ProofError::IncorrectProof(format!("proof of state transition execution did not contain expected document (time fields were not checked) after create with id {}", create_transition.base().id()))));
@@ -192,8 +199,15 @@ impl Drive {
                             platform_version,
                         )?;
 
+                        let transient_fields = document_type
+                            .transient_fields()
+                            .iter()
+                            .map(|a| a.as_str())
+                            .collect();
+
                         if !document.is_equal_ignoring_time_based_fields(
                             &expected_document,
+                            Some(transient_fields),
                             platform_version,
                         )? {
                             return Err(Error::Proof(ProofError::IncorrectProof(format!("proof of state transition execution did not contain expected document (time fields were not checked) after replace with id {}", replace_transition.base().id()))));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
We forgot to update sdk to ignore transient fields on proof verification.


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
Ran this afterwards in TUI and it fixed the issue.


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [X] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
