### PR TITLE
fix(drive): add estimation costs for token status information when registering a contract

### DIFF
--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v1/mod.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v1/mod.rs
@@ -175,6 +175,16 @@ impl Drive {
                 platform_version,
             )?;
 
+        if !contract.tokens().is_empty() {
+            if let Some(estimated_costs_only_with_layer_info) = estimated_costs_only_with_layer_info
+            {
+                Drive::add_estimation_costs_for_token_status_infos(
+                    estimated_costs_only_with_layer_info,
+                    &platform_version.drive,
+                )?;
+            }
+        }
+
         for (token_pos, token_config) in contract.tokens() {
             let token_id = contract.token_id(*token_pos).ok_or(Error::DataContract(
                 DataContractError::CorruptedDataContract(format!(

--- a/packages/rs-drive/src/drive/mod.rs
+++ b/packages/rs-drive/src/drive/mod.rs
@@ -89,7 +89,7 @@ pub struct Drive {
 //                                 /                                                                                                       \
 //                       Identities 32                                                                                                 Balances 96
 //             /                            \                                                                        /                                                       \
-//   Token_Balances 16                    Pools 48                                                    WithdrawalTransactions 80                                                Votes  112
+//       Tokens 16                    Pools 48                                                    WithdrawalTransactions 80                                                Votes  112
 //       /      \                           /                     \                                         /                           \                            /                          \
 //     NUPKH->I 8 UPKH->I 24   PreFundedSpecializedBalances 40  Masternode Lists 56 (reserved)     SpentAssetLockTransactions 72    GroupActions 88             Misc 104                        Versions 120
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
This update introduces the functionality to add estimation costs for token status information during the contract insertion process. This enhancement is crucial for accurate cost estimation in scenarios where contracts contain tokens.

## What was done?
- Implemented a check to determine if a contract contains tokens.
- Added logic to compute and add estimation costs for token status information if tokens are present in the contract.

## How Has This Been Tested?
The changes have been tested through unit tests that verify the correct addition of estimation costs when tokens are present in a contract.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added ! to the title and described breaking changes in the corresponding section if my code contains any.

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of contracts with tokens when estimating costs, ensuring more accurate estimations in specific scenarios.

- **Documentation**
  - Updated a comment diagram to correctly label "Tokens" for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->