### PR TITLE
build: enable drive image for Ivy Bridge CPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -263,11 +263,8 @@ set -ex -o pipefail
 git clone https://github.com/facebook/rocksdb.git -b v8.10.2 --depth 1 .
 source /root/env
 
-if [[ "$TARGETARCH" == "amd64" ]] ; then
-    export PORTABLE=haswell
-else
-    export PORTABLE=1
-fi
+# Support any CPU architecture
+export PORTABLE=1
 
 make -j$(nproc) static_lib
 mkdir -p /opt/rocksdb/usr/local/lib


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

In #2318, we compile librocksdb with CPU optimizations that require Haswell CPU instruction set. 
Unfortunately, some users use older CPUs like Ivy Bridge.

## What was done?

Build librocksdb on docker in `PORTALBLE=1` mode.

## How Has This Been Tested?

Local user-mode qemu instance, using `Nehalem` cpu.

* reproduced issue with drive 1.6.1
* tested with image dashpay/drive:1.6.2-pr.2363.1 - issue cannot be reproduced anymore

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
