### PR TITLE
fix(drive): more than one key was returned when expecting only one result

### DIFF
--- a/packages/rs-drive-abci/src/abci/handler/check_tx.rs
+++ b/packages/rs-drive-abci/src/abci/handler/check_tx.rs
@@ -151,10 +151,11 @@ where
             let handler_error = HandlerError::Internal(error.to_string());
 
             if tracing::enabled!(tracing::Level::ERROR) {
-                let st_hash = hex::encode(hash_single(tx));
+                let st_hash = hex::encode(hash_single(&tx));
 
                 tracing::error!(
                     ?error,
+                    st = hex::encode(tx),
                     st_hash,
                     check_tx_mode = r#type,
                     "Failed to check state transition ({}): {}",

--- a/packages/rs-drive/src/state_transition_action/identity/identity_credit_withdrawal/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_credit_withdrawal/transformer.rs
@@ -42,3 +42,66 @@ impl IdentityCreditWithdrawalTransitionAction {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::{Identity, IdentityPublicKey};
+    use dpp::state_transition::identity_credit_withdrawal_transition::v1::IdentityCreditWithdrawalTransitionV1;
+
+    #[test]
+    fn test_try_from_identity_credit_withdrawal_without_address_and_multiple_transfer_keys() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let platform_version = PlatformVersion::latest();
+
+        let mut identity = Identity::random_identity(1, Some(64), &platform_version)
+            .expect("create random identity");
+
+        let (transfer_key1, _) =
+            IdentityPublicKey::random_masternode_transfer_key(2, Some(64), &platform_version)
+                .expect("create random masternode transfer key");
+        let (transfer_key2, _) =
+            IdentityPublicKey::random_masternode_transfer_key(3, Some(64), &platform_version)
+                .expect("create random masternode transfer key");
+
+        identity.add_public_keys([transfer_key1, transfer_key2]);
+
+        let identity_id = identity.id();
+
+        drive
+            .add_new_identity(
+                identity,
+                true,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("create new identity");
+
+        let transition =
+            IdentityCreditWithdrawalTransition::V1(IdentityCreditWithdrawalTransitionV1 {
+                identity_id,
+                nonce: 0,
+                amount: 0,
+                core_fee_per_byte: 0,
+                pooling: Default::default(),
+                output_script: None,
+                user_fee_increase: 0,
+                signature_public_key_id: 0,
+                signature: Default::default(),
+            });
+
+        IdentityCreditWithdrawalTransitionAction::try_from_identity_credit_withdrawal(
+            &drive,
+            None,
+            &transition,
+            &BlockInfo::default(),
+            platform_version,
+        )
+        .expect("create action");
+    }
+}

--- a/packages/rs-drive/src/state_transition_action/identity/identity_credit_withdrawal/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_credit_withdrawal/v0/transformer.rs
@@ -93,7 +93,7 @@ impl IdentityCreditWithdrawalTransitionActionV0 {
             let key_request = IdentityKeysRequest {
                 identity_id: identity_credit_withdrawal.identity_id.to_buffer(),
                 request_type: KeyRequestType::RecentWithdrawalKeys,
-                limit: None,
+                limit: Some(1),
                 offset: None,
             };
             let key: Option<IdentityPublicKey> =
@@ -177,7 +177,7 @@ impl IdentityCreditWithdrawalTransitionActionV0 {
         let withdrawal_document = DocumentV0 {
             id: document_id,
             owner_id: identity_credit_withdrawal.identity_id,
-            properties: document_data.into_btree_string_map().unwrap(),
+            properties: document_data.into_btree_string_map()?,
             revision: Some(1),
             created_at: Some(block_info.time_ms),
             updated_at: Some(block_info.time_ms),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/dashpay/platform/issues/2418

## What was done?
<!--- Describe your changes in detail -->
- Limited number of recent withdrawal keys to 1 to comply with expected return type.
- Replaced `unwrap` to `?`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added an integration test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Since this error is happening on check tx we shouldn't have such transitions in the chain

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
