### PR TITLE
ci: fix releasing dashmate package for macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
           - package_type: deb
             os: ubuntu-22.04
           - package_type: macos
-            os: macos-12
+            os: macos-14
     steps:
       - name: Check out repo
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
We are attempting to build on MacOS 14 as 12 is outdated and occasionally hangs when doing a release


## What was done?
Changed GitHub actions to use MacOS 14 instead of 12


## How Has This Been Tested?
Has not, will be tested during a dev release


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
