### PR TITLE
chore: add .gitaipconfig to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ node_modules
 
 # Rust build artifacts
 /target
+.gitaipconfig


### PR DESCRIPTION
## Issue being fixed or feature implemented
This update adds the `.gitaipconfig` file to the `.gitignore` list to prevent it from being tracked by Git.

## What was done?
- Added `.gitaipconfig` to the `.gitignore` file to ensure it is not included in version control.

## How Has This Been Tested?
No specific tests are required for this change as it only affects the `.gitignore` file.

## Breaking Changes
None

## Checklist
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have added or updated relevant unit/integration/functional/e2e tests
  - [x] I have added ! to the title and described breaking changes in the corresponding section if my code contains any.

  **For repository code-owners and collaborators only**
  - [ ] I have assigned this pull request to a milestone