### PR TITLE
refactor(sdk)!: separate dash core client error

### DIFF
--- a/packages/rs-dpp/src/bls/native_bls.rs
+++ b/packages/rs-dpp/src/bls/native_bls.rs
@@ -2,7 +2,6 @@ use crate::bls_signatures::{
     Bls12381G2Impl, Pairing, PublicKey, SecretKey, Signature, SignatureSchemes,
 };
 use crate::{BlsModule, ProtocolError, PublicKeyValidationError};
-use std::array::TryFromSliceError;
 
 #[derive(Default)]
 pub struct NativeBlsModule;

--- a/packages/rs-drive-proof-verifier/src/error.rs
+++ b/packages/rs-drive-proof-verifier/src/error.rs
@@ -119,6 +119,10 @@ pub enum ContextProviderError {
     /// Async error, eg. when tokio runtime fails
     #[error("async error: {0}")]
     AsyncError(String),
+
+    /// Dash Core error
+    #[error("Dash Core error: {0}")]
+    DashCoreError(String),
 }
 
 impl From<drive::error::Error> for Error {

--- a/packages/rs-sdk/src/core/error.rs
+++ b/packages/rs-sdk/src/core/error.rs
@@ -1,0 +1,55 @@
+//! Errors that can occur in the Dash Core.
+
+use drive_proof_verifier::error::ContextProviderError;
+use rs_dapi_client::CanRetry;
+
+/// Dash Core still warming up
+pub const CORE_RPC_ERROR_IN_WARMUP: i32 = -28;
+/// Dash Core Client is not connected
+pub const CORE_RPC_CLIENT_NOT_CONNECTED: i32 = -9;
+/// Dash Core still downloading initial blocks
+pub const CORE_RPC_CLIENT_IN_INITIAL_DOWNLOAD: i32 = -10;
+
+#[derive(Debug, thiserror::Error)]
+/// Errors that can occur when communicating with the Dash Core.
+pub enum DashCoreError {
+    /// Error from Dash Core.
+    #[error("Dash Core RPC error: {0}")]
+    Rpc(#[from] dashcore_rpc::Error),
+    /// Invalid format of the hash.
+    #[error("Invalid data format: {0}")]
+    InvalidQuorum(String),
+
+    /// Fork not activated yet
+    #[error("Fork not activated yet: {0}")]
+    ActivationForkError(String),
+}
+
+impl From<DashCoreError> for ContextProviderError {
+    fn from(error: DashCoreError) -> Self {
+        match error {
+            DashCoreError::Rpc(e) => Self::DashCoreError(e.to_string()),
+            DashCoreError::InvalidQuorum(e) => Self::InvalidQuorum(e),
+            DashCoreError::ActivationForkError(e) => Self::ActivationForkError(e),
+        }
+    }
+}
+
+impl CanRetry for DashCoreError {
+    fn can_retry(&self) -> bool {
+        use dashcore_rpc::jsonrpc::error::Error as JsonRpcError;
+        use dashcore_rpc::Error as RpcError;
+        match self {
+            DashCoreError::Rpc(RpcError::JsonRpc(JsonRpcError::Transport(..))) => true,
+            DashCoreError::Rpc(RpcError::JsonRpc(JsonRpcError::Rpc(e))) => {
+                matches!(
+                    e.code,
+                    CORE_RPC_ERROR_IN_WARMUP
+                        | CORE_RPC_CLIENT_NOT_CONNECTED
+                        | CORE_RPC_CLIENT_IN_INITIAL_DOWNLOAD,
+                )
+            }
+            _ => false,
+        }
+    }
+}

--- a/packages/rs-sdk/src/core/error.rs
+++ b/packages/rs-sdk/src/core/error.rs
@@ -16,12 +16,12 @@ pub enum DashCoreError {
     /// Error from Dash Core.
     #[error("Dash Core RPC error: {0}")]
     Rpc(#[from] dashcore_rpc::Error),
-    /// Invalid format of the hash.
-    #[error("Invalid data format: {0}")]
+    /// Quorum is invalid.
+    #[error("Invalid quorum: {0}")]
     InvalidQuorum(String),
 
-    /// Fork not activated yet
-    #[error("Fork not activated yet: {0}")]
+    /// Fork activation error - most likely the fork is not activated yet.
+    #[error("Fork activation: {0}")]
     ActivationForkError(String),
 }
 

--- a/packages/rs-sdk/src/core/error.rs
+++ b/packages/rs-sdk/src/core/error.rs
@@ -16,6 +16,7 @@ pub enum DashCoreError {
     /// Error from Dash Core.
     #[error("Dash Core RPC error: {0}")]
     Rpc(#[from] dashcore_rpc::Error),
+
     /// Quorum is invalid.
     #[error("Invalid quorum: {0}")]
     InvalidQuorum(String),

--- a/packages/rs-sdk/src/core/mod.rs
+++ b/packages/rs-sdk/src/core/mod.rs
@@ -6,3 +6,5 @@ mod dash_core_client;
 mod transaction;
 #[cfg(feature = "mocks")]
 pub use dash_core_client::LowLevelDashCoreClient;
+mod error;
+pub use error::DashCoreError;

--- a/packages/rs-sdk/src/mock/provider.rs
+++ b/packages/rs-sdk/src/mock/provider.rs
@@ -215,7 +215,7 @@ impl ContextProvider for GrpcContextProvider {
     }
 
     fn get_platform_activation_height(&self) -> Result<CoreBlockHeight, ContextProviderError> {
-        self.core.get_platform_activation_height()
+        Ok(self.core.get_platform_activation_height()?)
     }
 }
 

--- a/packages/rs-sdk/src/sync.rs
+++ b/packages/rs-sdk/src/sync.rs
@@ -244,7 +244,6 @@ where
 mod test {
     use super::*;
     use derive_more::Display;
-    use http::Uri;
     use rs_dapi_client::ExecutionError;
     use std::{
         future::Future,

--- a/packages/rs-sdk/tests/fetch/config.rs
+++ b/packages/rs-sdk/tests/fetch/config.rs
@@ -10,7 +10,7 @@ use dpp::{
 };
 use rs_dapi_client::{Address, AddressList};
 use serde::Deserialize;
-use std::{path::PathBuf, str::FromStr};
+use std::path::PathBuf;
 use zeroize::Zeroizing;
 
 /// Existing document ID

--- a/packages/rs-sdk/tests/fetch/evonode.rs
+++ b/packages/rs-sdk/tests/fetch/evonode.rs
@@ -4,7 +4,6 @@ use super::{common::setup_logs, config::Config};
 use dash_sdk::platform::{types::evonode::EvoNode, FetchUnproved};
 use dpp::dashcore::{hashes::Hash, ProTxHash};
 use drive_proof_verifier::types::EvoNodeStatus;
-use http::Uri;
 use rs_dapi_client::Address;
 use std::time::Duration;
 /// Given some existing evonode URIs, WHEN we connect to them, THEN we get status.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

For #2328 , we need to retry on some errors returned by dash core.



## What was done?

* Introduced DashCoreError that implements CanRetry

Built on top of  #2328.

## How Has This Been Tested?

GHA

## Breaking Changes

1. LowLevelDashCoreClient now returns DashCoreError instead of ContextProviderError.
2. Added ContextProviderError::DashCoreError variant
3. dash_sdk::Error::CoreClientError now uses DashCoreError instead of dashcore_rpc::Error.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new `DashCoreError` variant for improved error handling within the SDK.
	- Added a caching mechanism to enhance data retrieval efficiency.

- **Bug Fixes**
	- Improved error handling in the `get_platform_activation_height` method to better propagate errors.

- **Tests**
	- Enhanced EvoNode tests with timeout mechanisms and improved assertions for status checks.

- **Chores**
	- Removed unused import in the configuration test file to simplify dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->