### PR TITLE
build: update rust to 1.80

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -3,9 +3,8 @@ name: "Rust Dependencies"
 description: "Install dependencies"
 inputs:
   toolchain:
-    description: Rust toolchain to use, stable / nightly / beta, or exact version
-    # The same as in /README.md
-    default: "1.76"
+    description: Rust toolchain to use, stable / nightly / beta, or exact version; uses rust-toolchain.toml if not specified
+    default: ""
   target:
     description: Target Rust platform
     required: false
@@ -21,11 +20,24 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Extract Rust toolchain version from rust-toolchain.toml
+      shell: bash
+      id: rust_toolchain
+      run: |
+        TOOLCHAIN_VERSION="${{ inputs.toolchain }}"
+        if [[ -z "$TOOLCHAIN_VERSION" ]]; then
+          TOOLCHAIN_VERSION=$(grep channel rust-toolchain.toml | awk '{print $3}' | tr -d '"')
+        fi
+
+        echo "TOOLCHAIN_VERSION=$TOOLCHAIN_VERSION" >> $GITHUB_ENV
+        echo "::set-output name=version::$TOOLCHAIN_VERSION"
+
     # TODO: Move to AMI and build every day
     - uses: dtolnay/rust-toolchain@master
       name: Install Rust toolchain
+      id: install_rust
       with:
-        toolchain: ${{ inputs.toolchain }}
+        toolchain: ${{ steps.rust_toolchain.outputs.version }}
         target: ${{ inputs.target }}
         components: ${{ inputs.components }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ members = [
     "packages/rs-json-schema-compatibility-validator",
     "packages/check-features",
 ]
+[workspace.package]
+
+rust-version = "1.76"
 
 [patch.crates-io]
 tower-service = { git = "https://github.com/QuantumExplorer/tower", branch = "fix/indexMap2OnV0413" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 [workspace.package]
 
-rust-version = "1.76"
+rust-version = "1.80"
 
 [patch.crates-io]
 tower-service = { git = "https://github.com/QuantumExplorer/tower", branch = "fix/indexMap2OnV0413" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,13 +68,17 @@ RUN npm config set --global audit false
 
 ARG TARGETARCH
 
+WORKDIR /platform
+
+
 # TODO: It doesn't sharing PATH between stages, so we need "source $HOME/.cargo/env" everywhere
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
-    --profile minimal \
-    -y \
-    # Rust version the same as in /README.md
-    --default-toolchain 1.76 \
-    --target wasm32-unknown-unknown
+COPY rust-toolchain.toml .
+RUN TOOLCHAIN_VERSION="$(grep channel rust-toolchain.toml | awk '{print $3}' | tr -d '"')" && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
+        --profile minimal \
+        -y \
+        --default-toolchain "${TOOLCHAIN_VERSION}" \
+        --target wasm32-unknown-unknown
 
 # Install protoc - protobuf compiler
 # The one shipped with Alpine does not work

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ this repository may be used on the following networks:
 - Install prerequisites:
   - [node.js](https://nodejs.org/) v20
   - [docker](https://docs.docker.com/get-docker/) v20.10+
-  - [rust](https://www.rust-lang.org/tools/install) v1.76+, with wasm32 target (`rustup target add wasm32-unknown-unknown`)
+  - [rust](https://www.rust-lang.org/tools/install) v1.80+, with wasm32 target (`rustup target add wasm32-unknown-unknown`)
   - [protoc - protobuf compiler](https://github.com/protocolbuffers/protobuf/releases) v25.2+
     - if needed, set PROTOC environment variable to location of `protoc` binary
   - [wasm-bingen toolchain](https://rustwasm.github.io/wasm-bindgen/):

--- a/packages/dapi-grpc/Cargo.toml
+++ b/packages/dapi-grpc/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
   "Ivan Shumkov <shumkov@dash.org>",
 ]
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [features]

--- a/packages/dashpay-contract/Cargo.toml
+++ b/packages/dashpay-contract/Cargo.toml
@@ -3,7 +3,7 @@ name = "dashpay-contract"
 description = "DashPay data contract schema and tools"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/packages/data-contracts/Cargo.toml
+++ b/packages/data-contracts/Cargo.toml
@@ -3,7 +3,7 @@ name = "data-contracts"
 description = "Dash Platform system data contracts"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/packages/dpns-contract/Cargo.toml
+++ b/packages/dpns-contract/Cargo.toml
@@ -3,7 +3,7 @@ name = "dpns-contract"
 description = "DPNS data contract schema and tools"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/packages/feature-flags-contract/Cargo.toml
+++ b/packages/feature-flags-contract/Cargo.toml
@@ -3,7 +3,7 @@ name = "feature-flags-contract"
 description = "Feature flags data contract schema and tools"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/packages/masternode-reward-shares-contract/Cargo.toml
+++ b/packages/masternode-reward-shares-contract/Cargo.toml
@@ -3,7 +3,7 @@ name = "masternode-reward-shares-contract"
 description = "Masternode reward shares data contract schema and tools"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/packages/rs-dpp/Cargo.toml
+++ b/packages/rs-dpp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dpp"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 authors = [
   "Anton Suprunchuk <anton.suprunchuk@gmail.com>",
   "Samuel Westrich <sam@dash.org>",

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
   "Igor Markin <igor.markin@dash.org>",
 ]
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/packages/rs-drive-proof-verifier/Cargo.toml
+++ b/packages/rs-drive-proof-verifier/Cargo.toml
@@ -2,7 +2,7 @@
 name = "drive-proof-verifier"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 
 crate-type = ["cdylib"]
 

--- a/packages/rs-drive-verify-c-binding/Cargo.toml
+++ b/packages/rs-drive-verify-c-binding/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rs-drive-verify-c-binding"
 version = "0.25.16-rc.3"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
   "Wisdom Ogwu <wisdom@dash.org",
 ]
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 resolver = "2"
 
@@ -55,7 +55,7 @@ grovedb = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d4
 grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91", optional = true }
 grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91" }
 grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91", optional = true }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91"}
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91" }
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/packages/rs-json-schema-compatibility-validator/Cargo.toml
+++ b/packages/rs-json-schema-compatibility-validator/Cargo.toml
@@ -2,10 +2,8 @@
 name = "json-schema-compatibility-validator"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
-authors = [
-  "Ivan Shumkov <ivan@shumkov.ru>",
-]
+rust-version.workspace = true
+authors = ["Ivan Shumkov <ivan@shumkov.ru>"]
 
 [dependencies]
 json-patch = "1.2.0"

--- a/packages/rs-platform-serialization-derive/Cargo.toml
+++ b/packages/rs-platform-serialization-derive/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Bincode serialization and deserialization derivations"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [lib]

--- a/packages/rs-platform-serialization/Cargo.toml
+++ b/packages/rs-platform-serialization/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Bincode based serialization and deserialization"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/packages/rs-platform-value-convertible/Cargo.toml
+++ b/packages/rs-platform-value-convertible/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Convertion to and from platform values"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [lib]

--- a/packages/rs-platform-value/Cargo.toml
+++ b/packages/rs-platform-value/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Samuel Westrich <sam@dash.org>"]
 description = "A simple value module"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -4,12 +4,12 @@ authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Versioning library for Platform"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]
 thiserror = { version = "1.0.59" }
-bincode = { version = "2.0.0-rc.3"}
+bincode = { version = "2.0.0-rc.3" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
 grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "2c14841e95b4222d489f0655c85238bc05267b91" }
 once_cell = "1.19.0"

--- a/packages/rs-platform-versioning/Cargo.toml
+++ b/packages/rs-platform-versioning/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Version derivation"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [lib]

--- a/packages/simple-signer/Cargo.toml
+++ b/packages/simple-signer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "simple-signer"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,4 +10,4 @@ rust-version = "1.76"
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
 dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.4" }
 dpp = { path = "../rs-dpp", features = ["abci"] }
-base64 = { version = "0.22.1"}
+base64 = { version = "0.22.1" }

--- a/packages/strategy-tests/Cargo.toml
+++ b/packages/strategy-tests/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
   "Paul DeLucia <paul.delucia@dash.org>",
 ]
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/packages/wasm-dpp/Cargo.toml
+++ b/packages/wasm-dpp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-dpp"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 authors = ["Anton Suprunchuk <anton.suprunchuk@gmail.com>"]
 
 [lib]

--- a/packages/withdrawals-contract/Cargo.toml
+++ b/packages/withdrawals-contract/Cargo.toml
@@ -3,7 +3,7 @@ name = "withdrawals-contract"
 description = "Witdrawals data contract schema and tools"
 version = "1.1.0-dev.1"
 edition = "2021"
-rust-version = "1.76"
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Rust version the same as in /README.md
-channel = "1.76"
+channel = "1.80"
 
 targets = ["wasm32-unknown-unknown"]

--- a/scripts/update_rust_version.sh
+++ b/scripts/update_rust_version.sh
@@ -1,0 +1,34 @@
+#! /bin/bash -e
+
+# This script updates the rust version to the one provided in the first argument.
+# Requires `yq` to be installed: https://github.com/mikefarah/yq
+PROJECT_ROOT="$(realpath "$(dirname "$0")"/..)"
+
+# Check if the first argument is provided
+if [ -z "${1}" ]; then
+    echo "Please provide the new rust version as the first argument."
+    exit 1
+fi
+
+VERSION="$1"
+
+function check {
+    for file in "$@"; do
+        if ! grep -q "${VERSION}" "${file}"; then
+            echo "The file ${file} does not contain the version ${VERSION}."
+            exit 1
+        fi
+    done
+}
+
+echo Update the rust version in the Cargo.toml file
+sed -i "s/^rust-version = \".*\"/rust-version = \"${VERSION}\"/" "${PROJECT_ROOT}"/*/*/Cargo.toml
+check "${PROJECT_ROOT}"/Cargo.toml
+
+echo Update the rust version in the README.md
+sed -i "s/\(\[rust\](https.*)\) v[0-9.]\++,/\1 v$VERSION+,/" "${PROJECT_ROOT}/README.md"
+check "${PROJECT_ROOT}/README.md"
+
+echo Update the rust version in rust-toolchain.toml
+sed -i "s/^channel = \".*\"/channel = \"${VERSION}\"/" "${PROJECT_ROOT}/rust-toolchain.toml"
+check "${PROJECT_ROOT}/rust-toolchain.toml"

--- a/scripts/update_rust_version.sh
+++ b/scripts/update_rust_version.sh
@@ -22,7 +22,7 @@ function check {
 }
 
 echo Update the rust version in the Cargo.toml file
-sed -i "s/^rust-version = \".*\"/rust-version = \"${VERSION}\"/" "${PROJECT_ROOT}"/*/*/Cargo.toml
+sed -i "s/^rust-version = \".*\"/rust-version = \"${VERSION}\"/" "${PROJECT_ROOT}"/Cargo.toml
 check "${PROJECT_ROOT}"/Cargo.toml
 
 echo Update the rust version in the README.md


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

## What was done?

1. Updated Rust to most recent stable version (1.80).
2. Crates inherit package-level rust version.
3. Added `scripts/update_rust_version.sh` script to quickly update rust version.
4. Dockerfile and github pipelines detect rust version automatically, based on rust-toolchain.toml file

## How Has This Been Tested?

Github Actions workflow must pass.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
