### PR TITLE
ci: replace actions/upload-artifact@v3 with actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -78,7 +78,7 @@ jobs:
           ls -lah ${{ env.DIGEST_DIR_PATH }}
 
       - name: Upload digest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.DIGEST_NAME }}
           path: ${{ env.DIGEST_DIR_PATH }}/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,7 @@ jobs:
         run: "${GITHUB_WORKSPACE}/scripts/pack_dashmate.sh ${{ matrix.package_type }}"
 
       - name: Upload artifacts to action summary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: github.event_name != 'release'
         with:
           name: dashmate


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

actions/upload-artifact@v3 is deprecated


## What was done?

replaced with actions/upload-artifact@v4

## How Has This Been Tested?

GHA

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
