### PR TITLE
fix(dashmate): unnecessary core indexes are required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,7 @@ source = "git+https://github.com/dashpay/rust-dashcore?branch=master#a29315dbe56
 [[package]]
 name = "dashcore-rpc"
 version = "0.15.2"
-source = "git+https://github.com/dashpay/rust-dashcore-rpc?rev=e553381318f5d1ef8e376981123310c6ce2f1d57#e553381318f5d1ef8e376981123310c6ce2f1d57"
+source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.3#1fdb29b18f27e1656ff8a35098ac2f61b105b6f9"
 dependencies = [
  "dashcore-private",
  "dashcore-rpc-json",
@@ -1277,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.15.2"
-source = "git+https://github.com/dashpay/rust-dashcore-rpc?rev=e553381318f5d1ef8e376981123310c6ce2f1d57#e553381318f5d1ef8e376981123310c6ce2f1d57"
+source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.3#1fdb29b18f27e1656ff8a35098ac2f61b105b6f9"
 dependencies = [
  "bincode",
  "dashcore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,8 +1261,8 @@ source = "git+https://github.com/dashpay/rust-dashcore?branch=master#a29315dbe56
 
 [[package]]
 name = "dashcore-rpc"
-version = "0.15.1"
-source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.2#9e596142f589d32a7347872b8f5c2b3b2ed54257"
+version = "0.15.2"
+source = "git+https://github.com/dashpay/rust-dashcore-rpc?rev=e553381318f5d1ef8e376981123310c6ce2f1d57#e553381318f5d1ef8e376981123310c6ce2f1d57"
 dependencies = [
  "dashcore-private",
  "dashcore-rpc-json",
@@ -1276,8 +1276,8 @@ dependencies = [
 
 [[package]]
 name = "dashcore-rpc-json"
-version = "0.15.1"
-source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.2#9e596142f589d32a7347872b8f5c2b3b2ed54257"
+version = "0.15.2"
+source = "git+https://github.com/dashpay/rust-dashcore-rpc?rev=e553381318f5d1ef8e376981123310c6ce2f1d57#e553381318f5d1ef8e376981123310c6ce2f1d57"
 dependencies = [
  "bincode",
  "dashcore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,7 @@ source = "git+https://github.com/dashpay/rust-dashcore?branch=master#a29315dbe56
 [[package]]
 name = "dashcore-rpc"
 version = "0.15.2"
-source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.3#1fdb29b18f27e1656ff8a35098ac2f61b105b6f9"
+source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.4#bd6efdb850151f1dcd8e3f38d4796d18c5be518c"
 dependencies = [
  "dashcore-private",
  "dashcore-rpc-json",
@@ -1277,7 +1277,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.15.2"
-source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.3#1fdb29b18f27e1656ff8a35098ac2f61b105b6f9"
+source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.4#bd6efdb850151f1dcd8e3f38d4796d18c5be518c"
 dependencies = [
  "bincode",
  "dashcore",

--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -140,7 +140,7 @@ export default function getBaseConfigFactory(homeDir) {
           },
         },
         logIps: 0,
-        indexes: true,
+        indexes: [],
       },
       platform: {
         gateway: {

--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -16,7 +16,7 @@ const { version } = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT_DIR, 'pack
  */
 export default function getBaseConfigFactory(homeDir) {
   const prereleaseTag = semver.prerelease(version) === null ? '' : `-${semver.prerelease(version)[0]}`;
-  const dockerImageVersion = `${semver.major(version)}.${semver.minor(version)}${prereleaseTag}`;
+  const dockerImageVersion = `${semver.major(version)}${prereleaseTag}`;
 
   /**
    * @typedef {function} getBaseConfig

--- a/packages/dashmate/configs/defaults/getMainnetConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getMainnetConfigFactory.js
@@ -27,7 +27,6 @@ export default function getMainnetConfigFactory(homeDir, getBaseConfig) {
         },
       },
       core: {
-        indexes: false,
         log: {
           file: {
             path: homeDir.joinPath('logs', 'mainnet', 'core.log'),

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -760,6 +760,8 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
         Object.entries(configFile.configs)
           .forEach(([, options]) => {
             options.core.indexes = [];
+            options.platform.drive.abci.docker.image = 'dashpay/drive:1';
+            options.platform.dapi.api.docker.image = 'dashpay/dapi:1';
           });
         return configFile;
       },

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -756,6 +756,13 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
           });
         return configFile;
       },
+      '1.0.2': (configFile) => {
+        Object.entries(configFile.configs)
+          .forEach(([, options]) => {
+            options.core.indexes = [];
+          });
+        return configFile;
+      },
     };
   }
 

--- a/packages/dashmate/src/config/configJsonSchema.js
+++ b/packages/dashmate/src/config/configJsonSchema.js
@@ -433,7 +433,14 @@ export default {
           enum: [0, 1],
         },
         indexes: {
-          type: 'boolean',
+          type: ['array'],
+          uniqueItems: true,
+          items: {
+            type: 'string',
+            enum: ['address', 'tx', 'timestamp', 'spent'],
+          },
+          description: 'List of core indexes to enable. `platform.enable`, '
+            + ' `core.masternode.enable`, and `core.insight.enabled` add indexes dynamically',
         },
       },
       required: ['docker', 'p2p', 'rpc', 'spork', 'masternode', 'miner', 'devnet', 'log',

--- a/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
@@ -55,13 +55,6 @@ function validateCoreDataDirectoryPathFactory(config) {
       return 'dash.conf should be configured for mainnet';
     }
 
-    // Config file should contain masternodeblsprivkey in case of masternode
-    if (config.get('core.masternode.enable')) {
-      if (!configFileContent.includes('masternodeblsprivkey=')) {
-        return 'dash.conf should contain masternodeblsprivkey';
-      }
-    }
-
     return true;
   }
 
@@ -124,6 +117,11 @@ export default function importCoreDataTaskFactory(
 
           if (masternodeOperatorPrivateKey) {
             ctx.config.set('core.masternode.operator.privateKey', masternodeOperatorPrivateKey);
+            // txindex is enabled by default for masternodes
+            ctx.isReindexRequired = false;
+          } else {
+            // We need to reindex Core if there weren't all required indexed enabled before
+            ctx.isReindexRequired = !configFileContent.match(/^txindex=1/);
           }
 
           const host = configFileContent.match(/^bind=([^ \n]+)/m)?.[1];
@@ -139,12 +137,6 @@ export default function importCoreDataTaskFactory(
 
           // eslint-disable-next-line prefer-destructuring
           ctx.importedExternalIp = configFileContent.match(/^externalip=([^ \n]+)/m)?.[1];
-
-          // We need to reindex Core if there weren't all required indexed enabled before
-          ctx.isReindexRequired = !configFileContent.match(/^txindex=1/)
-            || !configFileContent.match(/^addressindex=1/)
-            || !configFileContent.match(/^timestampindex=1/)
-            || !configFileContent.match(/^spentindex=1/);
 
           // Copy data directory to docker a volume
 

--- a/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/importCoreDataTaskFactory.js
@@ -113,15 +113,19 @@ export default function importCoreDataTaskFactory(
           // Read configuration from dashd.conf
           const configPath = path.join(coreDataPath, 'dash.conf');
           const configFileContent = fs.readFileSync(configPath, 'utf8');
-          const masternodeOperatorPrivateKey = configFileContent.match(/^masternodeblsprivkey=([^ \n]+)/m)?.[1];
 
-          if (masternodeOperatorPrivateKey) {
-            ctx.config.set('core.masternode.operator.privateKey', masternodeOperatorPrivateKey);
-            // txindex is enabled by default for masternodes
-            ctx.isReindexRequired = false;
-          } else {
-            // We need to reindex Core if there weren't all required indexed enabled before
-            ctx.isReindexRequired = !configFileContent.match(/^txindex=1/);
+          // Config file should contain masternodeblsprivkey in case of masternode
+          if (ctx.config.get('core.masternode.enable')) {
+            const masternodeOperatorPrivateKey = configFileContent.match(/^masternodeblsprivkey=([^ \n]+)/m)?.[1];
+
+            if (masternodeOperatorPrivateKey) {
+              ctx.config.set('core.masternode.operator.privateKey', masternodeOperatorPrivateKey);
+              // txindex is enabled by default for masternodes
+              ctx.isReindexRequired = false;
+            } else {
+              // We need to reindex Core if there weren't all required indexed enabled before
+              ctx.isReindexRequired = !configFileContent.match(/^txindex=1/);
+            }
           }
 
           const host = configFileContent.match(/^bind=([^ \n]+)/m)?.[1];

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -161,7 +161,7 @@ export default function setupLocalPresetTaskFactory(
                   config.set('core.miner.enable', true);
 
                   // We need them to register masternodes
-                  config.set('core.indexes', ['tx', 'address']);
+                  config.set('core.indexes', ['tx', 'address', 'timestamp', 'spent']);
 
                   // Disable platform for the seed node
                   config.set('platform.enable', false);

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -156,10 +156,12 @@ export default function setupLocalPresetTaskFactory(
                   config.set('description', 'seed node for local network');
 
                   config.set('core.masternode.enable', false);
-                  config.set('core.miner.enable', true);
 
                   // Enable miner for the seed node
                   config.set('core.miner.enable', true);
+
+                  // We need them to register masternodes
+                  config.set('core.indexes', ['tx', 'address']);
 
                   // Disable platform for the seed node
                   config.set('platform.enable', false);

--- a/packages/dashmate/templates/core/dash.conf.dot
+++ b/packages/dashmate/templates/core/dash.conf.dot
@@ -43,11 +43,15 @@ externalip={{=it.externalIp}}
 whitelist={{=it.externalIp}}
 {{?}}
 
-{{? it.core.indexes }}# Indices
+{{? it.core.insight.enabled }}
 txindex=1
 addressindex=1
 timestampindex=1
 spentindex=1
+{{??}}
+{{~it.core.indexes :index}}
+{{= index + 'index=1' }}
+{{~}}
 {{?}}
 
 # ZeroMQ notifications

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.8.5"
 tempfile = "3.3.0"
 hex = "0.4.3"
 indexmap = { version = "2.2.6", features = ["serde"] }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", rev = "e553381318f5d1ef8e376981123310c6ce2f1d57" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.3" }
 dpp = { path = "../rs-dpp", features = ["abci"] }
 simple-signer = { path = "../simple-signer" }
 rust_decimal = "1.2.5"

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.8.5"
 tempfile = "3.3.0"
 hex = "0.4.3"
 indexmap = { version = "2.2.6", features = ["serde"] }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.3" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.4" }
 dpp = { path = "../rs-dpp", features = ["abci"] }
 simple-signer = { path = "../simple-signer" }
 rust_decimal = "1.2.5"

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.8.5"
 tempfile = "3.3.0"
 hex = "0.4.3"
 indexmap = { version = "2.2.6", features = ["serde"] }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.2" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", rev = "e553381318f5d1ef8e376981123310c6ce2f1d57" }
 dpp = { path = "../rs-dpp", features = ["abci"] }
 simple-signer = { path = "../simple-signer" }
 rust_decimal = "1.2.5"

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -32,7 +32,7 @@ envy = { version = "0.4.2", optional = true }
 futures = { version = "0.3.30" }
 derive_more = { version = "0.99.17" }
 # dashcore-rpc is only needed for core rpc; TODO remove once we have correct core rpc impl
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.2" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", rev = "e553381318f5d1ef8e376981123310c6ce2f1d57" }
 lru = { version = "0.12.3", optional = true }
 bip37-bloom-filter = { git = "https://github.com/dashpay/rs-bip37-bloom-filter", branch = "develop" }
 pollster = { version = "0.3.0" }

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -32,7 +32,7 @@ envy = { version = "0.4.2", optional = true }
 futures = { version = "0.3.30" }
 derive_more = { version = "0.99.17" }
 # dashcore-rpc is only needed for core rpc; TODO remove once we have correct core rpc impl
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", rev = "e553381318f5d1ef8e376981123310c6ce2f1d57" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.3" }
 lru = { version = "0.12.3", optional = true }
 bip37-bloom-filter = { git = "https://github.com/dashpay/rs-bip37-bloom-filter", branch = "develop" }
 pollster = { version = "0.3.0" }

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -32,7 +32,7 @@ envy = { version = "0.4.2", optional = true }
 futures = { version = "0.3.30" }
 derive_more = { version = "0.99.17" }
 # dashcore-rpc is only needed for core rpc; TODO remove once we have correct core rpc impl
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.3" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.4" }
 lru = { version = "0.12.3", optional = true }
 bip37-bloom-filter = { git = "https://github.com/dashpay/rs-bip37-bloom-filter", branch = "develop" }
 pollster = { version = "0.3.0" }

--- a/packages/simple-signer/Cargo.toml
+++ b/packages/simple-signer/Cargo.toml
@@ -8,6 +8,6 @@ rust-version = "1.76"
 
 [dependencies]
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", rev = "e553381318f5d1ef8e376981123310c6ce2f1d57" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.3" }
 dpp = { path = "../rs-dpp", features = ["abci"] }
 base64 = { version = "0.22.1"}

--- a/packages/simple-signer/Cargo.toml
+++ b/packages/simple-signer/Cargo.toml
@@ -8,6 +8,6 @@ rust-version = "1.76"
 
 [dependencies]
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.2" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", rev = "e553381318f5d1ef8e376981123310c6ce2f1d57" }
 dpp = { path = "../rs-dpp", features = ["abci"] }
 base64 = { version = "0.22.1"}

--- a/packages/simple-signer/Cargo.toml
+++ b/packages/simple-signer/Cargo.toml
@@ -8,6 +8,6 @@ rust-version = "1.76"
 
 [dependencies]
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.3" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.4" }
 dpp = { path = "../rs-dpp", features = ["abci"] }
 base64 = { version = "0.22.1"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Local and testnet nodes enable unnecessary Core indexes.
Importing existing Core data requires unnecessary Core indexes.
We also should be able to specify particular indexes to enable.

## What was done?
<!--- Describe your changes in detail -->
- Changed `core.indexes` to accept array of required Core indexes
- Import Core Data requires only txindex or being a masternode
- Fixed migration on dapi and drive images
- Set dapi and drive images version to major

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
