### PR TITLE
fix(dashmate): core reindex command not working

### DIFF
--- a/packages/dashmate/src/templates/renderServiceTemplatesFactory.js
+++ b/packages/dashmate/src/templates/renderServiceTemplatesFactory.js
@@ -1,4 +1,3 @@
-import dots from 'dot';
 import * as glob from 'glob';
 import { TEMPLATES_DIR } from '../constants.js';
 

--- a/packages/dashmate/src/templates/renderServiceTemplatesFactory.js
+++ b/packages/dashmate/src/templates/renderServiceTemplatesFactory.js
@@ -15,8 +15,6 @@ export default function renderServiceTemplatesFactory(renderTemplate) {
    * @return {Object<string,string>}
    */
   function renderServiceTemplates(config) {
-    dots.templateSettings.strip = false;
-
     const templatePaths = glob.sync(`${TEMPLATES_DIR}/**/*.dot`, {
       ignore: {
         // Ignore manual rendered templates

--- a/packages/dashmate/src/templates/renderTemplateFactory.js
+++ b/packages/dashmate/src/templates/renderTemplateFactory.js
@@ -17,6 +17,10 @@ export default function renderTemplateFactory() {
    */
   function renderTemplate(templatePath, variables) {
     const templateString = fs.readFileSync(templatePath, 'utf-8');
+
+    // do not strip \n
+    dots.templateSettings.strip = false;
+
     const template = dots.template(templateString);
 
     return template({ ...variables, crypto });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reindex command is not working properly in the dashmate, it breaks the whole dash config by trimming \n characters. As a result, node begins to sync mainnet with all default options.

This PR fixes `dashmate core reindex` command

## What was done?
<!--- Describe your changes in detail -->
Moved `dots.templateSettings.strip = false` from renderServiceTemplatesFactory to renderTemplateFactory

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
