### PR TITLE
ci:  docker image always released as -dev

### DIFF
--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -190,7 +190,9 @@ runs:
         platforms: ${{ inputs.platform }}
         secret-files: |
           AWS=${{ env.HOME }}/.aws/credentials
-        build-args: ${{ steps.sccache.outputs.env_vars }}
+        build-args: |
+          CARGO_BUILD_PROFILE=${{ inputs.cargo_profile }}
+          ${{ steps.sccache.outputs.env_vars }}
         cache-from: ${{ steps.layer_cache_settings.outputs.cache_from }}
         cache-to: ${{ steps.layer_cache_settings.outputs.cache_to }}
         outputs: type=image,name=${{ inputs.image_org }}/${{ inputs.image_name }},push-by-digest=${{ inputs.push_tags != 'true' }},name-canonical=true,push=true

--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -68,6 +68,8 @@ jobs:
           cache_endpoint: ${{ vars.CACHE_S3_ENDPOINT }}
           cache_access_key_id: ${{ secrets.CACHE_KEY_ID }}
           cache_secret_access_key: ${{ secrets.CACHE_SECRET_KEY }}
+          # On release, we generate a new "base" image, so we need to save cache to name manifest, like '.../drive'
+          cache_to_name: ${{ github.event_name == 'release' && 'true' || 'false' }}
 
       - name: Export digest
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,9 +131,6 @@ RUN if [[ "$TARGETARCH" == "arm64" ]] ; then export PROTOC_ARCH=aarch_64; else e
 # Switch to clang
 RUN rm /usr/bin/cc && ln -s /usr/bin/clang /usr/bin/cc
 
-# Select whether we want dev or release
-ONBUILD ARG CARGO_BUILD_PROFILE=dev
-
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 
@@ -325,6 +322,10 @@ RUN --mount=type=secret,id=AWS \
     --disable-telemetry \
     --no-track \
     --no-confirm
+
+
+# Select whether we want dev or release
+ONBUILD ARG CARGO_BUILD_PROFILE=dev
 
 #
 # Rust build planner to speed up builds


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Due to some bug, docker images are always released as `dev`, not `release`

## What was done?

Restored missing line

## How Has This Been Tested?

GHA pipeline executed

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new input parameter `cargo_profile` for specifying the Cargo build profile during Docker image builds.
	- Enhanced configurability of the Docker build process by allowing users to set the Cargo profile through action inputs.
	- Added a new input parameter `cache_to_name` for improved caching during Docker image builds when a release is triggered.
	- Updated the Dockerfile to allow specification of the build profile, enhancing the build process for the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->