### PR TITLE
build(dashmate): update tenderdash image to fix-wrong-proposer-at-round

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -311,7 +311,7 @@ export default function getBaseConfigFactory() {
           tenderdash: {
             mode: 'full',
             docker: {
-              image: 'dashpay/tenderdash:1',
+              image: 'dashpay/tenderdash:fix-wrong-proposer-at-round',
             },
             p2p: {
               host: '0.0.0.0',

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -886,6 +886,13 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
           });
         return configFile;
       },
+      '1.3.0-dev.6': (configFile) => {
+        Object.entries(configFile.configs)
+          .forEach(([name, options]) => {
+            options.platform.drive.tenderdash.docker.image = 'dashpay/tenderdash:fix-wrong-proposer-at-round';
+          });
+        return configFile;
+      },
     };
   }
 

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -888,7 +888,7 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
       },
       '1.3.0-dev.6': (configFile) => {
         Object.entries(configFile.configs)
-          .forEach(([name, options]) => {
+          .forEach(([, options]) => {
             options.platform.drive.tenderdash.docker.image = 'dashpay/tenderdash:fix-wrong-proposer-at-round';
           });
         return configFile;


### PR DESCRIPTION
## Issue being fixed or feature implemented

We need to text next release candidate image of Tenderdash, tagged `dashpay/tenderdash:fix-wrong-proposer-at-round`, on testnet

## What was done?

Updated  dashmate configs

## How Has This Been Tested?

Not tested

## Breaking Changes

New image introduces new proposer selection algorithm, to be activated by Drive.
Before activation, it will behave as previously.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
