### PR TITLE
docs: update comment for data contract code range

### DIFF
--- a/packages/rs-dpp/src/errors/consensus/codes.rs
+++ b/packages/rs-dpp/src/errors/consensus/codes.rs
@@ -46,7 +46,7 @@ impl ErrorWithCode for BasicError {
             Self::InvalidIdentifierError { .. } => 10102,
             Self::ValueError(_) => 10103,
 
-            // DataContract Errors: 10200-10399
+            // DataContract Errors: 10200-10349
             Self::DataContractMaxDepthExceedError { .. } => 10200,
             Self::DuplicateIndexError { .. } => 10201,
             Self::IncompatibleRe2PatternError { .. } => 10202,


### PR DESCRIPTION
## Issue being fixed or feature implemented

The data contract error code comment was incorrect and showed the range overlapping with group error codes

## What was done?
Updated comment to the correct range

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Adjusted the range of error codes for "DataContract Errors" for clearer categorization, enhancing organization without introducing or removing any codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->