### PR TITLE
feat(platform)!: do not switch to oldest quorums in validator set update

### DIFF
--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/mod.rs
@@ -1,4 +1,5 @@
 mod v0;
+mod v1;
 
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
@@ -52,9 +53,14 @@ where
                 platform_state,
                 block_execution_context,
             ),
+            1 => self.validator_set_update_v1(
+                proposer_pro_tx_hash,
+                platform_state,
+                block_execution_context,
+            ),
             version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
                 method: "validator_set_update".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             })),
         }

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v0/mod.rs
@@ -92,7 +92,7 @@ where
             // we also need to perform a rotation if the validator set is being removed
             tracing::debug!(
                 method = "validator_set_update_v0",
-                "rotation: new quorums not containing current quorum current {:?}, {}. quorum rotation expected˚",
+                "rotation: new quorums not containing current quorum current {:?}, {}. quorum rotation expected",
                 block_execution_context
                     .block_platform_state()
                     .validator_sets()

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v1/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v1/mod.rs
@@ -47,7 +47,7 @@ where
                 // this means we are at the last member of the quorum
                 if last_member_pro_tx_hash.as_byte_array() == &proposer_pro_tx_hash {
                     tracing::debug!(
-                    method = "validator_set_update_v0",
+                    method = "validator_set_update_v1",
                     "rotation: quorum finished as we hit last member {} of quorum {}. All known quorums are: [{}]. quorum rotation expected",
                     hex::encode(proposer_pro_tx_hash),
                         hex::encode(platform_state.current_validator_set_quorum_hash().as_byte_array()),
@@ -62,7 +62,7 @@ where
             } else {
                 // the validator set has no members, very weird, but let's just perform a rotation
                 tracing::debug!(
-                    method = "validator_set_update_v0",
+                    method = "validator_set_update_v1",
                     "rotation: validator set has no members",
                 );
                 perform_rotation = true;
@@ -83,7 +83,7 @@ where
                 // 2 - The new proposer is before the old proposer
                 // 3 - There are more than one quorum in the system
                 tracing::debug!(
-                    method = "validator_set_update_v0",
+                    method = "validator_set_update_v1",
                 "rotation: quorum finished as we hit last an earlier member {} than last block proposer {} for quorum {}. All known quorums are: [{}]. quorum rotation expected",
                 hex::encode(proposer_pro_tx_hash),
                     hex::encode(block_execution_context.block_platform_state().last_committed_block_proposer_pro_tx_hash()),
@@ -99,8 +99,8 @@ where
         } else {
             // we also need to perform a rotation if the validator set is being removed
             tracing::debug!(
-                method = "validator_set_update_v0",
-                "rotation: new quorums not containing current quorum current {:?}, {}. quorum rotation expected˚",
+                method = "validator_set_update_v1",
+                "rotation: new quorums not containing current quorum current {:?}, {}. quorum rotation expected",
                 block_execution_context
                     .block_platform_state()
                     .validator_sets()
@@ -154,7 +154,7 @@ where
                             .get(quorum_hash)
                         {
                             tracing::debug!(
-                                method = "validator_set_update_v0",
+                                method = "validator_set_update_v1",
                                 "rotation: to new quorum: {} with {} members",
                                 &quorum_hash,
                                 new_validator_set.members().len()
@@ -177,7 +177,7 @@ where
                         .first()
                     {
                         tracing::debug!(
-                            method = "validator_set_update_v0",
+                            method = "validator_set_update_v1",
                             "rotation: all quorums changed, rotation to new quorum: {}",
                             &quorum_hash
                         );
@@ -200,13 +200,13 @@ where
                 // Something changed, for example the IP of a validator changed, or someone's ban status
 
                 tracing::debug!(
-                    method = "validator_set_update_v0",
+                    method = "validator_set_update_v1",
                     "validator set update without rotation"
                 );
                 Ok(Some(current_validator_set.into()))
             } else {
                 tracing::debug!(
-                    method = "validator_set_update_v0",
+                    method = "validator_set_update_v1",
                     "no validator set update",
                 );
                 Ok(None)

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v1/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v1/mod.rs
@@ -1,0 +1,213 @@
+use crate::error::execution::ExecutionError;
+use crate::error::Error;
+use crate::execution::types::block_execution_context::v0::{
+    BlockExecutionContextV0Getters, BlockExecutionContextV0MutableGetters,
+};
+use crate::execution::types::block_execution_context::BlockExecutionContext;
+use crate::platform_types::platform::Platform;
+use crate::platform_types::platform_state::v0::PlatformStateV0Methods;
+use crate::platform_types::platform_state::PlatformState;
+use crate::platform_types::validator_set::v0::ValidatorSetV0Getters;
+use crate::rpc::core::CoreRPCLike;
+use itertools::Itertools;
+
+use dpp::dashcore::hashes::Hash;
+use tenderdash_abci::proto::abci::ValidatorSetUpdate;
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// We need to validate against the platform state for rotation and not the block execution
+    /// context state
+    /// We introduced v1 because the end quorums could be rotating out, giving a small advantage
+    /// to proposers with a smaller pro_tx_hash
+    /// To understand this imagine we have proposers
+    /// `a b c d e f g h i j k` in quorum 24
+    /// c is the current proposer
+    /// Quorum 24 no longer is valid
+    /// We jump to quorum 0.
+    /// a b and c just got paid, but the rest did not.
+    #[inline(always)]
+    pub(super) fn validator_set_update_v1(
+        &self,
+        proposer_pro_tx_hash: [u8; 32],
+        platform_state: &PlatformState,
+        block_execution_context: &mut BlockExecutionContext,
+    ) -> Result<Option<ValidatorSetUpdate>, Error> {
+        let mut perform_rotation = false;
+
+        if let Some(validator_set) = block_execution_context
+            .block_platform_state()
+            .validator_sets()
+            .get(&platform_state.current_validator_set_quorum_hash())
+        {
+            if let Some((last_member_pro_tx_hash, _)) = validator_set.members().last_key_value() {
+                // we should also perform a rotation if the validator set went through all quorum members
+                // this means we are at the last member of the quorum
+                if last_member_pro_tx_hash.as_byte_array() == &proposer_pro_tx_hash {
+                    tracing::debug!(
+                    method = "validator_set_update_v0",
+                    "rotation: quorum finished as we hit last member {} of quorum {}. All known quorums are: [{}]. quorum rotation expected",
+                    hex::encode(proposer_pro_tx_hash),
+                        hex::encode(platform_state.current_validator_set_quorum_hash().as_byte_array()),
+                    block_execution_context
+                    .block_platform_state()
+                    .validator_sets()
+                    .keys()
+                    .map(hex::encode).collect::<Vec<_>>().join(" | "),
+                );
+                    perform_rotation = true;
+                }
+            } else {
+                // the validator set has no members, very weird, but let's just perform a rotation
+                tracing::debug!(
+                    method = "validator_set_update_v0",
+                    "rotation: validator set has no members",
+                );
+                perform_rotation = true;
+            }
+
+            // We should also perform a rotation if there are more than one quorum in the system
+            // and that the new proposer is on the same quorum and the last proposer but is before
+            // them in the list of proposers.
+            // This only works if Tenderdash goes through proposers properly
+            if &platform_state.last_committed_quorum_hash()
+                == platform_state
+                    .current_validator_set_quorum_hash()
+                    .as_byte_array()
+                && platform_state.last_committed_block_proposer_pro_tx_hash() > proposer_pro_tx_hash
+                && platform_state.validator_sets().len() > 1
+            {
+                // 1 - We haven't changed quorums
+                // 2 - The new proposer is before the old proposer
+                // 3 - There are more than one quorum in the system
+                tracing::debug!(
+                    method = "validator_set_update_v0",
+                "rotation: quorum finished as we hit last an earlier member {} than last block proposer {} for quorum {}. All known quorums are: [{}]. quorum rotation expected",
+                hex::encode(proposer_pro_tx_hash),
+                    hex::encode(block_execution_context.block_platform_state().last_committed_block_proposer_pro_tx_hash()),
+                    hex::encode(platform_state.current_validator_set_quorum_hash().as_byte_array()),
+                block_execution_context
+                .block_platform_state()
+                .validator_sets()
+                .keys()
+                .map(hex::encode).collect::<Vec<_>>().join(" | "),
+                );
+                perform_rotation = true;
+            }
+        } else {
+            // we also need to perform a rotation if the validator set is being removed
+            tracing::debug!(
+                method = "validator_set_update_v0",
+                "rotation: new quorums not containing current quorum current {:?}, {}. quorum rotation expected˚",
+                block_execution_context
+                    .block_platform_state()
+                    .validator_sets()
+                    .keys()
+                    .map(|quorum_hash| format!("{}", quorum_hash)),
+                &platform_state.current_validator_set_quorum_hash()
+            );
+            perform_rotation = true;
+        }
+
+        //todo: (maybe) perform a rotation if quorum health is low
+
+        if perform_rotation {
+            // get the index of the previous quorum
+            let mut index = platform_state
+                .validator_sets()
+                .get_index_of(&platform_state.current_validator_set_quorum_hash())
+                .ok_or(Error::Execution(ExecutionError::CorruptedCachedState(
+                    format!("perform_rotation: current validator set quorum hash {} not in current known validator sets [{}] processing block {}", platform_state.current_validator_set_quorum_hash(), platform_state
+                        .validator_sets().keys().map(|quorum_hash| quorum_hash.to_string()).join(" | "),
+                            platform_state.last_committed_block_height() + 1,
+                ))))?;
+            // we should rotate the quorum
+            let quorum_count = platform_state.validator_sets().len();
+            match quorum_count {
+                0 => Err(Error::Execution(ExecutionError::CorruptedCachedState(
+                    "no current quorums".to_string(),
+                ))),
+                1 => Ok(None), // no rotation as we are the only quorum
+                count => {
+                    let start_index = index;
+                    let oldest_quorum_index_we_can_go_to = if count > 10 {
+                        // if we have a lot of quorums (like on testnet and mainnet)
+                        // we shouldn't start using the last ones as they could cycle out
+                        count - 2
+                    } else {
+                        count
+                    };
+                    index = (index + 1) % oldest_quorum_index_we_can_go_to;
+                    // We can't just take the next item because it might no longer be in the state
+                    while index != start_index {
+                        let (quorum_hash, _) = platform_state
+                            .validator_sets()
+                            .get_index(index)
+                            .expect("expected next validator set");
+
+                        // We still have it in the state
+                        if let Some(new_validator_set) = block_execution_context
+                            .block_platform_state()
+                            .validator_sets()
+                            .get(quorum_hash)
+                        {
+                            tracing::debug!(
+                                method = "validator_set_update_v0",
+                                "rotation: to new quorum: {} with {} members",
+                                &quorum_hash,
+                                new_validator_set.members().len()
+                            );
+                            let validator_set_update = new_validator_set.into();
+                            block_execution_context
+                                .block_platform_state_mut()
+                                .set_next_validator_set_quorum_hash(Some(*quorum_hash));
+                            return Ok(Some(validator_set_update));
+                        }
+                        index = (index + 1) % oldest_quorum_index_we_can_go_to;
+                    }
+                    // All quorums changed
+                    if let Some((quorum_hash, new_validator_set)) = block_execution_context
+                        .block_platform_state()
+                        .validator_sets()
+                        .first()
+                    {
+                        tracing::debug!(
+                            method = "validator_set_update_v0",
+                            "rotation: all quorums changed, rotation to new quorum: {}",
+                            &quorum_hash
+                        );
+                        let validator_set_update = new_validator_set.into();
+                        let new_quorum_hash = *quorum_hash;
+                        block_execution_context
+                            .block_platform_state_mut()
+                            .set_next_validator_set_quorum_hash(Some(new_quorum_hash));
+                        return Ok(Some(validator_set_update));
+                    }
+                    tracing::debug!("no new quorums to choose from");
+                    Ok(None)
+                }
+            }
+        } else {
+            let current_validator_set = block_execution_context
+                .block_platform_state()
+                .current_validator_set()?;
+            if current_validator_set != platform_state.current_validator_set()? {
+                // Something changed, for example the IP of a validator changed, or someone's ban status
+
+                tracing::debug!(
+                    method = "validator_set_update_v0",
+                    "validator set update without rotation"
+                );
+                Ok(Some(current_validator_set.into()))
+            } else {
+                tracing::debug!(
+                    method = "validator_set_update_v0",
+                    "no validator set update",
+                );
+                Ok(None)
+            }
+        }
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v1/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/v1/mod.rs
@@ -141,7 +141,7 @@ where
                     };
                     index = (index + 1) % oldest_quorum_index_we_can_go_to;
                     // We can't just take the next item because it might no longer be in the state
-                    while index != start_index {
+                    for _i in 0..oldest_quorum_index_we_can_go_to {
                         let (quorum_hash, _) = platform_state
                             .validator_sets()
                             .get_index(index)
@@ -166,6 +166,9 @@ where
                             return Ok(Some(validator_set_update));
                         }
                         index = (index + 1) % oldest_quorum_index_we_can_go_to;
+                        if index == start_index {
+                            break;
+                        }
                     }
                     // All quorums changed
                     if let Some((quorum_hash, new_validator_set)) = block_execution_context

--- a/packages/rs-platform-version/src/version/v4.rs
+++ b/packages/rs-platform-version/src/version/v4.rs
@@ -699,7 +699,7 @@ pub const PLATFORM_V4: PlatformVersion = PlatformVersion {
             block_end: DriveAbciBlockEndMethodVersions {
                 update_state_cache: 0,
                 update_drive_cache: 0,
-                validator_set_update: 0,
+                validator_set_update: 1,
             },
             platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
                 fetch_platform_state: 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
This change fixes a small unfair advantage in the validator set rotation logic where validators with lower pro_tx_hash values could receive an increased chance of being selected as proposers when quorums rotate out. This occurred because quorums that were about to become invalid mid-cycle could cause the system to skip to the next quorum, favoring validators with lower pro_tx_hash. By adjusting the rotation logic to avoid using the last two quorums that are at risk of becoming invalid, we ensure fair proposer selection among all validators.


## What was done?
Modified the validator_set_update_v1 function to exclude the last two quorums when selecting the next quorum for proposer rotation if the total number of quorums is greater than 10.

## How Has This Been Tested?
Ran all tests.

## Breaking Changes
This is included as a change in protocol version 4.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [X] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new version (`v1`) for the validator set update process, enhancing the system's capability to manage multiple versions.
	- Added logic to determine when to rotate the validator set based on current platform conditions.

- **Bug Fixes**
	- Updated error handling to include the new version in the list of known versions.
	- Refined logging for improved clarity in the validator set update process.

- **Documentation**
	- Updated versioning for the validator set update method to reflect the new implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->