### PR TITLE
fix(dpp): panic when generating more than 12 identity keys

### DIFF
--- a/packages/rs-dpp/src/identity/identity_public_key/random.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/random.rs
@@ -615,15 +615,15 @@ impl IdentityPublicKey {
         used_key_matrix[4] = true; //also a master key
         used_key_matrix[8] = true; //also a master key
         used_key_matrix[12] = true; //also a master key
-        main_keys.extend((3..key_count).map(|i| {
-            Self::random_authentication_key_with_private_key_with_rng(
+        for i in 3..key_count {
+            let privkey = Self::random_authentication_key_with_private_key_with_rng(
                 i,
                 rng,
                 Some((i, &mut used_key_matrix)),
                 platform_version,
-            )
-            .unwrap()
-        }));
+            )?;
+            main_keys.push(privkey);
+        }
         Ok(main_keys)
     }
 

--- a/packages/rs-dpp/src/identity/identity_public_key/v0/random.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/v0/random.rs
@@ -69,15 +69,16 @@ impl IdentityPublicKeyV0 {
         used_key_matrix: Option<(KeyCount, &mut UsedKeyMatrix)>,
         platform_version: &PlatformVersion,
     ) -> Result<(Self, Vec<u8>), ProtocolError> {
+        const MAX_KEYS: u8 = 16;
         // we have 16 different permutations possible
-        let mut binding = [false; 16].to_vec();
+        let mut binding = [false; MAX_KEYS as usize].to_vec();
         let (key_count, key_matrix) = used_key_matrix.unwrap_or((0, &mut binding));
-        if key_count > 16 {
+        if key_count > MAX_KEYS as u32 {
             return Err(ProtocolError::PublicKeyGenerationError(
                 "too many keys already created".to_string(),
             ));
         }
-        let key_number = rng.gen_range(0..(12 - key_count as u8));
+        let key_number = rng.gen_range(0..(MAX_KEYS - key_count as u8));
         // now we need to find the first bool that isn't set to true
         let mut needed_pos = None;
         let mut counter = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

 pub fn random_authentication_key_with_private_key_with_rng panics

## What was done?

* fixed slice size
* fixed invalid error handling with `.unwrap()`

## How Has This Been Tested?

Using TUI, observed that the panic does not happen anymore.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
