### PR TITLE
fix(dashmate): remove `dash-cli` from protx registration instructions

### DIFF
--- a/packages/dashmate/src/listr/tasks/setup/regular/registerMasternode/registerMasternodeWithCoreWallet.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/registerMasternode/registerMasternodeWithCoreWallet.js
@@ -222,38 +222,16 @@ export default function registerMasternodeWithCoreWalletFactory(createIpAndPorts
 
       let command;
       if (ctx.isHP) {
-        command = `dash-cli protx register_evo \\
-  ${state.collateral.txId} \\
-  ${state.collateral.outputIndex} \\
-  ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort} \\
-  ${state.keys.ownerAddress} \\
-  ${operatorPublicKeyHex} \\
-  ${state.keys.votingAddress} \\
-  ${state.operator.rewardShare} \\
-  ${state.keys.payoutAddress} \\
-  ${deriveTenderdashNodeId(state.platformNodeKey)} \\
-  ${platformP2PPort} \\
-  ${platformHTTPPort}`;
+        command = `protx register_evo ${state.collateral.txId} ${state.collateral.outputIndex} ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort} ${state.keys.ownerAddress} ${operatorPublicKeyHex} ${state.keys.votingAddress} ${state.operator.rewardShare} ${state.keys.payoutAddress} ${deriveTenderdashNodeId(state.platformNodeKey)} ${platformP2PPort} ${platformHTTPPort}`;
       } else {
-        command = `dash-cli protx register \\
-  ${state.collateral.txId} \\
-  ${state.collateral.outputIndex} \\
-  ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort} \\
-  ${state.keys.ownerAddress} \\
-  ${operatorPublicKeyHex} \\
-  ${state.keys.votingAddress} \\
-  ${state.operator.rewardShare} \\
-  ${state.keys.payoutAddress}`;
+        command = `protx register ${state.collateral.txId} ${state.collateral.outputIndex} ${state.ipAndPorts.ip}:${state.ipAndPorts.coreP2PPort} ${state.keys.ownerAddress} ${operatorPublicKeyHex} ${state.keys.votingAddress} ${state.operator.rewardShare} ${state.keys.payoutAddress}`;
       }
 
       // Wrap the command to fit the terminal width (listr uses new lines to wrap the text)
       if (!ctx.isVerbose) {
-        command = command.replace(/\\/g, '');
         command = wrapAnsi(command, process.stdout.columns - 3, {
-          hard: true,
           trim: false,
         });
-        command = command.replace(/\n/g, '\\\n');
       }
 
       // TODO: We need to give more info on how to run this command


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`dashmate setup` command for new masternodes displays an instructions to register it in the network. This is usually done from the Dash Core GUI wallet and `dash-cli` prefix is obsolete, as well as slashes.

## What was done?
<!--- Describe your changes in detail -->
Roved dash-cli and slashes from the `dashmate setup`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
