### PR TITLE
chore: move BLS Sigs import to Rust Dash Core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "bls-dash-sys"
 version = "1.2.5"
-source = "git+https://github.com/dashpay/bls-signatures?tag=v1.3.1#1c2fc79c19dc8041610c005e68d58bfb4bc32721"
+source = "git+https://github.com/dashpay/bls-signatures?tag=1.3.3#4e070243aed142bc458472f8807ab77527dd879a"
 dependencies = [
  "bindgen 0.65.1",
  "cc",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "bls-signatures"
 version = "1.2.5"
-source = "git+https://github.com/dashpay/bls-signatures?tag=v1.3.1#1c2fc79c19dc8041610c005e68d58bfb4bc32721"
+source = "git+https://github.com/dashpay/bls-signatures?tag=1.3.3#4e070243aed142bc458472f8807ab77527dd879a"
 dependencies = [
  "bls-dash-sys",
  "hex",
@@ -1145,29 +1145,35 @@ dependencies = [
 
 [[package]]
 name = "dashcore"
-version = "0.30.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=0.31.0#003b1aed973be7eb98591c6ec3c8f82eafab4645"
+version = "0.32.0"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=0.32.0#6a0ec164ca1bdcb8d19b29f40e946120e99473eb"
 dependencies = [
  "anyhow",
  "bech32",
+ "bitflags 2.6.0",
+ "bls-signatures",
  "dashcore-private",
  "dashcore_hashes",
+ "ed25519-dalek",
  "hex",
  "hex_lit",
+ "lazy_static",
  "rustversion",
  "secp256k1",
  "serde",
+ "serde_repr",
+ "strum",
 ]
 
 [[package]]
 name = "dashcore-private"
 version = "0.1.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=0.31.0#003b1aed973be7eb98591c6ec3c8f82eafab4645"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=0.32.0#6a0ec164ca1bdcb8d19b29f40e946120e99473eb"
 
 [[package]]
 name = "dashcore-rpc"
-version = "0.15.7"
-source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.7#3a16a75496939e6855fc9c823a4d5de11c2f0ee8"
+version = "0.15.8"
+source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.8#4d4d5b1488daa7f083d254a1f5acf03b550d5b10"
 dependencies = [
  "dashcore-private",
  "dashcore-rpc-json",
@@ -1181,8 +1187,8 @@ dependencies = [
 
 [[package]]
 name = "dashcore-rpc-json"
-version = "0.15.7"
-source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.7#3a16a75496939e6855fc9c823a4d5de11c2f0ee8"
+version = "0.15.8"
+source = "git+https://github.com/dashpay/rust-dashcore-rpc?tag=v0.15.8#4d4d5b1488daa7f083d254a1f5acf03b550d5b10"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1195,8 +1201,8 @@ dependencies = [
 
 [[package]]
 name = "dashcore_hashes"
-version = "0.12.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=0.31.0#003b1aed973be7eb98591c6ec3c8f82eafab4645"
+version = "0.14.0"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=0.32.0#6a0ec164ca1bdcb8d19b29f40e946120e99473eb"
 dependencies = [
  "dashcore-private",
  "secp256k1",
@@ -1363,7 +1369,6 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bincode",
- "bls-signatures",
  "bs58",
  "byteorder",
  "chrono",
@@ -1372,7 +1377,6 @@ dependencies = [
  "data-contracts",
  "derive_more 1.0.0",
  "dpp",
- "ed25519-dalek",
  "env_logger 0.11.5",
  "getrandom",
  "hex",

--- a/packages/rs-dpp/Cargo.toml
+++ b/packages/rs-dpp/Cargo.toml
@@ -15,7 +15,6 @@ authors = [
 anyhow = { version = "1.0.81" }
 async-trait = { version = "0.1.79" }
 base64 = "0.22.1"
-bls-signatures = { git = "https://github.com/dashpay/bls-signatures", tag = "v1.3.1", optional = true }
 bs58 = "0.5"
 byteorder = { version = "1.4" }
 chrono = { version = "0.4.35", default-features = false, features = [
@@ -29,7 +28,9 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", features = [
   "rand",
   "signer",
   "serde",
-], default-features = false, tag = "0.31.0" }
+  "bls",
+  "eddsa"
+], default-features = false, tag = "0.32.0" }
 env_logger = { version = "0.11" }
 getrandom = { version = "0.2", features = ["js"] }
 hex = { version = "0.4" }
@@ -56,7 +57,6 @@ platform-versioning = { path = "../rs-platform-versioning" }
 platform-serialization = { path = "../rs-platform-serialization" }
 platform-serialization-derive = { path = "../rs-platform-serialization-derive" }
 derive_more = { version = "1.0", features = ["from", "display"] }
-ed25519-dalek = { version = "2.1", features = ["rand_core"], optional = true }
 nohash-hasher = "0.2.0"
 rust_decimal = "1.29.1"
 rust_decimal_macros = "1.29.1"
@@ -75,6 +75,8 @@ once_cell = "1.7"
 
 [features]
 default = ["platform-value", "state-transitions"]
+bls-signatures = ["dashcore/bls"]
+ed25519-dalek = ["dashcore/eddsa"]
 all_features = [
   "json-object",
   "platform-value",

--- a/packages/rs-dpp/src/bls/native_bls.rs
+++ b/packages/rs-dpp/src/bls/native_bls.rs
@@ -1,6 +1,6 @@
 use crate::{BlsModule, ProtocolError, PublicKeyValidationError};
 use anyhow::anyhow;
-use bls_signatures::{PrivateKey, PublicKey};
+use dashcore::bls_signatures::{self, PrivateKey, PublicKey};
 
 #[derive(Default)]
 pub struct NativeBlsModule;

--- a/packages/rs-dpp/src/identity/identity_public_key/key_type.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/key_type.rs
@@ -8,7 +8,7 @@ use dashcore::secp256k1::rand::rngs::StdRng as EcdsaRng;
 #[cfg(feature = "random-public-keys")]
 use dashcore::secp256k1::rand::SeedableRng;
 use dashcore::secp256k1::Secp256k1;
-use dashcore::Network;
+use dashcore::{bls_signatures, ed25519_dalek, Network};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 

--- a/packages/rs-dpp/src/identity/identity_public_key/v0/methods/mod.rs
+++ b/packages/rs-dpp/src/identity/identity_public_key/v0/methods/mod.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use dashcore::hashes::Hash;
 use dashcore::key::Secp256k1;
 use dashcore::secp256k1::SecretKey;
-use dashcore::{Network, PublicKey as ECDSAPublicKey};
+use dashcore::{bls_signatures, ed25519_dalek, Network, PublicKey as ECDSAPublicKey};
 use platform_value::Bytes20;
 
 impl IdentityPublicKeyHashMethodsV0 for IdentityPublicKeyV0 {

--- a/packages/rs-dpp/src/lib.rs
+++ b/packages/rs-dpp/src/lib.rs
@@ -90,11 +90,11 @@ pub mod prelude {
 
 pub use bincode;
 #[cfg(all(not(target_arch = "wasm32"), feature = "bls-signatures"))]
-pub use bls_signatures;
+pub use dashcore::bls_signatures;
+#[cfg(feature = "ed25519-dalek")]
+pub use dashcore::ed25519_dalek;
 #[cfg(feature = "system_contracts")]
 pub use data_contracts;
-#[cfg(feature = "ed25519-dalek")]
-pub use ed25519_dalek;
 #[cfg(feature = "jsonschema")]
 pub use jsonschema;
 pub use platform_serialization;

--- a/packages/rs-dpp/src/signing.rs
+++ b/packages/rs-dpp/src/signing.rs
@@ -8,7 +8,7 @@ use crate::serialization::PlatformMessageSignable;
 use crate::validation::SimpleConsensusValidationResult;
 #[cfg(feature = "message-signing")]
 use crate::{BlsModule, ProtocolError};
-use dashcore::signer;
+use dashcore::{bls_signatures, signer};
 
 impl PlatformMessageSignable for &[u8] {
     #[cfg(feature = "message-signature-verification")]

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.8.5"
 tempfile = "3.3.0"
 hex = "0.4.3"
 indexmap = { version = "2.2.6", features = ["serde"] }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.7" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.8" }
 dpp = { path = "../rs-dpp", features = ["abci"] }
 simple-signer = { path = "../simple-signer" }
 rust_decimal = "1.2.5"

--- a/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
@@ -213,7 +213,7 @@ mod tests {
 
     use dpp::consensus::ConsensusError;
     use dpp::dashcore::secp256k1::Secp256k1;
-    use dpp::dashcore::{key::KeyPair, signer, Network, PrivateKey};
+    use dpp::dashcore::{key::Keypair, signer, Network, PrivateKey};
 
     use dpp::data_contract::accessors::v0::{DataContractV0Getters, DataContractV0Setters};
     use dpp::data_contract::document_type::random_document::{
@@ -2659,7 +2659,7 @@ mod tests {
 
         let secp = Secp256k1::new();
 
-        let new_key_pair = KeyPair::new(&secp, &mut rng);
+        let new_key_pair = Keypair::new(&secp, &mut rng);
 
         let mut new_key = IdentityPublicKeyInCreationV0 {
             id: 2,
@@ -2760,7 +2760,7 @@ mod tests {
 
         let platform_state = platform.state.load();
 
-        let new_key_pair = KeyPair::new(&secp, &mut rng);
+        let new_key_pair = Keypair::new(&secp, &mut rng);
 
         let new_key = IdentityPublicKeyInCreationV0 {
             id: 2,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_update/mod.rs
@@ -122,7 +122,7 @@ mod tests {
     use dpp::block::block_info::BlockInfo;
     use dpp::consensus::ConsensusError;
     use dpp::dash_to_credits;
-    use dpp::dashcore::key::{KeyPair, Secp256k1};
+    use dpp::dashcore::key::{Keypair, Secp256k1};
     use dpp::data_contract::accessors::v0::DataContractV0Getters;
     use dpp::identity::accessors::IdentityGettersV0;
     use dpp::identity::contract_bounds::ContractBounds;
@@ -371,7 +371,7 @@ mod tests {
 
         let mut rng = StdRng::seed_from_u64(1292);
 
-        let new_key_pair = KeyPair::new(&secp, &mut rng);
+        let new_key_pair = Keypair::new(&secp, &mut rng);
 
         let new_key = IdentityPublicKeyInCreationV0 {
             id: 2,

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -33,7 +33,7 @@ envy = { version = "0.4.2", optional = true }
 futures = { version = "0.3.30" }
 derive_more = { version = "1.0", features = ["from"] }
 # dashcore-rpc is only needed for core rpc; TODO remove once we have correct core rpc impl
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.7" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.8" }
 lru = { version = "0.12.3", optional = true }
 bip37-bloom-filter = { git = "https://github.com/dashpay/rs-bip37-bloom-filter", branch = "develop" }
 zeroize = { version = "1.8", features = ["derive"] }

--- a/packages/simple-signer/Cargo.toml
+++ b/packages/simple-signer/Cargo.toml
@@ -8,6 +8,6 @@ rust-version.workspace = true
 
 [dependencies]
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.7" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.8" }
 dpp = { path = "../rs-dpp", features = ["abci"] }
 base64 = { version = "0.22.1" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
BLS Sigs are being used in different parts of the project, different versions could end up being build leading to longer compilation times.

## What was done?
Moved BLS Sigs to Rust Dash Core.


## How Has This Been Tested?
Passed tests.

## Breaking Changes
Not breaking


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added support for BLS and EdDSA public key types, enhancing cryptographic capabilities.
	- Improved public key generation and error handling for unsupported key conversions.

- **Bug Fixes**
	- Enhanced transaction checking mechanism with robust error handling for state transitions.
	- Updated validation logic for identity updates to handle version mismatches.

- **Chores**
	- Updated the `dashcore-rpc` dependency version across multiple packages to `v0.15.8`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->