### PR TITLE
fix(dashmate): status command shows tenderdash error before activation

### DIFF
--- a/packages/dashmate/README.md
+++ b/packages/dashmate/README.md
@@ -88,7 +88,7 @@ In some cases, you must also additionally reset platform data:
 ```bash
 $ dashmate stop
 $ npm install -g dashmate
-$ dashmate reset --platform-only --hard
+$ dashmate reset --platform --hard
 $ dashmate update
 $ dashmate setup
 $ dashmate start
@@ -283,14 +283,18 @@ The `reset` command removes all data corresponding to the specified config and a
 
 ```
 USAGE
-  $ dashmate reset [-v] [--config <value>] [-h] [-f] [-p]
+  $ dashmate reset [--config <value>] [-v] [-h] [-f] [-p] [--keep-data]
 
 FLAGS
-  -f, --force          skip running services check
-  -h, --hard           reset config as well as data
-  -p, --platform-only  reset platform data only
-  -v, --verbose        use verbose mode for output
-  --config=<value>     configuration name to use
+  -f, --force           skip running services check
+  -h, --hard            reset config as well as services and data
+  -p, --platform        reset platform services and data only
+  -v, --verbose         use verbose mode for output
+      --config=<value>  configuration name to use
+      --keep-data       keep data
+
+DESCRIPTION
+  Reset node data
 ```
 
 To reset a node:
@@ -446,7 +450,7 @@ USAGE
 
 FLAGS
   -f, --force          reset even running node
-  -p, --platform-only  reset platform data only
+  -p, --platform  reset platform data only
   -v, --verbose        use verbose mode for output
   --group=<value>      group name to use
   --hard               reset config as well as data

--- a/packages/dashmate/src/commands/status/platform.js
+++ b/packages/dashmate/src/commands/status/platform.js
@@ -32,6 +32,7 @@ export default class PlatformStatusCommand extends ConfigBaseCommand {
     flags,
     dockerCompose,
     createRpcClient,
+    getConnectionHost,
     config,
     getPlatformScope,
   ) {
@@ -57,6 +58,7 @@ export default class PlatformStatusCommand extends ConfigBaseCommand {
 
     if (flags.format === OUTPUT_FORMATS.PLAIN) {
       const {
+        platformActivation,
         httpService,
         httpPort,
         httpPortState,
@@ -67,6 +69,8 @@ export default class PlatformStatusCommand extends ConfigBaseCommand {
         tenderdash,
         drive,
       } = scope;
+
+      plain['Platform Activation'] = platformActivation ? colors.platformActivation(platformActivation)(platformActivation) : 'n/a';
 
       plain['HTTP service'] = httpService || 'n/a';
       plain['HTTP port'] = `${httpPort} ${httpPortState ? colors.portState(httpPortState)(httpPortState) : ''}`;

--- a/packages/dashmate/src/status/colors.js
+++ b/packages/dashmate/src/status/colors.js
@@ -34,6 +34,7 @@ export default {
         return chalk.green;
       case ServiceStatusEnum.syncing:
       case ServiceStatusEnum.wait_for_core:
+      case ServiceStatusEnum.wait_for_activation:
         return chalk.yellow;
       default:
         return chalk.red;
@@ -73,4 +74,5 @@ export default {
     }
     return chalk.red;
   },
+  platformActivation: (string) => (string.startsWith('Activated') ? chalk.green : chalk.yellow),
 };

--- a/packages/dashmate/src/status/determineStatus.js
+++ b/packages/dashmate/src/status/determineStatus.js
@@ -37,9 +37,14 @@ export default {
    * Determine platform ServiceStatus based on DockerStatusEnum and core readiness
    * @param dockerStatus {DockerStatusEnum}
    * @param coreIsSynced {boolean}
+   * @param mnRRSoftFork {object}
    * @returns {ServiceStatusEnum}
    */
-  platform: (dockerStatus, coreIsSynced) => {
+  platform: (dockerStatus, coreIsSynced, mnRRSoftFork) => {
+    if (coreIsSynced && !mnRRSoftFork.active) {
+      return ServiceStatusEnum.wait_for_activation;
+    }
+
     if (dockerStatus === DockerStatusEnum.running) {
       return coreIsSynced ? ServiceStatusEnum.up : ServiceStatusEnum.wait_for_core;
     }

--- a/packages/dashmate/src/status/enums/serviceStatus.js
+++ b/packages/dashmate/src/status/enums/serviceStatus.js
@@ -4,5 +4,6 @@ export const ServiceStatusEnum = {
   up: 'up',
   syncing: 'syncing',
   wait_for_core: 'wait_for_core',
+  wait_for_activation: 'wait_for_activation',
   error: 'error',
 };

--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -1,3 +1,4 @@
+import prettyMs from 'pretty-ms';
 import providers from '../providers.js';
 import { DockerStatusEnum } from '../enums/dockerStatus.js';
 import { ServiceStatusEnum } from '../enums/serviceStatus.js';
@@ -15,7 +16,7 @@ export default function getPlatformScopeFactory(
   createRpcClient,
   getConnectionHost,
 ) {
-  async function getMNSync(config) {
+  async function getCoreInfo(config) {
     const rpcClient = createRpcClient({
       port: config.get('core.rpc.port'),
       user: 'dashmate',
@@ -23,16 +24,27 @@ export default function getPlatformScopeFactory(
       host: await getConnectionHost(config, 'core', 'core.rpc.host'),
     });
 
+    const [mnSync, blockchainInfo] = await Promise.all([
+      rpcClient.mnsync('status'),
+      rpcClient.getBlockchainInfo(),
+    ]);
+
+    const {
+      result: {
+        softforks: { mn_rr: mnRR },
+      },
+    } = blockchainInfo;
+
     const {
       result: {
         IsSynced: isSynced,
       },
-    } = await rpcClient.mnsync('status');
+    } = mnSync;
 
-    return isSynced;
+    return { isSynced, mnRRSoftFork: mnRR };
   }
 
-  async function getTenderdashInfo(config, isCoreSynced) {
+  async function getTenderdashInfo(config, isCoreSynced, mnRRSoftFork) {
     const info = {
       p2pPortState: null,
       httpPortState: null,
@@ -63,7 +75,7 @@ export default function getPlatformScopeFactory(
       }
 
       const dockerStatus = await determineStatus.docker(dockerCompose, config, 'drive_tenderdash');
-      const serviceStatus = determineStatus.platform(dockerStatus, isCoreSynced);
+      const serviceStatus = determineStatus.platform(dockerStatus, isCoreSynced, mnRRSoftFork);
 
       info.dockerStatus = dockerStatus;
       info.serviceStatus = serviceStatus;
@@ -142,7 +154,7 @@ export default function getPlatformScopeFactory(
     return info;
   }
 
-  const getDriveInfo = async (config, isCoreSynced) => {
+  const getDriveInfo = async (config, isCoreSynced, mnRRSoftFork) => {
     const info = {
       dockerStatus: null,
       serviceStatus: null,
@@ -150,7 +162,7 @@ export default function getPlatformScopeFactory(
 
     try {
       info.dockerStatus = await determineStatus.docker(dockerCompose, config, 'drive_abci');
-      info.serviceStatus = determineStatus.platform(info.dockerStatus, isCoreSynced);
+      info.serviceStatus = determineStatus.platform(info.dockerStatus, isCoreSynced, mnRRSoftFork);
 
       if (info.serviceStatus === ServiceStatusEnum.up) {
         const driveEchoResult = await dockerCompose.execCommand(
@@ -194,6 +206,7 @@ export default function getPlatformScopeFactory(
     const rpcService = `${rpcHost}:${rpcPort}`;
 
     const scope = {
+      platformActivation: null,
       coreIsSynced: null,
       httpPort,
       httpService,
@@ -233,11 +246,14 @@ export default function getPlatformScopeFactory(
       }
     }
 
-    try {
-      const coreIsSynced = await getMNSync(config);
-      scope.coreIsSynced = coreIsSynced;
+    let coreInfo;
 
-      if (!coreIsSynced) {
+    try {
+      coreInfo = await getCoreInfo(config);
+
+      scope.coreIsSynced = coreInfo.isSynced;
+
+      if (!coreInfo.isSynced) {
         if (process.env.DEBUG) {
           // eslint-disable-next-line no-console
           console.error('Platform status is not available until masternode state is \'READY\'');
@@ -250,20 +266,34 @@ export default function getPlatformScopeFactory(
       }
     }
 
-    const [tenderdash, drive] = await Promise.all([
-      getTenderdashInfo(config, scope.coreIsSynced),
-      getDriveInfo(config, scope.coreIsSynced),
-    ]);
+    if (coreInfo) {
+      const { mnRRSoftFork } = coreInfo;
 
-    if (tenderdash) {
-      scope.tenderdash = tenderdash;
+      if (mnRRSoftFork.active) {
+        scope.platformActivation = `Activated (at height ${mnRRSoftFork.bip9.since})`;
+      } else {
+        const startTime = mnRRSoftFork.bip9.start_time;
 
-      scope.httpPortState = tenderdash.httpPortState;
-      scope.p2pPortState = tenderdash.p2pPortState;
-    }
+        const diff = (new Date().getTime() - startTime) / 1000;
 
-    if (drive) {
-      scope.drive = drive;
+        scope.platformActivation = `Waiting for activation (approximately in ${prettyMs(diff, {compact: true})})`;
+      }
+
+      const [tenderdash, drive] = await Promise.all([
+        getTenderdashInfo(config, scope.coreIsSynced, coreInfo.mnRRSoftFork),
+        getDriveInfo(config, scope.coreIsSynced, coreInfo.mnRRSoftFork),
+      ]);
+
+      if (tenderdash) {
+        scope.tenderdash = tenderdash;
+
+        scope.httpPortState = tenderdash.httpPortState;
+        scope.p2pPortState = tenderdash.p2pPortState;
+      }
+
+      if (drive) {
+        scope.drive = drive;
+      }
     }
 
     return scope;

--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -270,7 +270,7 @@ export default function getPlatformScopeFactory(
       const { mnRRSoftFork } = coreInfo;
 
       if (mnRRSoftFork.active) {
-        scope.platformActivation = `Activated (at height ${mnRRSoftFork.bip9.since})`;
+        scope.platformActivation = `Activated (at height ${mnRRSoftFork.height})`;
       } else {
         const startTime = mnRRSoftFork.bip9.start_time;
 

--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -276,7 +276,7 @@ export default function getPlatformScopeFactory(
 
         const diff = (new Date().getTime() - startTime) / 1000;
 
-        scope.platformActivation = `Waiting for activation (approximately in ${prettyMs(diff, {compact: true})})`;
+        scope.platformActivation = `Waiting for activation (approximately in ${prettyMs(diff, { compact: true })})`;
       }
 
       const [tenderdash, drive] = await Promise.all([

--- a/packages/dashmate/test/unit/status/scopes/platform.spec.js
+++ b/packages/dashmate/test/unit/status/scopes/platform.spec.js
@@ -63,6 +63,13 @@ describe('getPlatformScopeFactory', () => {
     it('should just work', async () => {
       mockDetermineDockerStatus.returns(DockerStatusEnum.running);
       mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          softforks: {
+            mn_rr: { active: true, bip9: { since: 1337 } },
+          },
+        },
+      });
       mockDockerCompose.isServiceRunning.returns(true);
       mockDockerCompose.execCommand.returns({ exitCode: 0, out: '' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
@@ -84,6 +91,7 @@ describe('getPlatformScopeFactory', () => {
       const mockNetInfo = { n_peers: 6, listening: true };
 
       const expectedScope = {
+        platformActivation: 'Activated (at height 1337)',
         coreIsSynced: true,
         httpPort,
         httpService,
@@ -129,6 +137,13 @@ describe('getPlatformScopeFactory', () => {
     it('should return platform syncing when it is catching up', async () => {
       mockDetermineDockerStatus.returns(DockerStatusEnum.running);
       mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          softforks: {
+            mn_rr: { active: true, bip9: { since: 1337 } },
+          },
+        },
+      });
       mockDockerCompose.isServiceRunning.returns(true);
       mockDockerCompose.execCommand.returns({ exitCode: 0, out: '' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
@@ -150,6 +165,7 @@ describe('getPlatformScopeFactory', () => {
       const mockNetInfo = { n_peers: 6, listening: true };
 
       const expectedScope = {
+        platformActivation: 'Activated (at height 1337)',
         coreIsSynced: true,
         httpPort,
         httpService,
@@ -202,6 +218,7 @@ describe('getPlatformScopeFactory', () => {
         .returns(DockerStatusEnum.running);
 
       const expectedScope = {
+        platformActivation: null,
         coreIsSynced: null,
         httpPort,
         httpService,
@@ -213,8 +230,8 @@ describe('getPlatformScopeFactory', () => {
         tenderdash: {
           httpPortState: null,
           p2pPortState: null,
-          dockerStatus: DockerStatusEnum.running,
-          serviceStatus: ServiceStatusEnum.wait_for_core,
+          dockerStatus: null,
+          serviceStatus: null,
           version: null,
           listening: null,
           catchingUp: null,
@@ -227,8 +244,8 @@ describe('getPlatformScopeFactory', () => {
           network: null,
         },
         drive: {
-          dockerStatus: DockerStatusEnum.running,
-          serviceStatus: ServiceStatusEnum.wait_for_core,
+          dockerStatus: null,
+          serviceStatus: null,
         },
       };
 
@@ -238,16 +255,22 @@ describe('getPlatformScopeFactory', () => {
     });
 
     it('should return empty scope if core is not synced', async () => {
-      mockDockerCompose.isServiceRunning
-        .withArgs(config, 'drive_tenderdash')
-        .returns(true);
+      mockDockerCompose.isServiceRunning.withArgs(config, 'drive_tenderdash').returns(true);
       mockDetermineDockerStatus.withArgs(mockDockerCompose, config, 'drive_tenderdash').returns(DockerStatusEnum.running);
       mockDetermineDockerStatus.withArgs(mockDockerCompose, config, 'drive_abci').returns(DockerStatusEnum.running);
       mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: false } });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          softforks: {
+            mn_rr: { active: true, bip9: { since: 1337 } },
+          },
+        },
+      });
       mockDockerCompose.execCommand.returns({ exitCode: 1, out: '' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
       const expectedScope = {
+        platformActivation: 'Activated (at height 1337)',
         coreIsSynced: false,
         httpPort,
         httpService,
@@ -285,6 +308,13 @@ describe('getPlatformScopeFactory', () => {
 
     it('should return drive info if tenderdash is failed', async () => {
       mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          softforks: {
+            mn_rr: { active: true, bip9: { since: 1337 } },
+          },
+        },
+      });
       mockDockerCompose.isServiceRunning
         .withArgs(config, 'drive_tenderdash')
         .returns(true);
@@ -296,6 +326,7 @@ describe('getPlatformScopeFactory', () => {
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
       const expectedScope = {
+        platformActivation: 'Activated (at height 1337)',
         coreIsSynced: true,
         httpPort,
         httpService,
@@ -333,6 +364,13 @@ describe('getPlatformScopeFactory', () => {
 
     it('should still return scope with tenderdash if drive is failed', async () => {
       mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          softforks: {
+            mn_rr: { active: true, bip9: { since: 1337 } },
+          },
+        },
+      });
       mockDockerCompose.isServiceRunning
         .withArgs(config, 'drive_tenderdash')
         .returns(true);
@@ -366,6 +404,7 @@ describe('getPlatformScopeFactory', () => {
         .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }));
 
       const expectedScope = {
+        platformActivation: 'Activated (at height 1337)',
         coreIsSynced: true,
         httpPort,
         httpService,
@@ -403,6 +442,13 @@ describe('getPlatformScopeFactory', () => {
 
     it('should have error service status in case FetchError to tenderdash', async () => {
       mockRpcClient.mnsync.returns({ result: { IsSynced: true } });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          softforks: {
+            mn_rr: { active: true, bip9: { since: 1337 } },
+          },
+        },
+      });
       mockDockerCompose.isServiceRunning
         .withArgs(config, 'drive_tenderdash')
         .returns(true);
@@ -412,6 +458,7 @@ describe('getPlatformScopeFactory', () => {
       mockFetch.returns(Promise.reject(new Error('FetchError')));
 
       const expectedScope = {
+        platformActivation: 'Activated (at height 1337)',
         coreIsSynced: true,
         httpPort,
         httpService,

--- a/packages/dashmate/test/unit/status/scopes/platform.spec.js
+++ b/packages/dashmate/test/unit/status/scopes/platform.spec.js
@@ -66,7 +66,7 @@ describe('getPlatformScopeFactory', () => {
       mockRpcClient.getBlockchainInfo.returns({
         result: {
           softforks: {
-            mn_rr: { active: true, bip9: { since: 1337 } },
+            mn_rr: { active: true, height: 1337 },
           },
         },
       });
@@ -140,7 +140,7 @@ describe('getPlatformScopeFactory', () => {
       mockRpcClient.getBlockchainInfo.returns({
         result: {
           softforks: {
-            mn_rr: { active: true, bip9: { since: 1337 } },
+            mn_rr: { active: true, height: 1337 },
           },
         },
       });
@@ -262,7 +262,7 @@ describe('getPlatformScopeFactory', () => {
       mockRpcClient.getBlockchainInfo.returns({
         result: {
           softforks: {
-            mn_rr: { active: true, bip9: { since: 1337 } },
+            mn_rr: { active: true, height: 1337 },
           },
         },
       });
@@ -311,7 +311,7 @@ describe('getPlatformScopeFactory', () => {
       mockRpcClient.getBlockchainInfo.returns({
         result: {
           softforks: {
-            mn_rr: { active: true, bip9: { since: 1337 } },
+            mn_rr: { active: true, height: 1337 },
           },
         },
       });
@@ -367,7 +367,7 @@ describe('getPlatformScopeFactory', () => {
       mockRpcClient.getBlockchainInfo.returns({
         result: {
           softforks: {
-            mn_rr: { active: true, bip9: { since: 1337 } },
+            mn_rr: { active: true, height: 1337 },
           },
         },
       });
@@ -445,7 +445,7 @@ describe('getPlatformScopeFactory', () => {
       mockRpcClient.getBlockchainInfo.returns({
         result: {
           softforks: {
-            mn_rr: { active: true, bip9: { since: 1337 } },
+            mn_rr: { active: true, height: 1337 },
           },
         },
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tenderdash RPC is only available after a platform activation, which will happen in 3 weeks from now. Since TD RPC is used to perform healthcheck on the service, we need to an additional check for softfork activation for the mainnet network configs.

## What was done?
<!--- Describe your changes in detail -->
Added a `getblockchaininfo` core rpc request in the `status platform` command
It will only query tenderdash if the mn_rr softfork is already active. 
An additional status line about platform activation time was also added.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
