### PR TITLE
fix(dashmate): doctor fails collecting to big logs

### DIFF
--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -487,13 +487,23 @@ export default class DockerCompose {
    * Logs
    *
    * @param {Config} config
+   * @param {string[]} services
+   * @param {Object} options
+   * @param {number} options.tail
    * @return {Promise<void>}
    */
-  async logs(config, services = []) {
+  async logs(config, services = [], options = {}) {
     await this.throwErrorIfNotInstalled();
 
+    const args = [...services];
+    if (options.tail) {
+      args.unshift('--tail', options.tail.toString());
+    }
+
+    const commandOptions = this.#createOptions(config);
+
     try {
-      return dockerCompose.logs(services, this.#createOptions(config));
+      await dockerCompose.logs(args, commandOptions);
     } catch (e) {
       throw new DockerComposeError(e);
     }

--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -490,7 +490,7 @@ export default class DockerCompose {
    * @param {string[]} services
    * @param {Object} options
    * @param {number} options.tail
-   * @return {Promise<void>}
+   * @return {Promise<{exitCode: number | null, out: string, err: string}>}
    */
   async logs(config, services = [], options = {}) {
     await this.throwErrorIfNotInstalled();
@@ -503,7 +503,7 @@ export default class DockerCompose {
     const commandOptions = this.#createOptions(config);
 
     try {
-      await dockerCompose.logs(args, commandOptions);
+      return await dockerCompose.logs(args, commandOptions);
     } catch (e) {
       throw new DockerComposeError(e);
     }

--- a/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/doctor/collectSamplesTaskFactory.js
@@ -323,7 +323,7 @@ export default function collectSamplesTaskFactory(
               services.map(async (service) => {
                 const [inspect, logs] = (await Promise.allSettled([
                   dockerCompose.inspectService(config, service.name),
-                  dockerCompose.logs(config, [service.name]),
+                  dockerCompose.logs(config, [service.name], { tail: 300000 }),
                 ])).map((e) => e.value || e.reason);
 
                 if (logs?.out) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The dashmate doctor command fails to collect big logs (> 900 MB). I am not sure if it's a good idea to send more than 100 MB logs per service. In this case, a sample archive file will be too big and inconvenient to send.

## What was done?
<!--- Describe your changes in detail -->
- Limitted collected service log to 300,000 lines (approximately 100 MB of text).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running doctor locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
