### PR TITLE
fix(sdk)!: overflow when using &&sdk in DapiRequestExecutor

### DIFF
--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -527,17 +527,6 @@ impl DapiRequestExecutor for Sdk {
     }
 }
 
-#[async_trait::async_trait]
-impl DapiRequestExecutor for &Sdk {
-    async fn execute<R: TransportRequest>(
-        &self,
-        request: R,
-        settings: RequestSettings,
-    ) -> Result<R::Response, DapiClientError<<R::Client as TransportClient>::Error>> {
-        DapiRequestExecutor::execute(self, request, settings).await
-    }
-}
-
 /// Dash Platform SDK Builder, used to configure and [`SdkBuilder::build()`] the [Sdk].
 ///
 /// [SdkBuilder] implements a "builder" design pattern to allow configuration of the Sdk before it is instantiated.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Calling `request.execute(&&Sdk)` causes overflow error.

## What was done?

Removed affected code.
Now, the compiler will show error when trying to use double-ref.

## How Has This Been Tested?

GHA

## Breaking Changes

Use of double-ref to `Sdk` in `DapiRequestExecutor::execute()` is not possible anymore.
You must deref or clone `Sdk`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
