### PR TITLE
feat(sdk): fetch many and return metadata and proof to client

### DIFF
--- a/packages/rs-dapi-client/src/executor.rs
+++ b/packages/rs-dapi-client/src/executor.rs
@@ -76,7 +76,7 @@ impl<E: CanRetry> CanRetry for ExecutionError<E> {
 }
 
 /// Request execution response.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ExecutionResponse<R> {
     /// The response from the request
     pub inner: R,

--- a/packages/rs-dapi-client/src/executor.rs
+++ b/packages/rs-dapi-client/src/executor.rs
@@ -76,7 +76,7 @@ impl<E: CanRetry> CanRetry for ExecutionError<E> {
 }
 
 /// Request execution response.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ExecutionResponse<R> {
     /// The response from the request
     pub inner: R,

--- a/packages/rs-sdk/src/platform/fetch_many.rs
+++ b/packages/rs-sdk/src/platform/fetch_many.rs
@@ -367,7 +367,7 @@ impl FetchMany<Identifier, Documents> for Document {
             let ExecutionResponse {
                 address,
                 retries,
-                inner: response, ..
+                inner: response
             } = request.execute(sdk, settings).await.map_err(|e| e.inner_into())?;
 
             tracing::trace!(request=?document_query, response=?response, ?address, retries, "fetch multiple documents");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Clients sometimes want to see the metadata or the proof data, this was implemented for fetch, but was not implemented for fetch_many.


## What was done?
Returns metadata and proof for fetch_many


## How Has This Been Tested?
Not tested


## Breaking Changes
No breaking changes


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new asynchronous methods in the `FetchMany` trait for enhanced data retrieval, including fetching with metadata and proof.
	- Updated the existing `fetch_many` method to return additional metadata alongside the fetched objects.

- **Bug Fixes**
	- Improved error handling and response parsing in the `fetch_many` method to accommodate new features.

- **Refactor**
	- Simplified the equality comparison behavior of the `ExecutionResponse` struct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->