### PR TITLE
feat!: store/fetch reduced platform state in drive

### DIFF
--- a/packages/rs-dpp/src/lib.rs
+++ b/packages/rs-dpp/src/lib.rs
@@ -60,6 +60,7 @@ pub mod voting;
 pub mod core_types;
 
 pub mod group;
+pub mod reduced_platform_state;
 pub mod withdrawal;
 
 pub use async_trait;

--- a/packages/rs-dpp/src/reduced_platform_state/mod.rs
+++ b/packages/rs-dpp/src/reduced_platform_state/mod.rs
@@ -1,0 +1,40 @@
+use crate::reduced_platform_state::v0::ReducedPlatformStateForSavingV0;
+use crate::serialization::{PlatformSerializable, ReducedPlatformDeserializable};
+use crate::ProtocolError;
+use bincode::{config, Decode, Encode};
+use derive_more::From;
+use platform_version::version::PlatformVersion;
+use platform_version::TryIntoPlatformVersioned;
+use serde::{Deserialize, Serialize};
+
+pub mod v0;
+
+/// Reduced Platform State For Saving
+#[derive(Clone, Debug, Encode, Decode)]
+pub enum ReducedPlatformStateForSaving {
+    V0(ReducedPlatformStateForSavingV0),
+}
+
+impl ReducedPlatformDeserializable for ReducedPlatformStateForSaving {
+    type Error = ();
+
+    fn versioned_deserialize(
+        data: &[u8],
+        platform_version: &PlatformVersion,
+    ) -> Result<Self, ProtocolError>
+    where
+        Self: Sized,
+    {
+        let config = config::standard().with_big_endian().with_no_limit();
+        let reduced_platform_state_in_save_format: ReducedPlatformStateForSaving =
+            bincode::decode_from_slice(data, config)
+                .map_err(|e| {
+                    ProtocolError::PlatformDeserializationError(format!(
+                        "unable to deserialize ReducedPlatformStateForSaving: {}",
+                        e
+                    ))
+                })?
+                .0;
+        Ok(reduced_platform_state_in_save_format)
+    }
+}

--- a/packages/rs-dpp/src/reduced_platform_state/mod.rs
+++ b/packages/rs-dpp/src/reduced_platform_state/mod.rs
@@ -16,7 +16,6 @@ pub enum ReducedPlatformStateForSaving {
 }
 
 impl ReducedPlatformDeserializable for ReducedPlatformStateForSaving {
-    type Error = ();
 
     fn versioned_deserialize(
         data: &[u8],

--- a/packages/rs-dpp/src/reduced_platform_state/v0/mod.rs
+++ b/packages/rs-dpp/src/reduced_platform_state/v0/mod.rs
@@ -8,8 +8,6 @@ use platform_value::Bytes32;
 /// Reduced Platform State for Saving V0
 #[derive(Clone, Debug, Encode, Decode)]
 pub struct ReducedPlatformStateForSavingV0 {
-    /// Information about the genesis block
-    pub genesis_block_info: Option<BlockInfo>,
     /// Information about the last block
     pub last_committed_block_info: Option<ExtendedBlockInfo>,
     /// Current Version

--- a/packages/rs-dpp/src/reduced_platform_state/v0/mod.rs
+++ b/packages/rs-dpp/src/reduced_platform_state/v0/mod.rs
@@ -1,0 +1,25 @@
+use crate::block::block_info::BlockInfo;
+use crate::block::extended_block_info::ExtendedBlockInfo;
+use crate::fee::default_costs::EpochIndexFeeVersionsForStorage;
+use crate::util::deserializer::ProtocolVersion;
+use bincode::{Decode, Encode};
+use platform_value::Bytes32;
+
+/// Reduced Platform State for Saving V0
+#[derive(Clone, Debug, Encode, Decode)]
+pub struct ReducedPlatformStateForSavingV0 {
+    /// Information about the genesis block
+    pub genesis_block_info: Option<BlockInfo>,
+    /// Information about the last block
+    pub last_committed_block_info: Option<ExtendedBlockInfo>,
+    /// Current Version
+    pub current_protocol_version_in_consensus: ProtocolVersion,
+    /// upcoming protocol version
+    pub next_epoch_protocol_version: ProtocolVersion,
+    /// current quorum
+    pub current_validator_set_quorum_hash: Bytes32,
+    /// next quorum
+    pub next_validator_set_quorum_hash: Option<Bytes32>,
+    /// previous Fee Versions
+    pub previous_fee_versions: EpochIndexFeeVersionsForStorage,
+}

--- a/packages/rs-dpp/src/serialization/serialization_traits.rs
+++ b/packages/rs-dpp/src/serialization/serialization_traits.rs
@@ -37,7 +37,6 @@ pub trait ReducedPlatformSerializable {
 }
 
 pub trait ReducedPlatformDeserializable {
-    type Error;
     fn versioned_deserialize(
         data: &[u8],
         platform_version: &PlatformVersion,

--- a/packages/rs-dpp/src/serialization/serialization_traits.rs
+++ b/packages/rs-dpp/src/serialization/serialization_traits.rs
@@ -31,6 +31,21 @@ pub trait PlatformSerializable {
     }
 }
 
+pub trait ReducedPlatformSerializable {
+    type Error;
+    fn reduced_serialize_to_bytes(&self) -> Result<Vec<u8>, Self::Error>;
+}
+
+pub trait ReducedPlatformDeserializable {
+    type Error;
+    fn versioned_deserialize(
+        data: &[u8],
+        platform_version: &PlatformVersion,
+    ) -> Result<Self, ProtocolError>
+    where
+        Self: Sized;
+}
+
 pub trait PlatformSerializableWithPlatformVersion {
     type Error;
     /// Version based serialization is done based on the desired structure version.

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/mod.rs
@@ -15,6 +15,7 @@ use dpp::version::PlatformVersion;
 use drive::grovedb::Transaction;
 
 mod v0;
+mod v1;
 
 impl<C> Platform<C>
 where
@@ -152,6 +153,16 @@ Your software version: {}, latest supported protocol version: {}."#,
             .run_block_proposal
         {
             0 => self.run_block_proposal_v0(
+                block_proposal,
+                known_from_us,
+                epoch_info,
+                transaction,
+                platform_state,
+                block_platform_state,
+                block_platform_version,
+                timer,
+            ),
+            1 => self.run_block_proposal_v1(
                 block_proposal,
                 known_from_us,
                 epoch_info,

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v1/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v1/mod.rs
@@ -1,0 +1,427 @@
+use dpp::block::epoch::Epoch;
+
+use dpp::validation::ValidationResult;
+use drive::error::Error::GroveDB;
+
+use dpp::version::PlatformVersion;
+use drive::grovedb::Transaction;
+
+use crate::abci::AbciError;
+use crate::error::execution::ExecutionError;
+
+use crate::error::Error;
+use crate::execution::types::block_execution_context::v0::{
+    BlockExecutionContextV0Getters, BlockExecutionContextV0MutableGetters,
+};
+use crate::execution::types::block_execution_context::BlockExecutionContext;
+use crate::execution::types::block_fees::v0::BlockFeesV0;
+use crate::execution::types::block_state_info::v0::{
+    BlockStateInfoV0Getters, BlockStateInfoV0Methods, BlockStateInfoV0Setters,
+};
+use crate::execution::types::{block_execution_context, block_state_info};
+use crate::metrics::HistogramTiming;
+use crate::platform_types::block_execution_outcome;
+use crate::platform_types::block_proposal;
+use crate::platform_types::epoch_info::v0::{EpochInfoV0Getters, EpochInfoV0Methods};
+use crate::platform_types::epoch_info::EpochInfo;
+use crate::platform_types::platform::Platform;
+use crate::platform_types::platform_state::v0::PlatformStateV0Methods;
+use crate::platform_types::platform_state::PlatformState;
+use crate::platform_types::verify_chain_lock_result::v0::VerifyChainLockResult;
+use crate::rpc::core::CoreRPCLike;
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// Runs a block proposal, either from process proposal or prepare proposal.
+    ///
+    /// This function takes a `BlockProposal` and a `Transaction` as input and processes the block
+    /// proposal. It first validates the block proposal and then processes raw state transitions,
+    /// withdrawal transactions, and block fees. It also updates the validator set.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_proposal` - The block proposal to be processed.
+    /// * `known_from_us` - Do we know that we made this block proposal?.
+    /// * `transaction` - The transaction associated with the block proposal.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<ValidationResult<BlockExecutionOutcome, Error>, Error>` - If the block proposal is
+    ///   successfully processed, it returns a `ValidationResult` containing the `BlockExecutionOutcome`.
+    ///   If the block proposal processing fails, it returns an `Error`. Consensus errors are returned
+    ///   in the `ValidationResult`, while critical system errors are returned in the `Result`.
+    ///
+    /// # Errors
+    ///
+    /// This function may return an `Error` variant if there is a problem with processing the block
+    /// proposal, updating the core info, processing raw state transitions, or processing block fees.
+    ///
+    pub(super) fn run_block_proposal_v1(
+        &self,
+        block_proposal: block_proposal::v0::BlockProposal,
+        known_from_us: bool,
+        epoch_info: EpochInfo,
+        transaction: &Transaction,
+        last_committed_platform_state: &PlatformState,
+        mut block_platform_state: PlatformState,
+        platform_version: &'static PlatformVersion,
+        timer: Option<&HistogramTiming>,
+    ) -> Result<ValidationResult<block_execution_outcome::v0::BlockExecutionOutcome, Error>, Error>
+    {
+        tracing::trace!(
+            method = "run_block_proposal_v1",
+            ?block_proposal,
+            ?epoch_info,
+            "Running a block proposal for height: {}, round: {}",
+            block_proposal.height,
+            block_proposal.round,
+        );
+
+        // Run block proposal determines version by itself based on the previous
+        // state and block time.
+        // It should provide correct version on prepare proposal to block header
+        // and validate it on process proposal.
+        // If version set to 0 (default number value) it means we are on prepare proposal,
+        // so there is no need for validation.
+        if !known_from_us
+            && block_proposal.consensus_versions.app != platform_version.protocol_version as u64
+        {
+            return Ok(ValidationResult::new_with_error(
+                AbciError::BadRequest(format!(
+                    "received a block proposal with protocol version {}, expected: {}",
+                    block_proposal.consensus_versions.app, platform_version.protocol_version
+                ))
+                .into(),
+            ));
+        }
+
+        let last_block_time_ms = last_committed_platform_state.last_committed_block_time_ms();
+        let last_block_height = last_committed_platform_state.last_committed_known_block_height_or(
+            self.config.abci.genesis_height.saturating_sub(1),
+        );
+        let last_block_core_height = last_committed_platform_state
+            .last_committed_known_core_height_or(self.config.abci.genesis_core_height);
+
+        // Init block execution context
+        let block_state_info = block_state_info::v0::BlockStateInfoV0::from_block_proposal(
+            &block_proposal,
+            last_block_time_ms,
+        );
+
+        // First let's check that this is the follower to a previous block
+        if !block_state_info.next_block_to(last_block_height, last_block_core_height)? {
+            // we are on the wrong height or round
+            return Ok(ValidationResult::new_with_error(AbciError::WrongBlockReceived(format!(
+                "received a block proposal for height: {} core height: {}, current height: {} core height: {}",
+                block_state_info.height, block_state_info.core_chain_locked_height, last_block_height, last_block_core_height
+            )).into()));
+        }
+
+        // Cleanup block cache before we execute a new proposal
+        self.clear_drive_block_cache(platform_version)?;
+
+        // destructure the block proposal
+        let block_proposal::v0::BlockProposal {
+            core_chain_locked_height,
+            core_chain_lock_update,
+            proposed_app_version,
+            proposer_pro_tx_hash,
+            validator_set_quorum_hash,
+            raw_state_transitions,
+            ..
+        } = block_proposal;
+
+        let block_info = block_state_info.to_block_info(
+            Epoch::new(epoch_info.current_epoch_index())
+                .expect("current epoch index should be in range"),
+        );
+
+        if epoch_info.is_epoch_change_but_not_genesis() {
+            tracing::info!(
+                epoch_index = epoch_info.current_epoch_index(),
+                "epoch change occurring from epoch {} to epoch {}",
+                epoch_info
+                    .previous_epoch_index()
+                    .expect("must be set since we aren't on genesis"),
+                epoch_info.current_epoch_index(),
+            );
+        }
+
+        // Update block platform state with current and next epoch protocol versions
+        // if it was proposed
+        // This is happening only on epoch change
+        self.upgrade_protocol_version_on_epoch_change(
+            &block_info,
+            &epoch_info,
+            last_committed_platform_state,
+            &mut block_platform_state,
+            transaction,
+            platform_version,
+        )?;
+
+        // If there is a core chain lock update, we should start by verifying it
+        if let Some(core_chain_lock_update) = core_chain_lock_update.as_ref() {
+            if !known_from_us {
+                let verification_result = self.verify_chain_lock(
+                    block_state_info.round, // the round is to allow us to bypass local verification in case of chain stall
+                    &block_platform_state,
+                    core_chain_lock_update,
+                    true, // if it's not known from us, then we should try submitting it
+                    platform_version,
+                );
+
+                let VerifyChainLockResult {
+                    chain_lock_signature_is_deserializable,
+                    found_valid_locally,
+                    found_valid_by_core,
+                    core_is_synced,
+                } = match verification_result {
+                    Ok(verification_result) => verification_result,
+                    Err(Error::Execution(e)) => {
+                        // This will happen only if an internal version error
+                        return Err(Error::Execution(e));
+                    }
+                    Err(e) => {
+                        // This will happen only if a core rpc error
+                        return Ok(ValidationResult::new_with_error(
+                            AbciError::InvalidChainLock(e.to_string()).into(),
+                        ));
+                    }
+                };
+
+                if !chain_lock_signature_is_deserializable {
+                    return Ok(ValidationResult::new_with_error(
+                        AbciError::InvalidChainLock(format!(
+                            "received a chain lock for height {} that has a signature that can not be deserialized {:?}",
+                            block_info.height, core_chain_lock_update,
+                        ))
+                            .into(),
+                    ));
+                }
+
+                if let Some(found_valid_locally) = found_valid_locally {
+                    // This means we are able to check if the chain lock is valid
+                    if !found_valid_locally {
+                        // The signature was not valid
+                        return Ok(ValidationResult::new_with_error(
+                            AbciError::InvalidChainLock(format!(
+                                "received a chain lock for height {} that we figured out was invalid based on platform state {:?}",
+                                block_info.height, core_chain_lock_update,
+                            ))
+                                .into(),
+                        ));
+                    }
+                }
+
+                if let Some(found_valid_by_core) = found_valid_by_core {
+                    // This means we asked core if the chain lock was valid
+                    if !found_valid_by_core {
+                        // Core said it wasn't valid
+                        return Ok(ValidationResult::new_with_error(
+                            AbciError::InvalidChainLock(format!(
+                                "received a chain lock for height {} that is invalid based on a core request {:?}",
+                                block_info.height, core_chain_lock_update,
+                            ))
+                                .into(),
+                        ));
+                    }
+                }
+
+                if let Some(core_is_synced) = core_is_synced {
+                    // Core is just not synced
+                    if !core_is_synced {
+                        // The submission was not accepted by core
+                        return Ok(ValidationResult::new_with_error(
+                            AbciError::ChainLockedBlockNotKnownByCore(format!(
+                                "received a chain lock for height {} that we could not accept because core is not synced {:?}",
+                                block_info.height, core_chain_lock_update,
+                            ))
+                                .into(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Update the masternode list and create masternode identities and also update the active quorums
+        self.update_core_info(
+            Some(last_committed_platform_state),
+            &mut block_platform_state,
+            core_chain_locked_height,
+            false,
+            &block_info,
+            transaction,
+            platform_version,
+        )?;
+
+        // Update the validator proposed app version
+        // It should be called after protocol version upgrade
+        self.drive
+            .update_validator_proposed_app_version(
+                proposer_pro_tx_hash,
+                proposed_app_version as u32,
+                Some(transaction),
+                &platform_version.drive,
+            )
+            .map_err(|e| {
+                Error::Execution(ExecutionError::UpdateValidatorProposedAppVersionError(e))
+            })?; // This is a system error
+
+        // Rebroadcast expired withdrawals if they exist
+        // We do that before we mark withdrawals as expired
+        // to rebroadcast them on the next block but not the same
+        // one
+        // TODO: It must be also only on core height change
+        self.rebroadcast_expired_withdrawal_documents(
+            &block_info,
+            last_committed_platform_state,
+            transaction,
+            platform_version,
+        )?;
+
+        // Mark all previously broadcasted and chainlocked withdrawals as complete
+        // only when we are on a new core height
+        if block_state_info.core_chain_locked_height() != last_block_core_height {
+            self.update_broadcasted_withdrawal_statuses(
+                &block_info,
+                transaction,
+                platform_version,
+            )?;
+        }
+
+        // Preparing withdrawal transactions for signing and broadcasting
+        // To process withdrawals we need to dequeue untiled transactions from the withdrawal transactions queue
+        // Untiled transactions then converted to unsigned transactions, appending current block information
+        // required for signature verification (core height and quorum hash)
+        // Then we save unsigned transaction bytes to block execution context
+        // to be signed (on extend_vote), verified (on verify_vote) and broadcasted (on finalize_block)
+        // Also, the dequeued untiled transaction added to the broadcasted transaction queue to for further
+        // resigning in case of failures.
+        let unsigned_withdrawal_transaction_bytes = self
+            .dequeue_and_build_unsigned_withdrawal_transactions(
+                validator_set_quorum_hash,
+                &block_info,
+                Some(transaction),
+                platform_version,
+            )?;
+
+        // Run all dao platform events, such as vote tallying and distribution of contested documents
+        // This must be done before state transition processing
+        // Otherwise we would expect a proof after a successful vote that has since been cleaned up.
+        self.run_dao_platform_events(
+            &block_info,
+            last_committed_platform_state,
+            &block_platform_state,
+            Some(transaction),
+            platform_version,
+        )?;
+
+        // Process transactions
+        let state_transitions_result = self.process_raw_state_transitions(
+            raw_state_transitions,
+            &block_platform_state,
+            &block_info,
+            transaction,
+            platform_version,
+            known_from_us,
+            timer,
+        )?;
+
+        // Pool withdrawals into transactions queue
+
+        // Takes queued withdrawals, creates untiled withdrawal transaction payload, saves them to queue
+        // Corresponding withdrawal documents are changed from queued to pooled
+        self.pool_withdrawals_into_transactions_queue(
+            &block_info,
+            last_committed_platform_state,
+            Some(transaction),
+            platform_version,
+        )?;
+
+        // Cleans up the expired locks for withdrawal amounts
+        // to update daily withdrawal limit
+        // This is for example when we make a withdrawal for 30 Dash
+        // But we can only withdraw 1000 Dash a day
+        // after the withdrawal we should only be able to withdraw 970 Dash
+        // But 24 hours later that locked 30 comes back
+        self.clean_up_expired_locks_of_withdrawal_amounts(
+            &block_info,
+            transaction,
+            platform_version,
+        )?;
+
+        // Create a new block execution context
+
+        let mut block_execution_context: BlockExecutionContext =
+            block_execution_context::v0::BlockExecutionContextV0 {
+                block_state_info: block_state_info.into(),
+                epoch_info,
+                unsigned_withdrawal_transactions: unsigned_withdrawal_transaction_bytes,
+                block_platform_state,
+                proposer_results: None,
+            }
+            .into();
+
+        // while we have the state transitions executed, we now need to process the block fees
+        let block_fees_v0: BlockFeesV0 = state_transitions_result.aggregated_fees().clone().into();
+
+        // Process fees
+        let processed_block_fees = self.process_block_fees_and_validate_sum_trees(
+            &block_execution_context,
+            block_fees_v0.into(),
+            transaction,
+            platform_version,
+        )?;
+
+        tracing::debug!(block_fees = ?processed_block_fees, "block fees are processed");
+
+        self.store_reduced_platform_state(
+            &block_execution_context.block_platform_state(),
+            Some(transaction),
+            platform_version,
+        )?;
+
+        let root_hash = self
+            .drive
+            .grove
+            .root_hash(Some(transaction), &platform_version.drive.grove_version)
+            .unwrap()
+            .map_err(|e| Error::Drive(GroveDB(e)))?; //GroveDb errors are system errors
+
+        block_execution_context
+            .block_state_info_mut()
+            .set_app_hash(Some(root_hash));
+
+        let validator_set_update = self.validator_set_update(
+            block_proposal.proposer_pro_tx_hash,
+            last_committed_platform_state,
+            &mut block_execution_context,
+            platform_version,
+        )?;
+
+        if tracing::enabled!(tracing::Level::TRACE) {
+            tracing::trace!(
+                method = "run_block_proposal_v0",
+                app_hash = hex::encode(root_hash),
+                platform_state_fingerprint = hex::encode(
+                    block_execution_context
+                        .block_platform_state()
+                        .fingerprint()?
+                ),
+                "Block proposal executed successfully",
+            );
+        }
+
+        Ok(ValidationResult::new_with_data(
+            block_execution_outcome::v0::BlockExecutionOutcome {
+                app_hash: root_hash,
+                state_transitions_result,
+                validator_set_update,
+                platform_version,
+                block_execution_context,
+            },
+        ))
+    }
+}

--- a/packages/rs-drive-abci/src/execution/storage/fetch_reduced_platform_state/mod.rs
+++ b/packages/rs-drive-abci/src/execution/storage/fetch_reduced_platform_state/mod.rs
@@ -1,0 +1,34 @@
+use crate::error::execution::ExecutionError;
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use dpp::reduced_platform_state::ReducedPlatformStateForSaving;
+use dpp::version::PlatformVersion;
+use drive::drive::Drive;
+use drive::query::TransactionArg;
+
+mod v0;
+
+impl<C> Platform<C> {
+    /// Fetches execution state from grovedb storage
+    pub fn fetch_reduced_platform_state(
+        drive: &Drive,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Option<ReducedPlatformStateForSaving>, Error> {
+        match platform_version
+            .drive_abci
+            .methods
+            .platform_reduced_state_storage
+            .fetch_reduced_platform_state
+        {
+            0 => {
+                Platform::<C>::fetch_reduced_platform_state_v0(drive, transaction, platform_version)
+            }
+            version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
+                method: "fetch_reduced_platform_state".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive-abci/src/execution/storage/fetch_reduced_platform_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/storage/fetch_reduced_platform_state/v0/mod.rs
@@ -1,0 +1,42 @@
+use crate::abci::AbciError;
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::platform_types::platform_state::PlatformState;
+use bincode::config;
+use dpp::reduced_platform_state::v0::ReducedPlatformStateForSavingV0;
+use dpp::reduced_platform_state::ReducedPlatformStateForSaving;
+use dpp::serialization::{
+    PlatformDeserializableFromVersionedStructure, ReducedPlatformDeserializable,
+};
+use dpp::version::PlatformVersion;
+use dpp::ProtocolError;
+use drive::drive::Drive;
+use drive::query::TransactionArg;
+
+impl<C> Platform<C> {
+    pub(super) fn fetch_reduced_platform_state_v0(
+        drive: &Drive,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Option<ReducedPlatformStateForSaving>, Error> {
+        drive
+            .fetch_reduced_platform_state_bytes(transaction, platform_version)
+            .map_err(Error::Drive)?
+            .map(|bytes| {
+                let result =
+                    ReducedPlatformStateForSaving::versioned_deserialize(&bytes, platform_version)
+                        .map_err(Error::Protocol);
+
+                if result.is_err() {
+                    tracing::error!(
+                        bytes = hex::encode(&bytes),
+                        "Unable deserialize reduced platform state for version {}",
+                        platform_version.protocol_version
+                    );
+                }
+
+                result
+            })
+            .transpose()
+    }
+}

--- a/packages/rs-drive-abci/src/execution/storage/mod.rs
+++ b/packages/rs-drive-abci/src/execution/storage/mod.rs
@@ -1,2 +1,4 @@
 mod fetch_platform_state;
+mod fetch_reduced_platform_state;
 mod store_platform_state;
+mod store_reduced_platform_state;

--- a/packages/rs-drive-abci/src/execution/storage/store_reduced_platform_state/mod.rs
+++ b/packages/rs-drive-abci/src/execution/storage/store_reduced_platform_state/mod.rs
@@ -1,0 +1,32 @@
+mod v0;
+
+use crate::error::execution::ExecutionError;
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::platform_types::platform_state::PlatformState;
+use dpp::version::PlatformVersion;
+use drive::query::TransactionArg;
+
+impl<C> Platform<C> {
+    /// Store the execution state in grovedb storage
+    pub fn store_reduced_platform_state(
+        &self,
+        state: &PlatformState,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        match platform_version
+            .drive_abci
+            .methods
+            .platform_state_storage
+            .store_platform_state
+        {
+            0 => self.store_reduced_platform_state_v0(state, transaction, platform_version),
+            version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
+                method: "store_reduced_platform_state".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive-abci/src/execution/storage/store_reduced_platform_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/storage/store_reduced_platform_state/v0/mod.rs
@@ -1,0 +1,24 @@
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::platform_types::platform_state::PlatformState;
+use dpp::serialization::{PlatformSerializable, ReducedPlatformSerializable};
+use dpp::version::PlatformVersion;
+use drive::query::TransactionArg;
+
+impl<C> Platform<C> {
+    pub(super) fn store_reduced_platform_state_v0(
+        &self,
+        state: &PlatformState,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        self.drive
+            .store_reduced_platform_state_bytes(
+                &state.reduced_serialize_to_bytes()?,
+                transaction,
+                platform_version,
+            )
+            .map_err(Error::Drive)?;
+        Ok(())
+    }
+}

--- a/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
@@ -30,6 +30,7 @@ use dpp::fee::default_costs::{
     CachedEpochIndexFeeVersions, CachedEpochIndexFeeVersionsFieldsBeforeVersion4,
     EpochIndexFeeVersionsForStorage,
 };
+use dpp::reduced_platform_state::v0::ReducedPlatformStateForSavingV0;
 use dpp::version::fee::FeeVersion;
 use itertools::Itertools;
 use std::collections::BTreeMap;
@@ -243,6 +244,31 @@ impl TryFrom<PlatformStateV0> for PlatformStateForSavingV1 {
                     ))
                 })
                 .collect::<Result<BTreeMap<Bytes32, Masternode>, Error>>()?,
+            previous_fee_versions: value
+                .previous_fee_versions
+                .into_iter()
+                .map(|(epoch_index, fee_version)| (epoch_index, fee_version.fee_version_number))
+                .collect(),
+        })
+    }
+}
+
+impl TryFrom<PlatformStateV0> for ReducedPlatformStateForSavingV0 {
+    type Error = Error;
+
+    fn try_from(value: PlatformStateV0) -> Result<Self, Self::Error> {
+        Ok(ReducedPlatformStateForSavingV0 {
+            genesis_block_info: value.genesis_block_info,
+            last_committed_block_info: value.last_committed_block_info,
+            current_protocol_version_in_consensus: value.current_protocol_version_in_consensus,
+            next_epoch_protocol_version: value.next_epoch_protocol_version,
+            current_validator_set_quorum_hash: value
+                .current_validator_set_quorum_hash
+                .to_byte_array()
+                .into(),
+            next_validator_set_quorum_hash: value
+                .next_validator_set_quorum_hash
+                .map(|quorum_hash| quorum_hash.to_byte_array().into()),
             previous_fee_versions: value
                 .previous_fee_versions
                 .into_iter()

--- a/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/v0/mod.rs
@@ -258,7 +258,6 @@ impl TryFrom<PlatformStateV0> for ReducedPlatformStateForSavingV0 {
 
     fn try_from(value: PlatformStateV0) -> Result<Self, Self::Error> {
         Ok(ReducedPlatformStateForSavingV0 {
-            genesis_block_info: value.genesis_block_info,
             last_committed_block_info: value.last_committed_block_info,
             current_protocol_version_in_consensus: value.current_protocol_version_in_consensus,
             next_epoch_protocol_version: value.next_epoch_protocol_version,

--- a/packages/rs-drive/src/drive/platform_state/fetch_reduced_platform_state_bytes/mod.rs
+++ b/packages/rs-drive/src/drive/platform_state/fetch_reduced_platform_state_bytes/mod.rs
@@ -1,0 +1,30 @@
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use dpp::version::PlatformVersion;
+use grovedb::TransactionArg;
+
+mod v0;
+
+impl Drive {
+    /// Fetches execution state from grovedb storage
+    pub fn fetch_reduced_platform_state_bytes(
+        &self,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        match platform_version
+            .drive
+            .methods
+            .reduced_platform_state
+            .fetch_reduced_platform_state_bytes
+        {
+            0 => self.fetch_reduced_platform_state_bytes_v0(transaction, platform_version),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "fetch_reduced_platform_state_bytes".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/platform_state/fetch_reduced_platform_state_bytes/v0/mod.rs
+++ b/packages/rs-drive/src/drive/platform_state/fetch_reduced_platform_state_bytes/v0/mod.rs
@@ -1,0 +1,38 @@
+use crate::drive::platform_state::REDUCED_PLATFORM_STATE_KEY;
+use crate::drive::system::misc_path_vec;
+use crate::drive::Drive;
+use crate::error::Error;
+use grovedb::{PathQuery, Query, TransactionArg};
+use platform_version::version::PlatformVersion;
+
+impl Drive {
+    pub(super) fn fetch_reduced_platform_state_bytes_v0(
+        &self,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        let mut query = Query::new();
+        query.insert_key(Vec::from(REDUCED_PLATFORM_STATE_KEY));
+
+        let path_query = PathQuery::new_unsized(misc_path_vec(), query.clone());
+
+        let (res, _) = self
+            .grove
+            .query_item_value(
+                &path_query,
+                true,
+                false,
+                true,
+                transaction,
+                &platform_version.drive.grove_version,
+            )
+            .value?;
+
+        if res.len() != 1 {
+            return Err(Error::GroveDB(grovedb::Error::InvalidQuery(
+                "Invalid number of reduced platform state elements",
+            )));
+        }
+        Ok(res.into_iter().next())
+    }
+}

--- a/packages/rs-drive/src/drive/platform_state/mod.rs
+++ b/packages/rs-drive/src/drive/platform_state/mod.rs
@@ -1,4 +1,7 @@
 mod fetch_platform_state_bytes;
+mod fetch_reduced_platform_state_bytes;
 mod store_platform_state_bytes;
+mod store_reduced_platform_state_bytes;
 
 const PLATFORM_STATE_KEY: &[u8; 11] = b"saved_state";
+const REDUCED_PLATFORM_STATE_KEY: &[u8; 19] = b"reduced_saved_state";

--- a/packages/rs-drive/src/drive/platform_state/store_reduced_platform_state_bytes/mod.rs
+++ b/packages/rs-drive/src/drive/platform_state/store_reduced_platform_state_bytes/mod.rs
@@ -1,0 +1,31 @@
+mod v0;
+
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use dpp::version::PlatformVersion;
+use grovedb::TransactionArg;
+
+impl Drive {
+    /// Store the execution state in grovedb storage
+    pub fn store_reduced_platform_state_bytes(
+        &self,
+        state_bytes: &[u8],
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        match platform_version
+            .drive
+            .methods
+            .reduced_platform_state
+            .store_reduced_platform_state_bytes
+        {
+            0 => self.store_reduced_platform_state_bytes_v0(state_bytes, transaction),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "store_reduced_platform_state_bytes".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/platform_state/store_reduced_platform_state_bytes/v0/mod.rs
+++ b/packages/rs-drive/src/drive/platform_state/store_reduced_platform_state_bytes/v0/mod.rs
@@ -1,0 +1,25 @@
+use crate::drive::platform_state::REDUCED_PLATFORM_STATE_KEY;
+use crate::drive::system::misc_path;
+use crate::drive::Drive;
+use crate::error::Error;
+use grovedb::{Element, TransactionArg};
+
+impl Drive {
+    pub(super) fn store_reduced_platform_state_bytes_v0(
+        &self,
+        reduced_state_bytes: &[u8],
+        transaction: TransactionArg,
+    ) -> Result<(), Error> {
+        self.grove
+            .insert_if_not_exists(
+                &misc_path(),
+                REDUCED_PLATFORM_STATE_KEY,
+                Element::Item(reduced_state_bytes.to_vec(), None),
+                transaction,
+                &Default::default(),
+            )
+            .unwrap()
+            .map_err(Error::GroveDB)?;
+        Ok(())
+    }
+}

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
@@ -26,12 +26,19 @@ pub struct DriveAbciMethodVersions {
     pub block_start: DriveAbciBlockStartMethodVersions,
     pub block_end: DriveAbciBlockEndMethodVersions,
     pub platform_state_storage: DriveAbciPlatformStateStorageMethodVersions,
+    pub platform_reduced_state_storage: DriveAbciReducedPlatformStateStorageMethodVersions,
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct DriveAbciPlatformStateStorageMethodVersions {
     pub fetch_platform_state: FeatureVersion,
     pub store_platform_state: FeatureVersion,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DriveAbciReducedPlatformStateStorageMethodVersions {
+    pub fetch_reduced_platform_state: FeatureVersion,
+    pub store_reduced_platform_state: FeatureVersion,
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v1.rs
@@ -8,6 +8,7 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciIdentityCreditWithdrawalMethodVersions, DriveAbciInitializationMethodVersions,
     DriveAbciMasternodeIdentitiesUpdatesMethodVersions, DriveAbciMethodVersions,
     DriveAbciPlatformStateStorageMethodVersions, DriveAbciProtocolUpgradeMethodVersions,
+    DriveAbciReducedPlatformStateStorageMethodVersions,
     DriveAbciStateTransitionProcessingMethodVersions, DriveAbciTokensProcessingMethodVersions,
     DriveAbciVotingMethodVersions,
 };
@@ -121,5 +122,9 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V1: DriveAbciMethodVersions = DriveAbciMeth
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,
         store_platform_state: 0,
+    },
+    platform_reduced_state_storage: DriveAbciReducedPlatformStateStorageMethodVersions {
+        fetch_reduced_platform_state: 0,
+        store_reduced_platform_state: 0,
     },
 };

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v2.rs
@@ -8,6 +8,7 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciIdentityCreditWithdrawalMethodVersions, DriveAbciInitializationMethodVersions,
     DriveAbciMasternodeIdentitiesUpdatesMethodVersions, DriveAbciMethodVersions,
     DriveAbciPlatformStateStorageMethodVersions, DriveAbciProtocolUpgradeMethodVersions,
+    DriveAbciReducedPlatformStateStorageMethodVersions,
     DriveAbciStateTransitionProcessingMethodVersions, DriveAbciTokensProcessingMethodVersions,
     DriveAbciVotingMethodVersions,
 };
@@ -122,5 +123,9 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V2: DriveAbciMethodVersions = DriveAbciMeth
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,
         store_platform_state: 0,
+    },
+    platform_reduced_state_storage: DriveAbciReducedPlatformStateStorageMethodVersions {
+        fetch_reduced_platform_state: 0,
+        store_reduced_platform_state: 0,
     },
 };

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v3.rs
@@ -8,6 +8,7 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciIdentityCreditWithdrawalMethodVersions, DriveAbciInitializationMethodVersions,
     DriveAbciMasternodeIdentitiesUpdatesMethodVersions, DriveAbciMethodVersions,
     DriveAbciPlatformStateStorageMethodVersions, DriveAbciProtocolUpgradeMethodVersions,
+    DriveAbciReducedPlatformStateStorageMethodVersions,
     DriveAbciStateTransitionProcessingMethodVersions, DriveAbciTokensProcessingMethodVersions,
     DriveAbciVotingMethodVersions,
 };
@@ -121,5 +122,9 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V3: DriveAbciMethodVersions = DriveAbciMeth
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,
         store_platform_state: 0,
+    },
+    platform_reduced_state_storage: DriveAbciReducedPlatformStateStorageMethodVersions {
+        fetch_reduced_platform_state: 0,
+        store_reduced_platform_state: 0,
     },
 };

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v4.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v4.rs
@@ -8,6 +8,7 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciIdentityCreditWithdrawalMethodVersions, DriveAbciInitializationMethodVersions,
     DriveAbciMasternodeIdentitiesUpdatesMethodVersions, DriveAbciMethodVersions,
     DriveAbciPlatformStateStorageMethodVersions, DriveAbciProtocolUpgradeMethodVersions,
+    DriveAbciReducedPlatformStateStorageMethodVersions,
     DriveAbciStateTransitionProcessingMethodVersions, DriveAbciTokensProcessingMethodVersions,
     DriveAbciVotingMethodVersions,
 };
@@ -121,5 +122,9 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V4: DriveAbciMethodVersions = DriveAbciMeth
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,
         store_platform_state: 0,
+    },
+    platform_reduced_state_storage: DriveAbciReducedPlatformStateStorageMethodVersions {
+        fetch_reduced_platform_state: 0,
+        store_reduced_platform_state: 0,
     },
 };

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v5.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v5.rs
@@ -8,6 +8,7 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciIdentityCreditWithdrawalMethodVersions, DriveAbciInitializationMethodVersions,
     DriveAbciMasternodeIdentitiesUpdatesMethodVersions, DriveAbciMethodVersions,
     DriveAbciPlatformStateStorageMethodVersions, DriveAbciProtocolUpgradeMethodVersions,
+    DriveAbciReducedPlatformStateStorageMethodVersions,
     DriveAbciStateTransitionProcessingMethodVersions, DriveAbciTokensProcessingMethodVersions,
     DriveAbciVotingMethodVersions,
 };
@@ -125,5 +126,9 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V5: DriveAbciMethodVersions = DriveAbciMeth
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,
         store_platform_state: 0,
+    },
+    platform_reduced_state_storage: DriveAbciReducedPlatformStateStorageMethodVersions {
+        fetch_reduced_platform_state: 0,
+        store_reduced_platform_state: 0,
     },
 };

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v6.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v6.rs
@@ -8,6 +8,7 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciIdentityCreditWithdrawalMethodVersions, DriveAbciInitializationMethodVersions,
     DriveAbciMasternodeIdentitiesUpdatesMethodVersions, DriveAbciMethodVersions,
     DriveAbciPlatformStateStorageMethodVersions, DriveAbciProtocolUpgradeMethodVersions,
+    DriveAbciReducedPlatformStateStorageMethodVersions,
     DriveAbciStateTransitionProcessingMethodVersions, DriveAbciTokensProcessingMethodVersions,
     DriveAbciVotingMethodVersions,
 };
@@ -17,7 +18,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V6: DriveAbciMethodVersions = DriveAbciMeth
     engine: DriveAbciEngineMethodVersions {
         init_chain: 0,
         check_tx: 0,
-        run_block_proposal: 0,
+        run_block_proposal: 1,
         finalize_block_proposal: 0,
         consensus_params_update: 1,
     },
@@ -122,5 +123,9 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V6: DriveAbciMethodVersions = DriveAbciMeth
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,
         store_platform_state: 0,
+    },
+    platform_reduced_state_storage: DriveAbciReducedPlatformStateStorageMethodVersions {
+        fetch_reduced_platform_state: 0,
+        store_reduced_platform_state: 0,
     },
 };

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_structure_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_structure_versions/mod.rs
@@ -6,6 +6,7 @@ use versioned_feature_core::FeatureVersion;
 pub struct DriveAbciStructureVersions {
     pub platform_state_structure: FeatureVersion,
     pub platform_state_for_saving_structure_default: FeatureVersion,
+    pub reduced_platform_state_for_saving_structure_default: FeatureVersion,
     pub state_transition_execution_context: FeatureVersion,
     pub commit: FeatureVersion,
     pub masternode: FeatureVersion,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_structure_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_structure_versions/v1.rs
@@ -4,6 +4,7 @@ pub const DRIVE_ABCI_STRUCTURE_VERSIONS_V1: DriveAbciStructureVersions =
     DriveAbciStructureVersions {
         platform_state_structure: 0,
         platform_state_for_saving_structure_default: 0,
+        reduced_platform_state_for_saving_structure_default: 0,
         state_transition_execution_context: 0,
         commit: 0,
         masternode: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/mod.rs
@@ -60,12 +60,19 @@ pub struct DriveMethodVersions {
     pub state_transitions: DriveStateTransitionMethodVersions,
     pub platform_state: DrivePlatformStateMethodVersions,
     pub group: DriveGroupMethodVersions,
+    pub reduced_platform_state: DriveReducedPlatformStateMethodVersions,
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct DrivePlatformStateMethodVersions {
     pub fetch_platform_state_bytes: FeatureVersion,
     pub store_platform_state_bytes: FeatureVersion,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DriveReducedPlatformStateMethodVersions {
+    pub fetch_reduced_platform_state_bytes: FeatureVersion,
+    pub store_reduced_platform_state_bytes: FeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/packages/rs-platform-version/src/version/drive_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v1.rs
@@ -15,7 +15,8 @@ use crate::version::drive_versions::{
     DriveInitializationMethodVersions, DriveMethodVersions, DriveOperationsMethodVersion,
     DrivePlatformStateMethodVersions, DrivePlatformSystemMethodVersions,
     DrivePrefundedSpecializedMethodVersions, DriveProtocolUpgradeVersions,
-    DriveProveMethodVersions, DriveSystemEstimationCostsMethodVersions, DriveVersion,
+    DriveProveMethodVersions, DriveReducedPlatformStateMethodVersions,
+    DriveSystemEstimationCostsMethodVersions, DriveVersion,
 };
 use grovedb_version::version::v1::GROVE_V1;
 
@@ -99,6 +100,10 @@ pub const DRIVE_VERSION_V1: DriveVersion = DriveVersion {
             empty_prefunded_specialized_balance: 0,
         },
         group: DRIVE_GROUP_METHOD_VERSIONS_V1,
+        reduced_platform_state: DriveReducedPlatformStateMethodVersions {
+            fetch_reduced_platform_state_bytes: 0,
+            store_reduced_platform_state_bytes: 0,
+        },
     },
     grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,
     grove_version: GROVE_V1,

--- a/packages/rs-platform-version/src/version/drive_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v2.rs
@@ -15,7 +15,8 @@ use crate::version::drive_versions::{
     DriveInitializationMethodVersions, DriveMethodVersions, DriveOperationsMethodVersion,
     DrivePlatformStateMethodVersions, DrivePlatformSystemMethodVersions,
     DrivePrefundedSpecializedMethodVersions, DriveProtocolUpgradeVersions,
-    DriveProveMethodVersions, DriveSystemEstimationCostsMethodVersions, DriveVersion,
+    DriveProveMethodVersions, DriveReducedPlatformStateMethodVersions,
+    DriveSystemEstimationCostsMethodVersions, DriveVersion,
 };
 use grovedb_version::version::v1::GROVE_V1;
 
@@ -99,6 +100,10 @@ pub const DRIVE_VERSION_V2: DriveVersion = DriveVersion {
             empty_prefunded_specialized_balance: 0,
         },
         group: DRIVE_GROUP_METHOD_VERSIONS_V1,
+        reduced_platform_state: DriveReducedPlatformStateMethodVersions {
+            fetch_reduced_platform_state_bytes: 0,
+            store_reduced_platform_state_bytes: 0,
+        },
     },
     grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,
     grove_version: GROVE_V1,

--- a/packages/rs-platform-version/src/version/drive_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v3.rs
@@ -15,7 +15,8 @@ use crate::version::drive_versions::{
     DriveInitializationMethodVersions, DriveMethodVersions, DriveOperationsMethodVersion,
     DrivePlatformStateMethodVersions, DrivePlatformSystemMethodVersions,
     DrivePrefundedSpecializedMethodVersions, DriveProtocolUpgradeVersions,
-    DriveProveMethodVersions, DriveSystemEstimationCostsMethodVersions, DriveVersion,
+    DriveProveMethodVersions, DriveReducedPlatformStateMethodVersions,
+    DriveSystemEstimationCostsMethodVersions, DriveVersion,
 };
 use grovedb_version::version::v1::GROVE_V1;
 
@@ -99,6 +100,10 @@ pub const DRIVE_VERSION_V3: DriveVersion = DriveVersion {
             empty_prefunded_specialized_balance: 0,
         },
         group: DRIVE_GROUP_METHOD_VERSIONS_V1,
+        reduced_platform_state: DriveReducedPlatformStateMethodVersions {
+            fetch_reduced_platform_state_bytes: 0,
+            store_reduced_platform_state_bytes: 0,
+        },
     },
     grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,
     grove_version: GROVE_V1,

--- a/packages/rs-platform-version/src/version/drive_versions/v4.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v4.rs
@@ -15,7 +15,8 @@ use crate::version::drive_versions::{
     DriveInitializationMethodVersions, DriveMethodVersions, DriveOperationsMethodVersion,
     DrivePlatformStateMethodVersions, DrivePlatformSystemMethodVersions,
     DrivePrefundedSpecializedMethodVersions, DriveProtocolUpgradeVersions,
-    DriveProveMethodVersions, DriveSystemEstimationCostsMethodVersions, DriveVersion,
+    DriveProveMethodVersions, DriveReducedPlatformStateMethodVersions,
+    DriveSystemEstimationCostsMethodVersions, DriveVersion,
 };
 use grovedb_version::version::v2::GROVE_V2;
 
@@ -99,6 +100,10 @@ pub const DRIVE_VERSION_V4: DriveVersion = DriveVersion {
             empty_prefunded_specialized_balance: 0,
         },
         group: DRIVE_GROUP_METHOD_VERSIONS_V1,
+        reduced_platform_state: DriveReducedPlatformStateMethodVersions {
+            fetch_reduced_platform_state_bytes: 0,
+            store_reduced_platform_state_bytes: 0,
+        },
     },
     grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,
     grove_version: GROVE_V2, //changed in V4

--- a/packages/rs-platform-version/src/version/mocks/v2_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v2_test.rs
@@ -42,7 +42,8 @@ use crate::version::drive_versions::{
     DriveInitializationMethodVersions, DriveMethodVersions, DriveOperationsMethodVersion,
     DrivePlatformStateMethodVersions, DrivePlatformSystemMethodVersions,
     DrivePrefundedSpecializedMethodVersions, DriveProtocolUpgradeVersions,
-    DriveProveMethodVersions, DriveSystemEstimationCostsMethodVersions, DriveVersion,
+    DriveProveMethodVersions, DriveReducedPlatformStateMethodVersions,
+    DriveSystemEstimationCostsMethodVersions, DriveVersion,
 };
 use crate::version::fee::v1::FEE_VERSION1;
 use crate::version::mocks::TEST_PROTOCOL_VERSION_SHIFT_BYTES;
@@ -135,6 +136,10 @@ pub const TEST_PLATFORM_V2: PlatformVersion = PlatformVersion {
                 empty_prefunded_specialized_balance: 0,
             },
             group: DRIVE_GROUP_METHOD_VERSIONS_V1,
+            reduced_platform_state: DriveReducedPlatformStateMethodVersions {
+                fetch_reduced_platform_state_bytes: 0,
+                store_reduced_platform_state_bytes: 0,
+            },
         },
         grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,
         grove_version: GROVE_V1,

--- a/packages/rs-platform-version/src/version/mocks/v3_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v3_test.rs
@@ -24,6 +24,7 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciIdentityCreditWithdrawalMethodVersions, DriveAbciInitializationMethodVersions,
     DriveAbciMasternodeIdentitiesUpdatesMethodVersions, DriveAbciMethodVersions,
     DriveAbciPlatformStateStorageMethodVersions, DriveAbciProtocolUpgradeMethodVersions,
+    DriveAbciReducedPlatformStateStorageMethodVersions,
     DriveAbciStateTransitionProcessingMethodVersions, DriveAbciTokensProcessingMethodVersions,
     DriveAbciVotingMethodVersions,
 };
@@ -50,7 +51,7 @@ pub const TEST_PLATFORM_V3: PlatformVersion = PlatformVersion {
             engine: DriveAbciEngineMethodVersions {
                 init_chain: 0,
                 check_tx: 0,
-                run_block_proposal: 0,
+                run_block_proposal: 1,
                 finalize_block_proposal: 0,
                 consensus_params_update: 1,
             },
@@ -155,6 +156,10 @@ pub const TEST_PLATFORM_V3: PlatformVersion = PlatformVersion {
             platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
                 fetch_platform_state: 0,
                 store_platform_state: 0,
+            },
+            platform_reduced_state_storage: DriveAbciReducedPlatformStateStorageMethodVersions {
+                fetch_reduced_platform_state: 0,
+                store_reduced_platform_state: 0,
             },
         },
         validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V3,


### PR DESCRIPTION
## Issue being fixed or feature implemented
Because of state sync, the need for storage of Platform state under the root tree in groveDB was brought.
Although, not all fields of PlatformState were required to be saved as many of them can be reconstructed using Core.
A minimal version of PlatformState was created storing only the essential data: ReducedPlatformState

## What was done?
run_block_proposal was bumped to v1, and stores the ReducedPlatformState at the very end.

## How Has This Been Tested?


## Breaking Changes


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a streamlined reduced platform state module that optimizes state serialization and deserialization.
  - Added new methods for efficient retrieval and storage of the reduced state, ensuring smooth state management.
  - Upgraded block proposal processing with an additional version for enhanced handling.
  - Expanded versioning support across execution and storage components to maintain backward compatibility while advancing state management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->