### PR TITLE
chore(dapi)!: connect to mainnet by default

### DIFF
--- a/packages/js-dapi-client/lib/DAPIClient.js
+++ b/packages/js-dapi-client/lib/DAPIClient.js
@@ -28,7 +28,7 @@ class DAPIClient extends EventEmitter {
     super();
 
     this.options = {
-      network: 'testnet',
+      network: 'mainnet',
       timeout: 10000,
       retries: 5,
       blockHeadersProviderOptions: BlockHeadersProvider.defaultOptions,
@@ -108,7 +108,7 @@ DAPIClient.EVENTS = EVENTS;
  * @property {Array<RawDAPIAddress|DAPIAddress|string>} [dapiAddresses]
  * @property {Array<RawDAPIAddress|DAPIAddress|string>} [seeds]
  * @property {Array<RawDAPIAddress|DAPIAddress|string>} [dapiAddressesWhiteList]
- * @property {string|Network} [network=testnet]
+ * @property {string|Network} [network=mainnet]
  * @property {number} [timeout=2000]
  * @property {number} [retries=3]
  * @property {number} [baseBanTime=60000]

--- a/packages/js-dapi-client/lib/networkConfigs.js
+++ b/packages/js-dapi-client/lib/networkConfigs.js
@@ -51,4 +51,13 @@ module.exports = {
     dapiAddresses: ['127.0.0.1'],
     network: 'regtest',
   },
+  mainnet: {
+    seeds: [
+      'seed-1.mainnet.networks.dash.org:1443',
+      'seed-2.mainnet.networks.dash.org:1443',
+      'seed-3.mainnet.networks.dash.org:1443',
+      'seed-4.mainnet.networks.dash.org:1443',
+    ],
+    network: 'mainnet',
+  },
 };

--- a/packages/js-dapi-client/test/unit/DAPIClient.spec.js
+++ b/packages/js-dapi-client/test/unit/DAPIClient.spec.js
@@ -19,7 +19,7 @@ describe('DAPIClient', () => {
       dapiClient = new DAPIClient(options);
 
       expect(dapiClient.options).to.deep.equal({
-        network: 'testnet',
+        network: 'mainnet',
         retries: 0,
         newOption: true,
         timeout: 10000,
@@ -48,7 +48,7 @@ describe('DAPIClient', () => {
       expect(dapiClient.options).to.deep.equal({
         retries: 5,
         timeout: 10000,
-        network: 'testnet',
+        network: 'mainnet',
         blockHeadersProviderOptions: BlockHeadersProvider.defaultOptions,
         loggerOptions: {
           identifier: '',
@@ -79,7 +79,7 @@ describe('DAPIClient', () => {
       expect(dapiClient.options).to.deep.equal({
         retries: 0,
         dapiAddresses: ['localhost'],
-        network: 'testnet',
+        network: 'mainnet',
         timeout: 10000,
         blockHeadersProviderOptions: BlockHeadersProvider.defaultOptions,
         loggerOptions: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JS DAPI Client connects to testnet by default

## What was done?
<!--- Describe your changes in detail -->
- Connect to mainnet by default.
- Configure seeds for mainnet

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
DAPI client connected to testnet by default previously. Now it connects to mainnet.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
