### PR TITLE
build: explicitly require tonic v1.12.3

### DIFF
--- a/packages/dapi-grpc/Cargo.toml
+++ b/packages/dapi-grpc/Cargo.toml
@@ -35,7 +35,7 @@ mocks = ["serde", "dep:serde_json"]
 [dependencies]
 prost = { version = "0.13" }
 futures-core = "0.3.30"
-tonic = { version = "0.12", features = [
+tonic = { version = "0.12.3", features = [
   "codegen",
   "prost",
 ], default-features = false }
@@ -49,7 +49,7 @@ dapi-grpc-macros = { path = "../rs-dapi-grpc-macros" }
 platform-version = { path = "../rs-platform-version" }
 
 [build-dependencies]
-tonic-build = { version = "0.12" }
+tonic-build = { version = "0.12.3" }
 
 [lib]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Tonic < 0.12.3 has security vulnerability

Closes #2199 

## What was done?

Explicitly require tonic >= 0.12.3.

This PR does not change anything, as we already build against 0.12.3 (at least since [v1.4.0](https://github.com/dashpay/platform/blob/e406d63b899387f2cb48d209f0a09b21e5b01497/Cargo.lock#L4901)). It just adds formal requirement.

## How Has This Been Tested?

GHA

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency versions for improved compatibility and potential bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->