### PR TITLE
fix: data contract proof doesn't work  with new auto fields

### DIFF
--- a/packages/rs-dpp/src/data_contract/serialized_version/mod.rs
+++ b/packages/rs-dpp/src/data_contract/serialized_version/mod.rs
@@ -96,6 +96,37 @@ impl DataContractInSerializationFormat {
             DataContractInSerializationFormat::V1(v1) => &v1.tokens,
         }
     }
+
+    pub fn eq_without_auto_fields(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                DataContractInSerializationFormat::V0(v0_self),
+                DataContractInSerializationFormat::V0(v0_other),
+            ) => v0_self == v0_other,
+            (
+                DataContractInSerializationFormat::V1(v1_self),
+                DataContractInSerializationFormat::V1(v1_other),
+            ) => {
+                v1_self.id == v1_other.id
+                    && v1_self.config == v1_other.config
+                    && v1_self.version == v1_other.version
+                    && v1_self.owner_id == v1_other.owner_id
+                    && v1_self.schema_defs == v1_other.schema_defs
+                    && v1_self.document_schemas == v1_other.document_schemas
+                    && v1_self.groups == v1_other.groups
+                    && v1_self.tokens == v1_other.tokens
+            }
+            // Cross-version comparisons return false
+            (
+                DataContractInSerializationFormat::V0(_),
+                DataContractInSerializationFormat::V1(_),
+            )
+            | (
+                DataContractInSerializationFormat::V1(_),
+                DataContractInSerializationFormat::V0(_),
+            ) => false,
+        }
+    }
 }
 
 impl TryFromPlatformVersioned<DataContractV0> for DataContractInSerializationFormat {

--- a/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
@@ -83,9 +83,13 @@ impl Drive {
                 let contract_for_serialization: DataContractInSerializationFormat = contract
                     .clone()
                     .try_into_platform_versioned(platform_version)?;
-                if &contract_for_serialization != data_contract_create.data_contract() {
+
+                if contract_for_serialization
+                    .eq_without_auto_fields(data_contract_create.data_contract())
+                {
                     return Err(Error::Proof(ProofError::IncorrectProof(format!("proof of state transition execution did not contain exact expected contract after create with id {}", data_contract_create.data_contract().id()))));
                 }
+
                 Ok((root_hash, VerifiedDataContract(contract)))
             }
             StateTransition::DataContractUpdate(data_contract_update) => {

--- a/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
@@ -84,7 +84,7 @@ impl Drive {
                     .clone()
                     .try_into_platform_versioned(platform_version)?;
 
-                if contract_for_serialization
+                if !contract_for_serialization
                     .eq_without_auto_fields(data_contract_create.data_contract())
                 {
                     return Err(Error::Proof(ProofError::IncorrectProof(format!("proof of state transition execution did not contain exact expected contract after create with id {}", data_contract_create.data_contract().id()))));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When we added auto generated fields to data contract, the proof logic that uses full equality doesn't work anymore, because on client side autogenerated fields are empty. 

## What was done?
<!--- Describe your changes in detail -->
- Compare without auto fields

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new comparison method for contract data that excludes transient, auto-generated fields.

- **Refactor**
  - Updated the state transition verification logic to use the enhanced comparison method for more reliable contract evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->