### PR TITLE
fix(dashmate): docker-compose version is obsolete

### DIFF
--- a/packages/dashmate/docker-compose.build.base.yml
+++ b/packages/dashmate/docker-compose.build.base.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+---
 
 services:
   _base:

--- a/packages/dashmate/docker-compose.build.dapi_api.yml
+++ b/packages/dashmate/docker-compose.build.dapi_api.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+---
 
 services:
   dapi_api:

--- a/packages/dashmate/docker-compose.build.dapi_core_streams.yml
+++ b/packages/dashmate/docker-compose.build.dapi_core_streams.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+---
 
 services:
   dapi_core_streams:

--- a/packages/dashmate/docker-compose.build.dashmate_helper.yml
+++ b/packages/dashmate/docker-compose.build.dashmate_helper.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+---
 
 services:
   dashmate_helper:

--- a/packages/dashmate/docker-compose.build.drive_abci.yml
+++ b/packages/dashmate/docker-compose.build.drive_abci.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+---
 
 services:
   drive_abci:

--- a/packages/dashmate/docker-compose.insight_api.yml
+++ b/packages/dashmate/docker-compose.insight_api.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+---
 
 services:
   core_insight:

--- a/packages/dashmate/docker-compose.insight_ui.yml
+++ b/packages/dashmate/docker-compose.insight_ui.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+---
 
 services:
   core_insight:

--- a/packages/dashmate/docker-compose.rate_limiter.metrics.yml
+++ b/packages/dashmate/docker-compose.rate_limiter.metrics.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+---
 
 services:
   gateway_rate_limiter_metrics:

--- a/packages/dashmate/docker-compose.rate_limiter.yml
+++ b/packages/dashmate/docker-compose.rate_limiter.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+---
 
 services:
   gateway:

--- a/packages/dashmate/docker-compose.yml
+++ b/packages/dashmate/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+---
 
 services:
   dashmate_helper:

--- a/packages/dashmate/templates/dynamic-compose.yml.dot
+++ b/packages/dashmate/templates/dynamic-compose.yml.dot
@@ -1,4 +1,4 @@
-version: '3.7'
+---
 
 services:
   core:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

When running the Platform, we can see warning `docker-compose version is obsolete`

## What was done?

Replaced `version` in docker-compose files with `---` which is a start sequence for yaml files.

## How Has This Been Tested?

GHA

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
