### PR TITLE
fix(drive): allow getting tree sum value from element directly

### DIFF
--- a/packages/rs-drive/src/error/drive.rs
+++ b/packages/rs-drive/src/error/drive.rs
@@ -127,7 +127,7 @@ pub enum DriveError {
 
     /// Error
     #[error("corrupted query returned non item error: {0}")]
-    CorruptedQueryReturnedNonItem(&'static str),
+    CorruptedQueryReturnedNonItem(String),
     /// Error
     #[error("corrupted withdrawal not an item error: {0}")]
     CorruptedWithdrawalNotItem(&'static str),

--- a/packages/rs-drive/src/util/grove_operations/grove_get_raw_value_u64_from_encoded_var_vec/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_get_raw_value_u64_from_encoded_var_vec/v0/mod.rs
@@ -35,8 +35,12 @@ impl Drive {
                     )))
                     .map(|(value, _)| value),
                 Element::SumItem(value, ..) => Ok(value as u64),
-                _ => Err(Error::Drive(DriveError::CorruptedQueryReturnedNonItem(
-                    "expected an item",
+                Element::SumTree(_, value, _) => Ok(value as u64),
+                element => Err(Error::Drive(DriveError::CorruptedQueryReturnedNonItem(
+                    format!(
+                        "expected an item, sum item or sum tree, got a {}",
+                        element.type_str()
+                    ),
                 ))),
             })
             .transpose()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
There was an issue reported by thephez where getting the value of the total tokens was failing.

## What was done?
Inside it required that we look at the root sum tree value, and that method had an issue that we fixed.

## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages to provide more detailed information when unexpected elements are encountered.
  - Enhanced handling of additional element types to prevent errors during certain operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->