### PR TITLE
fix(drive-abci): document purchase on mutable document from different epoch had issue

### DIFF
--- a/.github/actions/librocksdb/action.yaml
+++ b/.github/actions/librocksdb/action.yaml
@@ -6,9 +6,9 @@ name: "librocksdb"
 description: "Build and install librocksdb"
 inputs:
   version:
-    description: RocksDB version, eg. "8.10.2"
+    description: RocksDB version, eg. "9.9.3"
     required: false
-    default: "8.10.2"
+    default: "9.9.3"
   force:
     description: Force rebuild
     required: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -224,7 +224,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.75",
+ "syn 2.0.96",
  "which",
 ]
 
@@ -428,7 +428,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -438,7 +438,7 @@ source = "git+https://github.com/dashpay/rs-bip37-bloom-filter?branch=develop#35
 dependencies = [
  "bitvec",
  "murmur3",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -506,7 +506,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -560,7 +560,7 @@ dependencies = [
  "sha2",
  "sha3",
  "subtle",
- "thiserror",
+ "thiserror 1.0.64",
  "uint-zigzag",
  "vsss-rs",
  "zeroize",
@@ -616,7 +616,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
  "syn_derive",
 ]
 
@@ -756,7 +756,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -862,7 +862,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -879,12 +879,11 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colored"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -943,21 +942,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -992,6 +979,21 @@ checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -1125,7 +1127,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1151,7 +1153,7 @@ dependencies = [
  "dapi-grpc",
  "heck 0.5.0",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1175,7 +1177,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1186,7 +1188,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1205,7 +1207,7 @@ dependencies = [
  "dapi-grpc-macros",
  "dashcore-rpc",
  "data-contracts",
- "derive_more 1.0.0",
+ "derive_more",
  "dotenvy",
  "dpp",
  "drive",
@@ -1221,7 +1223,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-case",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tokio-test",
  "tokio-util",
@@ -1303,7 +1305,7 @@ dependencies = [
  "platform-value",
  "platform-version",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -1317,10 +1319,16 @@ dependencies = [
  "platform-value",
  "platform-version",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
  "wallet-utils-contract",
  "withdrawals-contract",
 ]
+
+[[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "delegate"
@@ -1330,7 +1338,7 @@ checksum = "5060bb0febb73fa907273f8a7ed17ab4bf831d585eac835b28ec24a1e2460956"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1361,20 +1369,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1394,7 +1389,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
  "unicode-xid",
 ]
 
@@ -1423,7 +1418,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1445,7 +1440,7 @@ dependencies = [
  "platform-value",
  "platform-version",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -1463,7 +1458,7 @@ dependencies = [
  "ciborium 0.2.0",
  "dashcore",
  "data-contracts",
- "derive_more 1.0.0",
+ "derive_more",
  "dpp",
  "env_logger 0.11.5",
  "getrandom",
@@ -1494,7 +1489,7 @@ dependencies = [
  "sha2",
  "strum",
  "test-case",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
 ]
 
@@ -1511,7 +1506,7 @@ dependencies = [
  "chrono",
  "ciborium 0.2.0",
  "criterion",
- "derive_more 1.0.0",
+ "derive_more",
  "dpp",
  "enum-map",
  "grovedb",
@@ -1535,7 +1530,7 @@ dependencies = [
  "serde_json",
  "sqlparser",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.64",
  "tracing",
 ]
 
@@ -1557,7 +1552,7 @@ dependencies = [
  "dapi-grpc",
  "dashcore-rpc",
  "delegate",
- "derive_more 1.0.0",
+ "derive_more",
  "dotenvy",
  "dpp",
  "drive",
@@ -1586,7 +1581,7 @@ dependencies = [
  "strategy-tests",
  "tempfile",
  "tenderdash-abci",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1600,7 +1595,7 @@ version = "1.8.0-dev.2"
 dependencies = [
  "bincode",
  "dapi-grpc",
- "derive_more 1.0.0",
+ "derive_more",
  "dpp",
  "drive",
  "hex",
@@ -1610,7 +1605,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tenderdash-abci",
- "thiserror",
+ "thiserror 1.0.64",
  "tracing",
 ]
 
@@ -1621,7 +1616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9c8d6ea916fadcd87e3d1ff4802b696d717c83519b47e76f267ab77e536dd5a"
 dependencies = [
  "ed-derive",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -1727,7 +1722,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1813,28 +1808,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
-]
-
-[[package]]
 name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,7 +1831,7 @@ dependencies = [
  "platform-value",
  "platform-version",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2033,7 +2006,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2139,15 +2112,13 @@ dependencies = [
 
 [[package]]
 name = "grovedb"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d91e8f87926c834c7338d0c69a48816c043e0cddf0062a8a567483db2fb1e24"
+checksum = "ebf36cc41af86d8ccb8b7f64fd15006cd83ec979c49cd2ad30628bf855c54d7d"
 dependencies = [
  "axum",
  "bincode",
- "bitvec",
  "blake3",
- "derive_more 0.99.18",
  "grovedb-costs",
  "grovedb-merk",
  "grovedb-path",
@@ -2160,12 +2131,11 @@ dependencies = [
  "indexmap 2.7.0",
  "integer-encoding",
  "intmap",
- "itertools 0.12.1",
- "nohash-hasher",
+ "itertools 0.14.0",
  "reqwest",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-util",
  "tower-http",
@@ -2174,40 +2144,38 @@ dependencies = [
 
 [[package]]
 name = "grovedb-costs"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360f7c8d3b20beafcbf3cde8754bbcfd201ae2a30ec7594a4b9678fd2fa3c7a8"
+checksum = "9cc526a58bdca58cb86340632081e27264e3557a73608cf29f6738ad9bfab316"
 dependencies = [
  "integer-encoding",
  "intmap",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acec1b6962d99d7b079c0fd1532cd3a2c83a3d659ffd9fcf02edda4599334bb4"
+checksum = "abd5f01eb50ff57b2c24e856377684d42dacdbd04de7c0189bf2e0e0cd109692"
 dependencies = [
  "grovedb-costs",
  "hex",
  "integer-encoding",
  "intmap",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "grovedb-merk"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72057865f239fdd24f92eaa8668acc0d618da168f330546577a62eda1701210e"
+checksum = "0ce3b133a76e9935f3a57e08598769849d79df582244e1ac99509177e23c2605"
 dependencies = [
  "bincode",
  "blake3",
- "byteorder",
  "colored",
  "ed",
- "failure",
  "grovedb-costs",
  "grovedb-path",
  "grovedb-storage",
@@ -2218,21 +2186,20 @@ dependencies = [
  "integer-encoding",
  "num_cpus",
  "rand",
- "thiserror",
- "time",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "grovedb-path"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d96cc6106e5ca88e548d66f130b877b664da78be226dfdba555fc210f8508f4"
+checksum = "67dc8bc00b9be473f7b25670d1422daadd706c9b09ed6aa5cf2caf8722a487ac"
 
 [[package]]
 name = "grovedb-storage"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c9b59bc9fa7123b8485f87f88a886dd109e7aff5f34a29a3812cb64eb897ff"
+checksum = "905cff776de89b9ee1e96979861e254b0912170b35d89678ad782f487a22a2e3"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -2245,34 +2212,34 @@ dependencies = [
  "rocksdb",
  "strum",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "grovedb-version"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4be0c1a1ef97068fe93212e7b6f349e0b44a9fc90063c8c28e110cfb8c2fcb2"
+checksum = "a987e051c8c9cf8fa381b29b243d4951f8c1f24f9c90ceed52afca3ac460986c"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.11",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "grovedb-visualize"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5865f4335eb99644512a7d80d6b1698ba1099a8268fdfd3ffb1a3a32dcb4af28"
+checksum = "56eee6f57d324505611de0042af2b6b9933235e704a1a6542ff7ba5b5c56f64e"
 dependencies = [
  "hex",
- "itertools 0.12.1",
+ "itertools 0.14.0",
 ]
 
 [[package]]
 name = "grovedbg-types"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921b9a29facf9d3f0de667cd1da083a34695ede9e7bfacd74bb5bd29f8f7c178"
+checksum = "7cfa37a90579ba2c71e074d6047c1dcfc19caa458fbcefd4e8e31a02f6a9fe38"
 dependencies = [
  "serde",
  "serde_with 3.9.0",
@@ -2689,9 +2656,9 @@ checksum = "0d762194228a2f1c11063e46e32e5acb96e66e906382b9eb5441f2e0504bbd5a"
 
 [[package]]
 name = "intmap"
-version = "2.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee87fd093563344074bacf24faa0bb0227fb6969fb223e922db798516de924d6"
+checksum = "615970152acd1ae5f372f98eae7fab7ea63d4ee022cf655cf7079883bde9c3ee"
 dependencies = [
  "serde",
 ]
@@ -2756,6 +2723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2788,7 +2764,7 @@ checksum = "ec9ad60d674508f3ca8f380a928cfe7b096bc729c4e2dbfe3852bc45da3ab30b"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2800,7 +2776,7 @@ dependencies = [
  "json-schema-compatibility-validator",
  "once_cell",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2881,19 +2857,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.17.1+9.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
 dependencies = [
  "bindgen 0.69.4",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "lz4-sys",
@@ -2965,13 +2940,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
 name = "masternode-reward-shares-contract"
 version = "1.8.0-dev.2"
 dependencies = [
  "platform-value",
  "platform-version",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -3032,7 +3017,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tracing",
 ]
@@ -3126,7 +3111,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3148,7 +3133,7 @@ dependencies = [
  "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror",
+ "thiserror 1.0.64",
  "triomphe",
  "uuid",
 ]
@@ -3278,7 +3263,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3371,7 +3356,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3418,7 +3403,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3480,18 +3465,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3502,14 +3476,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]
@@ -3551,7 +3523,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3596,7 +3568,7 @@ version = "1.8.0-dev.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
  "virtue 0.0.17",
 ]
 
@@ -3617,7 +3589,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
  "treediff",
 ]
 
@@ -3626,7 +3598,7 @@ name = "platform-value-convertible"
 version = "1.8.0-dev.2"
 dependencies = [
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3636,7 +3608,7 @@ dependencies = [
  "bincode",
  "grovedb-version",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.64",
  "versioned-feature-core 1.0.0 (git+https://github.com/dashpay/versioned-feature-core)",
 ]
 
@@ -3646,7 +3618,7 @@ version = "1.8.0-dev.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3741,7 +3713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3788,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -3822,7 +3794,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.75",
+ "syn 2.0.96",
  "tempfile",
 ]
 
@@ -3836,7 +3808,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4127,9 +4099,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -4150,7 +4122,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tracing",
 ]
@@ -4431,7 +4403,7 @@ checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4465,7 +4437,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4532,7 +4504,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4544,7 +4516,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4763,7 +4735,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4794,9 +4766,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4812,7 +4784,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4828,18 +4800,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 dependencies = [
  "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
 ]
 
 [[package]]
@@ -4900,7 +4860,7 @@ dependencies = [
  "semver",
  "serde_json",
  "tenderdash-proto",
- "thiserror",
+ "thiserror 1.0.64",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4916,7 +4876,7 @@ source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.2.1%2B1.3.0#a
 dependencies = [
  "bytes",
  "chrono",
- "derive_more 1.0.0",
+ "derive_more",
  "flex-error",
  "num-derive",
  "num-traits",
@@ -4940,7 +4900,7 @@ dependencies = [
  "tonic-build",
  "ureq",
  "walkdir",
- "zip 2.2.0",
+ "zip",
 ]
 
 [[package]]
@@ -4976,7 +4936,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4987,7 +4947,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
  "test-case-core",
 ]
 
@@ -4997,7 +4957,16 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.64",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -5008,7 +4977,18 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5133,7 +5113,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5295,7 +5275,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5372,7 +5352,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5626,7 +5606,7 @@ dependencies = [
  "platform-value",
  "platform-version",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -5665,7 +5645,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
@@ -5700,7 +5680,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5728,7 +5708,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.64",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-logger",
@@ -5814,7 +5794,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5825,7 +5805,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5834,7 +5814,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5844,16 +5824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5862,7 +5833,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5871,22 +5842,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5895,21 +5851,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5919,21 +5869,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5949,21 +5887,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5973,21 +5899,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6023,7 +5937,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -6070,7 +5984,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6097,27 +6011,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "aes",
- "byteorder",
- "bzip2",
- "constant_time_eq 0.1.5",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6126,24 +6020,36 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494"
 dependencies = [
+ "aes",
  "arbitrary",
+ "bzip2",
+ "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
+ "deflate64",
  "displaydoc",
  "flate2",
+ "hmac",
  "indexmap 2.7.0",
+ "lzma-rs",
  "memchr",
- "thiserror",
+ "pbkdf2",
+ "rand",
+ "sha1",
+ "thiserror 1.0.64",
+ "time",
+ "zeroize",
  "zopfli",
+ "zstd",
 ]
 
 [[package]]
 name = "zip-extensions"
-version = "0.6.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecf62554c4ff96bce01a7ef123d160c3ffe9180638820f8b4d545c65b221b8c"
+checksum = "386508a00aae1d8218b9252a41f59bba739ccee3f8e420bb90bcb1c30d960d4a"
 dependencies = [
- "zip 0.6.6",
+ "zip",
 ]
 
 [[package]]
@@ -6162,20 +6068,19 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -260,7 +260,7 @@ WORKDIR /tmp/rocksdb
 
 RUN --mount=type=secret,id=AWS <<EOS
 set -ex -o pipefail
-git clone https://github.com/facebook/rocksdb.git -b v8.10.2 --depth 1 .
+git clone https://github.com/facebook/rocksdb.git -b v9.9.3 --depth 1 .
 source /root/env
 
 # Support any CPU architecture

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -99,7 +99,7 @@ assert_matches = "1.5.0"
 drive-abci = { path = ".", features = ["testing-config"] }
 
 # For tests of grovedb verify
-rocksdb = { version = "0.22.0" }
+rocksdb = { version = "0.23.0" }
 integer-encoding = { version = "4.0.0" }
 
 [features]

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
@@ -6447,6 +6447,7 @@ mod tests {
     }
 
     mod nft_tests {
+        use crate::test::helpers::fast_forward_to_block::fast_forward_to_block;
         use super::*;
         #[test]
         fn test_document_set_price_on_document_without_ability_to_purchase() {
@@ -7114,6 +7115,392 @@ mod tests {
                     None,
                 )
                 .expect("expect to create documents batch transition for the purchase");
+
+            let documents_batch_purchase_serialized_transition =
+                documents_batch_purchase_transition
+                    .serialize_to_bytes()
+                    .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &vec![documents_batch_purchase_serialized_transition],
+                    &platform_state,
+                    &BlockInfo::default_with_time(50000000),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            assert_eq!(processing_result.invalid_paid_count(), 0);
+
+            assert_eq!(processing_result.invalid_unpaid_count(), 0);
+
+            assert_eq!(processing_result.valid_count(), 1);
+
+            assert_eq!(processing_result.aggregated_fees().storage_fee, 64611000);
+
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 4080480);
+
+            assert_eq!(
+                processing_result
+                    .aggregated_fees()
+                    .fee_refunds
+                    .calculate_refunds_amount_for_identity(identity.id()),
+                Some(22704503)
+            );
+
+            let query_sender_results = platform
+                .drive
+                .query_documents(query_sender_identity_documents, None, false, None, None)
+                .expect("expected query result");
+
+            let query_receiver_results = platform
+                .drive
+                .query_documents(query_receiver_identity_documents, None, false, None, None)
+                .expect("expected query result");
+
+            // We expect the sender to have no documents, and the receiver to have 1
+            assert_eq!(query_sender_results.documents().len(), 0);
+
+            assert_eq!(query_receiver_results.documents().len(), 1);
+
+            let seller_balance = platform
+                .drive
+                .fetch_identity_balance(identity.id().to_buffer(), None, platform_version)
+                .expect("expected to get identity balance")
+                .expect("expected that identity exists");
+
+            // the seller should have received 0.1 and already had 0.1 minus the processing fee and storage fee
+            assert_eq!(
+                seller_balance,
+                dash_to_credits!(0.2) - original_creation_cost + 20014623
+            );
+
+            let buyers_balance = platform
+                .drive
+                .fetch_identity_balance(purchaser.id().to_buffer(), None, platform_version)
+                .expect("expected to get purchaser balance")
+                .expect("expected that purchaser exists");
+
+            // the buyer payed 0.1, but also storage and processing fees
+            assert_eq!(buyers_balance, dash_to_credits!(0.9) - 68691480);
+        }
+
+        #[test]
+        fn test_document_set_price_and_purchase_different_epoch() {
+            let platform_version = PlatformVersion::latest();
+            let (mut platform, contract) = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_initial_state_structure()
+                .with_crypto_card_game_nft(TradeMode::DirectPurchase);
+
+            let mut rng = StdRng::seed_from_u64(433);
+
+            let platform_state = platform.state.load();
+
+            let (identity, signer, key) = setup_identity(&mut platform, 958, dash_to_credits!(0.1));
+
+            let (purchaser, recipient_signer, recipient_key) =
+                setup_identity(&mut platform, 450, dash_to_credits!(1.0));
+
+            let seller_balance = platform
+                .drive
+                .fetch_identity_balance(identity.id().to_buffer(), None, platform_version)
+                .expect("expected to get identity balance")
+                .expect("expected that identity exists");
+
+            assert_eq!(seller_balance, dash_to_credits!(0.1));
+
+            let card_document_type = contract
+                .document_type_for_name("card")
+                .expect("expected a profile document type");
+
+            assert!(!card_document_type.documents_mutable());
+
+            let entropy = Bytes32::random_with_rng(&mut rng);
+
+            let mut document = card_document_type
+                .random_document_with_identifier_and_entropy(
+                    &mut rng,
+                    identity.id(),
+                    entropy,
+                    DocumentFieldFillType::DoNotFillIfNotRequired,
+                    DocumentFieldFillSize::AnyDocumentFillSize,
+                    platform_version,
+                )
+                .expect("expected a random document");
+
+            document.set("attack", 4.into());
+            document.set("defense", 7.into());
+
+            let documents_batch_create_transition =
+                DocumentsBatchTransition::new_document_creation_transition_from_document(
+                    document.clone(),
+                    card_document_type,
+                    entropy.0,
+                    &key,
+                    2,
+                    0,
+                    &signer,
+                    platform_version,
+                    None,
+                    None,
+                    None,
+                )
+                    .expect("expect to create documents batch transition");
+
+            let documents_batch_create_serialized_transition = documents_batch_create_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &vec![documents_batch_create_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_eq!(processing_result.valid_count(), 1);
+
+            assert_eq!(
+                processing_result
+                    .aggregated_fees()
+                    .clone()
+                    .into_balance_change(identity.id())
+                    .change(),
+                &BalanceChange::RemoveFromBalance {
+                    required_removed_balance: 123579000,
+                    desired_removed_balance: 126435860,
+                }
+            );
+
+            let original_creation_cost = 126435860;
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let seller_balance = platform
+                .drive
+                .fetch_identity_balance(identity.id().to_buffer(), None, platform_version)
+                .expect("expected to get identity balance")
+                .expect("expected that identity exists");
+
+            // the seller already had 0.1 minus the processing fee and storage fee
+            assert_eq!(
+                seller_balance,
+                dash_to_credits!(0.1) - original_creation_cost
+            );
+
+            let sender_documents_sql_string =
+                format!("select * from card where $ownerId == '{}'", identity.id());
+
+            let query_sender_identity_documents = DriveDocumentQuery::from_sql_expr(
+                sender_documents_sql_string.as_str(),
+                &contract,
+                Some(&platform.config.drive),
+            )
+                .expect("expected document query");
+
+            let receiver_documents_sql_string =
+                format!("select * from card where $ownerId == '{}'", purchaser.id());
+
+            let query_receiver_identity_documents = DriveDocumentQuery::from_sql_expr(
+                receiver_documents_sql_string.as_str(),
+                &contract,
+                Some(&platform.config.drive),
+            )
+                .expect("expected document query");
+
+            let query_sender_results = platform
+                .drive
+                .query_documents(
+                    query_sender_identity_documents.clone(),
+                    None,
+                    false,
+                    None,
+                    None,
+                )
+                .expect("expected query result");
+
+            let query_receiver_results = platform
+                .drive
+                .query_documents(
+                    query_receiver_identity_documents.clone(),
+                    None,
+                    false,
+                    None,
+                    None,
+                )
+                .expect("expected query result");
+
+            // We expect the sender to have 1 document, and the receiver to have none
+            assert_eq!(query_sender_results.documents().len(), 1);
+
+            assert_eq!(query_receiver_results.documents().len(), 0);
+            
+            // now let's update price, but first go to next epoch
+
+            fast_forward_to_block(&platform, 1_200_000_000, 900, 42, 1, false); //next epoch
+
+            document.set_revision(Some(2));
+
+            let documents_batch_update_price_transition =
+                DocumentsBatchTransition::new_document_update_price_transition_from_document(
+                    document.clone(),
+                    card_document_type,
+                    dash_to_credits!(0.1),
+                    &key,
+                    3,
+                    0,
+                    &signer,
+                    platform_version,
+                    None,
+                    None,
+                    None,
+                )
+                    .expect("expect to create documents batch transition for the update price");
+
+            let documents_batch_transfer_serialized_transition =
+                documents_batch_update_price_transition
+                    .serialize_to_bytes()
+                    .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &vec![documents_batch_transfer_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default_with_time(50000000),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            assert_eq!(processing_result.invalid_paid_count(), 0);
+
+            assert_eq!(processing_result.invalid_unpaid_count(), 0);
+
+            assert_eq!(processing_result.valid_count(), 1);
+
+            assert_eq!(processing_result.aggregated_fees().storage_fee, 216000); // we added 8 bytes for the price
+
+            assert_eq!(
+                processing_result
+                    .aggregated_fees()
+                    .fee_refunds
+                    .calculate_refunds_amount_for_identity(identity.id()),
+                None
+            );
+
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 2473880);
+
+            let seller_balance = platform
+                .drive
+                .fetch_identity_balance(identity.id().to_buffer(), None, platform_version)
+                .expect("expected to get identity balance")
+                .expect("expected that identity exists");
+
+            // the seller should have received 0.1 and already had 0.1 minus the processing fee and storage fee
+            assert_eq!(
+                seller_balance,
+                dash_to_credits!(0.1) - original_creation_cost - 2689880
+            );
+
+            let query_sender_results = platform
+                .drive
+                .query_documents(
+                    query_sender_identity_documents.clone(),
+                    None,
+                    false,
+                    None,
+                    None,
+                )
+                .expect("expected query result");
+
+            let query_receiver_results = platform
+                .drive
+                .query_documents(
+                    query_receiver_identity_documents.clone(),
+                    None,
+                    false,
+                    None,
+                    None,
+                )
+                .expect("expected query result");
+
+            // We expect the sender to still have their document, and the receiver to have none
+            assert_eq!(query_sender_results.documents().len(), 1);
+
+            assert_eq!(query_receiver_results.documents().len(), 0);
+
+            // The sender document should have the desired price
+
+            let mut document = query_sender_results.documents_owned().remove(0);
+
+            let price: Credits = document
+                .properties()
+                .get_integer("$price")
+                .expect("expected to get back price");
+
+            assert_eq!(dash_to_credits!(0.1), price);
+
+            // At this point we want to have the receiver purchase the document at the next epoch
+
+            fast_forward_to_block(&platform, 1_700_000_000, 1200, 42, 2, false); //next epoch
+
+            document.set_revision(Some(3));
+
+            let documents_batch_purchase_transition =
+                DocumentsBatchTransition::new_document_purchase_transition_from_document(
+                    document.clone(),
+                    card_document_type,
+                    purchaser.id(),
+                    dash_to_credits!(0.1), //same price as requested
+                    &recipient_key,
+                    1, // 1 because he's never done anything
+                    0,
+                    &recipient_signer,
+                    platform_version,
+                    None,
+                    None,
+                    None,
+                )
+                    .expect("expect to create documents batch transition for the purchase");
 
             let documents_batch_purchase_serialized_transition =
                 documents_batch_purchase_transition

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/documents_batch/mod.rs
@@ -7678,14 +7678,14 @@ mod tests {
 
             assert_eq!(processing_result.aggregated_fees().storage_fee, 64611000);
 
-            assert_eq!(processing_result.aggregated_fees().processing_fee, 4339120);
+            assert_eq!(processing_result.aggregated_fees().processing_fee, 4345280);
 
             assert_eq!(
                 processing_result
                     .aggregated_fees()
                     .fee_refunds
                     .calculate_refunds_amount_for_identity(identity.id()),
-                Some(53203452)
+                Some(52987722)
             );
 
             let query_sender_results = platform
@@ -7712,7 +7712,7 @@ mod tests {
             // the seller should have received 0.1 and already had 0.1 minus the processing fee and storage fee
             assert_eq!(
                 seller_balance,
-                dash_to_credits!(0.2) - original_creation_cost + 50272452
+                dash_to_credits!(0.2) - original_creation_cost + 46955162
             );
 
             let buyers_balance = platform
@@ -7722,7 +7722,7 @@ mod tests {
                 .expect("expected that purchaser exists");
 
             // the buyer paid 0.1, but also storage and processing fees
-            assert_eq!(buyers_balance, dash_to_credits!(0.9) - 68950120);
+            assert_eq!(buyers_balance, dash_to_credits!(0.9) - 68956280);
         }
 
         #[test]

--- a/packages/rs-drive-abci/tests/supporting_files/contract/crypto-card-game/crypto-card-game-direct-purchase-documents-mutable.json
+++ b/packages/rs-drive-abci/tests/supporting_files/contract/crypto-card-game/crypto-card-game-direct-purchase-documents-mutable.json
@@ -1,0 +1,134 @@
+{
+  "$format_version": "0",
+  "id": "86LHvdC1Tqx5P97LQUSibGFqf2vnKFpB6VkqQ7oso86e",
+  "ownerId": "2QjL594djCH2NyDsn45vd6yQjEDHupMKo7CEGVTHtQxU",
+  "version": 1,
+  "documentSchemas": {
+    "card": {
+      "type": "object",
+      "documentsMutable": true,
+      "canBeDeleted": true,
+      "transferable": 1,
+      "tradeMode": 1,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the card",
+          "maxLength": 63,
+          "position": 0
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the card",
+          "maxLength": 256,
+          "position": 1
+        },
+        "imageUrl": {
+          "type": "string",
+          "description": "URL of the image associated with the card",
+          "maxLength": 2048,
+          "format": "uri",
+          "position": 2
+        },
+        "imageHash": {
+          "type": "array",
+          "description": "SHA256 hash of the bytes of the image specified by imageUrl",
+          "byteArray": true,
+          "minItems": 32,
+          "maxItems": 32,
+          "position": 3
+        },
+        "imageFingerprint": {
+          "type": "array",
+          "description": "dHash of the image specified by imageUrl",
+          "byteArray": true,
+          "minItems": 8,
+          "maxItems": 8,
+          "position": 4
+        },
+        "attack": {
+          "type": "integer",
+          "description": "Attack power of the card",
+          "minimum": 0,
+          "position": 5
+        },
+        "defense": {
+          "type": "integer",
+          "description": "Defense level of the card",
+          "minimum": 0,
+          "position": 6
+        }
+      },
+      "indices": [
+        {
+          "name": "owner",
+          "properties": [
+            {
+              "$ownerId": "asc"
+            }
+          ]
+        },
+        {
+          "name": "attack",
+          "properties": [
+            {
+              "attack": "asc"
+            }
+          ]
+        },
+        {
+          "name": "defense",
+          "properties": [
+            {
+              "defense": "asc"
+            }
+          ]
+        },
+        {
+          "name": "transferredAt",
+          "properties": [
+            {
+              "$transferredAt": "asc"
+            }
+          ]
+        },
+        {
+          "name": "ownerTransferredAt",
+          "properties": [
+            {
+              "$ownerId": "asc"
+            },
+            {
+              "$transferredAt": "asc"
+            }
+          ]
+        },
+        {
+          "name": "transferredAtBlockHeight",
+          "properties": [
+            {
+              "$transferredAtBlockHeight": "asc"
+            }
+          ]
+        },
+        {
+          "name": "transferredAtCoreBlockHeight",
+          "properties": [
+            {
+              "$transferredAtCoreBlockHeight": "asc"
+            }
+          ]
+        }
+      ],
+      "required": [
+        "name",
+        "$transferredAt",
+        "$transferredAtBlockHeight",
+        "$transferredAtCoreBlockHeight",
+        "attack",
+        "defense"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -49,15 +49,15 @@ bs58 = { version = "0.5.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
 tempfile = { version = "3", optional = true }
 enum-map = { version = "2.0.3", optional = true }
-intmap = { version = "2.0.0", features = ["serde"], optional = true }
+intmap = { version = "3.0.1", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.13", optional = true }
-grovedb = { version = "2.1.0", optional = true, default-features = false }
-grovedb-costs = { version = "2.1.0", optional = true }
-grovedb-path = { version = "2.1.0" }
-grovedb-storage = { version = "2.1.0", optional = true }
-grovedb-version = { version = "2.1.0" }
-grovedb-epoch-based-storage-flags = { version = "2.1.0" }
+grovedb = { version = "2.2.1", optional = true, default-features = false }
+grovedb-costs = { version = "2.2.1", optional = true }
+grovedb-path = { version = "2.2.1" }
+grovedb-storage = { version = "2.2.1", optional = true }
+grovedb-version = { version = "2.2.1" }
+grovedb-epoch-based-storage-flags = { version = "2.2.1" }
 
 [dev-dependencies]
 criterion = "0.5"
@@ -104,7 +104,7 @@ server = [
   "dpp/system_contracts",
   "dpp/state-transitions",
   "fee-distribution",
-  "grovedb/full",
+  "grovedb/minimal",
   "grovedb/estimated_costs",
   "grovedb-storage",
   "grovedb-costs",

--- a/packages/rs-drive/src/drive/document/estimation_costs/stateless_delete_of_non_tree_for_costs/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/estimation_costs/stateless_delete_of_non_tree_for_costs/v0/mod.rs
@@ -77,17 +77,17 @@ impl Drive {
                             )),
                         ))?;
 
-                        Ok((s as u64, layer_info.clone()))
+                        Ok((s, layer_info.clone()))
                     })
-                    .collect::<Result<IntMap<EstimatedLayerInformation>, Error>>()?;
+                    .collect::<Result<IntMap<u16, EstimatedLayerInformation>, Error>>()?;
                 // We need to update the current layer to only have 1 element that we want to delete
                 let mut last_layer_information = layer_map
-                    .remove((key_info_path.len() - 1) as u64)
+                    .remove((key_info_path.len() - 1) as u16)
                     .ok_or(Error::Fee(FeeError::CorruptedEstimatedLayerInfoMissing(
                         "last layer info missing".to_owned(),
                     )))?;
                 last_layer_information.estimated_layer_sizes = element_estimated_sizes;
-                layer_map.insert((key_info_path.len() - 1) as u64, last_layer_information);
+                layer_map.insert((key_info_path.len() - 1) as u16, last_layer_information);
                 Ok(BatchDeleteUpTreeApplyType::StatelessBatchDelete {
                     estimated_layer_info: layer_map,
                 })

--- a/packages/rs-drive/src/util/grove_operations/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/mod.rs
@@ -221,7 +221,7 @@ pub enum BatchDeleteUpTreeApplyType {
     /// Stateless batch delete
     StatelessBatchDelete {
         /// The estimated layer info
-        estimated_layer_info: IntMap<EstimatedLayerInformation>,
+        estimated_layer_info: IntMap<u16, EstimatedLayerInformation>,
     },
     /// Stateful batch delete
     StatefulBatchDelete {

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 thiserror = { version = "1.0.63" }
 bincode = { version = "2.0.0-rc.3" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
-grovedb-version = { version = "2.1.0" }
+grovedb-version = { version = "2.2.1" }
 once_cell = "1.19.0"
 
 [features]

--- a/packages/strategy-tests/Cargo.toml
+++ b/packages/strategy-tests/Cargo.toml
@@ -46,4 +46,4 @@ platform-version = { path = "../rs-platform-version", features = [
 ] }
 
 # For tests of grovedb verify
-rocksdb = { version = "0.22.0" }
+rocksdb = { version = "0.23.0" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
If a document was changed at a different epoch, the bought at a different later epoch, this would cause a grovedb error. This has now been fixed. 


## What was done?
We also took the time to upgrade some dependencies in GroveDB, and reduce some dependencies as well leading to slightly faster compilation time.


## How Has This Been Tested?
All tests are passing.

## Breaking Changes
None expected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [X] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [X] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Updates**
  - Updated `rocksdb` library version from 0.22.0 to 0.23.0 in multiple packages
  - Updated `grovedb` and related dependencies to version 2.2.1
  - Updated `intmap` library to version 3.0.1
  - Updated `grovedb-version` to version 2.2.1 in the platform-version package

- **New Test Files**
  - Added JSON schema for a crypto card game document
  - Introduced new test cases for document pricing and purchasing mechanisms

- **Internal Improvements**
  - Enhanced validation logic for document handling
  - Modified data type handling in some internal functions
  - Updated enum field types in grove operations

- **Action and Dockerfile Updates**
  - Updated default RocksDB version in GitHub action and Dockerfile to 9.9.3
<!-- end of auto-generated comment: release notes by coderabbit.ai -->