### PR TITLE
fix(drive-abci)!: fix wrong fields in dash top level domain 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,7 +2062,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "grovedb"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
+source = "git+https://github.com/dashpay/grovedb?rev=2c14841e95b4222d489f0655c85238bc05267b91#2c14841e95b4222d489f0655c85238bc05267b91"
 dependencies = [
  "axum 0.7.5",
  "bincode",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
+source = "git+https://github.com/dashpay/grovedb?rev=2c14841e95b4222d489f0655c85238bc05267b91#2c14841e95b4222d489f0655c85238bc05267b91"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -2105,7 +2105,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
+source = "git+https://github.com/dashpay/grovedb?rev=2c14841e95b4222d489f0655c85238bc05267b91#2c14841e95b4222d489f0655c85238bc05267b91"
 dependencies = [
  "bincode",
  "blake3",
@@ -2130,12 +2130,12 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
+source = "git+https://github.com/dashpay/grovedb?rev=2c14841e95b4222d489f0655c85238bc05267b91#2c14841e95b4222d489f0655c85238bc05267b91"
 
 [[package]]
 name = "grovedb-storage"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
+source = "git+https://github.com/dashpay/grovedb?rev=2c14841e95b4222d489f0655c85238bc05267b91#2c14841e95b4222d489f0655c85238bc05267b91"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -2154,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
+source = "git+https://github.com/dashpay/grovedb?rev=2c14841e95b4222d489f0655c85238bc05267b91#2c14841e95b4222d489f0655c85238bc05267b91"
 dependencies = [
  "thiserror",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
+source = "git+https://github.com/dashpay/grovedb?rev=2c14841e95b4222d489f0655c85238bc05267b91#2c14841e95b4222d489f0655c85238bc05267b91"
 dependencies = [
  "hex",
  "itertools 0.12.1",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "grovedbg-types"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
+source = "git+https://github.com/dashpay/grovedb?rev=2c14841e95b4222d489f0655c85238bc05267b91#2c14841e95b4222d489f0655c85238bc05267b91"
 dependencies = [
  "serde",
  "serde_with 3.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,7 +2062,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "grovedb"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=713ad96a0ca443f72fa15738e82df529be1becbb#713ad96a0ca443f72fa15738e82df529be1becbb"
+source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
 dependencies = [
  "axum 0.7.5",
  "bincode",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=713ad96a0ca443f72fa15738e82df529be1becbb#713ad96a0ca443f72fa15738e82df529be1becbb"
+source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -2105,8 +2105,9 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=713ad96a0ca443f72fa15738e82df529be1becbb#713ad96a0ca443f72fa15738e82df529be1becbb"
+source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
 dependencies = [
+ "bincode",
  "blake3",
  "byteorder",
  "colored",
@@ -2129,12 +2130,12 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=713ad96a0ca443f72fa15738e82df529be1becbb#713ad96a0ca443f72fa15738e82df529be1becbb"
+source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
 
 [[package]]
 name = "grovedb-storage"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=713ad96a0ca443f72fa15738e82df529be1becbb#713ad96a0ca443f72fa15738e82df529be1becbb"
+source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -2153,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=713ad96a0ca443f72fa15738e82df529be1becbb#713ad96a0ca443f72fa15738e82df529be1becbb"
+source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
 dependencies = [
  "thiserror",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2162,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=713ad96a0ca443f72fa15738e82df529be1becbb#713ad96a0ca443f72fa15738e82df529be1becbb"
+source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
 dependencies = [
  "hex",
  "itertools 0.12.1",
@@ -2171,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "grovedbg-types"
 version = "1.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=713ad96a0ca443f72fa15738e82df529be1becbb#713ad96a0ca443f72fa15738e82df529be1becbb"
+source = "git+https://github.com/dashpay/grovedb?rev=27067ef01b7790f7a7467430ec3ed8f1c4679865#27067ef01b7790f7a7467430ec3ed8f1c4679865"
 dependencies = [
  "serde",
  "serde_with 3.9.0",

--- a/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/v0/mod.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 
-use dpp::platform_value::{platform_value, BinaryData};
+use dpp::platform_value::platform_value;
 use dpp::ProtocolError;
 
 use drive::dpp::identity::TimestampMillis;
@@ -16,9 +16,7 @@ use drive::dpp::system_data_contracts::SystemDataContract;
 use drive::util::batch::{DataContractOperationType, DocumentOperationType, DriveOperation};
 
 use dpp::prelude::CoreBlockHeight;
-use dpp::system_data_contracts::dpns_contract::{
-    DPNS_DASH_TLD_DOCUMENT_ID, DPNS_DASH_TLD_PREORDER_SALT,
-};
+use dpp::system_data_contracts::dpns_contract::DPNS_DASH_TLD_DOCUMENT_ID;
 use drive::query::TransactionArg;
 use drive::util::object_size_info::{
     DataContractInfo, DocumentInfo, DocumentTypeInfo, OwnedDocumentInfo,

--- a/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/v0/mod.rs
@@ -126,9 +126,8 @@ impl<C> Platform<C> {
             "normalizedLabel" : domain,
             "parentDomainName" : "",
             "normalizedParentDomainName" : "",
-            "preorderSalt" : BinaryData::new(DPNS_DASH_TLD_PREORDER_SALT.to_vec()),
             "records" : {
-                "dashAliasIdentityId" : contract.owner_id(),
+                "identity" : contract.owner_id(),
             },
             "subdomainRules": {
                 "allowSubdomains": true,
@@ -138,6 +137,8 @@ impl<C> Platform<C> {
         let document_stub_properties = document_stub_properties_value
             .into_btree_string_map()
             .map_err(|e| Error::Protocol(ProtocolError::ValueError(e)))?;
+
+        println!("{:?}", document_stub_properties);
 
         let document = DocumentV0 {
             id: DPNS_DASH_TLD_DOCUMENT_ID.into(),
@@ -205,7 +206,7 @@ mod tests {
 
             assert_eq!(
                 hex::encode(root_hash),
-                "8163884a9eef0d3b306bd6f426806e7ff41d7b09f030c4ff2b79b3b4c646dfca"
+                "dc5b0d4be407428adda2315db7d782e64015cbe2d2b7df963f05622390dc3c9f"
             )
         }
     }

--- a/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/v0/mod.rs
@@ -136,8 +136,6 @@ impl<C> Platform<C> {
             .into_btree_string_map()
             .map_err(|e| Error::Protocol(ProtocolError::ValueError(e)))?;
 
-        println!("{:?}", document_stub_properties);
-
         let document = DocumentV0 {
             id: DPNS_DASH_TLD_DOCUMENT_ID.into(),
             properties: document_stub_properties,

--- a/packages/rs-drive-abci/tests/strategy_tests/main.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/main.rs
@@ -1198,7 +1198,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
             ),
-            "d12cc15405f4a810c239539f06fe6eee9f2b2d1ad49055a5ca55882b5842baa4".to_string()
+            "975735252c11cea7ef3fbba86928077e37ebe1926972e6ae38e237ce0864100c".to_string()
         )
     }
 
@@ -1938,7 +1938,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
             ),
-            "f55d96bb04c3e5e737c883a18538fc008a55aaf003ccd64d0e8dd3640b7fa888".to_string()
+            "0cc2c7a7749a0ce47a4abcd1f4db21d07734f96d09ffe08d6500a8d09a3455a1".to_string()
         )
     }
 
@@ -2073,7 +2073,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
             ),
-            "a409bbb8c0522bab91eed208e058f1a35320b52efd42f289be14d874a4cab807".to_string()
+            "5a08b133a19b11b09eaba6763ad2893c2bcbcc645fb698298790bb5d26e551e0".to_string()
         )
     }
 

--- a/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
@@ -17,7 +17,7 @@ use strategy_tests::operations::{
     DocumentAction, DocumentOp, FinalizeBlockOperation, IdentityUpdateOp, OperationType,
 };
 
-use dpp::document::{DocumentV0Getters, DocumentV0Setters};
+use dpp::document::DocumentV0Getters;
 use dpp::fee::Credits;
 use dpp::identity::{Identity, IdentityPublicKey, KeyID, KeyType, Purpose, SecurityLevel};
 use dpp::serialization::PlatformSerializableWithPlatformVersion;
@@ -937,7 +937,7 @@ impl NetworkStrategy {
                             //todo: fix this into a search key request for the following
                             //let search_key_request = BTreeMap::from([(Purpose::AUTHENTICATION as u8, BTreeMap::from([(SecurityLevel::HIGH as u8, AllKeysOfKindRequest)]))]);
 
-                            let mut random_new_document = document_type
+                            let random_new_document = document_type
                                 .random_document_with_rng(rng, platform_version)
                                 .unwrap();
                             let request = IdentityKeysRequest {

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -51,11 +51,11 @@ enum-map = { version = "2.0.3", optional = true }
 intmap = { version = "2.0.0", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.11.0", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "713ad96a0ca443f72fa15738e82df529be1becbb", optional = true, default-features = false }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "713ad96a0ca443f72fa15738e82df529be1becbb", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "713ad96a0ca443f72fa15738e82df529be1becbb" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "713ad96a0ca443f72fa15738e82df529be1becbb", optional = true }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "713ad96a0ca443f72fa15738e82df529be1becbb"}
+grovedb = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865", optional = true, default-features = false }
+grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865", optional = true }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865", optional = true }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865"}
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -51,11 +51,11 @@ enum-map = { version = "2.0.3", optional = true }
 intmap = { version = "2.0.0", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.11.0", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865", optional = true, default-features = false }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865", optional = true }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865"}
+grovedb = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91", optional = true, default-features = false }
+grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91", optional = true }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91", optional = true }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91"}
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -1939,6 +1939,8 @@ mod tests {
     use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 
     use dpp::prelude::Identifier;
+    use rand::prelude::StdRng;
+    use rand::SeedableRng;
     use serde_json::json;
     use std::borrow::Cow;
     use std::collections::BTreeMap;
@@ -2218,7 +2220,10 @@ mod tests {
     #[test]
     fn test_valid_query_drive_document_query() {
         let platform_version = PlatformVersion::latest();
-        let contract = get_dpns_data_contract_fixture(None, 0, 1).data_contract_owned();
+        let mut rng = StdRng::seed_from_u64(5);
+        let contract =
+            get_dpns_data_contract_fixture(Some(Identifier::random_with_rng(&mut rng)), 0, 1)
+                .data_contract_owned();
         let domain = contract
             .document_type_for_name("domain")
             .expect("expected to get domain");
@@ -2264,7 +2269,7 @@ mod tests {
             .construct_path_query(None, platform_version)
             .expect("expected to create path query");
 
-        println!("{}", path_query);
+        assert_eq!(path_query.to_string(), "PathQuery { path: [@, 0x1da29f488023e306ff9a680bc9837153fb0778c8ee9c934a87dc0de1d69abd3c, 0x01, domain, 0x7265636f7264732e6964656e74697479], query: SizedQuery { query: Query {\n  items: [\n    RangeTo(.. 8dc201fd7ad7905f8a84d66218e2b387daea7fe4739ae0e21e8c3ee755e6a2c0),\n  ],\n  default_subquery_branch: SubqueryBranch { subquery_path: [00], subquery: Query {\n  items: [\n    RangeFull,\n  ],\n  default_subquery_branch: SubqueryBranch { subquery_path: None subquery: None },\n  left_to_right: false,\n} },\n  conditional_subquery_branches: {\n    Key(): SubqueryBranch { subquery_path: [00], subquery: Query {\n  items: [\n    RangeFull,\n  ],\n  default_subquery_branch: SubqueryBranch { subquery_path: None subquery: None },\n  left_to_right: false,\n} },\n  },\n  left_to_right: false,\n}, limit: 6 } }");
 
         // Serialize the PathQuery to a Vec<u8>
         let encoded = bincode::encode_to_vec(&path_query, bincode::config::standard())
@@ -2273,8 +2278,7 @@ mod tests {
         // Convert the encoded bytes to a hex string
         let hex_string = hex::encode(encoded);
 
-        // Print the hex string
-        println!("{}", hex_string);
+        assert_eq!(hex_string, "050140201da29f488023e306ff9a680bc9837153fb0778c8ee9c934a87dc0de1d69abd3c010106646f6d61696e107265636f7264732e6964656e746974790105208dc201fd7ad7905f8a84d66218e2b387daea7fe4739ae0e21e8c3ee755e6a2c0010101000101030000000001010000010101000101030000000000010600");
     }
 
     #[test]

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -2265,6 +2265,16 @@ mod tests {
             .expect("expected to create path query");
 
         println!("{}", path_query);
+
+        // Serialize the PathQuery to a Vec<u8>
+        let encoded = bincode::encode_to_vec(&path_query, bincode::config::standard())
+            .expect("Failed to serialize PathQuery");
+
+        // Convert the encoded bytes to a hex string
+        let hex_string = hex::encode(encoded);
+
+        // Print the hex string
+        println!("{}", hex_string);
     }
 
     #[test]

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 thiserror = { version = "1.0.59" }
 bincode = { version = "2.0.0-rc.3"}
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "713ad96a0ca443f72fa15738e82df529be1becbb" }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865" }
 once_cell = "1.19.0"
 
 [features]

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 thiserror = { version = "1.0.59" }
 bincode = { version = "2.0.0-rc.3"}
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "27067ef01b7790f7a7467430ec3ed8f1c4679865" }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91" }
 once_cell = "1.19.0"
 
 [features]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
We were experiencing a few issues with an empty string being present as a tree in the domain table, this caused the contract based translation of the drive document queries to path queries to go a bit haywire which led to the result that an item that was expected would not be inserted due to a limit going down by 1 because of an empty tree.

## What was done?
Fixed the dash tld.


## How Has This Been Tested?
Not very well tested, however this is most likely the issue. I checked a strategy test to make sure things worked well after this change, however since the original issue was very hard to reproduce, we will only really be able to see if the fix works when it goes to Testnet.


## Breaking Changes
This fix is a breaking change.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
