### PR TITLE
feat(drive-abci): skip state transition txs if time limit is reached on prepare_proposal

### DIFF
--- a/packages/rs-drive-abci/src/abci/app/execution_result.rs
+++ b/packages/rs-drive-abci/src/abci/app/execution_result.rs
@@ -40,6 +40,10 @@ impl TryIntoPlatformVersioned<ExecTxResult> for StateTransitionExecutionResult {
                 info: String::default(),
                 ..Default::default()
             },
+            StateTransitionExecutionResult::NotExecuted(message) => ExecTxResult {
+                gas_used: 0,
+                ..Default::default()
+            }
         };
 
         Ok(response)

--- a/packages/rs-drive-abci/src/abci/app/execution_result.rs
+++ b/packages/rs-drive-abci/src/abci/app/execution_result.rs
@@ -40,7 +40,7 @@ impl TryIntoPlatformVersioned<ExecTxResult> for StateTransitionExecutionResult {
                 info: String::default(),
                 ..Default::default()
             },
-            StateTransitionExecutionResult::NotExecuted(message) => ExecTxResult {
+            StateTransitionExecutionResult::NotExecuted(_) => ExecTxResult {
                 gas_used: 0,
                 ..Default::default()
             },

--- a/packages/rs-drive-abci/src/abci/app/execution_result.rs
+++ b/packages/rs-drive-abci/src/abci/app/execution_result.rs
@@ -43,7 +43,7 @@ impl TryIntoPlatformVersioned<ExecTxResult> for StateTransitionExecutionResult {
             StateTransitionExecutionResult::NotExecuted(message) => ExecTxResult {
                 gas_used: 0,
                 ..Default::default()
-            }
+            },
         };
 
         Ok(response)

--- a/packages/rs-drive-abci/src/abci/app/execution_result.rs
+++ b/packages/rs-drive-abci/src/abci/app/execution_result.rs
@@ -7,43 +7,42 @@ use dpp::version::PlatformVersion;
 use dpp::version::TryIntoPlatformVersioned;
 use tenderdash_abci::proto::abci::ExecTxResult;
 
-impl TryIntoPlatformVersioned<ExecTxResult> for StateTransitionExecutionResult {
+impl TryIntoPlatformVersioned<Option<ExecTxResult>> for StateTransitionExecutionResult {
     type Error = Error;
 
     fn try_into_platform_versioned(
         self,
         platform_version: &PlatformVersion,
-    ) -> Result<ExecTxResult, Self::Error> {
+    ) -> Result<Option<ExecTxResult>, Self::Error> {
         let response = match self {
-            StateTransitionExecutionResult::SuccessfulExecution(_, actual_fees) => ExecTxResult {
-                code: 0,
-                gas_used: actual_fees.total_base_fee() as SignedCredits,
-                ..Default::default()
-            },
-            StateTransitionExecutionResult::UnpaidConsensusError(error) => ExecTxResult {
+            StateTransitionExecutionResult::SuccessfulExecution(_, actual_fees) => {
+                Some(ExecTxResult {
+                    code: 0,
+                    gas_used: actual_fees.total_base_fee() as SignedCredits,
+                    ..Default::default()
+                })
+            }
+            StateTransitionExecutionResult::UnpaidConsensusError(error) => Some(ExecTxResult {
                 code: HandlerError::from(&error).code(),
                 info: error.response_info_for_version(platform_version)?,
                 gas_used: 0,
                 ..Default::default()
-            },
+            }),
             StateTransitionExecutionResult::PaidConsensusError(error, actual_fees) => {
-                ExecTxResult {
+                Some(ExecTxResult {
                     code: HandlerError::from(&error).code(),
                     info: error.response_info_for_version(platform_version)?,
                     gas_used: actual_fees.total_base_fee() as SignedCredits,
                     ..Default::default()
-                }
+                })
             }
-            StateTransitionExecutionResult::InternalError(message) => ExecTxResult {
+            StateTransitionExecutionResult::InternalError(message) => Some(ExecTxResult {
                 code: HandlerError::Internal(message).code(),
                 // TODO: That would be nice to provide more information about the error for debugging
                 info: String::default(),
                 ..Default::default()
-            },
-            StateTransitionExecutionResult::NotExecuted(_) => ExecTxResult {
-                gas_used: 0,
-                ..Default::default()
-            },
+            }),
+            StateTransitionExecutionResult::NotExecuted(_) => None,
         };
 
         Ok(response)

--- a/packages/rs-drive-abci/src/abci/config.rs
+++ b/packages/rs-drive-abci/src/abci/config.rs
@@ -1,5 +1,6 @@
 //! Configuration of ABCI Application server
 
+use dpp::prelude::TimestampMillis;
 use serde::{Deserialize, Serialize};
 
 // We allow changes in the ABCI configuration, but there should be a social process
@@ -35,7 +36,7 @@ pub struct AbciConfig {
 
     /// Maximum time limit (in ms) to process state transitions in block proposals
     #[serde(default)]
-    pub tx_processing_time_limit: u128,
+    pub tx_processing_time_limit: TimestampMillis,
 }
 
 impl AbciConfig {
@@ -47,7 +48,7 @@ impl AbciConfig {
         1
     }
 
-    pub(crate) fn default_tx_processing_time_limit() -> u128 {
+    pub(crate) fn default_tx_processing_time_limit() -> TimestampMillis {
         8000
     }
 }

--- a/packages/rs-drive-abci/src/abci/config.rs
+++ b/packages/rs-drive-abci/src/abci/config.rs
@@ -35,7 +35,7 @@ pub struct AbciConfig {
     pub log: crate::logging::LogConfigs,
 
     /// Maximum time limit (in ms) to process state transitions in block proposals
-    #[serde(default)]
+    #[serde(default = "AbciConfig::default_tx_processing_time_limit")]
     pub tx_processing_time_limit: TimestampMillis,
 }
 

--- a/packages/rs-drive-abci/src/abci/config.rs
+++ b/packages/rs-drive-abci/src/abci/config.rs
@@ -32,6 +32,10 @@ pub struct AbciConfig {
     // Note it is parsed directly in PlatformConfig::from_env() so here we just set defaults.
     #[serde(default)]
     pub log: crate::logging::LogConfigs,
+
+    /// Maximum time limit (in ms) to process state transitions in block proposals
+    #[serde(default)]
+    pub tx_processing_time_limit: u128,
 }
 
 impl AbciConfig {
@@ -41,6 +45,10 @@ impl AbciConfig {
 
     pub(crate) fn default_genesis_core_height() -> u32 {
         1
+    }
+
+    pub(crate) fn default_tx_processing_time_limit() -> u128 {
+        8000
     }
 }
 
@@ -52,6 +60,7 @@ impl Default for AbciConfig {
             genesis_core_height: AbciConfig::default_genesis_core_height(),
             chain_id: "chain_id".to_string(),
             log: Default::default(),
+            tx_processing_time_limit: AbciConfig::default_tx_processing_time_limit(),
         }
     }
 }

--- a/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
+++ b/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
@@ -108,7 +108,7 @@ where
         true,
         &platform_state,
         transaction,
-        &timer,
+        Some(&timer),
     )?;
 
     if !run_result.is_valid() {
@@ -159,11 +159,13 @@ where
             StateTransitionExecutionResult::NotExecuted(..) => TxAction::Delayed,
         };
 
-        let tx_result: ExecTxResult =
+        let tx_result: Option<ExecTxResult> =
             state_transition_execution_result.try_into_platform_versioned(platform_version)?;
 
-        if tx_action != TxAction::Removed {
-            tx_results.push(tx_result);
+        if let Some(result) = tx_result {
+            if tx_action != TxAction::Removed {
+                tx_results.push(result);
+            }
         }
 
         tx_records.push(TxRecord {

--- a/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
+++ b/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
@@ -105,7 +105,7 @@ where
     // Running the proposal executes all the state transitions for the block
     let mut run_result =
         app.platform()
-            .run_block_proposal(block_proposal, true, &platform_state, transaction)?;
+            .run_block_proposal(block_proposal, true, &platform_state, transaction, &timer)?;
 
     if !run_result.is_valid() {
         // This is a system error, because we are proposing
@@ -151,6 +151,8 @@ where
             // We shouldn't include in the block any state transitions that produced an internal error
             // during execution
             StateTransitionExecutionResult::InternalError(..) => TxAction::Removed,
+            // State Transition was not executed as it reached the maximum time limit
+            StateTransitionExecutionResult::NotExecuted(..) => TxAction::Delayed,
         };
 
         let tx_result: ExecTxResult =

--- a/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
+++ b/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
@@ -103,9 +103,13 @@ where
         .expect("transaction must be started");
 
     // Running the proposal executes all the state transitions for the block
-    let mut run_result =
-        app.platform()
-            .run_block_proposal(block_proposal, true, &platform_state, transaction, &timer)?;
+    let mut run_result = app.platform().run_block_proposal(
+        block_proposal,
+        true,
+        &platform_state,
+        transaction,
+        &timer,
+    )?;
 
     if !run_result.is_valid() {
         // This is a system error, because we are proposing

--- a/packages/rs-drive-abci/src/abci/handler/process_proposal.rs
+++ b/packages/rs-drive-abci/src/abci/handler/process_proposal.rs
@@ -177,6 +177,7 @@ where
         false,
         &platform_state,
         transaction,
+        &timer,
     )?;
 
     if !run_result.is_valid() {

--- a/packages/rs-drive-abci/src/abci/handler/process_proposal.rs
+++ b/packages/rs-drive-abci/src/abci/handler/process_proposal.rs
@@ -177,7 +177,7 @@ where
         false,
         &platform_state,
         transaction,
-        &timer,
+        None,
     )?;
 
     if !run_result.is_valid() {
@@ -256,7 +256,11 @@ where
                     | StateTransitionExecutionResult::PaidConsensusError(..)
             )
         })
-        .map(|execution_result| execution_result.try_into_platform_versioned(platform_version))
+        .filter_map(|execution_result| {
+            execution_result
+                .try_into_platform_versioned(platform_version)
+                .transpose()
+        })
         .collect::<Result<_, _>>()?;
 
     let response = proto::ResponseProcessProposal {

--- a/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
@@ -360,6 +360,8 @@ mod tests {
 
         assert!(check_result.is_valid());
 
+        let timer = crate::metrics::abci_request_duration("");
+
         platform
             .platform
             .process_raw_state_transitions(
@@ -368,6 +370,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -471,6 +475,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -479,6 +485,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -670,6 +678,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -678,6 +688,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -821,6 +833,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -829,6 +843,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -966,6 +982,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         platform
             .platform
             .process_raw_state_transitions(
@@ -974,6 +992,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1080,6 +1100,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1088,6 +1110,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1159,6 +1183,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let update_processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1167,6 +1193,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1286,6 +1314,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1294,6 +1324,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1403,6 +1435,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1411,6 +1445,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
@@ -154,7 +154,7 @@ where
         check_tx_result.unique_identifiers = state_transition.unique_identifiers();
 
         let validation_result = state_transition_to_execution_event_for_check_tx(
-            &platform_ref,
+            platform_ref,
             state_transition,
             check_tx_level,
             platform_version,
@@ -360,8 +360,6 @@ mod tests {
 
         assert!(check_result.is_valid());
 
-        let timer = crate::metrics::abci_request_duration("");
-
         platform
             .platform
             .process_raw_state_transitions(
@@ -371,7 +369,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -475,8 +473,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -486,7 +482,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -678,8 +674,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -689,7 +683,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -833,8 +827,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -844,7 +836,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -982,8 +974,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         platform
             .platform
             .process_raw_state_transitions(
@@ -993,7 +983,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1100,8 +1090,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1111,7 +1099,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1183,8 +1171,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let update_processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1194,7 +1180,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1314,8 +1300,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1325,7 +1309,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1435,8 +1419,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1446,7 +1428,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/mod.rs
@@ -47,7 +47,7 @@ where
         known_from_us: bool,
         platform_state: &PlatformState,
         transaction: &Transaction,
-        timer: &HistogramTiming,
+        timer: Option<&HistogramTiming>,
     ) -> Result<ValidationResult<block_execution_outcome::v0::BlockExecutionOutcome, Error>, Error>
     {
         // Epoch information is always calculated with the last committed platform version

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/mod.rs
@@ -1,5 +1,6 @@
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
+use crate::metrics::HistogramTiming;
 use crate::platform_types::epoch_info::v0::EpochInfoV0Methods;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::v0::PlatformStateV0Methods;
@@ -9,7 +10,6 @@ use crate::rpc::core::CoreRPCLike;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::grovedb::Transaction;
-use crate::metrics::HistogramTiming;
 
 mod v0;
 

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/mod.rs
@@ -9,6 +9,7 @@ use crate::rpc::core::CoreRPCLike;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::grovedb::Transaction;
+use crate::metrics::HistogramTiming;
 
 mod v0;
 
@@ -46,6 +47,7 @@ where
         known_from_us: bool,
         platform_state: &PlatformState,
         transaction: &Transaction,
+        timer: &HistogramTiming,
     ) -> Result<ValidationResult<block_execution_outcome::v0::BlockExecutionOutcome, Error>, Error>
     {
         // Epoch information is always calculated with the last committed platform version
@@ -127,6 +129,7 @@ Your software version: {}, latest supported protocol version: {}."#,
                 platform_state,
                 block_platform_state,
                 block_platform_version,
+                timer,
             ),
             version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
                 method: "run_block_proposal".to_string(),

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
@@ -67,7 +67,7 @@ where
         last_committed_platform_state: &PlatformState,
         mut block_platform_state: PlatformState,
         platform_version: &'static PlatformVersion,
-        timer: &HistogramTiming,
+        timer: Option<&HistogramTiming>,
     ) -> Result<ValidationResult<block_execution_outcome::v0::BlockExecutionOutcome, Error>, Error>
     {
         tracing::trace!(
@@ -312,7 +312,7 @@ where
             transaction,
             platform_version,
             known_from_us,
-            &timer,
+            timer,
         )?;
 
         // Pool withdrawals into transactions queue

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
@@ -19,7 +19,7 @@ use crate::execution::types::block_state_info::v0::{
     BlockStateInfoV0Getters, BlockStateInfoV0Methods, BlockStateInfoV0Setters,
 };
 use crate::execution::types::{block_execution_context, block_state_info};
-
+use crate::metrics::HistogramTiming;
 use crate::platform_types::block_execution_outcome;
 use crate::platform_types::block_proposal;
 use crate::platform_types::epoch_info::v0::{EpochInfoV0Getters, EpochInfoV0Methods};
@@ -67,6 +67,7 @@ where
         last_committed_platform_state: &PlatformState,
         mut block_platform_state: PlatformState,
         platform_version: &'static PlatformVersion,
+        timer: &HistogramTiming,
     ) -> Result<ValidationResult<block_execution_outcome::v0::BlockExecutionOutcome, Error>, Error>
     {
         tracing::trace!(
@@ -310,6 +311,8 @@ where
             &block_info,
             transaction,
             platform_version,
+            known_from_us,
+            &timer,
         )?;
 
         // Pool withdrawals into transactions queue

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/mod.rs
@@ -43,8 +43,8 @@ where
         block_info: &BlockInfo,
         transaction: &Transaction,
         platform_version: &PlatformVersion,
-        known_from_us: bool,
-        timer: &HistogramTiming,
+        proposing_state_transitions: bool,
+        timer: Option<&HistogramTiming>,
     ) -> Result<StateTransitionsProcessingResult, Error> {
         match platform_version
             .drive_abci
@@ -58,7 +58,7 @@ where
                 block_info,
                 transaction,
                 platform_version,
-                known_from_us,
+                proposing_state_transitions,
                 timer,
             ),
             version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/mod.rs
@@ -2,6 +2,7 @@ mod v0;
 
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
+use crate::metrics::HistogramTiming;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
 use crate::platform_types::state_transitions_processing_result::StateTransitionsProcessingResult;
@@ -9,7 +10,6 @@ use crate::rpc::core::CoreRPCLike;
 use dpp::block::block_info::BlockInfo;
 use dpp::version::PlatformVersion;
 use drive::grovedb::Transaction;
-use crate::metrics::HistogramTiming;
 
 impl<C> Platform<C>
 where

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/mod.rs
@@ -9,6 +9,7 @@ use crate::rpc::core::CoreRPCLike;
 use dpp::block::block_info::BlockInfo;
 use dpp::version::PlatformVersion;
 use drive::grovedb::Transaction;
+use crate::metrics::HistogramTiming;
 
 impl<C> Platform<C>
 where
@@ -42,6 +43,8 @@ where
         block_info: &BlockInfo,
         transaction: &Transaction,
         platform_version: &PlatformVersion,
+        known_from_us: bool,
+        timer: &HistogramTiming,
     ) -> Result<StateTransitionsProcessingResult, Error> {
         match platform_version
             .drive_abci
@@ -55,6 +58,8 @@ where
                 block_info,
                 transaction,
                 platform_version,
+                known_from_us,
+                timer,
             ),
             version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
                 method: "process_raw_state_transitions".to_string(),

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/v0/mod.rs
@@ -12,7 +12,7 @@ use crate::execution::types::state_transition_container::v0::{
     SuccessfullyDecodedStateTransition,
 };
 use crate::execution::validation::state_transition::processor::process_state_transition;
-use crate::metrics::state_transition_execution_histogram;
+use crate::metrics::{HistogramTiming, state_transition_execution_histogram};
 use crate::platform_types::event_execution_result::EventExecutionResult;
 use crate::platform_types::platform_state::v0::PlatformStateV0Methods;
 use crate::platform_types::state_transitions_processing_result::{
@@ -66,6 +66,8 @@ where
         block_info: &BlockInfo,
         transaction: &Transaction,
         platform_version: &PlatformVersion,
+        known_from_us: bool,
+        timer: &HistogramTiming,
     ) -> Result<StateTransitionsProcessingResult, Error> {
         let platform_ref = PlatformRef {
             drive: &self.drive,
@@ -80,118 +82,127 @@ where
         let mut processing_result = StateTransitionsProcessingResult::default();
 
         for decoded_state_transition in state_transition_container.into_iter() {
-            let execution_result = match decoded_state_transition {
-                DecodedStateTransition::SuccessfullyDecoded(
-                    SuccessfullyDecodedStateTransition {
-                        decoded: state_transition,
-                        raw: raw_state_transition,
-                        elapsed_time: decoding_elapsed_time,
-                    },
-                ) => {
-                    let start_time = Instant::now();
 
-                    let state_transition_name = state_transition.name();
+            let execution_result: StateTransitionExecutionResult;
 
-                    if tracing::enabled!(tracing::Level::TRACE) {
-                        let st_hash = hex::encode(hash_single(raw_state_transition));
+            if known_from_us && timer.elapsed().as_millis() > self.config.abci.tx_processing_time_limit {
+                execution_result = StateTransitionExecutionResult::NotExecuted("not executed".to_string());
+            }
+            else {
+                execution_result = match decoded_state_transition {
+                    DecodedStateTransition::SuccessfullyDecoded(
+                        SuccessfullyDecodedStateTransition {
+                            decoded: state_transition,
+                            raw: raw_state_transition,
+                            elapsed_time: decoding_elapsed_time,
+                        },
+                    ) => {
+                        let start_time = Instant::now();
 
-                        tracing::trace!(
+                        let state_transition_name = state_transition.name();
+
+                        if tracing::enabled!(tracing::Level::TRACE) {
+                            let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                            tracing::trace!(
                             ?state_transition,
                             st_hash,
                             "Processing {} state transition",
                             state_transition_name
                         );
-                    }
-
-                    // Validate state transition and produce an execution event
-                    let execution_result = process_state_transition(
-                        &platform_ref,
-                        block_info,
-                        state_transition,
-                        Some(transaction),
-                    )
-                    .map(|validation_result| {
-                        self.process_validation_result_v0(
-                            raw_state_transition,
-                            &state_transition_name,
-                            validation_result,
-                            block_info,
-                            transaction,
-                            platform_version,
-                            platform_ref.state.previous_fee_versions(),
-                        )
-                        .unwrap_or_else(error_to_internal_error_execution_result)
-                    })
-                    .map_err(|error| StateTransitionAwareError {
-                        error,
-                        raw_state_transition,
-                        state_transition_name: Some(state_transition_name.to_string()),
-                    })
-                    .unwrap_or_else(error_to_internal_error_execution_result);
-
-                    // Store metrics
-                    let elapsed_time = start_time.elapsed() + decoding_elapsed_time;
-
-                    let code = match &execution_result {
-                        StateTransitionExecutionResult::SuccessfulExecution(_, _) => 0,
-                        StateTransitionExecutionResult::PaidConsensusError(error, _)
-                        | StateTransitionExecutionResult::UnpaidConsensusError(error) => {
-                            error.code()
                         }
-                        StateTransitionExecutionResult::InternalError(_) => 1,
-                    };
 
-                    state_transition_execution_histogram(
-                        elapsed_time,
-                        &state_transition_name,
-                        code,
-                    );
+                        // Validate state transition and produce an execution event
+                        let execution_result = process_state_transition(
+                            &platform_ref,
+                            block_info,
+                            state_transition,
+                            Some(transaction),
+                        )
+                            .map(|validation_result| {
+                                self.process_validation_result_v0(
+                                    raw_state_transition,
+                                    &state_transition_name,
+                                    validation_result,
+                                    block_info,
+                                    transaction,
+                                    platform_version,
+                                    platform_ref.state.previous_fee_versions(),
+                                )
+                                    .unwrap_or_else(error_to_internal_error_execution_result)
+                            })
+                            .map_err(|error| StateTransitionAwareError {
+                                error,
+                                raw_state_transition,
+                                state_transition_name: Some(state_transition_name.to_string()),
+                            })
+                            .unwrap_or_else(error_to_internal_error_execution_result);
 
-                    execution_result
-                }
-                DecodedStateTransition::InvalidEncoding(InvalidStateTransition {
-                    raw,
-                    error,
-                    elapsed_time: decoding_elapsed_time,
-                }) => {
-                    if tracing::enabled!(tracing::Level::DEBUG) {
-                        let st_hash = hex::encode(hash_single(raw));
+                        // Store metrics
+                        let elapsed_time = start_time.elapsed() + decoding_elapsed_time;
 
-                        tracing::debug!(
+                        let code = match &execution_result {
+                            StateTransitionExecutionResult::SuccessfulExecution(_, _) => 0,
+                            StateTransitionExecutionResult::PaidConsensusError(error, _)
+                            | StateTransitionExecutionResult::UnpaidConsensusError(error) => {
+                                error.code()
+                            }
+                            StateTransitionExecutionResult::InternalError(_) => 1,
+                            StateTransitionExecutionResult::NotExecuted(_) => 1, //todo
+                        };
+
+                        state_transition_execution_histogram(
+                            elapsed_time,
+                            &state_transition_name,
+                            code,
+                        );
+
+                        execution_result
+                    }
+                    DecodedStateTransition::InvalidEncoding(InvalidStateTransition {
+                                                                raw,
+                                                                error,
+                                                                elapsed_time: decoding_elapsed_time,
+                                                            }) => {
+                        if tracing::enabled!(tracing::Level::DEBUG) {
+                            let st_hash = hex::encode(hash_single(raw));
+
+                            tracing::debug!(
                             ?error,
                             st_hash,
                             "Invalid unknown state transition ({}): {}",
                             st_hash,
                             error
                         );
+                        }
+
+                        // Store metrics
+                        state_transition_execution_histogram(
+                            decoding_elapsed_time,
+                            "Unknown",
+                            error.code(),
+                        );
+
+                        StateTransitionExecutionResult::UnpaidConsensusError(error)
                     }
+                    DecodedStateTransition::FailedToDecode(
+                        InvalidWithProtocolErrorStateTransition {
+                            raw,
+                            error: protocol_error,
+                            elapsed_time: decoding_elapsed_time,
+                        },
+                    ) => {
+                        // Store metrics
+                        state_transition_execution_histogram(decoding_elapsed_time, "Unknown", 1);
 
-                    // Store metrics
-                    state_transition_execution_histogram(
-                        decoding_elapsed_time,
-                        "Unknown",
-                        error.code(),
-                    );
-
-                    StateTransitionExecutionResult::UnpaidConsensusError(error)
-                }
-                DecodedStateTransition::FailedToDecode(
-                    InvalidWithProtocolErrorStateTransition {
-                        raw,
-                        error: protocol_error,
-                        elapsed_time: decoding_elapsed_time,
-                    },
-                ) => {
-                    // Store metrics
-                    state_transition_execution_histogram(decoding_elapsed_time, "Unknown", 1);
-
-                    error_to_internal_error_execution_result(StateTransitionAwareError {
-                        error: protocol_error.into(),
-                        raw_state_transition: raw,
-                        state_transition_name: None,
-                    })
-                }
-            };
+                        error_to_internal_error_execution_result(StateTransitionAwareError {
+                            error: protocol_error.into(),
+                            raw_state_transition: raw,
+                            state_transition_name: None,
+                        })
+                    }
+                };
+            }
 
             processing_result.add(execution_result)?;
         }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
@@ -193,8 +193,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -204,7 +202,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -258,8 +256,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -269,7 +265,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -323,8 +319,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -334,7 +328,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
@@ -193,6 +193,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -201,6 +203,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -254,6 +258,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -262,6 +268,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -315,6 +323,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -323,6 +333,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/mod.rs
@@ -629,8 +629,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -640,7 +638,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/mod.rs
@@ -629,6 +629,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -637,6 +639,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
@@ -355,6 +355,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -363,6 +365,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -454,6 +458,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -462,6 +468,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
             assert_eq!(
@@ -695,6 +703,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -706,6 +716,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -720,6 +732,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -731,6 +745,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -1059,6 +1075,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1072,6 +1090,8 @@ mod tests {
                     ),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -1262,6 +1282,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1270,6 +1292,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -1322,6 +1346,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1330,6 +1356,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -1422,6 +1450,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1430,6 +1460,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -1463,6 +1495,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1471,6 +1505,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -1562,6 +1598,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1570,6 +1608,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -1603,6 +1643,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1611,6 +1653,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -1688,6 +1732,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1696,6 +1742,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -1782,6 +1830,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1790,6 +1840,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -1886,6 +1938,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1894,6 +1948,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -1984,6 +2040,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1992,6 +2050,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2025,6 +2085,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2033,6 +2095,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2144,6 +2208,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2152,6 +2218,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2186,6 +2254,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2194,6 +2264,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2305,6 +2377,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2313,6 +2387,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2347,6 +2423,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2355,6 +2433,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2448,6 +2528,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2456,6 +2538,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2490,6 +2574,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2498,6 +2584,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2579,6 +2667,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2587,6 +2677,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2691,6 +2783,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2699,6 +2793,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2736,6 +2832,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2744,6 +2842,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2825,6 +2925,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2833,6 +2935,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -2917,6 +3021,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2925,6 +3031,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -3029,6 +3137,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3037,6 +3147,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -3121,6 +3233,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3129,6 +3243,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -3271,6 +3387,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3279,6 +3397,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -3374,6 +3494,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3382,6 +3504,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -3466,6 +3590,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3474,6 +3600,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -3533,6 +3661,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3541,6 +3671,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -3621,6 +3753,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3629,6 +3763,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -3690,6 +3826,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3698,6 +3836,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -3777,6 +3917,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3785,6 +3927,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -3869,6 +4013,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3877,6 +4023,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -3993,6 +4141,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4001,6 +4151,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4111,6 +4263,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4119,6 +4273,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4225,6 +4381,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4233,6 +4391,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4367,6 +4527,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4375,6 +4537,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4412,6 +4576,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4420,6 +4586,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4460,6 +4628,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4468,6 +4638,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4555,6 +4727,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4563,6 +4737,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4600,6 +4776,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4608,6 +4786,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4648,6 +4828,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4656,6 +4838,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4748,6 +4932,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4756,6 +4942,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4793,6 +4981,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4801,6 +4991,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4841,6 +5033,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4849,6 +5043,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -4951,6 +5147,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4959,6 +5157,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -5045,6 +5245,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5053,6 +5255,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -5137,6 +5341,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5145,6 +5351,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -5229,6 +5437,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5237,6 +5447,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -5319,6 +5531,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5327,6 +5541,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -5366,6 +5582,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5374,6 +5592,8 @@ mod tests {
                     &BlockInfo::default_with_time(50000000),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -5745,6 +5965,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5757,6 +5979,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -5771,6 +5995,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5783,6 +6009,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -6189,6 +6417,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -6201,6 +6431,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -6215,6 +6447,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -6227,6 +6461,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
@@ -355,8 +355,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -366,7 +364,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -458,8 +456,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -469,7 +465,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
             assert_eq!(
@@ -703,8 +699,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -717,7 +711,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -732,8 +726,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -746,7 +738,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -1075,8 +1067,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1091,7 +1081,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -1282,8 +1272,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1293,7 +1281,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -1346,8 +1334,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1357,7 +1343,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -1450,8 +1436,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1461,7 +1445,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -1495,8 +1479,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1506,7 +1488,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -1598,8 +1580,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1609,7 +1589,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -1643,8 +1623,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1654,7 +1632,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -1732,8 +1710,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1743,7 +1719,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -1830,8 +1806,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1841,7 +1815,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -1938,8 +1912,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -1949,7 +1921,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2040,8 +2012,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2051,7 +2021,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2085,8 +2055,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2096,7 +2064,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2208,8 +2176,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2219,7 +2185,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2254,8 +2220,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2265,7 +2229,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2377,8 +2341,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2388,7 +2350,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2423,8 +2385,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2434,7 +2394,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2528,8 +2488,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2539,7 +2497,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2574,8 +2532,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2585,7 +2541,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2667,8 +2623,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2678,7 +2632,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2783,8 +2737,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2794,7 +2746,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2832,8 +2784,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2843,7 +2793,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -2925,8 +2875,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -2936,7 +2884,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -3021,8 +2969,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3032,7 +2978,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -3137,8 +3083,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3148,7 +3092,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -3233,8 +3177,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3244,7 +3186,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -3387,8 +3329,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3398,7 +3338,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -3494,8 +3434,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3505,7 +3443,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -3590,8 +3528,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3601,7 +3537,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -3661,8 +3597,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3672,7 +3606,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -3753,8 +3687,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3764,7 +3696,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -3826,8 +3758,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3837,7 +3767,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -3917,8 +3847,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -3928,7 +3856,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4013,8 +3941,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4024,7 +3950,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4141,8 +4067,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4152,7 +4076,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4263,8 +4187,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4274,7 +4196,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4381,8 +4303,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4392,7 +4312,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4527,8 +4447,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4538,7 +4456,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4576,8 +4494,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4587,7 +4503,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4628,8 +4544,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4639,7 +4553,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4727,8 +4641,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4738,7 +4650,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4776,8 +4688,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4787,7 +4697,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4828,8 +4738,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4839,7 +4747,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4932,8 +4840,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4943,7 +4849,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -4981,8 +4887,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -4992,7 +4896,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -5033,8 +4937,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5044,7 +4946,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -5147,8 +5049,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5158,7 +5058,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -5245,8 +5145,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5256,7 +5154,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -5341,8 +5239,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5352,7 +5248,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -5437,8 +5333,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5448,7 +5342,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -5531,8 +5425,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5542,7 +5434,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -5582,8 +5474,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5593,7 +5483,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -5965,8 +5855,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -5980,7 +5868,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -5995,8 +5883,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -6010,7 +5896,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -6417,8 +6303,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -6432,7 +6316,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -6447,8 +6331,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -6462,7 +6344,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
@@ -294,8 +294,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -305,7 +303,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -450,8 +448,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -461,7 +457,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -516,8 +512,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -527,7 +521,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -687,8 +681,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -698,7 +690,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -756,8 +748,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -767,7 +757,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -920,8 +910,6 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
-            let timer = crate::metrics::abci_request_duration("");
-
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -931,7 +919,7 @@ mod tests {
                     &transaction,
                     platform_version,
                     false,
-                    &timer,
+                    None,
                 )
                 .expect("expected to process state transition");
 
@@ -989,8 +977,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1000,7 +986,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1141,8 +1127,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1152,7 +1136,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1175,8 +1159,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1186,7 +1168,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1234,8 +1216,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1245,7 +1225,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
@@ -294,6 +294,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -302,6 +304,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -446,6 +450,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -454,6 +460,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -508,6 +516,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -516,6 +526,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -675,6 +687,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -683,6 +697,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -740,6 +756,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -748,6 +766,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -900,6 +920,8 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            let timer = crate::metrics::abci_request_duration("");
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(
@@ -908,6 +930,8 @@ mod tests {
                     &BlockInfo::default(),
                     &transaction,
                     platform_version,
+                    false,
+                    &timer,
                 )
                 .expect("expected to process state transition");
 
@@ -965,6 +989,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -973,6 +999,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1113,6 +1141,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1121,6 +1151,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1143,6 +1175,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1151,6 +1185,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1198,6 +1234,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1206,6 +1244,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_withdrawal/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_withdrawal/mod.rs
@@ -190,8 +190,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -201,7 +199,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_withdrawal/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_withdrawal/mod.rs
@@ -190,6 +190,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -198,6 +200,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
@@ -213,6 +213,8 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -221,6 +223,8 @@ mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
@@ -213,8 +213,6 @@ mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -224,7 +222,7 @@ mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
@@ -350,6 +350,8 @@ pub(crate) mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -358,6 +360,8 @@ pub(crate) mod tests {
                 &block_info,
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -889,6 +893,8 @@ pub(crate) mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -905,6 +911,8 @@ pub(crate) mod tests {
                 ),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -918,6 +926,8 @@ pub(crate) mod tests {
         assert_eq!(processing_result.valid_count(), 2);
 
         let transaction = platform.drive.grove.start_transaction();
+
+        let timer = crate::metrics::abci_request_duration("");
 
         let processing_result = platform
             .platform
@@ -935,6 +945,8 @@ pub(crate) mod tests {
                 ),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1169,6 +1181,8 @@ pub(crate) mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1185,6 +1199,8 @@ pub(crate) mod tests {
                 ),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1198,6 +1214,8 @@ pub(crate) mod tests {
         assert_eq!(processing_result.valid_count(), 2);
 
         let transaction = platform.drive.grove.start_transaction();
+
+        let timer = crate::metrics::abci_request_duration("");
 
         let processing_result = platform
             .platform
@@ -1215,6 +1233,8 @@ pub(crate) mod tests {
                 ),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1346,6 +1366,8 @@ pub(crate) mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1359,6 +1381,8 @@ pub(crate) mod tests {
                 ),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1373,6 +1397,8 @@ pub(crate) mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1386,6 +1412,8 @@ pub(crate) mod tests {
                 ),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 
@@ -1665,6 +1693,8 @@ pub(crate) mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
+        let timer = crate::metrics::abci_request_duration("");
+
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1673,6 +1703,8 @@ pub(crate) mod tests {
                 &BlockInfo::default(),
                 &transaction,
                 platform_version,
+                false,
+                &timer,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
@@ -350,8 +350,6 @@ pub(crate) mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -361,7 +359,7 @@ pub(crate) mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -893,8 +891,6 @@ pub(crate) mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -912,7 +908,7 @@ pub(crate) mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -926,8 +922,6 @@ pub(crate) mod tests {
         assert_eq!(processing_result.valid_count(), 2);
 
         let transaction = platform.drive.grove.start_transaction();
-
-        let timer = crate::metrics::abci_request_duration("");
 
         let processing_result = platform
             .platform
@@ -946,7 +940,7 @@ pub(crate) mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1181,8 +1175,6 @@ pub(crate) mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1200,7 +1192,7 @@ pub(crate) mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1214,8 +1206,6 @@ pub(crate) mod tests {
         assert_eq!(processing_result.valid_count(), 2);
 
         let transaction = platform.drive.grove.start_transaction();
-
-        let timer = crate::metrics::abci_request_duration("");
 
         let processing_result = platform
             .platform
@@ -1234,7 +1224,7 @@ pub(crate) mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1366,8 +1356,6 @@ pub(crate) mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1382,7 +1370,7 @@ pub(crate) mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1396,8 +1384,6 @@ pub(crate) mod tests {
         assert_eq!(processing_result.valid_count(), 1);
 
         let transaction = platform.drive.grove.start_transaction();
-
-        let timer = crate::metrics::abci_request_duration("");
 
         let processing_result = platform
             .platform
@@ -1413,7 +1399,7 @@ pub(crate) mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 
@@ -1693,8 +1679,6 @@ pub(crate) mod tests {
 
         let transaction = platform.drive.grove.start_transaction();
 
-        let timer = crate::metrics::abci_request_duration("");
-
         let processing_result = platform
             .platform
             .process_raw_state_transitions(
@@ -1704,7 +1688,7 @@ pub(crate) mod tests {
                 &transaction,
                 platform_version,
                 false,
-                &timer,
+                None,
             )
             .expect("expected to process state transition");
 

--- a/packages/rs-drive-abci/src/platform_types/state_transitions_processing_result/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/state_transitions_processing_result/mod.rs
@@ -4,8 +4,15 @@ use crate::error::Error;
 use crate::platform_types::event_execution_result::EstimatedFeeResult;
 use dpp::fee::fee_result::FeeResult;
 
+/// The reason the state transition was not executed
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NotExecutedReason {
+    /// The proposer ran out of time
+    ProposerRanOutOfTime,
+}
+
 /// State Transition Execution Result represents a result of the single state transition execution.
-/// There are four possible outcomes of the state transition execution described by this enum
+/// There are five possible outcomes of the state transition execution described by this enum
 #[derive(Debug, Clone, PartialEq)]
 pub enum StateTransitionExecutionResult {
     /// State Transition is invalid, but we have a proved identity associated with it,
@@ -21,8 +28,9 @@ pub enum StateTransitionExecutionResult {
     InternalError(String),
     /// State Transition was successfully executed
     SuccessfulExecution(Option<EstimatedFeeResult>, FeeResult),
-    /// State Transition was not executed as it reached the maximum time limit
-    NotExecuted(String),
+    /// State Transition was not executed at all.
+    /// The only current reason for this is that the proposer reached the maximum time limit
+    NotExecuted(NotExecutedReason),
 }
 
 /// State Transitions Processing Result produced by [process_raw_state_transitions] and represents

--- a/packages/rs-drive-abci/src/platform_types/state_transitions_processing_result/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/state_transitions_processing_result/mod.rs
@@ -21,6 +21,8 @@ pub enum StateTransitionExecutionResult {
     InternalError(String),
     /// State Transition was successfully executed
     SuccessfulExecution(Option<EstimatedFeeResult>, FeeResult),
+    /// State Transition was not executed as it reached the maximum time limit
+    NotExecuted(String),
 }
 
 /// State Transitions Processing Result produced by [process_raw_state_transitions] and represents
@@ -54,6 +56,9 @@ impl StateTransitionsProcessingResult {
                 self.valid_count += 1;
 
                 self.fees.checked_add_assign(actual_fees.clone())?;
+            }
+            StateTransitionExecutionResult::NotExecuted(_) => {
+                self.failed_count += 1;
             }
         }
 

--- a/packages/rs-drive/src/drive/initialization/genesis_core_height/mod.rs
+++ b/packages/rs-drive/src/drive/initialization/genesis_core_height/mod.rs
@@ -86,7 +86,6 @@ mod tests {
         let db_transaction = drive.grove.start_transaction();
 
         let platform_version = PlatformVersion::latest();
-        let drive_version = &platform_version.drive;
 
         let core_genesis_height: CoreBlockHeight = 1320;
         drive


### PR DESCRIPTION
## Issue being fixed or feature implemented


## What was done?

- When a node is preparing a block proposal, it will skip and mark as not executed remaining state transitions txs when a time limit is reached.
- Added in Abci config the value of the limit with a default value of 8 seconds. 

## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
