### PR TITLE
fix(sdk): compare underlying returned data on proof verification

### DIFF
--- a/packages/rs-dpp/src/document/document_methods/is_equal_ignoring_timestamps/v0/mod.rs
+++ b/packages/rs-dpp/src/document/document_methods/is_equal_ignoring_timestamps/v0/mod.rs
@@ -1,5 +1,6 @@
 use crate::document::document_methods::DocumentGetRawForDocumentTypeV0;
 use crate::document::DocumentV0Getters;
+use platform_value::btreemap_extensions::EqualUnderlyingData;
 use platform_value::Value;
 use std::collections::BTreeMap;
 
@@ -30,9 +31,9 @@ pub trait DocumentIsEqualIgnoringTimestampsV0:
 
         let properties_equal = if let Some(fields) = &also_ignore_fields {
             filtered_properties(self.properties(), fields)
-                == filtered_properties(rhs.properties(), fields)
+                .equal_underlying_data(&filtered_properties(rhs.properties(), fields))
         } else {
-            self.properties() == rhs.properties()
+            self.properties().equal_underlying_data(rhs.properties())
         };
 
         self.id() == rhs.id()

--- a/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
@@ -187,7 +187,7 @@ impl Drive {
                                     Some(transient_fields),
                                     platform_version,
                                 )? {
-                                    return Err(Error::Proof(ProofError::IncorrectProof(format!("proof of state transition execution did not contain expected document (time fields were not checked) after create with id {}", create_transition.base().id()))));
+                                    return Err(Error::Proof(ProofError::IncorrectProof(format!("proof of state transition execution did not contain expected document (time fields were not checked) after create, got: [{}] vs expected: [{}], state transition is [{}]", document, expected_document, create_transition))));
                                 }
                                 Ok((
                                     root_hash,
@@ -224,7 +224,7 @@ impl Drive {
                                     Some(transient_fields),
                                     platform_version,
                                 )? {
-                                    return Err(Error::Proof(ProofError::IncorrectProof(format!("proof of state transition execution did not contain expected document (time fields were not checked) after replace with id {}", replace_transition.base().id()))));
+                                    return Err(Error::Proof(ProofError::IncorrectProof(format!("proof of state transition execution did not contain expected document (time fields were not checked) after replace, got: [{}] vs expected: [{}], state transition is [{}]", document, expected_document, replace_transition))));
                                 }
 
                                 Ok((

--- a/packages/rs-platform-value/src/btreemap_extensions/equal_underlying_data.rs
+++ b/packages/rs-platform-value/src/btreemap_extensions/equal_underlying_data.rs
@@ -1,0 +1,95 @@
+use crate::Value;
+use std::collections::BTreeMap;
+/* ========================================================= *
+ *   Trait: EqualUnderlyingData                              *
+ * ========================================================= */
+
+/// Compare two structures by the data they ultimately represent,
+/// not necessarily by their concrete variants.
+pub trait EqualUnderlyingData {
+    fn equal_underlying_data(&self, other: &Self) -> bool;
+}
+
+/* ========================================================= *
+ *   Impl for `BTreeMap<String, Value>`                      *
+ * ========================================================= */
+
+impl EqualUnderlyingData for &BTreeMap<String, Value> {
+    fn equal_underlying_data(&self, other: &Self) -> bool {
+        // quick size check
+        if self.len() != other.len() {
+            return false;
+        }
+        // every key must exist in both and values must match by underlying data
+        self.iter().all(|(k, v_self)| {
+            other
+                .get(k)
+                .map(|v_other| v_self.equal_underlying_data(v_other))
+                .unwrap_or(false)
+        })
+    }
+}
+
+impl EqualUnderlyingData for BTreeMap<String, Value> {
+    fn equal_underlying_data(&self, other: &Self) -> bool {
+        // quick size check
+        if self.len() != other.len() {
+            return false;
+        }
+        // every key must exist in both and values must match by underlying data
+        self.iter().all(|(k, v_self)| {
+            other
+                .get(k)
+                .map(|v_other| v_self.equal_underlying_data(v_other))
+                .unwrap_or(false)
+        })
+    }
+}
+
+impl EqualUnderlyingData for BTreeMap<&String, Value> {
+    fn equal_underlying_data(&self, other: &Self) -> bool {
+        // quick size check
+        if self.len() != other.len() {
+            return false;
+        }
+        // every key must exist in both and values must match by underlying data
+        self.iter().all(|(k, v_self)| {
+            other
+                .get(k)
+                .map(|v_other| v_self.equal_underlying_data(v_other))
+                .unwrap_or(false)
+        })
+    }
+}
+
+impl EqualUnderlyingData for BTreeMap<&String, &Value> {
+    fn equal_underlying_data(&self, other: &Self) -> bool {
+        // quick size check
+        if self.len() != other.len() {
+            return false;
+        }
+        // every key must exist in both and values must match by underlying data
+        self.iter().all(|(k, v_self)| {
+            other
+                .get(k)
+                .map(|v_other| v_self.equal_underlying_data(v_other))
+                .unwrap_or(false)
+        })
+    }
+}
+
+impl EqualUnderlyingData for BTreeMap<String, &Value> {
+    fn equal_underlying_data(&self, other: &Self) -> bool {
+        // quick size check
+        if self.len() != other.len() {
+            return false;
+        }
+        // every key must exist in both and values must match by underlying data
+        self.iter().all(|(k, v_self)| {
+            other
+                .get(k)
+                .map(|v_other| v_self.equal_underlying_data(v_other))
+                .unwrap_or(false)
+        })
+    }
+}

--- a/packages/rs-platform-value/src/btreemap_extensions/mod.rs
+++ b/packages/rs-platform-value/src/btreemap_extensions/mod.rs
@@ -15,6 +15,7 @@ mod btreemap_path_extensions;
 mod btreemap_path_insertion_extensions;
 mod btreemap_removal_extensions;
 mod btreemap_removal_inner_value_extensions;
+mod equal_underlying_data;
 
 pub use btreemap_field_replacement::BTreeValueMapReplacementPathHelper;
 pub use btreemap_mut_value_extensions::BTreeMutValueMapHelper;
@@ -23,6 +24,7 @@ pub use btreemap_path_insertion_extensions::BTreeValueMapInsertionPathHelper;
 pub use btreemap_removal_extensions::BTreeValueRemoveFromMapHelper;
 pub use btreemap_removal_extensions::BTreeValueRemoveTupleFromMapHelper;
 pub use btreemap_removal_inner_value_extensions::BTreeValueRemoveInnerValueFromMapHelper;
+pub use equal_underlying_data::EqualUnderlyingData;
 
 pub trait BTreeValueMapHelper {
     fn get_optional_identifier(&self, key: &str) -> Result<Option<Identifier>, Error>;

--- a/packages/rs-platform-value/src/eq.rs
+++ b/packages/rs-platform-value/src/eq.rs
@@ -106,3 +106,66 @@ impl PartialEq<f64> for &Value {
         }
     }
 }
+
+impl PartialEq<Vec<u8>> for Value {
+    #[inline]
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.as_bytes_slice() == Ok(other.as_slice())
+    }
+}
+impl PartialEq<Vec<u8>> for &Value {
+    #[inline]
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.as_bytes_slice() == Ok(other.as_slice())
+    }
+}
+
+macro_rules! impl_bytes_array_eq {
+    ($($n:expr),+ $(,)?) => {$(
+        impl PartialEq<[u8; $n]> for Value {
+            #[inline]
+            fn eq(&self, other: &[u8; $n]) -> bool {
+                self.as_bytes_slice() == Ok(other.as_slice())
+            }
+        }
+        impl PartialEq<[u8; $n]> for &Value {
+            #[inline]
+            fn eq(&self, other: &[u8; $n]) -> bool {
+                self.as_bytes_slice() == Ok(other.as_slice())
+            }
+        }
+    )+};
+}
+impl_bytes_array_eq! { 20, 32, 36 }
+
+impl Value {
+    /* -------------------------------------------------------- *
+     *  equality on underlying data                             *
+     * -------------------------------------------------------- */
+
+    /// Returns `true` when the *data* represented by the two `Value`s
+    /// is identical, even if they are stored in different but
+    /// compatible variants.
+    ///
+    /// * All “bytes-like” variants (`Bytes`, `Bytes20`, `Bytes32`,
+    ///   `Bytes36`, `Identifier`) compare equal when their byte
+    ///   sequences match.
+    /// * All integer variants (`U*`, `I*`) compare equal when they
+    ///   represent the same numeric value.
+    /// * Otherwise falls back to normal `==` (`PartialEq`) behaviour.
+    #[inline]
+    pub fn equal_underlying_data(&self, other: &Value) -> bool {
+        // 1) bytes-like cross-variant equality
+        if let (Ok(a), Ok(b)) = (self.as_bytes_slice(), other.as_bytes_slice()) {
+            return a == b;
+        }
+
+        // 2) integer cross-variant equality
+        if let (Some(a), Some(b)) = (self.as_i128_unified(), other.as_i128_unified()) {
+            return a == b;
+        }
+
+        // 3) default
+        self == other
+    }
+}

--- a/packages/rs-platform-value/src/lib.rs
+++ b/packages/rs-platform-value/src/lib.rs
@@ -1265,6 +1265,28 @@ impl Value {
         }
     }
 
+    /// Returns the numeric value as `i128` if this is any signed /
+    /// unsigned integer variant **and** the conversion is loss-less.
+    #[inline]
+    fn as_i128_unified(&self) -> Option<i128> {
+        use Value::*;
+        match self {
+            I128(v) => Some(*v),
+            I64(v) => Some(*v as i128),
+            I32(v) => Some(*v as i128),
+            I16(v) => Some(*v as i128),
+            I8(v) => Some(*v as i128),
+
+            U128(v) if *v <= i128::MAX as u128 => Some(*v as i128),
+            U64(v) => Some(*v as i128),
+            U32(v) => Some(*v as i128),
+            U16(v) => Some(*v as i128),
+            U8(v) => Some(*v as i128),
+
+            _ => None,
+        }
+    }
+
     /// can determine if there is any very big data in a value
     pub fn has_data_larger_than(&self, size: u32) -> Option<(Option<Value>, u32)> {
         match self {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
We had an issue where Bytes32 and Bytes value types were not showing as equal when verifying returned data in a proof. This is now fixed.


## What was done?
We now verify the equality of the underlying data instead of the wrapper of the data.


## How Has This Been Tested?
Checked in DET that this worked.

## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced advanced equality checks for documents and values, allowing comparisons based on underlying data rather than strict type or variant matches.
  - Added support for comparing values directly to byte arrays and vectors of various sizes.
- **Improvements**
  - Enhanced error messages during state transition verification to provide more detailed debug information when expected documents are missing.
- **Documentation**
  - Publicly re-exported new equality trait for broader use in the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->