### PR TITLE
feat(dashmate): a flag to keep data on reset

### DIFF
--- a/packages/dashmate/src/commands/reset.js
+++ b/packages/dashmate/src/commands/reset.js
@@ -9,10 +9,11 @@ export default class ResetCommand extends ConfigBaseCommand {
 
   static flags = {
     ...ConfigBaseCommand.flags,
-    hard: Flags.boolean({ char: 'h', description: 'reset config as well as data', default: false }),
+    hard: Flags.boolean({ char: 'h', description: 'reset config as well as services and data', default: false }),
     force: Flags.boolean({ char: 'f', description: 'skip running services check', default: false }),
     platform: Flags.boolean({ char: 'p', description: 'reset platform services and data only', default: false }),
     verbose: Flags.boolean({ char: 'v', description: 'use verbose mode for output', default: false }),
+    'keep-data': Flags.boolean({ description: 'keep data', default: false }),
   };
 
   /**
@@ -30,6 +31,7 @@ export default class ResetCommand extends ConfigBaseCommand {
       hard: isHardReset,
       force: isForce,
       platform: isPlatformOnlyReset,
+      'keep-data': keepData,
     },
     config,
     resetNodeTask,
@@ -58,6 +60,7 @@ export default class ResetCommand extends ConfigBaseCommand {
         isPlatformOnlyReset,
         isForce,
         isVerbose,
+        keepData,
       });
     } catch (e) {
       throw new MuteOneLineError(e);

--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -414,15 +414,23 @@ export default class DockerCompose {
    * Down docker compose
    *
    * @param {Config} config
+   * @param {Object} [options]
+   * @param {Object} [options.removeVolumes=false]
    * @return {Promise<void>}
    */
-  async down(config) {
+  async down(config, options = {}) {
     await this.throwErrorIfNotInstalled();
+
+    const commandOptions = ['--remove-orphans'];
+
+    if (options.removeVolumes) {
+      commandOptions.push('-v');
+    }
 
     try {
       await dockerCompose.down({
         ...this.#createOptions(config),
-        commandOptions: ['-v', '--remove-orphans'],
+        commandOptions,
       });
     } catch (e) {
       throw new DockerComposeError(e);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We should be able to reset node but keep docker volumes so we don't need to resync Core or Platform again.
This is useful during dashmate upgrade when existing dashmate had outdated docker containers.
Also haveing this you can sync a fullnode and then convert it to masternode.

## What was done?
<!--- Describe your changes in detail -->
- Added `--keep-data` flag to keep docker containers to the reset command

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
