### PR TITLE
feat(dpp): add a convenience method to get the public key data for a private key depending on the key type

### DIFF
--- a/packages/rs-dpp/src/identity/identity_public_key/key_type.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/key_type.rs
@@ -204,14 +204,14 @@ impl KeyType {
     /// Gets the public key data for a private key depending on the key type
     pub fn public_key_data_from_private_key_data(
         &self,
-        private_key_bytes: Vec<u8>,
+        private_key_bytes: &[u8],
         network: Network,
     ) -> Result<Vec<u8>, ProtocolError> {
         match self {
             KeyType::ECDSA_SECP256K1 => {
                 let secp = Secp256k1::new();
                 let secret_key =
-                    dashcore::secp256k1::SecretKey::from_slice(private_key_bytes.as_slice())
+                    dashcore::secp256k1::SecretKey::from_slice(private_key_bytes)
                         .map_err(|e| ProtocolError::Generic(e.to_string()))?;
                 let private_key = dashcore::PrivateKey::new(secret_key, network);
 
@@ -219,7 +219,7 @@ impl KeyType {
             }
             KeyType::BLS12_381 => {
                 let private_key =
-                    bls_signatures::PrivateKey::from_bytes(private_key_bytes.as_slice(), false)
+                    bls_signatures::PrivateKey::from_bytes(private_key_bytes, false)
                         .map_err(|e| ProtocolError::Generic(e.to_string()))?;
                 let public_key_bytes = private_key
                     .g1_element()
@@ -231,7 +231,7 @@ impl KeyType {
             KeyType::ECDSA_HASH160 => {
                 let secp = Secp256k1::new();
                 let secret_key =
-                    dashcore::secp256k1::SecretKey::from_slice(private_key_bytes.as_slice())
+                    dashcore::secp256k1::SecretKey::from_slice(private_key_bytes)
                         .map_err(|e| ProtocolError::Generic(e.to_string()))?;
                 let private_key = dashcore::PrivateKey::new(secret_key, network);
 
@@ -241,7 +241,7 @@ impl KeyType {
                 #[cfg(feature = "ed25519-dalek")]
                 {
                     let key_pair = ed25519_dalek::SigningKey::from_bytes(
-                        &private_key_bytes.as_slice().try_into().map_err(|_| {
+                        &private_key_bytes.try_into().map_err(|_| {
                             ProtocolError::InvalidVectorSizeError(InvalidVectorSizeError::new(
                                 32,
                                 private_key_bytes.len(),

--- a/packages/rs-dpp/src/identity/identity_public_key/key_type.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/key_type.rs
@@ -17,7 +17,7 @@ use lazy_static::lazy_static;
 
 use crate::fee::Credits;
 use crate::version::PlatformVersion;
-use crate::ProtocolError;
+use crate::{InvalidVectorSizeError, ProtocolError};
 #[cfg(feature = "random-public-keys")]
 use rand::rngs::StdRng;
 #[cfg(feature = "random-public-keys")]
@@ -201,6 +201,61 @@ impl KeyType {
                 known_versions: vec![0],
                 received: version,
             }),
+        }
+    }
+
+    /// Gets the public key data for a private key depending on the key type
+    pub fn public_key_data_from_private_key_data(
+        &self,
+        private_key_bytes: Vec<u8>,
+        network: Network,
+    ) -> Result<Vec<u8>, ProtocolError> {
+        match self {
+            KeyType::ECDSA_SECP256K1 => {
+                let secp = Secp256k1::new();
+                let secret_key =
+                    dashcore::secp256k1::SecretKey::from_slice(private_key_bytes.as_slice())
+                        .map_err(|e| ProtocolError::Generic(e.to_string()))?;
+                let private_key = dashcore::PrivateKey::new(secret_key, network);
+
+                Ok(private_key.public_key(&secp).to_bytes())
+            }
+            KeyType::BLS12_381 => {
+                let private_key =
+                    bls_signatures::PrivateKey::from_bytes(private_key_bytes.as_slice(), false)
+                        .map_err(|e| ProtocolError::Generic(e.to_string()))?;
+                let public_key_bytes = private_key
+                    .g1_element()
+                    .expect("expected to get a public key from a bls private key")
+                    .to_bytes()
+                    .to_vec();
+                Ok(public_key_bytes)
+            }
+            KeyType::ECDSA_HASH160 => {
+                let secp = Secp256k1::new();
+                let secret_key =
+                    dashcore::secp256k1::SecretKey::from_slice(private_key_bytes.as_slice())
+                        .map_err(|e| ProtocolError::Generic(e.to_string()))?;
+                let private_key = dashcore::PrivateKey::new(secret_key, network);
+
+                Ok(ripemd160_sha256(private_key.public_key(&secp).to_bytes().as_slice()).to_vec())
+            }
+            KeyType::EDDSA_25519_HASH160 => {
+                let key_pair = ed25519_dalek::SigningKey::from_bytes(
+                    &private_key_bytes.as_slice().try_into().map_err(|_| {
+                        ProtocolError::InvalidVectorSizeError(InvalidVectorSizeError::new(
+                            32,
+                            private_key_bytes.len(),
+                        ))
+                    })?,
+                );
+                Ok(ripemd160_sha256(key_pair.verifying_key().to_bytes().as_slice()).to_vec())
+            }
+            KeyType::BIP13_SCRIPT_HASH => {
+                return Err(ProtocolError::NotSupported(
+                    "Converting a private key to a script hash is not supported".to_string(),
+                ));
+            }
         }
     }
 

--- a/packages/rs-dpp/src/identity/identity_public_key/key_type.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/key_type.rs
@@ -210,9 +210,8 @@ impl KeyType {
         match self {
             KeyType::ECDSA_SECP256K1 => {
                 let secp = Secp256k1::new();
-                let secret_key =
-                    dashcore::secp256k1::SecretKey::from_slice(private_key_bytes)
-                        .map_err(|e| ProtocolError::Generic(e.to_string()))?;
+                let secret_key = dashcore::secp256k1::SecretKey::from_slice(private_key_bytes)
+                    .map_err(|e| ProtocolError::Generic(e.to_string()))?;
                 let private_key = dashcore::PrivateKey::new(secret_key, network);
 
                 Ok(private_key.public_key(&secp).to_bytes())
@@ -237,9 +236,8 @@ impl KeyType {
             }
             KeyType::ECDSA_HASH160 => {
                 let secp = Secp256k1::new();
-                let secret_key =
-                    dashcore::secp256k1::SecretKey::from_slice(private_key_bytes)
-                        .map_err(|e| ProtocolError::Generic(e.to_string()))?;
+                let secret_key = dashcore::secp256k1::SecretKey::from_slice(private_key_bytes)
+                    .map_err(|e| ProtocolError::Generic(e.to_string()))?;
                 let private_key = dashcore::PrivateKey::new(secret_key, network);
 
                 Ok(ripemd160_sha256(private_key.public_key(&secp).to_bytes().as_slice()).to_vec())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
It wasn't convenient to get public key data when we knew the private key data and the key type.


## What was done?
Added a convenience method to get the public key data for a private key depending on the key type


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
Not breaking


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to convert private key data into public key data, enhancing key management capabilities.
- **Bug Fixes**
	- Improved error handling for invalid input sizes related to key conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->