### PR TITLE
feat: specify transition names within documents batch

### DIFF
--- a/packages/rs-dpp/src/state_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/mod.rs
@@ -1,4 +1,6 @@
 use derive_more::From;
+use documents_batch_transition::accessors::DocumentsBatchTransitionAccessorsV0;
+use documents_batch_transition::document_transition::DocumentTransition;
 #[cfg(feature = "state-transition-serde-conversion")]
 use serde::{Deserialize, Serialize};
 
@@ -343,17 +345,35 @@ impl StateTransition {
     }
 
     /// Returns state transition name
-    pub fn name(&self) -> &'static str {
+    pub fn name(&self) -> String {
         match self {
-            Self::DataContractCreate(_) => "DataContractCreate",
-            Self::DataContractUpdate(_) => "DataContractUpdate",
-            Self::DocumentsBatch(_) => "DocumentsBatch",
-            Self::IdentityCreate(_) => "IdentityCreate",
-            Self::IdentityTopUp(_) => "IdentityTopUp",
-            Self::IdentityCreditWithdrawal(_) => "IdentityCreditWithdrawal",
-            Self::IdentityUpdate(_) => "IdentityUpdate",
-            Self::IdentityCreditTransfer(_) => "IdentityCreditTransfer",
-            Self::MasternodeVote(_) => "MasternodeVote",
+            Self::DataContractCreate(_) => "DataContractCreate".to_string(),
+            Self::DataContractUpdate(_) => "DataContractUpdate".to_string(),
+            Self::DocumentsBatch(documents_batch_transition) => {
+                let mut document_transition_types = vec![];
+                match documents_batch_transition {
+                    DocumentsBatchTransition::V0(documents_batch_transition_v0) => {
+                        for transition in documents_batch_transition_v0.transitions() {
+                            let document_transition_name = match transition {
+                                DocumentTransition::Create(_) => "Create",
+                                DocumentTransition::Replace(_) => "Replace",
+                                DocumentTransition::Delete(_) => "Delete",
+                                DocumentTransition::Transfer(_) => "Transfer",
+                                DocumentTransition::UpdatePrice(_) => "UpdatePrice",
+                                DocumentTransition::Purchase(_) => "Purchase",
+                            };
+                            document_transition_types.push(document_transition_name);
+                        }
+                    }
+                }
+                format!("DocumentsBatch({:?})", document_transition_types)
+            }
+            Self::IdentityCreate(_) => "IdentityCreate".to_string(),
+            Self::IdentityTopUp(_) => "IdentityTopUp".to_string(),
+            Self::IdentityCreditWithdrawal(_) => "IdentityCreditWithdrawal".to_string(),
+            Self::IdentityUpdate(_) => "IdentityUpdate".to_string(),
+            Self::IdentityCreditTransfer(_) => "IdentityCreditTransfer".to_string(),
+            Self::MasternodeVote(_) => "MasternodeVote".to_string(),
         }
     }
 

--- a/packages/rs-dpp/src/state_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/mod.rs
@@ -353,7 +353,7 @@ impl StateTransition {
                 let mut document_transition_types = vec![];
                 match documents_batch_transition {
                     DocumentsBatchTransition::V0(documents_batch_transition_v0) => {
-                        for transition in documents_batch_transition_v0.transitions() {
+                        for transition in documents_batch_transition_v0.transitions().iter() {
                             let document_transition_name = match transition {
                                 DocumentTransition::Create(_) => "Create",
                                 DocumentTransition::Replace(_) => "Replace",
@@ -366,7 +366,7 @@ impl StateTransition {
                         }
                     }
                 }
-                format!("DocumentsBatch({:?})", document_transition_types)
+                format!("DocumentsBatch([{}])", document_transition_types.join(", "))
             }
             Self::IdentityCreate(_) => "IdentityCreate".to_string(),
             Self::IdentityTopUp(_) => "IdentityTopUp".to_string(),

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/v0/mod.rs
@@ -113,7 +113,7 @@ where
                     .map(|validation_result| {
                         self.process_validation_result_v0(
                             raw_state_transition,
-                            state_transition_name,
+                            &state_transition_name,
                             validation_result,
                             block_info,
                             transaction,
@@ -141,7 +141,11 @@ where
                         StateTransitionExecutionResult::InternalError(_) => 1,
                     };
 
-                    state_transition_execution_histogram(elapsed_time, state_transition_name, code);
+                    state_transition_execution_histogram(
+                        elapsed_time,
+                        &state_transition_name,
+                        code,
+                    );
 
                     execution_result
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The name() function for state transitions only returned "DocumentsBatch" but it would be nice if it was more specific.

## What was done?
<!--- Describe your changes in detail -->
Instead of just "DocumentsBatch" it's now "DocumentsBatch([vector_of_transition_names])". For example "DocumentsBatch(["Create", "Create", "Delete", "UpdatePrice"])".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TUI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
