### PR TITLE
feat(dpp): added identity public key private key validation methods

### DIFF
--- a/packages/rs-dpp/src/identity/identity_public_key/key_type.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/key_type.rs
@@ -305,7 +305,7 @@ impl KeyType {
             KeyType::EDDSA_25519_HASH160 => {
                 let key_pair = ed25519_dalek::SigningKey::generate(rng);
                 (
-                    key_pair.verifying_key().to_bytes().to_vec(),
+                    ripemd160_sha256(key_pair.verifying_key().to_bytes().as_slice()).to_vec(),
                     key_pair.to_bytes().to_vec(),
                 )
             }

--- a/packages/rs-dpp/src/identity/identity_public_key/methods/hash/mod.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/methods/hash/mod.rs
@@ -2,12 +2,23 @@ mod v0;
 
 use crate::identity::IdentityPublicKey;
 use crate::ProtocolError;
+use dashcore::Network;
 pub use v0::*;
 
 impl IdentityPublicKeyHashMethodsV0 for IdentityPublicKey {
     fn public_key_hash(&self) -> Result<[u8; 20], ProtocolError> {
         match self {
             IdentityPublicKey::V0(v0) => v0.public_key_hash(),
+        }
+    }
+
+    fn validate_private_key_bytes(
+        &self,
+        private_key_bytes: &[u8],
+        network: Network,
+    ) -> Result<bool, ProtocolError> {
+        match self {
+            IdentityPublicKey::V0(v0) => v0.validate_private_key_bytes(private_key_bytes, network),
         }
     }
 }

--- a/packages/rs-dpp/src/identity/identity_public_key/methods/hash/v0/mod.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/methods/hash/v0/mod.rs
@@ -1,6 +1,14 @@
 use crate::ProtocolError;
+use dashcore::Network;
 
 pub trait IdentityPublicKeyHashMethodsV0 {
     /// Get the original public key hash
     fn public_key_hash(&self) -> Result<[u8; 20], ProtocolError>;
+
+    /// Verifies that the private key bytes match this identity public key
+    fn validate_private_key_bytes(
+        &self,
+        private_key_bytes: &[u8],
+        network: Network,
+    ) -> Result<bool, ProtocolError>;
 }

--- a/packages/rs-dpp/src/identity/identity_public_key/v0/methods/mod.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/v0/methods/mod.rs
@@ -72,12 +72,12 @@ impl IdentityPublicKeyHashMethodsV0 for IdentityPublicKeyV0 {
                             Ok(secret_key) => secret_key,
                             Err(_) => return Ok(false),
                         };
-                    let public_key_bytes = private_key
-                        .g1_element()
-                        .expect("expected to get a public key from a bls private key")
-                        .to_bytes()
-                        .to_vec();
-                    Ok(public_key_bytes == self.data.as_slice())
+                    let g1_element = match private_key.g1_element() {
+                        Ok(g1_element) => g1_element,
+                        Err(_) => return Ok(false),
+                    };
+
+                    Ok(g1_element.to_bytes().as_slice() == self.data.as_slice())
                 }
                 #[cfg(not(feature = "bls-signatures"))]
                 return Err(ProtocolError::NotSupported(

--- a/packages/rs-dpp/src/identity/identity_public_key/v0/methods/mod.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/v0/methods/mod.rs
@@ -124,3 +124,136 @@ impl IdentityPublicKeyHashMethodsV0 for IdentityPublicKeyV0 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::{Purpose, SecurityLevel};
+    use dashcore::Network;
+    use dpp::version::PlatformVersion;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    #[cfg(feature = "random-public-keys")]
+    #[test]
+    fn test_validate_private_key_bytes_with_random_keys() {
+        let platform_version = PlatformVersion::latest();
+        let mut rng = StdRng::from_entropy();
+
+        // Test for ECDSA_SECP256K1
+        let key_type = KeyType::ECDSA_SECP256K1;
+        let (public_key_data, private_key_data) = key_type
+            .random_public_and_private_key_data(&mut rng, &platform_version)
+            .expect("expected to generate random keys");
+
+        let identity_public_key = IdentityPublicKeyV0 {
+            id: 1,
+            purpose: Purpose::AUTHENTICATION,
+            security_level: SecurityLevel::HIGH,
+            contract_bounds: None,
+            key_type,
+            data: public_key_data.into(),
+            read_only: false,
+            disabled_at: None,
+        };
+
+        // Validate that the private key matches the public key
+        assert_eq!(
+            identity_public_key
+                .validate_private_key_bytes(&private_key_data, Network::Testnet)
+                .unwrap(),
+            true
+        );
+
+        // Test with an invalid private key
+        let invalid_private_key_bytes = vec![0u8; private_key_data.len()];
+        assert_eq!(
+            identity_public_key
+                .validate_private_key_bytes(&invalid_private_key_bytes, Network::Testnet)
+                .unwrap(),
+            false
+        );
+    }
+
+    #[cfg(all(feature = "random-public-keys", feature = "bls-signatures"))]
+    #[test]
+    fn test_validate_private_key_bytes_with_random_keys_bls12_381() {
+        let platform_version = PlatformVersion::latest();
+        let mut rng = StdRng::from_entropy();
+
+        // Test for BLS12_381
+        let key_type = KeyType::BLS12_381;
+        let (public_key_data, private_key_data) = key_type
+            .random_public_and_private_key_data(&mut rng, &platform_version)
+            .expect("expected to generate random keys");
+
+        let identity_public_key = IdentityPublicKeyV0 {
+            id: 2,
+            purpose: Purpose::AUTHENTICATION,
+            security_level: SecurityLevel::HIGH,
+            contract_bounds: None,
+            key_type,
+            data: public_key_data.into(),
+            read_only: false,
+            disabled_at: None,
+        };
+
+        // Validate that the private key matches the public key
+        assert_eq!(
+            identity_public_key
+                .validate_private_key_bytes(&private_key_data, Network::Testnet)
+                .unwrap(),
+            true
+        );
+
+        // Test with an invalid private key
+        let invalid_private_key_bytes = vec![0u8; private_key_data.len()];
+        assert_eq!(
+            identity_public_key
+                .validate_private_key_bytes(&invalid_private_key_bytes, Network::Testnet)
+                .unwrap(),
+            false
+        );
+    }
+
+    #[cfg(all(feature = "random-public-keys", feature = "ed25519-dalek"))]
+    #[test]
+    fn test_validate_private_key_bytes_with_random_keys_eddsa_25519_hash160() {
+        let platform_version = PlatformVersion::latest();
+        let mut rng = StdRng::from_entropy();
+
+        // Test for EDDSA_25519_HASH160
+        let key_type = KeyType::EDDSA_25519_HASH160;
+        let (public_key_data, private_key_data) = key_type
+            .random_public_and_private_key_data(&mut rng, &platform_version)
+            .expect("expected to generate random keys");
+
+        let identity_public_key = IdentityPublicKeyV0 {
+            id: 3,
+            purpose: Purpose::AUTHENTICATION,
+            security_level: SecurityLevel::HIGH,
+            contract_bounds: None,
+            key_type,
+            data: public_key_data.into(),
+            read_only: false,
+            disabled_at: None,
+        };
+
+        // Validate that the private key matches the public key
+        assert_eq!(
+            identity_public_key
+                .validate_private_key_bytes(&private_key_data, Network::Testnet)
+                .unwrap(),
+            true
+        );
+
+        // Test with an invalid private key
+        let invalid_private_key_bytes = vec![0u8; private_key_data.len()];
+        assert_eq!(
+            identity_public_key
+                .validate_private_key_bytes(&invalid_private_key_bytes, Network::Testnet)
+                .unwrap(),
+            false
+        );
+    }
+}

--- a/packages/rs-dpp/src/identity/identity_public_key/v0/methods/mod.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/v0/methods/mod.rs
@@ -5,7 +5,9 @@ use crate::util::hash::ripemd160_sha256;
 use crate::ProtocolError;
 use anyhow::anyhow;
 use dashcore::hashes::Hash;
-use dashcore::PublicKey as ECDSAPublicKey;
+use dashcore::key::Secp256k1;
+use dashcore::secp256k1::SecretKey;
+use dashcore::{Network, PublicKey as ECDSAPublicKey};
 use platform_value::Bytes20;
 
 impl IdentityPublicKeyHashMethodsV0 for IdentityPublicKeyV0 {
@@ -42,6 +44,82 @@ impl IdentityPublicKeyHashMethodsV0 for IdentityPublicKeyV0 {
             }
             KeyType::ECDSA_HASH160 | KeyType::BIP13_SCRIPT_HASH | KeyType::EDDSA_25519_HASH160 => {
                 Ok(Bytes20::from_vec(self.data.to_vec())?.into_buffer())
+            }
+        }
+    }
+
+    fn validate_private_key_bytes(
+        &self,
+        private_key_bytes: &[u8],
+        network: Network,
+    ) -> Result<bool, ProtocolError> {
+        match self.key_type {
+            KeyType::ECDSA_SECP256K1 => {
+                let secp = Secp256k1::new();
+                let secret_key = match SecretKey::from_slice(private_key_bytes) {
+                    Ok(secret_key) => secret_key,
+                    Err(_) => return Ok(false),
+                };
+                let private_key = dashcore::PrivateKey::new(secret_key, network);
+
+                Ok(private_key.public_key(&secp).to_bytes() == self.data.as_slice())
+            }
+            KeyType::BLS12_381 => {
+                #[cfg(feature = "bls-signatures")]
+                {
+                    let private_key =
+                        match bls_signatures::PrivateKey::from_bytes(private_key_bytes, false) {
+                            Ok(secret_key) => secret_key,
+                            Err(_) => return Ok(false),
+                        };
+                    let public_key_bytes = private_key
+                        .g1_element()
+                        .expect("expected to get a public key from a bls private key")
+                        .to_bytes()
+                        .to_vec();
+                    Ok(public_key_bytes == self.data.as_slice())
+                }
+                #[cfg(not(feature = "bls-signatures"))]
+                return Err(ProtocolError::NotSupported(
+                    "Converting a private key to a bls public key is not supported without the bls-signatures feature".to_string(),
+                ));
+            }
+            KeyType::ECDSA_HASH160 => {
+                let secp = Secp256k1::new();
+                let secret_key = match SecretKey::from_slice(private_key_bytes) {
+                    Ok(secret_key) => secret_key,
+                    Err(_) => return Ok(false),
+                };
+                let private_key = dashcore::PrivateKey::new(secret_key, network);
+
+                Ok(
+                    ripemd160_sha256(private_key.public_key(&secp).to_bytes().as_slice())
+                        .as_slice()
+                        == self.data.as_slice(),
+                )
+            }
+            KeyType::EDDSA_25519_HASH160 => {
+                #[cfg(feature = "ed25519-dalek")]
+                {
+                    let secret_key = match private_key_bytes.try_into() {
+                        Ok(secret_key) => secret_key,
+                        Err(_) => return Ok(false),
+                    };
+                    let key_pair = ed25519_dalek::SigningKey::from_bytes(&secret_key);
+                    Ok(
+                        ripemd160_sha256(key_pair.verifying_key().to_bytes().as_slice()).as_slice()
+                            == self.data.as_slice(),
+                    )
+                }
+                #[cfg(not(feature = "ed25519-dalek"))]
+                return Err(ProtocolError::NotSupported(
+                    "Converting a private key to a eddsa hash 160 is not supported without the ed25519-dalek feature".to_string(),
+                ));
+            }
+            KeyType::BIP13_SCRIPT_HASH => {
+                return Err(ProtocolError::NotSupported(
+                    "Converting a private key to a script hash is not supported".to_string(),
+                ));
             }
         }
     }

--- a/packages/rs-platform-value/src/types/identifier.rs
+++ b/packages/rs-platform-value/src/types/identifier.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "json")]
 use serde_json::Value as JsonValue;
 
-use crate::string_encoding::Encoding::Base58;
 use crate::string_encoding::{Encoding, ALL_ENCODINGS};
 use crate::types::encoding_string_to_encoding;
 use crate::{string_encoding, Error, Value};

--- a/packages/rs-sdk/src/platform/types/evonode.rs
+++ b/packages/rs-sdk/src/platform/types/evonode.rs
@@ -10,7 +10,7 @@ use futures::{FutureExt, TryFutureExt};
 use rs_dapi_client::transport::{
     AppliedRequestSettings, PlatformGrpcClient, TransportClient, TransportRequest,
 };
-use rs_dapi_client::{Address, ConnectionPool, DapiClientError, RequestSettings};
+use rs_dapi_client::{Address, ConnectionPool, RequestSettings};
 #[cfg(feature = "mocks")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
This PR introduces the validate_private_key_bytes method to the IdentityPublicKeyHashMethodsV0 trait and implements it for IdentityPublicKeyV0. This new method allows the validation of private key bytes against the public key stored within the identity. The validation ensures that the private key corresponds to the public key and is implemented for various key types such as ECDSA, BLS12-381, ECDSA_HASH160, and EDDSA_25519_HASH160.


## What was done?
	•	Added a new method validate_private_key_bytes to the IdentityPublicKeyHashMethodsV0 trait:
	•	The method accepts private key bytes and the network as input.
	•	It returns a Result<bool, ProtocolError>, indicating whether the private key matches the associated public key.
	•	Implemented validate_private_key_bytes in IdentityPublicKeyV0:
	•	ECDSA_SECP256K1: Verifies using the Secp256k1 curve to check if the derived public key matches the stored data.
	•	BLS12_381: Verifies the BLS key if the bls-signatures feature is enabled.
	•	ECDSA_HASH160: Validates the private key by deriving the public key and computing the RIPEMD160-SHA256 hash.
	•	EDDSA_25519_HASH160: Verifies the ED25519 key when the ed25519-dalek feature is enabled.
	•	BIP13_SCRIPT_HASH: Currently not supported; the method returns a NotSupported error for this key type.
	•	Added validation and error handling to ensure correct private key length and format for each key type.
	•	Included appropriate error messages for unsupported features and scenarios.


## How Has This Been Tested?
	•	Unit tests were added to cover each key type supported by the validate_private_key_bytes method.
	•	Test cases include:
	•	Validating matching private keys for ECDSA, BLS12-381, ECDSA_HASH160, and EDDSA_25519_HASH160 key types.
	•	Ensuring unsupported or malformed keys return appropriate errors.
	•	Tests with and without required feature flags (bls-signatures and ed25519-dalek).



## Breaking Changes
None expected as this PR adds a new method and does not modify existing behavior.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to validate private key bytes for enhanced security.
	- Added new methods for creating identifiers from various data types, including random generation.

- **Bug Fixes**
	- Improved error handling for unsupported key types.

- **Chores**
	- Simplified dependencies by removing unnecessary imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->