### PR TITLE
fix(platform): unique token keeps history documents

### DIFF
--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_transition.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_transition.rs
@@ -200,11 +200,7 @@ pub trait TokenTransitionV0Methods {
         token_history_contract: &'a DataContract,
     ) -> Result<DocumentTypeRef<'a>, ProtocolError>;
     /// Historical document id
-    fn historical_document_id(
-        &self,
-        owner_id: Identifier,
-        owner_nonce: IdentityNonce,
-    ) -> Identifier;
+    fn historical_document_id(&self, owner_id: Identifier) -> Identifier;
     fn associated_token_event(
         &self,
         token_configuration: &TokenConfiguration,
@@ -213,7 +209,6 @@ pub trait TokenTransitionV0Methods {
     /// Historical document id
     fn build_historical_document(
         &self,
-        token_historical_contract: &DataContract,
         token_id: Identifier,
         owner_id: Identifier,
         owner_nonce: IdentityNonce,
@@ -327,16 +322,14 @@ impl TokenTransitionV0Methods for TokenTransition {
     }
 
     /// Historical document id
-    fn historical_document_id(
-        &self,
-        owner_id: Identifier,
-        owner_nonce: IdentityNonce,
-    ) -> Identifier {
+    fn historical_document_id(&self, owner_id: Identifier) -> Identifier {
+        let token_id = self.token_id();
         let name = self.historical_document_type_name();
+        let owner_nonce = self.identity_contract_nonce();
         Document::generate_document_id_v0(
-            &(TOKEN_HISTORY_ID_BYTES.into()),
+            &token_id,
             &owner_id,
-            name,
+            format!("history_{}", name).as_str(),
             owner_nonce.to_be_bytes().as_slice(),
         )
     }
@@ -344,7 +337,6 @@ impl TokenTransitionV0Methods for TokenTransition {
     /// Historical document id
     fn build_historical_document(
         &self,
-        token_historical_contract: &DataContract,
         token_id: Identifier,
         owner_id: Identifier,
         owner_nonce: IdentityNonce,
@@ -354,7 +346,6 @@ impl TokenTransitionV0Methods for TokenTransition {
     ) -> Result<Document, ProtocolError> {
         self.associated_token_event(token_configuration, owner_id)?
             .build_historical_document_owned(
-                token_historical_contract,
                 token_id,
                 owner_id,
                 owner_nonce,

--- a/packages/rs-dpp/src/tokens/token_event.rs
+++ b/packages/rs-dpp/src/tokens/token_event.rs
@@ -80,7 +80,6 @@ impl TokenEvent {
 
     pub fn build_historical_document_owned(
         self,
-        token_history_contract: &DataContract,
         token_id: Identifier,
         owner_id: Identifier,
         owner_nonce: IdentityNonce,
@@ -88,9 +87,9 @@ impl TokenEvent {
         platform_version: &PlatformVersion,
     ) -> Result<Document, ProtocolError> {
         let document_id = Document::generate_document_id_v0(
-            &token_history_contract.id(),
+            &token_id,
             &owner_id,
-            self.associated_document_type_name(),
+            format!("history_{}", self.associated_document_type_name()).as_str(),
             owner_nonce.to_be_bytes().as_slice(),
         );
 

--- a/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
@@ -22,10 +22,8 @@ use drive_abci::platform_types::platform::PlatformRef;
 use drive_abci::rpc::core::MockCoreRPCLike;
 use tenderdash_abci::proto::abci::ExecTxResult;
 use dpp::block::extended_block_info::v0::ExtendedBlockInfoV0Getters;
-use dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
 use dpp::data_contracts::SystemDataContract;
 use dpp::document::serialization_traits::DocumentPlatformConversionMethodsV0;
-use dpp::prelude::Identifier;
 use dpp::voting::votes::Vote;
 use drive::drive::votes::resolved::vote_polls::ResolvedVotePoll;
 use drive::drive::votes::resolved::votes::resolved_resource_vote::accessors::v0::ResolvedResourceVoteGettersV0;
@@ -285,12 +283,7 @@ pub(crate) fn verify_state_transitions_were_or_were_not_executed(
                                                 .to_string(),
                                             document_type_keeps_history: false,
                                             document_id: token_transition_action
-                                                .historical_document_id(
-                                                    batch_transition.owner_id(),
-                                                    token_transition_action
-                                                        .base()
-                                                        .identity_contract_nonce(),
-                                                )
+                                                .historical_document_id(batch_transition.owner_id())
                                                 .to_vec(),
                                             document_contested_status: 0,
                                         },
@@ -532,12 +525,7 @@ pub(crate) fn verify_state_transitions_were_or_were_not_executed(
                                         document_type_name,
                                         document_type_keeps_history: false,
                                         document_id: token_transition_action
-                                            .historical_document_id(
-                                                batch_transition.owner_id(),
-                                                token_transition_action
-                                                    .base()
-                                                    .identity_contract_nonce(),
-                                            )
+                                            .historical_document_id(batch_transition.owner_id())
                                             .to_buffer(),
                                         block_time_ms: None, //None because we want latest
                                         contested_status:
@@ -566,7 +554,6 @@ pub(crate) fn verify_state_transitions_were_or_were_not_executed(
 
                                     let expected_document = token_transition_action
                                         .build_historical_document(
-                                            &token_history,
                                             token_id,
                                             batch_transition.owner_id(),
                                             token_transition_action

--- a/packages/rs-drive/src/drive/tokens/add_transaction_history_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/tokens/add_transaction_history_operations/v0/mod.rs
@@ -32,7 +32,6 @@ impl Drive {
         let document_type = event.associated_document_type(&contract)?;
 
         let document = event.build_historical_document_owned(
-            &contract,
             token_id,
             owner_id,
             owner_nonce,

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/mod.rs
@@ -128,16 +128,14 @@ impl TokenTransitionAction {
     }
 
     /// Historical document id
-    pub fn historical_document_id(
-        &self,
-        owner_id: Identifier,
-        owner_nonce: IdentityNonce,
-    ) -> Identifier {
+    pub fn historical_document_id(&self, owner_id: Identifier) -> Identifier {
+        let token_id = self.base().token_id();
         let name = self.historical_document_type_name();
+        let owner_nonce = self.base().identity_contract_nonce();
         Document::generate_document_id_v0(
-            &SystemDataContract::TokenHistory.id(),
+            &token_id,
             &owner_id,
-            name,
+            format!("history_{}", name).as_str(),
             owner_nonce.to_be_bytes().as_slice(),
         )
     }
@@ -145,7 +143,6 @@ impl TokenTransitionAction {
     /// Historical document id
     pub fn build_historical_document(
         &self,
-        token_historical_contract: &DataContract,
         token_id: Identifier,
         owner_id: Identifier,
         owner_nonce: IdentityNonce,
@@ -154,7 +151,6 @@ impl TokenTransitionAction {
     ) -> Result<Document, Error> {
         self.associated_token_event()
             .build_historical_document_owned(
-                token_historical_contract,
                 token_id,
                 owner_id,
                 owner_nonce,

--- a/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
@@ -335,7 +335,7 @@ impl Drive {
                                 document_type_name: token_history_document_type_name,
                                 document_type_keeps_history: false,
                                 document_id: token_transition
-                                    .historical_document_id(owner_id, identity_contract_nonce)
+                                    .historical_document_id(owner_id)
                                     .to_buffer(),
                                 block_time_ms: None, //None because we want latest
                                 contested_status:
@@ -352,7 +352,6 @@ impl Drive {
                             let document = document.ok_or(Error::Proof(ProofError::IncorrectProof(format!("proof did not contain document with id {} expected to exist because the token keeps historical documents", token_transition.historical_document_type_name()))))?;
 
                             let expected_document = token_transition.build_historical_document(
-                                &token_history_contract,
                                 token_id,
                                 owner_id,
                                 identity_contract_nonce,

--- a/packages/wasm-dpp/src/document/state_transition/batch_transition/token_transition/mod.rs
+++ b/packages/wasm-dpp/src/document/state_transition/batch_transition/token_transition/mod.rs
@@ -103,14 +103,8 @@ impl TokenTransitionWasm {
     }
 
     #[wasm_bindgen(js_name=getHistoricalDocumentId)]
-    pub fn historical_document_id(
-        &self,
-        owner_id: IdentifierWrapper,
-        owner_nonce: IdentityNonce,
-    ) -> IdentifierWrapper {
-        self.0
-            .historical_document_id(owner_id.into(), owner_nonce)
-            .into()
+    pub fn historical_document_id(&self, owner_id: IdentifierWrapper) -> IdentifierWrapper {
+        self.0.historical_document_id(owner_id.into()).into()
     }
 
     #[wasm_bindgen(js_name=getIdentityContractNonce)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Historical documents for token events were using the same document ids based on the token history contract, and identity contract nonce for the token contract, but this meant that if a user would send token A, then send token B the second transaction would use the same document id to try to store info on the transaction.

## What was done?
Historical document id now looks like:
`    fn historical_document_id(&self, owner_id: Identifier) -> Identifier {
        let token_id = self.token_id();
        let name = self.historical_document_type_name();
        let owner_nonce = self.identity_contract_nonce();
        Document::generate_document_id_v0(
            &token_id,
            &owner_id,
            format!("history_{}", name).as_str(),
            owner_nonce.to_be_bytes().as_slice(),
        )
    }`


## How Has This Been Tested?
Not tested, but tests still pass.


## Breaking Changes
Breaking, (but previous was failing). It's shouldn't be considered breaking compared to 1.8.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
