### PR TITLE
chore(release): replace colima with native docker in macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,9 +242,11 @@ jobs:
       - name: Install macOS build deps
         if: runner.os == 'macOS'
         run: |
-          brew install llvm docker colima coreutils
-          colima start
-          echo "/usr/local/opt/llvm/bin" >> $GITHUB_PATH
+          brew install llvm coreutils
+
+      - name: Set up Docker for macOS
+        if: runner.os == 'macOS'
+        uses: docker-practice/actions-setup-docker@master
 
       - name: Install the Apple certificate
         if: runner.os == 'macOS'
@@ -278,7 +280,7 @@ jobs:
 
       - name: Create package
         env:
-          OSX_KEYCHAIN: $RUNNER_TEMP/app-signing.keychain-db
+          OSX_KEYCHAIN: ${{ runner.temp }}/app-signing.keychain-db
         run: "${GITHUB_WORKSPACE}/scripts/pack_dashmate.sh ${{ matrix.package_type }}"
 
       - name: Upload artifacts to action summary


### PR DESCRIPTION
## Issue being fixed or feature implemented
Colima was causing startup failures in GitHub Actions for macOS builds, preventing successful execution of the workflow. This change aims to resolve these issues and ensure a more stable build process.

## What was done?
- Removed Colima setup from the macOS build steps in the GitHub Actions workflow
- Configured the workflow to use the native Docker installation provided by GitHub Actions runners for macOS
- Updated relevant build scripts and configuration files to work with the native Docker setup

## How Has This Been Tested?
-not yet tested



## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Removed outdated workflows for publishing documentation, managing runs, and linting pull requests.
	- Improved the workflow for releasing packages and images, enhancing efficiency for macOS builds.
	- Streamlined installation of Docker-related dependencies and focused macOS build dependencies.
	- Retained the notarization process for macOS releases to ensure compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->