### PR TITLE
revert: replace actions/upload-artifact@v3 with actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -80,7 +80,7 @@ jobs:
           ls -lah ${{ env.DIGEST_DIR_PATH }}
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.DIGEST_NAME }}
           path: ${{ env.DIGEST_DIR_PATH }}/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,7 @@ jobs:
         run: "${GITHUB_WORKSPACE}/scripts/pack_dashmate.sh ${{ matrix.package_type }}"
 
       - name: Upload artifacts to action summary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: github.event_name != 'release'
         with:
           name: dashmate


### PR DESCRIPTION
Reverts dashpay/platform#2359

In #2359, we changed to [upload-artifacts](https://github.com/actions/upload-artifact) v4 without updating the logic to address the following breaking change:

## Breaking Changes

### Uploading to the same named Artifact multiple times.

Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new input parameter `only_drive` for specifying Drive image builds.
  
- **Bug Fixes**
	- Enhanced conditional logic for steps in the release process based on artifact existence.

- **Chores**
	- Updated action versions for `upload-artifact` and `download-artifact` from `v4` to `v3` in multiple workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->