### PR TITLE
refactor: import CREDITS_PER_DUFF for use in conversion converter

### DIFF
--- a/packages/rs-dpp/src/identity/credits_converter.rs
+++ b/packages/rs-dpp/src/identity/credits_converter.rs
@@ -1,16 +1,15 @@
 use crate::fee::Credits;
 use crate::ProtocolError;
-
-pub const RATIO: u64 = 1000;
+use crate::balances::credits::CREDITS_PER_DUFF;
 
 pub fn convert_duffs_to_credits(amount: u64) -> Result<Credits, ProtocolError> {
-    amount.checked_mul(RATIO).ok_or(ProtocolError::Overflow(
+    amount.checked_mul(CREDITS_PER_DUFF).ok_or(ProtocolError::Overflow(
         "converting duffs to credits failed",
     ))
 }
 
 pub fn convert_credits_to_duffs(amount: Credits) -> Result<u64, ProtocolError> {
-    amount.checked_div(RATIO).ok_or(ProtocolError::Overflow(
+    amount.checked_div(CREDITS_PER_DUFF).ok_or(ProtocolError::Overflow(
         "converting credits to duffs failed",
     ))
 }
@@ -23,20 +22,19 @@ mod test {
     fn test_should_convert_satoshi_to_credits() {
         let amount = 42;
         let converted = convert_duffs_to_credits(amount).unwrap();
-
-        assert_eq!(converted, amount * RATIO);
+        assert_eq!(converted, amount * CREDITS_PER_DUFF);
     }
 
     #[test]
     fn test_should_convert_credits_to_satoshi() {
         let amount = 10000;
         let converted = convert_credits_to_duffs(amount).unwrap();
-        assert_eq!(converted, amount / RATIO);
+        assert_eq!(converted, amount / CREDITS_PER_DUFF);
     }
 
     #[test]
     fn test_convert_to_0_satoshi_if_amount_lower_than_ratio() {
-        let amount = RATIO - 1;
+        let amount = CREDITS_PER_DUFF - 1;
         let converted = convert_credits_to_duffs(amount).unwrap();
         assert_eq!(converted, 0);
     }


### PR DESCRIPTION
Eliminates a second definition for the same constant (credits/duff ratio)

## Issue being fixed or feature implemented
Credit/duff ratio was defined in two locations

## What was done?
Updated credit_converter to import the credit/duff value defined elsewhere

## How Has This Been Tested?


## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
