### PR TITLE
chore(sdk): expose drive module in public API for rs-sdk

### DIFF
--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -75,6 +75,7 @@ pub use sdk::{RequestSettings, Sdk, SdkBuilder};
 
 pub use dashcore_rpc;
 pub use dpp;
+pub use drive;
 pub use rs_dapi_client as dapi_client;
 
 /// Version of the SDK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Exposed the `drive` module to make it accessible from the public API.


## What was done?
Updated the module visibility to `pub` for the `drive` module.


## How Has This Been Tested?
Tested by building the project and verifying that the module is accessible when imported in other parts of the codebase.

## Breaking Changes
None.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `drive` module is now publicly accessible, enhancing the SDK's functionality for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->