### PR TITLE
fix(platform): document serialization v1 to fix serialization and deserialization of integers

### DIFF
--- a/packages/rs-dpp/src/document/document_methods/hash/v0/mod.rs
+++ b/packages/rs-dpp/src/document/document_methods/hash/v0/mod.rs
@@ -18,7 +18,7 @@ pub trait DocumentHashV0Method: DocumentPlatformConversionMethodsV0 {
     ) -> Result<Vec<u8>, ProtocolError> {
         let mut buf = contract.id().to_vec();
         buf.extend(document_type.name().as_bytes()); // TODO: Why we put it here?
-        buf.extend(self.serialize(document_type, platform_version)?);
+        buf.extend(self.serialize(document_type, contract, platform_version)?);
         Ok(hash_double_to_vec(buf))
     }
 }

--- a/packages/rs-dpp/src/document/extended_document/v0/serialize.rs
+++ b/packages/rs-dpp/src/document/extended_document/v0/serialize.rs
@@ -31,7 +31,7 @@ impl ExtendedDocumentPlatformSerializationMethodsV0 for ExtendedDocumentV0 {
     /// The serialization of an extended document follows the pattern:
     /// data contract | document type name | document
     fn serialize_v0(&self, platform_version: &PlatformVersion) -> Result<Vec<u8>, ProtocolError> {
-        let mut buffer: Vec<u8> = 0.encode_var_vec(); //version 0
+        let mut buffer: Vec<u8> = 0u64.encode_var_vec(); //version 0
 
         buffer.append(
             &mut self
@@ -40,11 +40,11 @@ impl ExtendedDocumentPlatformSerializationMethodsV0 for ExtendedDocumentV0 {
         );
         buffer.push(self.document_type_name.len() as u8);
         buffer.extend(self.document_type_name.as_bytes());
-        buffer.append(
-            &mut self
-                .document
-                .serialize(self.document_type()?, platform_version)?,
-        );
+        buffer.append(&mut self.document.serialize(
+            self.document_type()?,
+            &self.data_contract,
+            platform_version,
+        )?);
         Ok(buffer)
     }
 }
@@ -110,7 +110,7 @@ impl ExtendedDocumentPlatformConversionMethodsV0 for ExtendedDocumentV0 {
         match platform_version
             .dpp
             .document_versions
-            .document_serialization_version
+            .extended_document_serialization_version
             .default_current_version
         {
             0 => self.serialize_v0(platform_version),

--- a/packages/rs-dpp/src/document/mod.rs
+++ b/packages/rs-dpp/src/document/mod.rs
@@ -265,6 +265,7 @@ mod tests {
             let serialized = <Document as DocumentPlatformConversionMethodsV0>::serialize(
                 &document,
                 document_type,
+                &contract,
                 platform_version,
             )
             .expect("should serialize");
@@ -306,6 +307,7 @@ mod tests {
             let serialized = <Document as DocumentPlatformConversionMethodsV0>::serialize(
                 &document,
                 document_type,
+                &contract,
                 platform_version,
             )
             .expect("should serialize");
@@ -322,6 +324,7 @@ mod tests {
             let serialized = <Document as DocumentPlatformConversionMethodsV0>::serialize(
                 &document,
                 document_type,
+                &contract,
                 platform_version,
             )
             .expect("should serialize");

--- a/packages/rs-dpp/src/document/serialization_traits/platform_serialization_conversion/deserialize/v0/mod.rs
+++ b/packages/rs-dpp/src/document/serialization_traits/platform_serialization_conversion/deserialize/v0/mod.rs
@@ -6,7 +6,19 @@ use platform_version::version::PlatformVersion;
 
 pub(in crate::document) trait DocumentPlatformDeserializationMethodsV0 {
     /// Reads a serialized document and creates a Document from it.
+    /// Version 0 will always decode integers as i64s,
+    /// as all integers were stored as i64 in version 0
     fn from_bytes_v0(
+        serialized_document: &[u8],
+        document_type: DocumentTypeRef,
+        platform_version: &PlatformVersion,
+    ) -> Result<Self, DataContractError>
+    where
+        Self: Sized;
+
+    /// Reads a serialized document and creates a Document from it.
+    /// Version 1 properly uses the data contract encoded integer types
+    fn from_bytes_v1(
         serialized_document: &[u8],
         document_type: DocumentTypeRef,
         platform_version: &PlatformVersion,
@@ -18,6 +30,8 @@ pub(in crate::document) trait DocumentPlatformDeserializationMethodsV0 {
 #[cfg(feature = "extended-document")]
 pub(in crate::document) trait ExtendedDocumentPlatformDeserializationMethodsV0 {
     /// Reads a serialized document and creates a Document from it.
+    /// Version 0 will always decode integers as i64s,
+    /// as all integers were stored as i64 in version 0
     fn from_bytes_v0(
         serialized_document: &[u8],
         platform_version: &PlatformVersion,

--- a/packages/rs-dpp/src/document/serialization_traits/platform_serialization_conversion/mod.rs
+++ b/packages/rs-dpp/src/document/serialization_traits/platform_serialization_conversion/mod.rs
@@ -3,6 +3,7 @@ pub(in crate::document) mod serialize;
 mod v0;
 
 use crate::data_contract::document_type::DocumentTypeRef;
+use crate::data_contract::DataContract;
 use crate::document::{Document, DocumentV0};
 #[cfg(feature = "validation")]
 use crate::prelude::ConsensusValidationResult;
@@ -18,22 +19,28 @@ impl DocumentPlatformConversionMethodsV0 for Document {
     fn serialize(
         &self,
         document_type: DocumentTypeRef,
+        data_contract: &DataContract,
         platform_version: &PlatformVersion,
     ) -> Result<Vec<u8>, ProtocolError> {
         match self {
-            Document::V0(document_v0) => document_v0.serialize(document_type, platform_version),
+            Document::V0(document_v0) => {
+                document_v0.serialize(document_type, data_contract, platform_version)
+            }
         }
     }
 
     fn serialize_specific_version(
         &self,
         document_type: DocumentTypeRef,
+        data_contract: &DataContract,
         feature_version: FeatureVersion,
     ) -> Result<Vec<u8>, ProtocolError> {
         match self {
-            Document::V0(document_v0) => {
-                document_v0.serialize_specific_version(document_type, feature_version)
-            }
+            Document::V0(document_v0) => document_v0.serialize_specific_version(
+                document_type,
+                data_contract,
+                feature_version,
+            ),
         }
     }
 
@@ -116,7 +123,7 @@ mod tests {
             .expect("expected to get a random document");
 
         let serialized_document = document
-            .serialize(document_type, platform_version)
+            .serialize(document_type, &contract, platform_version)
             .expect("expected to serialize");
 
         let deserialized_document = Document::from_bytes(
@@ -131,7 +138,7 @@ mod tests {
                 .random_document(Some(3333), platform_version)
                 .expect("expected to get a random document");
             document
-                .serialize(document_type, platform_version)
+                .serialize(document_type, &contract, platform_version)
                 .expect("expected to serialize consume");
         }
     }

--- a/packages/rs-dpp/src/document/serialization_traits/platform_serialization_conversion/serialize/v0/mod.rs
+++ b/packages/rs-dpp/src/document/serialization_traits/platform_serialization_conversion/serialize/v0/mod.rs
@@ -8,7 +8,15 @@ pub(in crate::document) trait DocumentPlatformSerializationMethodsV0 {
     ///
     /// The serialization of a document follows the pattern:
     /// id 32 bytes + owner_id 32 bytes + encoded values byte arrays
+    /// In serialize v0 all integers are always encoded as i64s
     fn serialize_v0(&self, document_type: DocumentTypeRef) -> Result<Vec<u8>, ProtocolError>;
+
+    /// Serializes the document.
+    ///
+    /// The serialization of a document follows the pattern:
+    /// id 32 bytes + owner_id 32 bytes + encoded values byte arrays
+    /// Serialize v1 will encode integers normally with their known size
+    fn serialize_v1(&self, document_type: DocumentTypeRef) -> Result<Vec<u8>, ProtocolError>;
 }
 
 #[cfg(feature = "extended-document")]

--- a/packages/rs-dpp/src/document/serialization_traits/platform_serialization_conversion/v0/mod.rs
+++ b/packages/rs-dpp/src/document/serialization_traits/platform_serialization_conversion/v0/mod.rs
@@ -1,4 +1,5 @@
 use crate::data_contract::document_type::DocumentTypeRef;
+use crate::prelude::DataContract;
 #[cfg(feature = "validation")]
 use crate::validation::ConsensusValidationResult;
 use crate::version::PlatformVersion;
@@ -13,6 +14,7 @@ pub trait DocumentPlatformConversionMethodsV0: Clone {
     fn serialize(
         &self,
         document_type: DocumentTypeRef,
+        data_contract: &DataContract,
         platform_version: &PlatformVersion,
     ) -> Result<Vec<u8>, ProtocolError>;
 
@@ -23,6 +25,7 @@ pub trait DocumentPlatformConversionMethodsV0: Clone {
     fn serialize_specific_version(
         &self,
         document_type: DocumentTypeRef,
+        data_contract: &DataContract,
         feature_version: FeatureVersion,
     ) -> Result<Vec<u8>, ProtocolError>;
 

--- a/packages/rs-dpp/src/document/v0/serialize.rs
+++ b/packages/rs-dpp/src/document/v0/serialize.rs
@@ -1,4 +1,4 @@
-use crate::data_contract::document_type::DocumentTypeRef;
+use crate::data_contract::document_type::{DocumentPropertyType, DocumentTypeRef};
 use crate::data_contract::errors::DataContractError;
 
 use crate::document::property_names::{
@@ -10,7 +10,7 @@ use crate::document::property_names::{
 #[cfg(feature = "validation")]
 use crate::prelude::ConsensusValidationResult;
 
-use crate::prelude::Revision;
+use crate::prelude::{DataContract, Revision};
 
 use crate::ProtocolError;
 
@@ -34,6 +34,8 @@ use crate::consensus::basic::decode::DecodingError;
 use crate::consensus::basic::BasicError;
 #[cfg(feature = "validation")]
 use crate::consensus::ConsensusError;
+use crate::data_contract::accessors::v0::DataContractV0Getters;
+use crate::data_contract::config::DataContractConfig;
 use std::io::{BufReader, Read};
 
 impl DocumentPlatformSerializationMethodsV0 for DocumentV0 {
@@ -41,8 +43,233 @@ impl DocumentPlatformSerializationMethodsV0 for DocumentV0 {
     ///
     /// The serialization of a document follows the pattern:
     /// id 32 bytes + owner_id 32 bytes + encoded values byte arrays
+    /// In serialize v0 all integers are always encoded as i64s
     fn serialize_v0(&self, document_type: DocumentTypeRef) -> Result<Vec<u8>, ProtocolError> {
-        let mut buffer: Vec<u8> = 0.encode_var_vec(); //version 0
+        let mut buffer: Vec<u8> = 0u64.encode_var_vec(); //version 0
+
+        // $id
+        buffer.extend(self.id.as_slice());
+
+        // $ownerId
+        buffer.extend(self.owner_id.as_slice());
+
+        // $revision
+        if let Some(revision) = self.revision {
+            buffer.extend(revision.encode_var_vec())
+        } else if document_type.requires_revision() {
+            buffer.extend((1 as Revision).encode_var_vec())
+        }
+
+        let mut bitwise_exists_flag: u16 = 0;
+
+        let mut time_fields_data_buffer = vec![];
+
+        // $createdAt
+        if let Some(created_at) = &self.created_at {
+            bitwise_exists_flag |= 1;
+            // dbg!("we pushed created at {}", hex::encode(created_at.to_be_bytes()));
+            time_fields_data_buffer.extend(created_at.to_be_bytes());
+        } else if document_type.required_fields().contains(CREATED_AT) {
+            return Err(ProtocolError::DataContractError(
+                DataContractError::MissingRequiredKey(
+                    "created at field is not present".to_string(),
+                ),
+            ));
+        }
+
+        // $updatedAt
+        if let Some(updated_at) = &self.updated_at {
+            bitwise_exists_flag |= 2;
+            // dbg!("we pushed updated at {}", hex::encode(updated_at.to_be_bytes()));
+            time_fields_data_buffer.extend(updated_at.to_be_bytes());
+        } else if document_type.required_fields().contains(UPDATED_AT) {
+            return Err(ProtocolError::DataContractError(
+                DataContractError::MissingRequiredKey(
+                    "updated at field is not present".to_string(),
+                ),
+            ));
+        }
+
+        // $transferredAt
+        if let Some(transferred_at) = &self.transferred_at {
+            bitwise_exists_flag |= 4;
+            // dbg!("we pushed transferred at {}", hex::encode(transferred_at.to_be_bytes()));
+            time_fields_data_buffer.extend(transferred_at.to_be_bytes());
+        } else if document_type.required_fields().contains(TRANSFERRED_AT) {
+            return Err(ProtocolError::DataContractError(
+                DataContractError::MissingRequiredKey(
+                    "transferred at field is not present".to_string(),
+                ),
+            ));
+        }
+
+        // $createdAtBlockHeight
+        if let Some(created_at_block_height) = &self.created_at_block_height {
+            bitwise_exists_flag |= 8;
+            time_fields_data_buffer.extend(created_at_block_height.to_be_bytes());
+        } else if document_type
+            .required_fields()
+            .contains(CREATED_AT_BLOCK_HEIGHT)
+        {
+            return Err(ProtocolError::DataContractError(
+                DataContractError::MissingRequiredKey(
+                    "created_at_block_height field is not present".to_string(),
+                ),
+            ));
+        }
+
+        // $updatedAtBlockHeight
+        if let Some(updated_at_block_height) = &self.updated_at_block_height {
+            bitwise_exists_flag |= 16;
+            time_fields_data_buffer.extend(updated_at_block_height.to_be_bytes());
+        } else if document_type
+            .required_fields()
+            .contains(UPDATED_AT_BLOCK_HEIGHT)
+        {
+            return Err(ProtocolError::DataContractError(
+                DataContractError::MissingRequiredKey(
+                    "updated_at_block_height field is not present".to_string(),
+                ),
+            ));
+        }
+
+        // $transferredAtBlockHeight
+        if let Some(transferred_at_block_height) = &self.transferred_at_block_height {
+            bitwise_exists_flag |= 32;
+            time_fields_data_buffer.extend(transferred_at_block_height.to_be_bytes());
+        } else if document_type
+            .required_fields()
+            .contains(TRANSFERRED_AT_BLOCK_HEIGHT)
+        {
+            return Err(ProtocolError::DataContractError(
+                DataContractError::MissingRequiredKey(
+                    "transferred_at_block_height field is not present".to_string(),
+                ),
+            ));
+        }
+
+        // $createdAtCoreBlockHeight
+        if let Some(created_at_core_block_height) = &self.created_at_core_block_height {
+            bitwise_exists_flag |= 64;
+            time_fields_data_buffer.extend(created_at_core_block_height.to_be_bytes());
+        } else if document_type
+            .required_fields()
+            .contains(CREATED_AT_CORE_BLOCK_HEIGHT)
+        {
+            return Err(ProtocolError::DataContractError(
+                DataContractError::MissingRequiredKey(
+                    "created_at_core_block_height field is not present".to_string(),
+                ),
+            ));
+        }
+
+        // $updatedAtCoreBlockHeight
+        if let Some(updated_at_core_block_height) = &self.updated_at_core_block_height {
+            bitwise_exists_flag |= 128;
+            time_fields_data_buffer.extend(updated_at_core_block_height.to_be_bytes());
+        } else if document_type
+            .required_fields()
+            .contains(UPDATED_AT_CORE_BLOCK_HEIGHT)
+        {
+            return Err(ProtocolError::DataContractError(
+                DataContractError::MissingRequiredKey(
+                    "updated_at_core_block_height field is not present".to_string(),
+                ),
+            ));
+        }
+
+        // $transferredAtCoreBlockHeight
+        if let Some(transferred_at_core_block_height) = &self.transferred_at_core_block_height {
+            bitwise_exists_flag |= 256;
+            time_fields_data_buffer.extend(transferred_at_core_block_height.to_be_bytes());
+        } else if document_type
+            .required_fields()
+            .contains(TRANSFERRED_AT_CORE_BLOCK_HEIGHT)
+        {
+            return Err(ProtocolError::DataContractError(
+                DataContractError::MissingRequiredKey(
+                    "transferred_at_core_block_height field is not present".to_string(),
+                ),
+            ));
+        }
+
+        buffer.extend(bitwise_exists_flag.to_be_bytes().as_slice());
+        buffer.append(&mut time_fields_data_buffer);
+
+        // Now we serialize the price which might not be necessary unless called for by the document type
+
+        if document_type.trade_mode().seller_sets_price() {
+            if let Some(price) = self.properties.get(PRICE) {
+                buffer.push(1);
+                let price_as_u64: u64 = price.to_integer().map_err(ProtocolError::ValueError)?;
+                buffer.append(&mut price_as_u64.to_be_bytes().to_vec());
+            } else {
+                buffer.push(0);
+            }
+        }
+
+        // User defined properties
+        document_type
+            .properties()
+            .iter()
+            .try_for_each(|(field_name, property)| {
+                if let Some(value) = self.properties.get(field_name) {
+                    if value.is_null() {
+                        if property.required && !property.transient {
+                            Err(ProtocolError::DataContractError(
+                                DataContractError::MissingRequiredKey(
+                                    "a required field is not present".to_string(),
+                                ),
+                            ))
+                        } else {
+                            // dbg!("we pushed {} with 0", field_name);
+                            // We don't have something that wasn't required
+                            buffer.push(0);
+                            Ok(())
+                        }
+                    } else {
+                        if !property.required || property.transient {
+                            // dbg!("we added 1", field_name);
+                            buffer.push(1);
+                        }
+                        let value = if property.property_type.is_integer() {
+                            DocumentPropertyType::I64
+                                .encode_value_ref_with_size(value, property.required)
+                        } else {
+                            property
+                                .property_type
+                                .encode_value_ref_with_size(value, property.required)
+                        }?;
+
+                        // dbg!("we pushed {} with {}", field_name, hex::encode(&value));
+                        buffer.extend(value.as_slice());
+                        Ok(())
+                    }
+                } else if property.required && !property.transient {
+                    Err(ProtocolError::DataContractError(
+                        DataContractError::MissingRequiredKey(format!(
+                            "a required field {field_name} is not present"
+                        )),
+                    ))
+                } else {
+                    // dbg!("we pushed {} with 0", field_name);
+                    // We don't have something that wasn't required
+                    buffer.push(0);
+                    Ok(())
+                }
+            })?;
+
+        Ok(buffer)
+    }
+
+    /// Serializes the document.
+    ///
+    /// The serialization of a document follows the pattern:
+    /// id 32 bytes + owner_id 32 bytes + encoded values byte arrays
+    /// Serialize v1 will encode integers normally with their known size.
+    /// Otherwise it is almost identical to V0. V1 represents the original code.
+    fn serialize_v1(&self, document_type: DocumentTypeRef) -> Result<Vec<u8>, ProtocolError> {
+        let mut buffer: Vec<u8> = 1u64.encode_var_vec(); //version 1
 
         // $id
         buffer.extend(self.id.as_slice());
@@ -436,6 +663,229 @@ impl DocumentPlatformDeserializationMethodsV0 for DocumentV0 {
                         None
                     };
                 }
+
+                // In version 0 all integers are encoded as I64 (in theory)
+                let read_value = if property.property_type.is_integer() {
+                    DocumentPropertyType::I64
+                        .read_optionally_from(&mut buf, property.required & !property.transient)
+                } else {
+                    property
+                        .property_type
+                        .read_optionally_from(&mut buf, property.required & !property.transient)
+                };
+
+                match read_value {
+                    Ok(read_value) => {
+                        finished_buffer |= read_value.1;
+                        read_value.0.map(|read_value| Ok((key.clone(), read_value)))
+                    }
+                    Err(e) => Some(Err(e)),
+                }
+            })
+            .collect::<Result<BTreeMap<String, Value>, DataContractError>>()?;
+
+        if let Some(price) = price {
+            properties.insert(PRICE.to_string(), price.into());
+        }
+
+        Ok(DocumentV0 {
+            id: Identifier::new(id),
+            properties,
+            owner_id: Identifier::new(owner_id),
+            revision,
+            created_at,
+            updated_at,
+            transferred_at,
+            created_at_block_height,
+            updated_at_block_height,
+            transferred_at_block_height,
+            created_at_core_block_height,
+            updated_at_core_block_height,
+            transferred_at_core_block_height,
+        })
+    }
+
+    /// Reads a serialized document and creates a Document from it.
+    fn from_bytes_v1(
+        serialized_document: &[u8],
+        document_type: DocumentTypeRef,
+        _platform_version: &PlatformVersion,
+    ) -> Result<Self, DataContractError> {
+        let mut buf = BufReader::new(serialized_document);
+        if serialized_document.len() < 64 {
+            return Err(DataContractError::DecodingDocumentError(
+                DecodingError::new(
+                    "serialized document is too small, must have id and owner id".to_string(),
+                ),
+            ));
+        }
+
+        // $id
+        let mut id = [0; 32];
+        buf.read_exact(&mut id).map_err(|_| {
+            DataContractError::DecodingDocumentError(DecodingError::new(
+                "error reading from serialized document for id".to_string(),
+            ))
+        })?;
+
+        // $ownerId
+        let mut owner_id = [0; 32];
+        buf.read_exact(&mut owner_id).map_err(|_| {
+            DataContractError::DecodingDocumentError(DecodingError::new(
+                "error reading from serialized document for owner id".to_string(),
+            ))
+        })?;
+
+        // $revision
+        // if the document type is mutable then we should deserialize the revision
+        let revision: Option<Revision> = if document_type.requires_revision() {
+            let revision = buf.read_varint().map_err(|_| {
+                DataContractError::DecodingDocumentError(DecodingError::new(
+                    "error reading revision from serialized document for revision".to_string(),
+                ))
+            })?;
+            Some(revision)
+        } else {
+            None
+        };
+
+        let timestamp_flags = buf.read_u16::<BigEndian>().map_err(|_| {
+            DataContractError::CorruptedSerialization(
+                "error reading timestamp flags from serialized document".to_string(),
+            )
+        })?;
+
+        let created_at = if timestamp_flags & 1 > 0 {
+            Some(buf.read_u64::<BigEndian>().map_err(|_| {
+                DataContractError::CorruptedSerialization(
+                    "error reading created_at timestamp from serialized document".to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        let updated_at = if timestamp_flags & 2 > 0 {
+            Some(buf.read_u64::<BigEndian>().map_err(|_| {
+                DataContractError::CorruptedSerialization(
+                    "error reading updated_at timestamp from serialized document".to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        let transferred_at = if timestamp_flags & 4 > 0 {
+            Some(buf.read_u64::<BigEndian>().map_err(|_| {
+                DataContractError::CorruptedSerialization(
+                    "error reading transferred_at timestamp from serialized document".to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        let created_at_block_height = if timestamp_flags & 8 > 0 {
+            Some(buf.read_u64::<BigEndian>().map_err(|_| {
+                DataContractError::CorruptedSerialization(
+                    "error reading created_at_block_height from serialized document".to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        let updated_at_block_height = if timestamp_flags & 16 > 0 {
+            Some(buf.read_u64::<BigEndian>().map_err(|_| {
+                DataContractError::CorruptedSerialization(
+                    "error reading updated_at_block_height from serialized document".to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        let transferred_at_block_height = if timestamp_flags & 32 > 0 {
+            Some(buf.read_u64::<BigEndian>().map_err(|_| {
+                DataContractError::CorruptedSerialization(
+                    "error reading transferred_at_block_height from serialized document"
+                        .to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        let created_at_core_block_height = if timestamp_flags & 64 > 0 {
+            Some(buf.read_u32::<BigEndian>().map_err(|_| {
+                DataContractError::CorruptedSerialization(
+                    "error reading created_at_core_block_height from serialized document"
+                        .to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        let updated_at_core_block_height = if timestamp_flags & 128 > 0 {
+            Some(buf.read_u32::<BigEndian>().map_err(|_| {
+                DataContractError::CorruptedSerialization(
+                    "error reading updated_at_core_block_height from serialized document"
+                        .to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        let transferred_at_core_block_height = if timestamp_flags & 256 > 0 {
+            Some(buf.read_u32::<BigEndian>().map_err(|_| {
+                DataContractError::CorruptedSerialization(
+                    "error reading updated_at_core_block_height from serialized document"
+                        .to_string(),
+                )
+            })?)
+        } else {
+            None
+        };
+
+        // Now we deserialize the price which might not be necessary unless called for by the document type
+
+        let price = if document_type.trade_mode().seller_sets_price() {
+            let has_price = buf.read_u8().map_err(|_| {
+                DataContractError::CorruptedSerialization(
+                    "error reading has price bool from serialized document".to_string(),
+                )
+            })?;
+            if has_price > 0 {
+                let price = buf.read_u64::<BigEndian>().map_err(|_| {
+                    DataContractError::CorruptedSerialization(
+                        "error reading price u64 from serialized document".to_string(),
+                    )
+                })?;
+                Some(price)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let mut finished_buffer = false;
+
+        let mut properties = document_type
+            .properties()
+            .iter()
+            .filter_map(|(key, property)| {
+                if finished_buffer {
+                    return if property.required && !property.transient {
+                        Some(Err(DataContractError::CorruptedSerialization(
+                            "required field after finished buffer".to_string(),
+                        )))
+                    } else {
+                        None
+                    };
+                }
                 let read_value = property
                     .property_type
                     .read_optionally_from(&mut buf, property.required & !property.transient);
@@ -480,33 +930,62 @@ impl DocumentPlatformConversionMethodsV0 for DocumentV0 {
     fn serialize(
         &self,
         document_type: DocumentTypeRef,
+        contract: &DataContract,
         platform_version: &PlatformVersion,
     ) -> Result<Vec<u8>, ProtocolError> {
-        match platform_version
-            .dpp
-            .document_versions
-            .document_serialization_version
-            .default_current_version
+        if matches!(contract, DataContract::V0(_))
+            || matches!(contract.config(), DataContractConfig::V0(_))
         {
-            0 => self.serialize_v0(document_type),
-            version => Err(ProtocolError::UnknownVersionMismatch {
-                method: "DocumentV0::serialize".to_string(),
-                known_versions: vec![0],
-                received: version,
-            }),
+            // Any data contract in version 0 should always serialize documents in version 0
+            // This is because integers in such a data contract if made through normal versioning should always
+            // be i64
+            // While it's possible in theory maybe that they are not i64 using serialize_v0
+            // will encode all integers as i64.
+            self.serialize_v0(document_type)
+        } else {
+            match platform_version
+                .dpp
+                .document_versions
+                .document_serialization_version
+                .default_current_version
+            {
+                0 => self.serialize_v0(document_type),
+                // Version 1 coincides with protocol version 9, which contains tokens, new document types,
+                // and most importantly different integer types.
+                // Document types now have properties that are known to be things like u8, i32 etc.
+                1 => self.serialize_v1(document_type),
+                version => Err(ProtocolError::UnknownVersionMismatch {
+                    method: "DocumentV0::serialize".to_string(),
+                    known_versions: vec![0, 1],
+                    received: version,
+                }),
+            }
         }
     }
 
     fn serialize_specific_version(
         &self,
         document_type: DocumentTypeRef,
+        contract: &DataContract,
         feature_version: FeatureVersion,
     ) -> Result<Vec<u8>, ProtocolError> {
+        if (matches!(contract, DataContract::V0(_))
+            || matches!(contract.config(), DataContractConfig::V0(_)))
+            && feature_version != 0
+        {
+            // Any data contract in version 0 should always serialize documents in version 0
+            // This is because integers in such a data contract if made through normal versioning should always
+            // be i64
+            // While it's possible in theory maybe that they are not i64 using serialize_v0
+            // will encode all integers as i64.
+            return Err(ProtocolError::NotSupported("Serializing with data contract version 0 or data contract config version 0 is not supported outside of feature version 0".to_string()));
+        };
         match feature_version {
             0 => self.serialize_v0(document_type),
+            1 => self.serialize_v1(document_type),
             version => Err(ProtocolError::UnknownVersionMismatch {
                 method: "DocumentV0::serialize".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             }),
         }
@@ -524,11 +1003,39 @@ impl DocumentPlatformConversionMethodsV0 for DocumentV0 {
             ))
         })?;
         match serialized_version {
-            0 => DocumentV0::from_bytes_v0(serialized_document, document_type, platform_version)
+            0 => {
+                match DocumentV0::from_bytes_v0(
+                    serialized_document,
+                    document_type,
+                    platform_version,
+                )
+                .map_err(ProtocolError::DataContractError)
+                {
+                    Ok(document) => Ok(document),
+                    Err(first_err) => {
+                        // let's try decoding in V1 just to be safe
+                        // Version 0 will decode all integers as I64
+                        // Version 1 will decode all integers properly
+                        // When version was 0 used (protocol version 1 to 8) integers other than I64
+                        // existed, but were probably never used, which is why we try v1 just to be safe
+                        match DocumentV0::from_bytes_v1(
+                            serialized_document,
+                            document_type,
+                            platform_version,
+                        ) {
+                            Ok(document_from_version_1_deserialization) => {
+                                Ok(document_from_version_1_deserialization)
+                            }
+                            Err(_) => Err(first_err),
+                        }
+                    }
+                }
+            }
+            1 => DocumentV0::from_bytes_v1(serialized_document, document_type, platform_version)
                 .map_err(ProtocolError::DataContractError),
             version => Err(ProtocolError::UnknownVersionMismatch {
                 method: "Document::from_bytes (deserialization)".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             }),
         }
@@ -554,6 +1061,36 @@ impl DocumentPlatformConversionMethodsV0 for DocumentV0 {
                     platform_version,
                 ) {
                     Ok(document) => Ok(ConsensusValidationResult::new_with_data(document)),
+                    Err(first_err) => {
+                        // let's try decoding in V1 just to be safe
+                        // Version 0 will decode all integers as I64
+                        // Version 1 will decode all integers properly
+                        // When version was 0 used (protocol version 1 to 8) integers other than I64
+                        // existed, but were probably never used, which is why we try v1 just to be safe
+                        match DocumentV0::from_bytes_v1(
+                            serialized_document,
+                            document_type,
+                            platform_version,
+                        ) {
+                            Ok(document_from_version_1_deserialization) => {
+                                Ok(ConsensusValidationResult::new_with_data(
+                                    document_from_version_1_deserialization,
+                                ))
+                            }
+                            Err(_) => Ok(ConsensusValidationResult::new_with_error(
+                                ConsensusError::BasicError(BasicError::ContractError(first_err)),
+                            )),
+                        }
+                    }
+                }
+            }
+            1 => {
+                match DocumentV0::from_bytes_v1(
+                    serialized_document,
+                    document_type,
+                    platform_version,
+                ) {
+                    Ok(document) => Ok(ConsensusValidationResult::new_with_data(document)),
                     Err(err) => Ok(ConsensusValidationResult::new_with_error(
                         ConsensusError::BasicError(BasicError::ContractError(err)),
                     )),
@@ -561,7 +1098,7 @@ impl DocumentPlatformConversionMethodsV0 for DocumentV0 {
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
                 method: "Document::from_bytes (deserialization)".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             }),
         }

--- a/packages/rs-dpp/src/system_data_contracts.rs
+++ b/packages/rs-dpp/src/system_data_contracts.rs
@@ -63,3 +63,22 @@ pub fn load_system_data_contracts(
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_load_system_data_contract_v8_vs_v9() {
+        let contract_1 = load_system_data_contract(
+            SystemDataContract::TokenHistory,
+            PlatformVersion::get(8).unwrap(),
+        )
+        .expect("data_contract");
+        let contract_2 = load_system_data_contract(
+            SystemDataContract::TokenHistory,
+            PlatformVersion::get(9).unwrap(),
+        )
+        .expect("data_contract");
+        assert_ne!(contract_1, contract_2);
+    }
+}

--- a/packages/rs-dpp/src/voting/contender_structs/contender/mod.rs
+++ b/packages/rs-dpp/src/voting/contender_structs/contender/mod.rs
@@ -1,6 +1,7 @@
 pub mod v0;
 
 use crate::data_contract::document_type::DocumentTypeRef;
+use crate::data_contract::DataContract;
 use crate::document::Document;
 use crate::serialization::{PlatformDeserializable, PlatformSerializable};
 use crate::voting::contender_structs::contender::v0::ContenderV0;
@@ -130,11 +131,16 @@ impl Contender {
     pub fn try_into_contender_with_serialized_document(
         self,
         document_type_ref: DocumentTypeRef,
+        data_contract: &DataContract,
         platform_version: &PlatformVersion,
     ) -> Result<ContenderWithSerializedDocument, ProtocolError> {
         match self {
             Contender::V0(v0) => Ok(v0
-                .try_into_contender_with_serialized_document(document_type_ref, platform_version)?
+                .try_into_contender_with_serialized_document(
+                    document_type_ref,
+                    data_contract,
+                    platform_version,
+                )?
                 .into()),
         }
     }
@@ -142,11 +148,16 @@ impl Contender {
     pub fn try_to_contender_with_serialized_document(
         &self,
         document_type_ref: DocumentTypeRef,
+        data_contract: &DataContract,
         platform_version: &PlatformVersion,
     ) -> Result<ContenderWithSerializedDocument, ProtocolError> {
         match self {
             Contender::V0(v0) => Ok(v0
-                .try_to_contender_with_serialized_document(document_type_ref, platform_version)?
+                .try_to_contender_with_serialized_document(
+                    document_type_ref,
+                    data_contract,
+                    platform_version,
+                )?
                 .into()),
         }
     }
@@ -154,19 +165,29 @@ impl Contender {
     pub fn serialize(
         &self,
         document_type: DocumentTypeRef,
+        data_contract: &DataContract,
         platform_version: &PlatformVersion,
     ) -> Result<Vec<u8>, ProtocolError> {
-        self.try_to_contender_with_serialized_document(document_type, platform_version)?
-            .serialize_to_bytes()
+        self.try_to_contender_with_serialized_document(
+            document_type,
+            data_contract,
+            platform_version,
+        )?
+        .serialize_to_bytes()
     }
 
     pub fn serialize_consume(
         self,
         document_type: DocumentTypeRef,
+        data_contract: &DataContract,
         platform_version: &PlatformVersion,
     ) -> Result<Vec<u8>, ProtocolError> {
-        self.try_into_contender_with_serialized_document(document_type, platform_version)?
-            .serialize_to_bytes()
+        self.try_into_contender_with_serialized_document(
+            document_type,
+            data_contract,
+            platform_version,
+        )?
+        .serialize_to_bytes()
     }
 
     pub fn from_bytes(

--- a/packages/rs-dpp/src/voting/contender_structs/contender/v0/mod.rs
+++ b/packages/rs-dpp/src/voting/contender_structs/contender/v0/mod.rs
@@ -1,4 +1,5 @@
 use crate::data_contract::document_type::DocumentTypeRef;
+use crate::data_contract::DataContract;
 use crate::document::serialization_traits::DocumentPlatformConversionMethodsV0;
 use crate::document::Document;
 use crate::ProtocolError;
@@ -39,6 +40,7 @@ impl ContenderV0 {
     pub fn try_into_contender_with_serialized_document(
         self,
         document_type_ref: DocumentTypeRef,
+        data_contract: &DataContract,
         platform_version: &PlatformVersion,
     ) -> Result<ContenderWithSerializedDocumentV0, ProtocolError> {
         let ContenderV0 {
@@ -50,7 +52,9 @@ impl ContenderV0 {
         Ok(ContenderWithSerializedDocumentV0 {
             identity_id,
             serialized_document: document
-                .map(|document| document.serialize(document_type_ref, platform_version))
+                .map(|document| {
+                    document.serialize(document_type_ref, data_contract, platform_version)
+                })
                 .transpose()?,
             vote_tally,
         })
@@ -59,6 +63,7 @@ impl ContenderV0 {
     pub fn try_to_contender_with_serialized_document(
         &self,
         document_type_ref: DocumentTypeRef,
+        data_contract: &DataContract,
         platform_version: &PlatformVersion,
     ) -> Result<ContenderWithSerializedDocumentV0, ProtocolError> {
         let ContenderV0 {
@@ -71,7 +76,9 @@ impl ContenderV0 {
             identity_id: *identity_id,
             serialized_document: document
                 .as_ref()
-                .map(|document| document.serialize(document_type_ref, platform_version))
+                .map(|document| {
+                    document.serialize(document_type_ref, data_contract, platform_version)
+                })
                 .transpose()?,
             vote_tally: *vote_tally,
         })

--- a/packages/rs-drive-abci/src/execution/platform_events/block_processing_end_events/tests.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_processing_end_events/tests.rs
@@ -134,6 +134,7 @@ mod refund_tests {
 
     fn setup_initial_document(
         platform: &TempPlatform<MockCoreRPCLike>,
+        dashpay: &DataContract,
         profile: DocumentTypeRef,
         rng: &mut StdRng,
         identity: &Identity,
@@ -173,7 +174,7 @@ mod refund_tests {
         altered_document.set("avatarUrl", "http://test.com/cat.jpg".into());
 
         let serialized_len = document
-            .serialize(profile, platform_version)
+            .serialize(profile, dashpay, platform_version)
             .expect("expected to serialize")
             .len() as u64;
 
@@ -298,8 +299,15 @@ mod refund_tests {
             dash_to_credits!(1),
         );
 
-        let (document, insertion_fee_result, current_user_balance) =
-            setup_initial_document(&platform, profile, &mut rng, &identity, &key, &signer);
+        let (document, insertion_fee_result, current_user_balance) = setup_initial_document(
+            &platform,
+            &dashpay_contract_no_indexes,
+            profile,
+            &mut rng,
+            &identity,
+            &key,
+            &signer,
+        );
 
         let documents_batch_delete_transition =
             BatchTransition::new_document_deletion_transition_from_document(
@@ -396,8 +404,15 @@ mod refund_tests {
             dash_to_credits!(1),
         );
 
-        let (document, insertion_fee_result, current_user_balance) =
-            setup_initial_document(&platform, profile, &mut rng, &identity, &key, &signer);
+        let (document, insertion_fee_result, current_user_balance) = setup_initial_document(
+            &platform,
+            &dashpay_contract_no_indexes,
+            profile,
+            &mut rng,
+            &identity,
+            &key,
+            &signer,
+        );
 
         fast_forward_to_block(&platform, 1_200_000_000, 900, 42, 1, false); //next epoch
 
@@ -499,8 +514,15 @@ mod refund_tests {
             dash_to_credits!(1),
         );
 
-        let (document, insertion_fee_result, current_user_balance) =
-            setup_initial_document(&platform, profile, &mut rng, &identity, &key, &signer);
+        let (document, insertion_fee_result, current_user_balance) = setup_initial_document(
+            &platform,
+            &dashpay_contract_no_indexes,
+            profile,
+            &mut rng,
+            &identity,
+            &key,
+            &signer,
+        );
 
         fast_forward_to_block(&platform, 1_200_000_000, 900, 42, 40, false); //a year later
 
@@ -598,8 +620,15 @@ mod refund_tests {
             dash_to_credits!(1),
         );
 
-        let (document, insertion_fee_result, current_user_balance) =
-            setup_initial_document(&platform, profile, &mut rng, &identity, &key, &signer);
+        let (document, insertion_fee_result, current_user_balance) = setup_initial_document(
+            &platform,
+            &dashpay_contract_no_indexes,
+            profile,
+            &mut rng,
+            &identity,
+            &key,
+            &signer,
+        );
 
         fast_forward_to_block(&platform, 10_200_000_000, 9000, 42, 40 * 25, false); //25 years later
 
@@ -697,8 +726,15 @@ mod refund_tests {
             dash_to_credits!(1),
         );
 
-        let (document, _, current_user_balance) =
-            setup_initial_document(&platform, profile, &mut rng, &identity, &key, &signer);
+        let (document, _, current_user_balance) = setup_initial_document(
+            &platform,
+            &dashpay_contract_no_indexes,
+            profile,
+            &mut rng,
+            &identity,
+            &key,
+            &signer,
+        );
 
         fast_forward_to_block(&platform, 10_200_000_000, 9000, 42, 40 * 50, false); //50 years later
 
@@ -797,8 +833,15 @@ mod refund_tests {
             dash_to_credits!(1),
         );
 
-        let (document, insertion_fee_result, current_user_balance) =
-            setup_initial_document(&platform, profile, &mut rng, &identity, &key, &signer);
+        let (document, insertion_fee_result, current_user_balance) = setup_initial_document(
+            &platform,
+            &dashpay_contract_no_indexes,
+            profile,
+            &mut rng,
+            &identity,
+            &key,
+            &signer,
+        );
 
         fast_forward_to_block(&platform, 1_200_000_000, 900, 42, 10, false); //next epoch
 

--- a/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
@@ -66,6 +66,10 @@ impl<C> Platform<C> {
         previous_protocol_version: ProtocolVersion,
         platform_version: &PlatformVersion,
     ) -> Result<(), Error> {
+        self.drive
+            .cache
+            .system_data_contracts
+            .reload_system_contracts(platform_version)?;
         if previous_protocol_version < 4 && platform_version.protocol_version >= 4 {
             self.transition_to_version_4(
                 platform_state,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/data_triggers/triggers/withdrawals/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/data_triggers/triggers/withdrawals/v0/mod.rs
@@ -233,7 +233,7 @@ mod tests {
         .expect("expected withdrawal document");
 
         let serialized = document
-            .serialize(document_type, platform_version)
+            .serialize(document_type, &data_contract, platform_version)
             .expect("expected to serialize document");
         Document::from_bytes(&serialized, document_type, platform_version)
             .expect("expected to deserialize document");

--- a/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
@@ -462,6 +462,7 @@ pub(crate) fn verify_state_transitions_were_or_were_not_executed(
                                         token_transition_action
                                             .historical_document_type(&token_history)
                                             .expect("expected document type"),
+                                        &token_history,
                                         platform_version,
                                     )
                                     .expect("expected to serialize");

--- a/packages/rs-drive-abci/tests/strategy_tests/voting_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/voting_tests.rs
@@ -319,7 +319,8 @@ mod tests {
     }
 
     #[test]
-    fn run_chain_block_two_state_transitions_conflicting_unique_index_inserted_same_block() {
+    fn run_chain_block_two_state_transitions_conflicting_unique_index_inserted_same_block_version_8(
+    ) {
         // In this test we try to insert two state transitions with the same unique index
         // We use the DPNS contract, and we insert two documents both with the same "name"
         // This is a common scenario we should see quite often
@@ -337,9 +338,10 @@ mod tests {
         };
         let mut platform = TestPlatformBuilder::new()
             .with_config(config.clone())
+            .with_initial_protocol_version(8)
             .build_with_mock_rpc();
 
-        let platform_version = PlatformVersion::latest();
+        let platform_version = PlatformVersion::get(8).expect("failed to get platform_version");
 
         let mut rng = StdRng::seed_from_u64(567);
 

--- a/packages/rs-drive/benches/benchmarks.rs
+++ b/packages/rs-drive/benches/benchmarks.rs
@@ -46,7 +46,7 @@ fn test_drive_10_serialization(c: &mut Criterion) {
             |documents| {
                 documents.iter().for_each(|document| {
                     document
-                        .serialize(document_type, platform_version)
+                        .serialize(document_type, &contract, platform_version)
                         .expect("expected to serialize");
                 })
             },
@@ -78,7 +78,7 @@ fn test_drive_10_serialization(c: &mut Criterion) {
             |documents| {
                 documents.into_iter().for_each(|document| {
                     document
-                        .serialize(document_type, platform_version)
+                        .serialize(document_type, &contract, platform_version)
                         .expect("expected to serialize");
                 })
             },
@@ -108,7 +108,8 @@ fn test_drive_10_deserialization(c: &mut Criterion) {
             .iter()
             .map(|a| {
                 (
-                    a.serialize(document_type, platform_version).unwrap(),
+                    a.serialize(document_type, &contract, platform_version)
+                        .unwrap(),
                     a.to_cbor().expect("expected to encode to cbor"),
                 )
             })

--- a/packages/rs-drive/src/drive/document/delete/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/mod.rs
@@ -323,7 +323,7 @@ mod tests {
         .expect("expected to get document");
 
         let serialized = person_document0
-            .serialize(document_type, platform_version)
+            .serialize(document_type, &contract, platform_version)
             .expect("expected to serialize");
         let _deserialized = Document::from_bytes(&serialized, document_type, platform_version)
             .expect("expected to deserialize");

--- a/packages/rs-drive/src/drive/document/insert/add_document_to_primary_storage/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_document_to_primary_storage/v0/mod.rs
@@ -145,99 +145,103 @@ impl Drive {
                 drive_version,
             )?;
             let encoded_time = DocumentPropertyType::encode_date_timestamp(block_info.time_ms);
-            let path_key_element_info = match &document_and_contract_info
-                .owned_document_info
-                .document_info
-            {
-                DocumentRefAndSerialization((document, serialized_document, storage_flags)) => {
-                    let element = Element::Item(
-                        serialized_document.to_vec(),
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    let document_id_in_primary_path =
-                        contract_documents_keeping_history_primary_key_path_for_document_id(
-                            contract.id_ref().as_bytes(),
-                            document_type.name().as_str(),
-                            document.id_ref().as_slice(),
+            let path_key_element_info =
+                match &document_and_contract_info.owned_document_info.document_info {
+                    DocumentRefAndSerialization((document, serialized_document, storage_flags)) => {
+                        let element = Element::Item(
+                            serialized_document.to_vec(),
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
                         );
-                    PathFixedSizeKeyRefElement((
-                        document_id_in_primary_path,
-                        encoded_time.as_slice(),
-                        element,
-                    ))
-                }
-                DocumentAndSerialization((document, serialized_document, storage_flags)) => {
-                    let element = Element::Item(
-                        serialized_document.to_vec(),
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    let document_id_in_primary_path =
-                        contract_documents_keeping_history_primary_key_path_for_document_id(
-                            contract.id_ref().as_bytes(),
-                            document_type.name().as_str(),
-                            document.id_ref().as_slice(),
+                        let document_id_in_primary_path =
+                            contract_documents_keeping_history_primary_key_path_for_document_id(
+                                contract.id_ref().as_bytes(),
+                                document_type.name().as_str(),
+                                document.id_ref().as_slice(),
+                            );
+                        PathFixedSizeKeyRefElement((
+                            document_id_in_primary_path,
+                            encoded_time.as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentAndSerialization((document, serialized_document, storage_flags)) => {
+                        let element = Element::Item(
+                            serialized_document.to_vec(),
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
                         );
-                    PathFixedSizeKeyRefElement((
-                        document_id_in_primary_path,
-                        encoded_time.as_slice(),
-                        element,
-                    ))
-                }
-                DocumentOwnedInfo((document, storage_flags)) => {
-                    let serialized_document = document
-                        .serialize(document_and_contract_info.document_type, platform_version)?;
-                    let element = Element::Item(
-                        serialized_document,
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    let document_id_in_primary_path =
-                        contract_documents_keeping_history_primary_key_path_for_document_id(
-                            contract.id_ref().as_bytes(),
-                            document_type.name().as_str(),
-                            document.id_ref().as_slice(),
+                        let document_id_in_primary_path =
+                            contract_documents_keeping_history_primary_key_path_for_document_id(
+                                contract.id_ref().as_bytes(),
+                                document_type.name().as_str(),
+                                document.id_ref().as_slice(),
+                            );
+                        PathFixedSizeKeyRefElement((
+                            document_id_in_primary_path,
+                            encoded_time.as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentOwnedInfo((document, storage_flags)) => {
+                        let serialized_document = document.serialize(
+                            document_and_contract_info.document_type,
+                            document_and_contract_info.contract,
+                            platform_version,
+                        )?;
+                        let element = Element::Item(
+                            serialized_document,
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
                         );
-                    PathFixedSizeKeyRefElement((
-                        document_id_in_primary_path,
-                        encoded_time.as_slice(),
-                        element,
-                    ))
-                }
-                DocumentRefInfo((document, storage_flags)) => {
-                    let serialized_document = document
-                        .serialize(document_and_contract_info.document_type, platform_version)?;
-                    let element = Element::Item(
-                        serialized_document,
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    let document_id_in_primary_path =
-                        contract_documents_keeping_history_primary_key_path_for_document_id(
-                            contract.id_ref().as_bytes(),
-                            document_type.name().as_str(),
-                            document.id_ref().as_slice(),
+                        let document_id_in_primary_path =
+                            contract_documents_keeping_history_primary_key_path_for_document_id(
+                                contract.id_ref().as_bytes(),
+                                document_type.name().as_str(),
+                                document.id_ref().as_slice(),
+                            );
+                        PathFixedSizeKeyRefElement((
+                            document_id_in_primary_path,
+                            encoded_time.as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentRefInfo((document, storage_flags)) => {
+                        let serialized_document = document.serialize(
+                            document_and_contract_info.document_type,
+                            document_and_contract_info.contract,
+                            platform_version,
+                        )?;
+                        let element = Element::Item(
+                            serialized_document,
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
                         );
-                    PathFixedSizeKeyRefElement((
-                        document_id_in_primary_path,
-                        encoded_time.as_slice(),
-                        element,
-                    ))
-                }
-                DocumentEstimatedAverageSize(max_size) => {
-                    let document_id_in_primary_path =
+                        let document_id_in_primary_path =
+                            contract_documents_keeping_history_primary_key_path_for_document_id(
+                                contract.id_ref().as_bytes(),
+                                document_type.name().as_str(),
+                                document.id_ref().as_slice(),
+                            );
+                        PathFixedSizeKeyRefElement((
+                            document_id_in_primary_path,
+                            encoded_time.as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentEstimatedAverageSize(max_size) => {
+                        let document_id_in_primary_path =
                         contract_documents_keeping_history_primary_key_path_for_unknown_document_id(
                             contract.id_ref().as_bytes(),
                             document_type,
                         );
-                    PathKeyUnknownElementSize((
-                        document_id_in_primary_path,
-                        KnownKey(encoded_time.clone()),
-                        Element::required_item_space(
-                            *max_size,
-                            STORAGE_FLAGS_SIZE,
-                            &platform_version.drive.grove_version,
-                        )?,
-                    ))
-                }
-            };
+                        PathKeyUnknownElementSize((
+                            document_id_in_primary_path,
+                            KnownKey(encoded_time.clone()),
+                            Element::required_item_space(
+                                *max_size,
+                                STORAGE_FLAGS_SIZE,
+                                &platform_version.drive.grove_version,
+                            )?,
+                        ))
+                    }
+                };
             self.batch_insert(path_key_element_info, drive_operations, drive_version)?;
             let path_key_element_info = if document_and_contract_info
                 .owned_document_info
@@ -290,138 +294,146 @@ impl Drive {
 
             self.batch_insert(path_key_element_info, drive_operations, drive_version)?;
         } else if insert_without_check {
-            let path_key_element_info = match &document_and_contract_info
-                .owned_document_info
-                .document_info
-            {
-                DocumentRefAndSerialization((document, serialized_document, storage_flags)) => {
-                    let element = Element::Item(
-                        serialized_document.to_vec(),
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentAndSerialization((document, serialized_document, storage_flags)) => {
-                    let element = Element::Item(
-                        serialized_document.to_vec(),
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentRefInfo((document, storage_flags)) => {
-                    let serialized_document = document
-                        .serialize(document_and_contract_info.document_type, platform_version)?;
-                    let element = Element::Item(
-                        serialized_document,
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentEstimatedAverageSize(average_size) => PathKeyUnknownElementSize((
-                    KeyInfoPath::from_known_path(primary_key_path),
-                    KeyInfo::MaxKeySize {
-                        unique_id: document_type.unique_id_for_storage().to_vec(),
-                        max_size: DEFAULT_HASH_SIZE_U8,
-                    },
-                    Element::required_item_space(
-                        *average_size,
-                        STORAGE_FLAGS_SIZE,
-                        &platform_version.drive.grove_version,
-                    )?,
-                )),
-                DocumentOwnedInfo((document, storage_flags)) => {
-                    let serialized_document = document
-                        .serialize(document_and_contract_info.document_type, platform_version)?;
-                    let element = Element::Item(
-                        serialized_document,
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-            };
+            let path_key_element_info =
+                match &document_and_contract_info.owned_document_info.document_info {
+                    DocumentRefAndSerialization((document, serialized_document, storage_flags)) => {
+                        let element = Element::Item(
+                            serialized_document.to_vec(),
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentAndSerialization((document, serialized_document, storage_flags)) => {
+                        let element = Element::Item(
+                            serialized_document.to_vec(),
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentRefInfo((document, storage_flags)) => {
+                        let serialized_document = document.serialize(
+                            document_and_contract_info.document_type,
+                            document_and_contract_info.contract,
+                            platform_version,
+                        )?;
+                        let element = Element::Item(
+                            serialized_document,
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentEstimatedAverageSize(average_size) => PathKeyUnknownElementSize((
+                        KeyInfoPath::from_known_path(primary_key_path),
+                        KeyInfo::MaxKeySize {
+                            unique_id: document_type.unique_id_for_storage().to_vec(),
+                            max_size: DEFAULT_HASH_SIZE_U8,
+                        },
+                        Element::required_item_space(
+                            *average_size,
+                            STORAGE_FLAGS_SIZE,
+                            &platform_version.drive.grove_version,
+                        )?,
+                    )),
+                    DocumentOwnedInfo((document, storage_flags)) => {
+                        let serialized_document = document.serialize(
+                            document_and_contract_info.document_type,
+                            document_and_contract_info.contract,
+                            platform_version,
+                        )?;
+                        let element = Element::Item(
+                            serialized_document,
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                };
             self.batch_insert(path_key_element_info, drive_operations, drive_version)?;
         } else {
-            let path_key_element_info = match &document_and_contract_info
-                .owned_document_info
-                .document_info
-            {
-                DocumentRefAndSerialization((document, serialized_document, storage_flags)) => {
-                    let element = Element::Item(
-                        serialized_document.to_vec(),
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentAndSerialization((document, serialized_document, storage_flags)) => {
-                    let element = Element::Item(
-                        serialized_document.to_vec(),
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentOwnedInfo((document, storage_flags)) => {
-                    let serialized_document = document
-                        .serialize(document_and_contract_info.document_type, platform_version)?;
-                    let element = Element::Item(
-                        serialized_document,
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentRefInfo((document, storage_flags)) => {
-                    let serialized_document = document
-                        .serialize(document_and_contract_info.document_type, platform_version)?;
-                    let element = Element::Item(
-                        serialized_document,
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentEstimatedAverageSize(max_size) => PathKeyUnknownElementSize((
-                    KeyInfoPath::from_known_path(primary_key_path),
-                    KeyInfo::MaxKeySize {
-                        unique_id: document_type.unique_id_for_storage().to_vec(),
-                        max_size: DEFAULT_HASH_SIZE_U8,
-                    },
-                    Element::required_item_space(
-                        *max_size,
-                        STORAGE_FLAGS_SIZE,
-                        &platform_version.drive.grove_version,
-                    )?,
-                )),
-            };
+            let path_key_element_info =
+                match &document_and_contract_info.owned_document_info.document_info {
+                    DocumentRefAndSerialization((document, serialized_document, storage_flags)) => {
+                        let element = Element::Item(
+                            serialized_document.to_vec(),
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentAndSerialization((document, serialized_document, storage_flags)) => {
+                        let element = Element::Item(
+                            serialized_document.to_vec(),
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentOwnedInfo((document, storage_flags)) => {
+                        let serialized_document = document.serialize(
+                            document_and_contract_info.document_type,
+                            document_and_contract_info.contract,
+                            platform_version,
+                        )?;
+                        let element = Element::Item(
+                            serialized_document,
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentRefInfo((document, storage_flags)) => {
+                        let serialized_document = document.serialize(
+                            document_and_contract_info.document_type,
+                            document_and_contract_info.contract,
+                            platform_version,
+                        )?;
+                        let element = Element::Item(
+                            serialized_document,
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentEstimatedAverageSize(max_size) => PathKeyUnknownElementSize((
+                        KeyInfoPath::from_known_path(primary_key_path),
+                        KeyInfo::MaxKeySize {
+                            unique_id: document_type.unique_id_for_storage().to_vec(),
+                            max_size: DEFAULT_HASH_SIZE_U8,
+                        },
+                        Element::required_item_space(
+                            *max_size,
+                            STORAGE_FLAGS_SIZE,
+                            &platform_version.drive.grove_version,
+                        )?,
+                    )),
+                };
             let apply_type = if estimated_costs_only_with_layer_info.is_none() {
                 BatchInsertApplyType::StatefulBatchInsert
             } else {

--- a/packages/rs-drive/src/drive/document/insert_contested/add_contested_document_to_primary_storage/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert_contested/add_contested_document_to_primary_storage/v0/mod.rs
@@ -67,138 +67,146 @@ impl Drive {
         }
 
         if insert_without_check {
-            let path_key_element_info = match &document_and_contract_info
-                .owned_document_info
-                .document_info
-            {
-                DocumentRefAndSerialization((document, serialized_document, storage_flags)) => {
-                    let element = Element::Item(
-                        serialized_document.to_vec(),
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentAndSerialization((document, serialized_document, storage_flags)) => {
-                    let element = Element::Item(
-                        serialized_document.to_vec(),
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentRefInfo((document, storage_flags)) => {
-                    let serialized_document = document
-                        .serialize(document_and_contract_info.document_type, platform_version)?;
-                    let element = Element::Item(
-                        serialized_document,
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentEstimatedAverageSize(average_size) => PathKeyUnknownElementSize((
-                    KeyInfoPath::from_known_path(primary_key_path),
-                    KeyInfo::MaxKeySize {
-                        unique_id: document_type.unique_id_for_storage().to_vec(),
-                        max_size: DEFAULT_HASH_SIZE_U8,
-                    },
-                    Element::required_item_space(
-                        *average_size,
-                        STORAGE_FLAGS_SIZE,
-                        &platform_version.drive.grove_version,
-                    )?,
-                )),
-                DocumentOwnedInfo((document, storage_flags)) => {
-                    let serialized_document = document
-                        .serialize(document_and_contract_info.document_type, platform_version)?;
-                    let element = Element::Item(
-                        serialized_document,
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-            };
+            let path_key_element_info =
+                match &document_and_contract_info.owned_document_info.document_info {
+                    DocumentRefAndSerialization((document, serialized_document, storage_flags)) => {
+                        let element = Element::Item(
+                            serialized_document.to_vec(),
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentAndSerialization((document, serialized_document, storage_flags)) => {
+                        let element = Element::Item(
+                            serialized_document.to_vec(),
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentRefInfo((document, storage_flags)) => {
+                        let serialized_document = document.serialize(
+                            document_and_contract_info.document_type,
+                            document_and_contract_info.contract,
+                            platform_version,
+                        )?;
+                        let element = Element::Item(
+                            serialized_document,
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentEstimatedAverageSize(average_size) => PathKeyUnknownElementSize((
+                        KeyInfoPath::from_known_path(primary_key_path),
+                        KeyInfo::MaxKeySize {
+                            unique_id: document_type.unique_id_for_storage().to_vec(),
+                            max_size: DEFAULT_HASH_SIZE_U8,
+                        },
+                        Element::required_item_space(
+                            *average_size,
+                            STORAGE_FLAGS_SIZE,
+                            &platform_version.drive.grove_version,
+                        )?,
+                    )),
+                    DocumentOwnedInfo((document, storage_flags)) => {
+                        let serialized_document = document.serialize(
+                            document_and_contract_info.document_type,
+                            document_and_contract_info.contract,
+                            platform_version,
+                        )?;
+                        let element = Element::Item(
+                            serialized_document,
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                };
             self.batch_insert(path_key_element_info, drive_operations, drive_version)?;
         } else {
-            let path_key_element_info = match &document_and_contract_info
-                .owned_document_info
-                .document_info
-            {
-                DocumentRefAndSerialization((document, serialized_document, storage_flags)) => {
-                    let element = Element::Item(
-                        serialized_document.to_vec(),
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentAndSerialization((document, serialized_document, storage_flags)) => {
-                    let element = Element::Item(
-                        serialized_document.to_vec(),
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentOwnedInfo((document, storage_flags)) => {
-                    let serialized_document = document
-                        .serialize(document_and_contract_info.document_type, platform_version)?;
-                    let element = Element::Item(
-                        serialized_document,
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentRefInfo((document, storage_flags)) => {
-                    let serialized_document = document
-                        .serialize(document_and_contract_info.document_type, platform_version)?;
-                    let element = Element::Item(
-                        serialized_document,
-                        StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
-                    );
-                    PathFixedSizeKeyRefElement((
-                        primary_key_path,
-                        document.id_ref().as_slice(),
-                        element,
-                    ))
-                }
-                DocumentEstimatedAverageSize(max_size) => PathKeyUnknownElementSize((
-                    KeyInfoPath::from_known_path(primary_key_path),
-                    KeyInfo::MaxKeySize {
-                        unique_id: document_type.unique_id_for_storage().to_vec(),
-                        max_size: DEFAULT_HASH_SIZE_U8,
-                    },
-                    Element::required_item_space(
-                        *max_size,
-                        STORAGE_FLAGS_SIZE,
-                        &platform_version.drive.grove_version,
-                    )?,
-                )),
-            };
+            let path_key_element_info =
+                match &document_and_contract_info.owned_document_info.document_info {
+                    DocumentRefAndSerialization((document, serialized_document, storage_flags)) => {
+                        let element = Element::Item(
+                            serialized_document.to_vec(),
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentAndSerialization((document, serialized_document, storage_flags)) => {
+                        let element = Element::Item(
+                            serialized_document.to_vec(),
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentOwnedInfo((document, storage_flags)) => {
+                        let serialized_document = document.serialize(
+                            document_and_contract_info.document_type,
+                            document_and_contract_info.contract,
+                            platform_version,
+                        )?;
+                        let element = Element::Item(
+                            serialized_document,
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentRefInfo((document, storage_flags)) => {
+                        let serialized_document = document.serialize(
+                            document_and_contract_info.document_type,
+                            document_and_contract_info.contract,
+                            platform_version,
+                        )?;
+                        let element = Element::Item(
+                            serialized_document,
+                            StorageFlags::map_borrowed_cow_to_some_element_flags(storage_flags),
+                        );
+                        PathFixedSizeKeyRefElement((
+                            primary_key_path,
+                            document.id_ref().as_slice(),
+                            element,
+                        ))
+                    }
+                    DocumentEstimatedAverageSize(max_size) => PathKeyUnknownElementSize((
+                        KeyInfoPath::from_known_path(primary_key_path),
+                        KeyInfo::MaxKeySize {
+                            unique_id: document_type.unique_id_for_storage().to_vec(),
+                            max_size: DEFAULT_HASH_SIZE_U8,
+                        },
+                        Element::required_item_space(
+                            *max_size,
+                            STORAGE_FLAGS_SIZE,
+                            &platform_version.drive.grove_version,
+                        )?,
+                    )),
+                };
             let apply_type = if estimated_costs_only_with_layer_info.is_none() {
                 BatchInsertApplyType::StatefulBatchInsert
             } else {

--- a/packages/rs-drive/src/drive/document/update/mod.rs
+++ b/packages/rs-drive/src/drive/document/update/mod.rs
@@ -915,6 +915,7 @@ mod tests {
         let document_serialized = DocumentPlatformConversionMethodsV0::serialize(
             &document,
             document_type,
+            &contract,
             platform_version,
         )
         .expect("expected to serialize document");

--- a/packages/rs-drive/src/drive/initialization/v0/mod.rs
+++ b/packages/rs-drive/src/drive/initialization/v0/mod.rs
@@ -186,7 +186,7 @@ impl Drive {
         batch.add_insert(
             misc_path_vec(),
             TOTAL_SYSTEM_CREDITS_STORAGE_KEY.to_vec(),
-            Element::Item(0.encode_var_vec(), None),
+            Element::Item(0u64.encode_var_vec(), None),
         );
 
         // In Pools: initialize the pools with epochs

--- a/packages/rs-drive/tests/query_tests.rs
+++ b/packages/rs-drive/tests/query_tests.rs
@@ -495,6 +495,7 @@ fn test_serialization_and_deserialization() {
         let serialized = <Document as DocumentPlatformConversionMethodsV0>::serialize(
             &document,
             document_type,
+            &contract,
             platform_version,
         )
         .expect("should serialize");
@@ -544,6 +545,7 @@ fn test_serialization_and_deserialization_with_null_values_should_fail_if_requir
     <Document as DocumentPlatformConversionMethodsV0>::serialize(
         &document,
         document_type,
+        &contract,
         platform_version,
     )
     .expect_err("expected to not be able to serialize domain document");
@@ -591,9 +593,13 @@ fn test_serialization_and_deserialization_with_null_values() {
     let mut document =
         Document::from_platform_value(value, platform_version).expect("expected value");
     document.set_revision(Some(1));
-    let serialized =
-        DocumentPlatformConversionMethodsV0::serialize(&document, document_type, platform_version)
-            .expect("expected to be able to serialize domain document");
+    let serialized = DocumentPlatformConversionMethodsV0::serialize(
+        &document,
+        document_type,
+        &contract,
+        platform_version,
+    )
+    .expect("expected to be able to serialize domain document");
 
     Document::from_bytes(&serialized, document_type, platform_version)
         .expect("expected to deserialize domain document");

--- a/packages/rs-platform-version/src/version/dpp_versions/dpp_document_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions/dpp_document_versions/mod.rs
@@ -1,6 +1,7 @@
 use versioned_feature_core::{FeatureVersion, FeatureVersionBounds};
 
 pub mod v1;
+pub mod v2;
 
 #[derive(Clone, Debug, Default)]
 pub struct DPPDocumentVersions {

--- a/packages/rs-platform-version/src/version/dpp_versions/dpp_document_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions/dpp_document_versions/v2.rs
@@ -1,0 +1,31 @@
+use crate::version::dpp_versions::dpp_document_versions::{
+    DPPDocumentVersions, DocumentMethodVersions,
+};
+use versioned_feature_core::FeatureVersionBounds;
+
+pub const DOCUMENT_VERSIONS_V2: DPPDocumentVersions = DPPDocumentVersions {
+    document_structure_version: 0,
+    document_serialization_version: FeatureVersionBounds {
+        min_version: 0,
+        max_version: 1,
+        default_current_version: 1,
+    },
+    document_cbor_serialization_version: FeatureVersionBounds {
+        min_version: 0,
+        max_version: 0,
+        default_current_version: 0,
+    },
+    extended_document_structure_version: 0,
+    extended_document_serialization_version: FeatureVersionBounds {
+        min_version: 0,
+        max_version: 0,
+        default_current_version: 0,
+    },
+    document_method_versions: DocumentMethodVersions {
+        is_equal_ignoring_timestamps: 0,
+        hash: 0,
+        get_raw_for_contract: 0,
+        get_raw_for_document_type: 0,
+        try_into_asset_unlock_base_transaction_info: 0,
+    },
+};

--- a/packages/rs-platform-version/src/version/v9.rs
+++ b/packages/rs-platform-version/src/version/v9.rs
@@ -2,7 +2,7 @@ use crate::version::consensus_versions::ConsensusVersions;
 use crate::version::dpp_versions::dpp_asset_lock_versions::v1::DPP_ASSET_LOCK_VERSIONS_V1;
 use crate::version::dpp_versions::dpp_contract_versions::v2::CONTRACT_VERSIONS_V2;
 use crate::version::dpp_versions::dpp_costs_versions::v1::DPP_COSTS_VERSIONS_V1;
-use crate::version::dpp_versions::dpp_document_versions::v1::DOCUMENT_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_document_versions::v2::DOCUMENT_VERSIONS_V2;
 use crate::version::dpp_versions::dpp_factory_versions::v1::DPP_FACTORY_VERSIONS_V1;
 use crate::version::dpp_versions::dpp_identity_versions::v1::IDENTITY_VERSIONS_V1;
 use crate::version::dpp_versions::dpp_method_versions::v1::DPP_METHOD_VERSIONS_V1;
@@ -49,7 +49,7 @@ pub const PLATFORM_V9: PlatformVersion = PlatformVersion {
         state_transition_method_versions: STATE_TRANSITION_METHOD_VERSIONS_V1,
         state_transitions: STATE_TRANSITION_VERSIONS_V2,
         contract_versions: CONTRACT_VERSIONS_V2, // changed
-        document_versions: DOCUMENT_VERSIONS_V1,
+        document_versions: DOCUMENT_VERSIONS_V2, // changed to support new serialization
         identity_versions: IDENTITY_VERSIONS_V1,
         voting_versions: VOTING_VERSION_V2,
         token_versions: TOKEN_VERSIONS_V1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
In data contract config v1 there is an option to have integers be based on the type that mosts suits the use case. For example using a u8 if we can only have 0, 1, 2. However serialization could happen on old contract versions that didn't have this feature, leading to deserialization problems where we didn't know what system was used.

## What was done?
Introduced a new document serialization version that informs the deserializer if this feature was active.
Reload all system contracts whenever the network updates protocol versions. This will make data contracts in version 0 "transform" into version 1 on protocol version 9.

## How Has This Been Tested?
Verified that some tests worked.

## Breaking Changes
Not breaking.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for a new document serialization version that encodes integers using their native sizes, enhancing compatibility and efficiency.
  - Added versioned deserialization methods for documents, improving handling of different document formats.
  - Enabled atomic reloading of system data contracts after platform upgrades.

- **Bug Fixes**
  - Improved error handling for missing required fields and unsupported serialization versions during document serialization and deserialization.

- **Refactor**
  - Updated serialization and deserialization methods throughout the platform to consistently require the data contract as an argument.
  - Unified and clarified serialization logic for documents in storage operations and tests.

- **Tests**
  - Enhanced and added tests to verify document serialization/deserialization across versions and system contract changes.
  - Updated test cases to reflect new serialization method signatures and platform versioning.

- **Chores**
  - Updated platform version constants and module imports to support the new document serialization version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->