### PR TITLE
fix(drive-abci): don't add up bytes for the same epochindex

### DIFF
--- a/packages/rs-drive/src/util/storage_flags/mod.rs
+++ b/packages/rs-drive/src/util/storage_flags/mod.rs
@@ -131,12 +131,8 @@ impl StorageFlags {
                 other_epoch_index_map
                     .iter()
                     .for_each(|(epoch_index, bytes_added)| {
-                        let original_value = combined_index_map.remove(epoch_index);
-                        match original_value {
-                            None => combined_index_map.insert(*epoch_index, *bytes_added),
-                            Some(original_bytes) => combined_index_map
-                                .insert(*epoch_index, original_bytes + *bytes_added),
-                        };
+                        // Simply insert the value from rhs, overwriting any existing value
+                        combined_index_map.insert(*epoch_index, *bytes_added);
                     });
                 Some(combined_index_map)
             } else {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Strategy test `run_chain_insert_many_new_identity_per_block_many_document_insertions_updates_and_deletions_with_epoch_change` panickes with integer overflow when executed with 70+ blocks (default was 30: explanation why test isn't failing).

Function `combine_non_base_epoch_bytes` for each epoch was adding up the same value resulting into a geometrical growth of added_bytes.
`combine_non_base_epoch_bytes: self:{2: 31} & rhs:{2: 31} -> {2: 62}`
`combine_non_base_epoch_bytes: self:{2: 62} & rhs:{2: 62} -> {2: 124}`
`...`

## What was done?
`combine_non_base_epoch_bytes` was updated to keep the value of bytes from `rhs` `epoch_index_map` for each corresponding epoch instead.
Updated behavior:
`combine_non_base_epoch_bytes: self:{2: 21} & rhs:{2: 21} -> {2: 21}`

## How Has This Been Tested?
With this fix, the same test succeeds for 1000 blocks.

## Breaking Changes
not sure if this is breaking change

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
