### PR TITLE
fix(dpp): do not allow mint of 0 tokens

### DIFF
--- a/packages/rs-dpp/src/errors/consensus/basic/token/invalid_token_amount_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/token/invalid_token_amount_error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
     Error, Debug, Clone, PartialEq, Eq, Encode, Decode, PlatformSerialize, PlatformDeserialize,
 )]
 #[error(
-    "Invalid token amount {}, exceeds maximum allowed {}",
+    "Invalid token amount {}, should be between 1 and maximum allowed {}",
     token_amount,
     max_token_amount
 )]

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_burn_transition/validate_structure/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_burn_transition/validate_structure/v0/mod.rs
@@ -1,6 +1,7 @@
 use crate::consensus::basic::token::{InvalidTokenAmountError, InvalidTokenNoteTooBigError};
 use crate::consensus::basic::BasicError;
 use crate::consensus::ConsensusError;
+use crate::data_contract::associated_token::token_perpetual_distribution::distribution_function::MAX_DISTRIBUTION_PARAM;
 use crate::state_transition::batch_transition::token_burn_transition::v0::v0_methods::TokenBurnTransitionV0Methods;
 use crate::state_transition::batch_transition::TokenBurnTransition;
 use crate::tokens::MAX_TOKEN_NOTE_LEN;
@@ -12,10 +13,10 @@ pub(super) trait TokenBurnTransitionActionStructureValidationV0 {
 }
 impl TokenBurnTransitionActionStructureValidationV0 for TokenBurnTransition {
     fn validate_structure_v0(&self) -> Result<SimpleConsensusValidationResult, ProtocolError> {
-        if self.burn_amount() > i64::MAX as u64 {
+        if self.burn_amount() > MAX_DISTRIBUTION_PARAM || self.burn_amount() == 0 {
             return Ok(SimpleConsensusValidationResult::new_with_error(
                 ConsensusError::BasicError(BasicError::InvalidTokenAmountError(
-                    InvalidTokenAmountError::new(i64::MAX as u64, self.burn_amount()),
+                    InvalidTokenAmountError::new(MAX_DISTRIBUTION_PARAM, self.burn_amount()),
                 )),
             ));
         }

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_direct_purchase_transition/validate_structure/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_direct_purchase_transition/validate_structure/v0/mod.rs
@@ -12,7 +12,7 @@ pub(super) trait TokenDirectPurchaseTransitionActionStructureValidationV0 {
 }
 impl TokenDirectPurchaseTransitionActionStructureValidationV0 for TokenDirectPurchaseTransition {
     fn validate_structure_v0(&self) -> Result<SimpleConsensusValidationResult, ProtocolError> {
-        if self.token_count() > MAX_DISTRIBUTION_PARAM {
+        if self.token_count() > MAX_DISTRIBUTION_PARAM || self.token_count() == 0 {
             return Ok(SimpleConsensusValidationResult::new_with_error(
                 ConsensusError::BasicError(BasicError::InvalidTokenAmountError(
                     InvalidTokenAmountError::new(MAX_DISTRIBUTION_PARAM, self.token_count()),

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_mint_transition/validate_structure/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_mint_transition/validate_structure/v0/mod.rs
@@ -1,6 +1,7 @@
 use crate::consensus::basic::token::{InvalidTokenAmountError, InvalidTokenNoteTooBigError};
 use crate::consensus::basic::BasicError;
 use crate::consensus::ConsensusError;
+use crate::data_contract::associated_token::token_perpetual_distribution::distribution_function::MAX_DISTRIBUTION_PARAM;
 use crate::state_transition::batch_transition::token_mint_transition::v0::v0_methods::TokenMintTransitionV0Methods;
 use crate::state_transition::batch_transition::TokenMintTransition;
 use crate::tokens::MAX_TOKEN_NOTE_LEN;
@@ -12,10 +13,10 @@ pub(super) trait TokenMintTransitionActionStructureValidationV0 {
 }
 impl TokenMintTransitionActionStructureValidationV0 for TokenMintTransition {
     fn validate_structure_v0(&self) -> Result<SimpleConsensusValidationResult, ProtocolError> {
-        if self.amount() > i64::MAX as u64 {
+        if self.amount() > MAX_DISTRIBUTION_PARAM || self.amount() == 0 {
             return Ok(SimpleConsensusValidationResult::new_with_error(
                 ConsensusError::BasicError(BasicError::InvalidTokenAmountError(
-                    InvalidTokenAmountError::new(i64::MAX as u64, self.amount()),
+                    InvalidTokenAmountError::new(MAX_DISTRIBUTION_PARAM, self.amount()),
                 )),
             ));
         }

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_transfer_transition/validate_structure/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_transfer_transition/validate_structure/v0/mod.rs
@@ -2,6 +2,7 @@ use platform_value::Identifier;
 use crate::consensus::basic::BasicError;
 use crate::consensus::basic::token::{InvalidTokenAmountError, InvalidTokenNoteTooBigError, TokenTransferToOurselfError};
 use crate::consensus::ConsensusError;
+use crate::data_contract::associated_token::token_perpetual_distribution::distribution_function::MAX_DISTRIBUTION_PARAM;
 use crate::ProtocolError;
 use crate::state_transition::batch_transition::token_base_transition::token_base_transition_accessors::TokenBaseTransitionAccessors;
 use crate::state_transition::batch_transition::token_base_transition::v0::v0_methods::TokenBaseTransitionV0Methods;
@@ -21,10 +22,10 @@ impl TokenTransferTransitionActionStructureValidationV0 for TokenTransferTransit
         &self,
         owner_id: Identifier,
     ) -> Result<SimpleConsensusValidationResult, ProtocolError> {
-        if self.amount() > i64::MAX as u64 {
+        if self.amount() > MAX_DISTRIBUTION_PARAM || self.amount() == 0 {
             return Ok(SimpleConsensusValidationResult::new_with_error(
                 ConsensusError::BasicError(BasicError::InvalidTokenAmountError(
-                    InvalidTokenAmountError::new(i64::MAX as u64, self.amount()),
+                    InvalidTokenAmountError::new(MAX_DISTRIBUTION_PARAM, self.amount()),
                 )),
             ));
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
We were allowing the state transitions to succeed if you would try to mint or burn 0 tokens. This should not be allowed.

## What was done?
Added validation that we can mint, burn, transfer, or purchase amounts between 1 and 2^48 only.


## How Has This Been Tested?
Will test in DET.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for token-related actions to ensure token amounts must be greater than zero and do not exceed the defined maximum limit.
  - Updated error messages to clearly state the valid range for token amounts.

- **Style**
  - Clarified error message wording to specify both lower and upper bounds for valid token amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->