### PR TITLE
feat(sdk): detect stale nodes

### DIFF
--- a/packages/rs-dapi-client/src/dapi_client.rs
+++ b/packages/rs-dapi-client/src/dapi_client.rs
@@ -42,9 +42,9 @@ impl<TE: CanRetry + Mockable> CanRetry for DapiClientError<TE> {
     fn can_retry(&self) -> bool {
         use DapiClientError::*;
         match self {
-            NoAvailableAddresses => true,
+            NoAvailableAddresses => false,
             Transport(transport_error, _) => transport_error.can_retry(),
-            AddressList(_) => true,
+            AddressList(_) => false,
             #[cfg(feature = "mocks")]
             Mock(_) => false,
         }
@@ -264,7 +264,7 @@ impl DapiRequestExecutor for DapiClient {
                     duration.as_secs_f32()
                 )
             })
-            .when(|e| !e.can_retry())
+            .when(|e| e.can_retry())
             .instrument(tracing::info_span!("request routine"))
             .await;
 

--- a/packages/rs-dapi-client/src/dapi_client.rs
+++ b/packages/rs-dapi-client/src/dapi_client.rs
@@ -269,8 +269,13 @@ impl DapiRequestExecutor for DapiClient {
             .await;
 
         if let Err(error) = &result {
-            if !error.can_retry().unwrap_or(false) {
-                tracing::error!(?error, "request failed");
+            match error.can_retry() {
+                Some(false) | None => {
+                    tracing::error!(?error, "request failed");
+                }
+                Some(true) => {
+                    tracing::warn!(?error, "request failed, retrying");
+                }
             }
         }
 

--- a/packages/rs-dapi-client/src/dapi_client.rs
+++ b/packages/rs-dapi-client/src/dapi_client.rs
@@ -39,12 +39,12 @@ pub enum DapiClientError<TE: Mockable> {
 }
 
 impl<TE: CanRetry + Mockable> CanRetry for DapiClientError<TE> {
-    fn is_node_failure(&self) -> bool {
+    fn can_retry(&self) -> bool {
         use DapiClientError::*;
         match self {
-            NoAvailableAddresses => false,
-            Transport(transport_error, _) => transport_error.is_node_failure(),
-            AddressList(_) => false,
+            NoAvailableAddresses => true,
+            Transport(transport_error, _) => transport_error.can_retry(),
+            AddressList(_) => true,
             #[cfg(feature = "mocks")]
             Mock(_) => false,
         }
@@ -233,7 +233,7 @@ impl DapiRequestExecutor for DapiClient {
                         tracing::trace!(?response, "received {} response", response_name);
                     }
                     Err(error) => {
-                        if error.is_node_failure() {
+                        if !error.can_retry() {
                             if applied_settings.ban_failed_address {
                                 let mut address_list = self
                                     .address_list
@@ -264,12 +264,12 @@ impl DapiRequestExecutor for DapiClient {
                     duration.as_secs_f32()
                 )
             })
-            .when(|e| e.is_node_failure())
+            .when(|e| !e.can_retry())
             .instrument(tracing::info_span!("request routine"))
             .await;
 
         if let Err(error) = &result {
-            if error.is_node_failure() {
+            if !error.can_retry() {
                 tracing::error!(?error, "request failed");
             }
         }

--- a/packages/rs-dapi-client/src/lib.rs
+++ b/packages/rs-dapi-client/src/lib.rs
@@ -74,6 +74,14 @@ impl<T: transport::TransportRequest + Send> DapiRequest for T {
 /// Allows to flag the transport error variant how tolerant we are of it and whether we can
 /// try to do a request again.
 pub trait CanRetry {
+    /// Returns true if the operation can be retried safely, false means it's unspecified
+    fn can_retry(&self) -> bool;
+
     /// Get boolean flag that indicates if the error is retryable.
-    fn is_node_failure(&self) -> bool;
+    ///
+    /// Depreacted in favor of [CanRetry::can_retry].
+    #[deprecated = "Use !can_retry() instead"]
+    fn is_node_failure(&self) -> bool {
+        !self.can_retry()
+    }
 }

--- a/packages/rs-dapi-client/src/lib.rs
+++ b/packages/rs-dapi-client/src/lib.rs
@@ -72,18 +72,15 @@ impl<T: transport::TransportRequest + Send> DapiRequest for T {
 }
 
 /// Returns true if the operation can be retried.
-/// `None` means unspecified - in this case, you should either inspect the error
-/// in more details, or assume `false`.
 pub trait CanRetry {
     /// Returns true if the operation can be retried safely.
-    /// None value means it's unspecified
-    fn can_retry(&self) -> Option<bool>;
+    fn can_retry(&self) -> bool;
 
     /// Get boolean flag that indicates if the error is retryable.
     ///
     /// Depreacted in favor of [CanRetry::can_retry].
     #[deprecated = "Use !can_retry() instead"]
     fn is_node_failure(&self) -> bool {
-        !self.can_retry().unwrap_or(false)
+        !self.can_retry()
     }
 }

--- a/packages/rs-dapi-client/src/lib.rs
+++ b/packages/rs-dapi-client/src/lib.rs
@@ -71,17 +71,19 @@ impl<T: transport::TransportRequest + Send> DapiRequest for T {
     }
 }
 
-/// Allows to flag the transport error variant how tolerant we are of it and whether we can
-/// try to do a request again.
+/// Returns true if the operation can be retried.
+/// `None` means unspecified - in this case, you should either inspect the error
+/// in more details, or assume `false`.
 pub trait CanRetry {
-    /// Returns true if the operation can be retried safely, false means it's unspecified
-    fn can_retry(&self) -> bool;
+    /// Returns true if the operation can be retried safely.
+    /// None value means it's unspecified
+    fn can_retry(&self) -> Option<bool>;
 
     /// Get boolean flag that indicates if the error is retryable.
     ///
     /// Depreacted in favor of [CanRetry::can_retry].
     #[deprecated = "Use !can_retry() instead"]
     fn is_node_failure(&self) -> bool {
-        !self.can_retry()
+        !self.can_retry().unwrap_or(false)
     }
 }

--- a/packages/rs-dapi-client/src/transport/grpc.rs
+++ b/packages/rs-dapi-client/src/transport/grpc.rs
@@ -117,11 +117,12 @@ impl TransportClient for CoreGrpcClient {
 }
 
 impl CanRetry for dapi_grpc::tonic::Status {
-    fn can_retry(&self) -> bool {
+    fn can_retry(&self) -> Option<bool> {
         let code = self.code();
 
         use dapi_grpc::tonic::Code::*;
-        !matches!(
+
+        let retry = !matches!(
             code,
             Ok | DataLoss
                 | Cancelled
@@ -131,7 +132,13 @@ impl CanRetry for dapi_grpc::tonic::Status {
                 | Aborted
                 | Internal
                 | Unavailable
-        )
+        );
+
+        if retry {
+            Some(true)
+        } else {
+            None
+        }
     }
 }
 

--- a/packages/rs-dapi-client/src/transport/grpc.rs
+++ b/packages/rs-dapi-client/src/transport/grpc.rs
@@ -117,12 +117,12 @@ impl TransportClient for CoreGrpcClient {
 }
 
 impl CanRetry for dapi_grpc::tonic::Status {
-    fn can_retry(&self) -> Option<bool> {
+    fn can_retry(&self) -> bool {
         let code = self.code();
 
         use dapi_grpc::tonic::Code::*;
 
-        let retry = !matches!(
+        !matches!(
             code,
             Ok | DataLoss
                 | Cancelled
@@ -132,13 +132,7 @@ impl CanRetry for dapi_grpc::tonic::Status {
                 | Aborted
                 | Internal
                 | Unavailable
-        );
-
-        if retry {
-            Some(true)
-        } else {
-            None
-        }
+        )
     }
 }
 

--- a/packages/rs-dapi-client/src/transport/grpc.rs
+++ b/packages/rs-dapi-client/src/transport/grpc.rs
@@ -117,11 +117,11 @@ impl TransportClient for CoreGrpcClient {
 }
 
 impl CanRetry for dapi_grpc::tonic::Status {
-    fn is_node_failure(&self) -> bool {
+    fn can_retry(&self) -> bool {
         let code = self.code();
 
         use dapi_grpc::tonic::Code::*;
-        matches!(
+        !matches!(
             code,
             Ok | DataLoss
                 | Cancelled

--- a/packages/rs-drive-proof-verifier/src/error.rs
+++ b/packages/rs-drive-proof-verifier/src/error.rs
@@ -93,10 +93,10 @@ pub enum Error {
 pub enum StaleProofError {
     /// Stale proof height
     #[error("stale proof height: expected height {expected_height}, received {received_height}, tolerance {tolerance_blocks}; try another server")]
-    StaleProofHeight {
+    Height {
         /// Expected height - last block height seen by the Sdk
         expected_height: u64,
-        /// Actual height - block height received from the server in the proof
+        /// Block height received from the server in the proof
         received_height: u64,
         /// Tolerance - how many blocks can be behind the expected height
         tolerance_blocks: u64,

--- a/packages/rs-drive-proof-verifier/src/error.rs
+++ b/packages/rs-drive-proof-verifier/src/error.rs
@@ -82,37 +82,6 @@ pub enum Error {
     /// Context provider error
     #[error("context provider error: {0}")]
     ContextProviderError(#[from] ContextProviderError),
-
-    /// Remote node is stale; try another server
-    #[error(transparent)]
-    StaleNode(#[from] StaleNodeError),
-}
-
-/// Server returned stale metadata
-#[derive(Debug, thiserror::Error)]
-pub enum StaleNodeError {
-    /// Server returned metadata with outdated height
-    #[error("received height is outdated: expected {expected_height}, received {received_height}, tolerance {tolerance_blocks}; try another server")]
-    Height {
-        /// Expected height - last block height seen by the Sdk
-        expected_height: u64,
-        /// Block height received from the server
-        received_height: u64,
-        /// Tolerance - how many blocks can be behind the expected height
-        tolerance_blocks: u64,
-    },
-    /// Server returned metadata with time outside of the tolerance
-    #[error(
-        "received invalid time: expected {expected_timestamp_ms}ms, received {received_timestamp_ms} ms, tolerance {tolerance_ms} ms; try another server"
-    )]
-    Time {
-        /// Expected time in milliseconds - is local time when the message was received
-        expected_timestamp_ms: u64,
-        /// Time received from the server in the message, in milliseconds
-        received_timestamp_ms: u64,
-        /// Tolerance in milliseconds
-        tolerance_ms: u64,
-    },
 }
 
 /// Errors returned by the context provider

--- a/packages/rs-drive-proof-verifier/src/error.rs
+++ b/packages/rs-drive-proof-verifier/src/error.rs
@@ -84,7 +84,7 @@ pub enum Error {
     ContextProviderError(#[from] ContextProviderError),
 
     /// Proof is stale; try another server
-    #[error("proof is stale; try another server")]
+    #[error(transparent)]
     StaleProof(#[from] StaleProofError),
 }
 
@@ -92,24 +92,24 @@ pub enum Error {
 #[derive(Debug, thiserror::Error)]
 pub enum StaleProofError {
     /// Stale proof height
-    #[error("stale proof height: expected height {expected_height}, received {actual_height}, tolerance {tolerance}, try another server")]
+    #[error("stale proof height: expected height {expected_height}, received {received_height}, tolerance {tolerance_blocks}; try another server")]
     StaleProofHeight {
         /// Expected height - last block height seen by the Sdk
         expected_height: u64,
         /// Actual height - block height received from the server in the proof
-        actual_height: u64,
+        received_height: u64,
         /// Tolerance - how many blocks can be behind the expected height
-        tolerance: u64,
+        tolerance_blocks: u64,
     },
     /// Proof time is stale
     #[error(
-        "received outdated proof time: expected {expected_ms} ms, received {actual_ms} ms, tolerance {tolerance_ms} ms, try another server"
+        "stale proof time: expected {expected_timestamp_ms}ms, received {received_timestamp_ms} ms, tolerance {tolerance_ms} ms; try another server"
     )]
     Time {
         /// Expected time in milliseconds - is local time when the proof was received
-        expected_ms: u64,
-        /// Actual time in milliseconds - time received from the server in the proof
-        actual_ms: u64,
+        expected_timestamp_ms: u64,
+        /// Time received from the server in the proof, in milliseconds
+        received_timestamp_ms: u64,
         /// Tolerance in milliseconds
         tolerance_ms: u64,
     },

--- a/packages/rs-drive-proof-verifier/src/error.rs
+++ b/packages/rs-drive-proof-verifier/src/error.rs
@@ -83,32 +83,32 @@ pub enum Error {
     #[error("context provider error: {0}")]
     ContextProviderError(#[from] ContextProviderError),
 
-    /// Proof is stale; try another server
+    /// Remote node is stale; try another server
     #[error(transparent)]
-    StaleProof(#[from] StaleProofError),
+    StaleNode(#[from] StaleNodeError),
 }
 
-/// Received proof is stale; try another server
+/// Server returned stale metadata
 #[derive(Debug, thiserror::Error)]
-pub enum StaleProofError {
-    /// Stale proof height
-    #[error("stale proof height: expected height {expected_height}, received {received_height}, tolerance {tolerance_blocks}; try another server")]
+pub enum StaleNodeError {
+    /// Server returned metadata with outdated height
+    #[error("received height is outdated: expected {expected_height}, received {received_height}, tolerance {tolerance_blocks}; try another server")]
     Height {
         /// Expected height - last block height seen by the Sdk
         expected_height: u64,
-        /// Block height received from the server in the proof
+        /// Block height received from the server
         received_height: u64,
         /// Tolerance - how many blocks can be behind the expected height
         tolerance_blocks: u64,
     },
-    /// Proof time is stale
+    /// Server returned metadata with time outside of the tolerance
     #[error(
-        "stale proof time: expected {expected_timestamp_ms}ms, received {received_timestamp_ms} ms, tolerance {tolerance_ms} ms; try another server"
+        "received invalid time: expected {expected_timestamp_ms}ms, received {received_timestamp_ms} ms, tolerance {tolerance_ms} ms; try another server"
     )]
     Time {
-        /// Expected time in milliseconds - is local time when the proof was received
+        /// Expected time in milliseconds - is local time when the message was received
         expected_timestamp_ms: u64,
-        /// Time received from the server in the proof, in milliseconds
+        /// Time received from the server in the message, in milliseconds
         received_timestamp_ms: u64,
         /// Tolerance in milliseconds
         tolerance_ms: u64,

--- a/packages/rs-drive-proof-verifier/src/error.rs
+++ b/packages/rs-drive-proof-verifier/src/error.rs
@@ -82,6 +82,13 @@ pub enum Error {
     /// Context provider error
     #[error("context provider error: {0}")]
     ContextProviderError(#[from] ContextProviderError),
+
+    /// Proof is stale; try another server
+    #[error("proof is stale; try another server")]
+    StaleProof {
+        expected_height: u64,
+        actual_height: u64,
+    },
 }
 
 /// Errors returned by the context provider

--- a/packages/rs-drive-proof-verifier/src/error.rs
+++ b/packages/rs-drive-proof-verifier/src/error.rs
@@ -85,9 +85,33 @@ pub enum Error {
 
     /// Proof is stale; try another server
     #[error("proof is stale; try another server")]
-    StaleProof {
+    StaleProof(#[from] StaleProofError),
+}
+
+/// Received proof is stale; try another server
+#[derive(Debug, thiserror::Error)]
+pub enum StaleProofError {
+    /// Stale proof height
+    #[error("stale proof height: expected height {expected_height}, received {actual_height}, tolerance {tolerance}, try another server")]
+    StaleProofHeight {
+        /// Expected height - last block height seen by the Sdk
         expected_height: u64,
+        /// Actual height - block height received from the server in the proof
         actual_height: u64,
+        /// Tolerance - how many blocks can be behind the expected height
+        tolerance: u64,
+    },
+    /// Proof time is stale
+    #[error(
+        "received outdated proof time: expected {expected_ms} ms, received {actual_ms} ms, tolerance {tolerance_ms} ms, try another server"
+    )]
+    Time {
+        /// Expected time in milliseconds - is local time when the proof was received
+        expected_ms: u64,
+        /// Actual time in milliseconds - time received from the server in the proof
+        actual_ms: u64,
+        /// Tolerance in milliseconds
+        tolerance_ms: u64,
     },
 }
 

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 
 arc-swap = { version = "1.7.1" }
+chrono = { version = "0.4.38" }
 dpp = { path = "../rs-dpp", default-features = false, features = [
   "dash-sdk-features",
 ] }
@@ -52,7 +53,6 @@ data-contracts = { path = "../data-contracts" }
 tokio-test = { version = "0.4.4" }
 clap = { version = "4.5.4", features = ["derive"] }
 sanitize-filename = { version = "0.5.0" }
-chrono = { version = "0.4.38" }
 test-case = { version = "3.3.1" }
 
 [features]

--- a/packages/rs-sdk/src/error.rs
+++ b/packages/rs-sdk/src/error.rs
@@ -82,19 +82,13 @@ impl From<PlatformVersionError> for Error {
 }
 
 impl CanRetry for Error {
-    fn can_retry(&self) -> Option<bool> {
-        let retry = matches!(
+    fn can_retry(&self) -> bool {
+        matches!(
             self,
             Error::Proof(drive_proof_verifier::Error::StaleNode(..))
                 | Error::DapiClientError(_)
                 | Error::CoreClientError(_)
                 | Error::TimeoutReached(_, _)
-        );
-
-        if retry {
-            Some(true)
-        } else {
-            None
-        }
+        )
     }
 }

--- a/packages/rs-sdk/src/error.rs
+++ b/packages/rs-sdk/src/error.rs
@@ -85,7 +85,7 @@ impl CanRetry for Error {
     fn can_retry(&self) -> Option<bool> {
         let retry = matches!(
             self,
-            Error::Proof(drive_proof_verifier::Error::StaleProof { .. })
+            Error::Proof(drive_proof_verifier::Error::StaleProof(..))
                 | Error::DapiClientError(_)
                 | Error::CoreClientError(_)
                 | Error::TimeoutReached(_, _)

--- a/packages/rs-sdk/src/error.rs
+++ b/packages/rs-sdk/src/error.rs
@@ -87,13 +87,7 @@ impl From<PlatformVersionError> for Error {
 
 impl CanRetry for Error {
     fn can_retry(&self) -> bool {
-        matches!(
-            self,
-            Error::StaleNode(..)
-                | Error::DapiClientError(_)
-                | Error::CoreClientError(_)
-                | Error::TimeoutReached(_, _)
-        )
+        matches!(self, Error::StaleNode(..) | Error::TimeoutReached(_, _))
     }
 }
 

--- a/packages/rs-sdk/src/error.rs
+++ b/packages/rs-sdk/src/error.rs
@@ -80,13 +80,21 @@ impl From<PlatformVersionError> for Error {
         Self::Protocol(value.into())
     }
 }
+
 impl CanRetry for Error {
-    /// Returns true if the operation can be retried, false means it's unspecified
-    /// False means
-    fn can_retry(&self) -> bool {
-        matches!(
+    fn can_retry(&self) -> Option<bool> {
+        let retry = matches!(
             self,
-            Error::CoreLockedHeightNotYetAvailable(_, _) | Error::QuorumNotFound { .. }
-        )
+            Error::Proof(drive_proof_verifier::Error::StaleProof { .. })
+                | Error::DapiClientError(_)
+                | Error::CoreClientError(_)
+                | Error::TimeoutReached(_, _)
+        );
+
+        if retry {
+            Some(true)
+        } else {
+            None
+        }
     }
 }

--- a/packages/rs-sdk/src/error.rs
+++ b/packages/rs-sdk/src/error.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use dapi_grpc::mock::Mockable;
 use dpp::version::PlatformVersionError;
 use dpp::ProtocolError;
-use rs_dapi_client::DapiClientError;
+use rs_dapi_client::{CanRetry, DapiClientError};
 
 pub use drive_proof_verifier::error::ContextProviderError;
 
@@ -78,5 +78,15 @@ impl<T: Debug + Mockable> From<DapiClientError<T>> for Error {
 impl From<PlatformVersionError> for Error {
     fn from(value: PlatformVersionError) -> Self {
         Self::Protocol(value.into())
+    }
+}
+impl CanRetry for Error {
+    /// Returns true if the operation can be retried, false means it's unspecified
+    /// False means
+    fn can_retry(&self) -> bool {
+        matches!(
+            self,
+            Error::CoreLockedHeightNotYetAvailable(_, _) | Error::QuorumNotFound { .. }
+        )
     }
 }

--- a/packages/rs-sdk/src/error.rs
+++ b/packages/rs-sdk/src/error.rs
@@ -85,7 +85,7 @@ impl CanRetry for Error {
     fn can_retry(&self) -> Option<bool> {
         let retry = matches!(
             self,
-            Error::Proof(drive_proof_verifier::Error::StaleProof(..))
+            Error::Proof(drive_proof_verifier::Error::StaleNode(..))
                 | Error::DapiClientError(_)
                 | Error::CoreClientError(_)
                 | Error::TimeoutReached(_, _)

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -648,14 +648,12 @@ fn verify_proof_height(
             tolerance,
             "received proof with stale height; you should retry with another server"
         );
-        return Err(
-            drive_proof_verifier::error::StaleProofError::StaleProofHeight {
-                expected_height: prev,
-                received_height: received,
-                tolerance_blocks: tolerance,
-            }
-            .into(),
-        );
+        return Err(drive_proof_verifier::error::StaleProofError::Height {
+            expected_height: prev,
+            received_height: received,
+            tolerance_blocks: tolerance,
+        }
+        .into());
     }
 
     // New proof is ahead of the previous proof, so we update the previous proof height.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

When fetching information from a node that has chain halt, we receive outdated information.


## What was done?

Implemented two mechanisms to detect stale nodes:

1. Ensure height of received response  is not older than the last seen height minus some tolerance (defaults to 1).
2. Ensure time of received response is within some time window (mechanism disabled by default).
3. Added error StaleNodeError to Sdk  that is emitted by Sdk if the conditions above are not met. 
4. Added CanRetry trait to dash_sdk::Error that will return true is the request should be retried

## How Has This Been Tested?

Added tests.


## Breaking Changes

None on API level, but the behavior changed a bit.

`rs_dapi_client::CanRetry::is_node_failure()` is deprecated in favor of `can_retry()`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling with a new `StaleNodeError` type for detailed reporting of stale metadata issues.
	- Added retry logic improvements in the DAPI client, allowing for more nuanced error handling.
	- Introduced new fields in the SDK for managing proof staleness based on height and time.
	- Added methods for verifying proof metadata against defined tolerances.

- **Bug Fixes**
	- Updated logic for determining retry capabilities based on error types, improving reliability during DAPI requests.

- **Documentation**
	- Improved clarity in documentation comments related to the new retry logic and error handling.

- **Tests**
	- Added unit tests for new verification functions to ensure proof validity checks work as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->