### PR TITLE
fix(platform): core info is lost between genesis and first block

### DIFF
--- a/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_masternode_list/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_masternode_list/v0/mod.rs
@@ -58,36 +58,33 @@ where
             core_block_height,
             block_platform_state.last_committed_core_height()
         );
-        //todo: there's a weird condition that can happen if we are not on init chain, but we are
-        // in the genesis and we are not on round 0, and the core height changed
-        if block_platform_state.last_committed_block_info().is_some() || is_init_chain {
-            let update_state_masternode_list_outcome::v0::UpdateStateMasternodeListOutcome {
-                masternode_list_diff,
-                removed_masternodes,
-            } = self.update_state_masternode_list_v0(
-                block_platform_state,
-                core_block_height,
-                is_init_chain,
-            )?;
+        
+        let update_state_masternode_list_outcome::v0::UpdateStateMasternodeListOutcome {
+            masternode_list_diff,
+            removed_masternodes,
+        } = self.update_state_masternode_list_v0(
+            block_platform_state,
+            core_block_height,
+            is_init_chain,
+        )?;
 
-            self.update_masternode_identities(
-                masternode_list_diff,
-                &removed_masternodes,
-                block_info,
-                platform_state,
-                transaction,
-                platform_version,
-            )?;
+        self.update_masternode_identities(
+            masternode_list_diff,
+            &removed_masternodes,
+            block_info,
+            platform_state,
+            transaction,
+            platform_version,
+        )?;
 
-            if !removed_masternodes.is_empty() {
-                self.drive.remove_validators_proposed_app_versions(
-                    removed_masternodes
-                        .into_keys()
-                        .map(|pro_tx_hash| pro_tx_hash.into()),
-                    Some(transaction),
-                    &platform_version.drive,
-                )?;
-            }
+        if !removed_masternodes.is_empty() {
+            self.drive.remove_validators_proposed_app_versions(
+                removed_masternodes
+                    .into_keys()
+                    .map(|pro_tx_hash| pro_tx_hash.into()),
+                Some(transaction),
+                &platform_version.drive,
+            )?;
         }
 
         Ok(())

--- a/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_masternode_list/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_based_updates/update_masternode_list/v0/mod.rs
@@ -58,7 +58,7 @@ where
             core_block_height,
             block_platform_state.last_committed_core_height()
         );
-        
+
         let update_state_masternode_list_outcome::v0::UpdateStateMasternodeListOutcome {
             masternode_list_diff,
             removed_masternodes,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Some masternode update information would be lost between init chain and the first block. This fixes this.


## What was done?
Removed a check that was no longer valid.


## How Has This Been Tested?
Tests still pass


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [X] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
