### PR TITLE
refactor(dpp): using deprecated param to init wasm module

### DIFF
--- a/packages/wasm-dpp/lib/index.ts
+++ b/packages/wasm-dpp/lib/index.ts
@@ -35,7 +35,7 @@ const loadDppModule = async () => {
     let wasmUrl = URL.createObjectURL(blob);
     await init(wasmUrl);
   } else {
-    dpp_module.initSync(bytes);
+    dpp_module.initSync({ module: bytes });
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When wasm-dpp is initialized we see:
```
using deprecated parameters for `initSync()`; pass a single object instead
```

## What was done?
<!--- Describe your changes in detail -->
- Use new way to pass the wasm module bytes to the `initSync` function

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the initialization process for the DPP module to enhance data encapsulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->