### PR TITLE
fix(dashmate): invalid platform version in the status command

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -16,6 +16,7 @@ npmAuditExcludePackages:
   - "@humanwhocodes/object-schema" # TODO: Update eslint
   - micromatch # TODO: remove when new micromatch will be released https://github.com/advisories/GHSA-952p-6rrq-rcjv
   - eslint # TODO: Update eslint https://github.com/dashpay/platform/issues/2212
+  - elliptic # TODO: Remove when elliptic >6.5.7 released
 
 packageExtensions:
   "@dashevo/protobufjs@*":

--- a/packages/dashmate/src/commands/group/status.js
+++ b/packages/dashmate/src/commands/group/status.js
@@ -86,7 +86,7 @@ export default class GroupStatusCommand extends GroupBaseCommand {
             plain['Platform Status'] = colors.status(scope.platform.tenderdash.serviceStatus)(scope.platform.tenderdash.serviceStatus) || 'n/a';
           } else {
             plain['Platform Status'] = colors.status(scope.platform.tenderdash.serviceStatus)(scope.platform.tenderdash.serviceStatus) || 'n/a';
-            plain['Platform Version'] = scope.platform.tenderdash.version || 'n/a';
+            plain['Platform Version'] = scope.platform.drive.version || 'n/a';
             plain['Platform Block Height'] = scope.platform.tenderdash.latestBlockHeight || 'n/a';
             plain['Platform Peers'] = scope.platform.tenderdash.peers || 'n/a';
             plain['Platform Network'] = scope.platform.tenderdash.network || 'n/a';

--- a/packages/dashmate/src/commands/status/index.js
+++ b/packages/dashmate/src/commands/status/index.js
@@ -112,7 +112,7 @@ export default class StatusCommand extends ConfigBaseCommand {
         plain['Platform Status'] = colors.status(platform.tenderdash.serviceStatus)(platform.tenderdash.serviceStatus) || 'n/a';
 
         if (platform.tenderdash.serviceStatus === ServiceStatusEnum.up) {
-          plain['Platform Version'] = platform.tenderdash.version || 'n/a';
+          plain['Platform Version'] = platform.drive.version || 'n/a';
           plain['Platform Block Height'] = platform.tenderdash.latestBlockHeight || 'n/a';
           plain['Platform Peers'] = platform.tenderdash.peers || 'n/a';
           plain['Platform Network'] = platform.tenderdash.network || 'n/a';

--- a/packages/dashmate/src/commands/status/platform.js
+++ b/packages/dashmate/src/commands/status/platform.js
@@ -32,7 +32,6 @@ export default class PlatformStatusCommand extends ConfigBaseCommand {
     flags,
     dockerCompose,
     createRpcClient,
-    getConnectionHost,
     config,
     getPlatformScope,
   ) {

--- a/packages/dashmate/src/status/scopes/overview.js
+++ b/packages/dashmate/src/status/scopes/overview.js
@@ -57,8 +57,9 @@ export default function getOverviewScopeFactory(
     }
 
     if (config.get('platform.enable')) {
-      const { tenderdash } = await getPlatformScope(config);
+      const { drive, tenderdash } = await getPlatformScope(config);
 
+      platform.drive = drive;
       platform.tenderdash = tenderdash;
     }
 

--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -174,6 +174,18 @@ export default function getPlatformScopeFactory(
         if (driveEchoResult.exitCode !== 0) {
           info.serviceStatus = ServiceStatusEnum.error;
         }
+
+        const driveVersionResult = await dockerCompose.execCommand(
+          config,
+          'drive_abci',
+          'drive-abci version',
+        );
+
+        console.dir(driveVersionResult);
+
+        if (driveVersionResult.exitCode === 0) {
+          info.version = driveVersionResult.stdout;
+        }
       }
 
       return info;

--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -191,22 +191,22 @@ export default function getPlatformScopeFactory(
           throw e;
         }
       }
+    }
 
-      try {
-        const driveVersionResult = await dockerCompose.execCommand(
-          config,
-          'drive_abci',
-          'drive-abci version',
-        );
+    try {
+      const driveVersionResult = await dockerCompose.execCommand(
+        config,
+        'drive_abci',
+        'drive-abci version',
+      );
 
-        info.version = driveVersionResult.out.trim();
-      } catch (e) {
-        // Throw an error if it's not a Drive issue
-        if (!(e instanceof DockerComposeError
-          && e.dockerComposeExecutionResult
-          && e.dockerComposeExecutionResult.exitCode !== 0)) {
-          throw e;
-        }
+      info.version = driveVersionResult.out.trim();
+    } catch (e) {
+      // Throw an error if it's not a Drive issue
+      if (!(e instanceof DockerComposeError
+        && e.dockerComposeExecutionResult
+        && e.dockerComposeExecutionResult.exitCode !== 0)) {
+        throw e;
       }
     }
 

--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -159,6 +159,7 @@ export default function getPlatformScopeFactory(
     const info = {
       dockerStatus: null,
       serviceStatus: null,
+      version: null,
     };
 
     try {
@@ -189,17 +190,22 @@ export default function getPlatformScopeFactory(
         } else {
           throw e;
         }
+      }
 
+      try {
         const driveVersionResult = await dockerCompose.execCommand(
           config,
           'drive_abci',
           'drive-abci version',
         );
 
-        console.dir(driveVersionResult);
-
-        if (driveVersionResult.exitCode === 0) {
-          info.version = driveVersionResult.stdout;
+        info.version = driveVersionResult.out.trim();
+      } catch (e) {
+        // Throw an error if it's not a Drive issue
+        if (!(e instanceof DockerComposeError
+          && e.dockerComposeExecutionResult
+          && e.dockerComposeExecutionResult.exitCode !== 0)) {
+          throw e;
         }
       }
     }

--- a/packages/dashmate/test/unit/status/scopes/platform.spec.js
+++ b/packages/dashmate/test/unit/status/scopes/platform.spec.js
@@ -1,5 +1,6 @@
 import ContainerIsNotPresentError
   from '../../../../src/docker/errors/ContainerIsNotPresentError.js';
+import DockerComposeError from '../../../../src/docker/errors/DockerComposeError.js';
 import providers from '../../../../src/status/providers.js';
 import determineStatus from '../../../../src/status/determineStatus.js';
 import getConfigMock from '../../../../src/test/mock/getConfigMock.js';
@@ -73,7 +74,8 @@ describe('getPlatformScopeFactory', () => {
         },
       });
       mockDockerCompose.isServiceRunning.returns(true);
-      mockDockerCompose.execCommand.returns({ exitCode: 0, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci status').resolves({ exitCode: 0, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
       const mockStatus = {
@@ -121,6 +123,7 @@ describe('getPlatformScopeFactory', () => {
         drive: {
           dockerStatus: DockerStatusEnum.running,
           serviceStatus: ServiceStatusEnum.up,
+          version: '1.4.1',
         },
       };
 
@@ -147,7 +150,7 @@ describe('getPlatformScopeFactory', () => {
         },
       });
       mockDockerCompose.isServiceRunning.returns(true);
-      mockDockerCompose.execCommand.returns({ exitCode: 0, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
       const mockStatus = {
@@ -195,6 +198,7 @@ describe('getPlatformScopeFactory', () => {
         drive: {
           dockerStatus: DockerStatusEnum.running,
           serviceStatus: ServiceStatusEnum.up,
+          version: '1.4.1',
         },
       };
 
@@ -212,7 +216,6 @@ describe('getPlatformScopeFactory', () => {
 
     it('should return empty scope if error during request to core', async () => {
       mockRpcClient.mnsync.withArgs('status').throws(new Error());
-      mockDockerCompose.execCommand.returns({ exitCode: 0, out: '' });
       mockDockerCompose.isServiceRunning.returns(true);
       mockDetermineDockerStatus.withArgs(mockDockerCompose, config, 'drive_tenderdash')
         .returns(DockerStatusEnum.running);
@@ -268,7 +271,7 @@ describe('getPlatformScopeFactory', () => {
           },
         },
       });
-      mockDockerCompose.execCommand.returns({ exitCode: 1, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
       const expectedScope = {
@@ -300,6 +303,7 @@ describe('getPlatformScopeFactory', () => {
         drive: {
           dockerStatus: DockerStatusEnum.running,
           serviceStatus: ServiceStatusEnum.wait_for_core,
+          version: '1.4.1',
         },
       };
 
@@ -324,7 +328,7 @@ describe('getPlatformScopeFactory', () => {
         .returns(DockerStatusEnum.running);
       mockDetermineDockerStatus.withArgs(mockDockerCompose, config, 'drive_abci')
         .returns(DockerStatusEnum.running);
-      mockDockerCompose.execCommand.returns({ exitCode: 0, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
       const expectedScope = {
@@ -356,6 +360,7 @@ describe('getPlatformScopeFactory', () => {
         drive: {
           dockerStatus: DockerStatusEnum.running,
           serviceStatus: ServiceStatusEnum.up,
+          version: '1.4.1',
         },
       };
 
@@ -380,8 +385,11 @@ describe('getPlatformScopeFactory', () => {
         .returns(DockerStatusEnum.running);
       mockDetermineDockerStatus.withArgs(mockDockerCompose, config, 'drive_abci')
         .throws(new ContainerIsNotPresentError('drive_abci'));
-      mockDockerCompose.execCommand.returns({ exitCode: 0, out: '' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
+      const error = new DockerComposeError({
+        exitCode: 1,
+      });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').rejects(error);
 
       const mockStatus = {
         node_info: {
@@ -434,6 +442,7 @@ describe('getPlatformScopeFactory', () => {
         drive: {
           dockerStatus: DockerStatusEnum.not_started,
           serviceStatus: ServiceStatusEnum.stopped,
+          version: null,
         },
       };
 
@@ -454,7 +463,8 @@ describe('getPlatformScopeFactory', () => {
       mockDockerCompose.isServiceRunning
         .withArgs(config, 'drive_tenderdash')
         .returns(true);
-      mockDockerCompose.execCommand.returns({ exitCode: 0, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci status').resolves({ exitCode: 0, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
       mockDetermineDockerStatus.returns(DockerStatusEnum.running);
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
       mockFetch.returns(Promise.reject(new Error('FetchError')));
@@ -488,6 +498,7 @@ describe('getPlatformScopeFactory', () => {
         drive: {
           dockerStatus: DockerStatusEnum.running,
           serviceStatus: ServiceStatusEnum.up,
+          version: '1.4.1',
         },
       };
 

--- a/packages/rs-drive-abci/src/main.rs
+++ b/packages/rs-drive-abci/src/main.rs
@@ -225,16 +225,11 @@ fn main() -> Result<(), ExitCode> {
 
     runtime.spawn(handle_signals(cancel.clone(), loggers));
 
-    let result = match cli.run(&runtime, config, cancel) {
-        Ok(()) => {
-            tracing::debug!("shutdown complete");
-            Ok(())
-        }
-        Err(e) => {
-            tracing::error!(error = e, "drive-abci failed: {e}");
-            Err(ExitCode::FAILURE)
-        }
-    };
+    let result = cli.run(&runtime, config, cancel).map_err(|e| {
+        tracing::error!(error = e, "drive-abci failed: {e}");
+
+        ExitCode::FAILURE
+    });
 
     drop(runtime_guard);
     runtime.shutdown_timeout(Duration::from_millis(SHUTDOWN_TIMEOUT_MILIS));

--- a/packages/rs-drive-abci/src/main.rs
+++ b/packages/rs-drive-abci/src/main.rs
@@ -54,6 +54,10 @@ enum Commands {
     /// by creating `.fsck` file in database directory (`DB_PATH`).
     #[command()]
     Verify,
+
+    /// Print current software version
+    #[command()]
+    Version,
 }
 
 /// Server that accepts connections from Tenderdash, and
@@ -134,6 +138,7 @@ impl Cli {
             Commands::Config => dump_config(&config)?,
             Commands::Status => check_status(&config)?,
             Commands::Verify => verify_grovedb(&config.db_path, true)?,
+            Commands::Version => print_version(),
         };
 
         Ok(())
@@ -384,6 +389,11 @@ fn verify_grovedb(db_path: &PathBuf, force: bool) -> Result<(), String> {
             Err(e)
         }
     }
+}
+
+/// Print current software version.
+fn print_version() {
+    println!("{}", env!("CARGO_PKG_VERSION"));
 }
 
 fn load_config(path: &Option<PathBuf>) -> PlatformConfig {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The dashmate status command shows the tenderdash version as "Platform Version" which is confusing.

## What was done?
<!--- Describe your changes in detail -->
- Added version command to Drive
- Display Drive version as Platform Version in the status command

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Calling the status command locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new CLI command to display the current software version for RS-Drive-ABCI.
	- Enhanced the platform status functionality with improved error handling and version retrieval for the 'drive_abci' service.

- **Bug Fixes**
	- Updated logic for assigning platform version to ensure accurate reporting based on service status.

- **Refactor**
	- Simplified method signatures in the PlatformStatusCommand for improved clarity.
	- Adjusted the `getDriveInfo` function to include a version property in the returned object.
	- Updated the `.yarnrc.yml` file for better package management and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->