### PR TITLE
fix(dashmate): status command fails if drive is not running

### DIFF
--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -6,6 +6,7 @@ import { DockerStatusEnum } from '../enums/dockerStatus.js';
 import { ServiceStatusEnum } from '../enums/serviceStatus.js';
 import determineStatus from '../determineStatus.js';
 import ContainerIsNotPresentError from '../../docker/errors/ContainerIsNotPresentError.js';
+import ServiceIsNotRunningError from '../../docker/errors/ServiceIsNotRunningError.js';
 
 /**
  * @returns {getPlatformScopeFactory}
@@ -218,7 +219,8 @@ export default function getPlatformScopeFactory(
       // Throw an error if it's not a Drive issue
       if (!(e instanceof DockerComposeError
         && e.dockerComposeExecutionResult
-        && e.dockerComposeExecutionResult.exitCode !== 0)) {
+        && e.dockerComposeExecutionResult.exitCode !== 0)
+          && !(e instanceof ServiceIsNotRunningError)) {
         throw e;
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The dashmate status is failing if drive is restarting 
```
ServiceIsNotRunningError: Service drive_abci for mainnet is not running. Please run the service first.

```

## What was done?
<!--- Describe your changes in detail -->
- Handled service is not running error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running command locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new error handling mechanism for when services are not running, enhancing the robustness of the application.
  
- **Bug Fixes**
	- Improved error management in the `getDriveInfo` function to prevent unnecessary error throws when the service is down.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->