### PR TITLE
ci: run devcontainers workflow only on push to master

### DIFF
--- a/.github/workflows/prebuild-devcontainers.yml
+++ b/.github/workflows/prebuild-devcontainers.yml
@@ -7,6 +7,8 @@ on:
       - '.github/workflows/prebuild-devcontainers.yml'
       - rust-toolchain.toml
       - Dockerfile
+    branches:
+      - master
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, a long devcontainers worflow is running in case if related files are changed on push to any branch

## What was done?
<!--- Describe your changes in detail -->
- Trigger workflow only on push to master

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to restrict prebuild triggers to the `master` branch only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->