### PR TITLE
fix(platform)!: ensure correct critical security level for token transitions and allow any security level key in signing if allowed to do so with options

### DIFF
--- a/packages/rs-dpp/src/state_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/mod.rs
@@ -283,21 +283,12 @@ impl OptionallyAssetLockProved for StateTransition {
 }
 
 /// The state transition signing options
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 pub struct StateTransitionSigningOptions {
     /// This will allow signing with any security level for debugging purposes
     pub allow_signing_with_any_security_level: bool,
     /// This will allow signing with any purpose for debugging purposes
     pub allow_signing_with_any_purpose: bool,
-}
-
-impl Default for StateTransitionSigningOptions {
-    fn default() -> Self {
-        StateTransitionSigningOptions {
-            allow_signing_with_any_security_level: false,
-            allow_signing_with_any_purpose: false,
-        }
-    }
 }
 
 impl StateTransition {

--- a/packages/rs-dpp/src/state_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/mod.rs
@@ -568,8 +568,8 @@ impl StateTransition {
                             ),
                         ));
                     }
-                    st.verify_public_key_is_enabled(identity_public_key)?;
                 }
+                st.verify_public_key_is_enabled(identity_public_key)?;
             }
             StateTransition::IdentityCreditWithdrawal(st) => {
                 st.verify_public_key_level_and_purpose(identity_public_key, options)?;

--- a/packages/rs-dpp/src/state_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/mod.rs
@@ -557,12 +557,6 @@ impl StateTransition {
                     ));
                 }
                 if !options.allow_signing_with_any_security_level {
-                    let get_data_contract_security_level_requirement =
-                        get_data_contract_security_level_requirement
-                            .ok_or(ProtocolError::CorruptedCodeExecution(
-                                "must supply get_data_contract when signing a documents batch transition"
-                                    .to_string(),
-                            ))?;
                     let security_level_requirement = st.combined_security_level_requirement(
                         get_data_contract_security_level_requirement,
                     )?;

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/mod.rs
@@ -28,6 +28,7 @@ use crate::state_transition::batch_transition::BatchTransition;
 use crate::state_transition::batch_transition::{BatchTransitionV0, BatchTransitionV1};
 #[cfg(feature = "state-transition-signing")]
 use crate::state_transition::StateTransition;
+use crate::state_transition::StateTransitionSigningOptions;
 #[cfg(feature = "state-transition-signing")]
 use crate::tokens::emergency_action::TokenEmergencyAction;
 #[cfg(feature = "state-transition-signing")]
@@ -45,6 +46,14 @@ use platform_version::version::{FeatureVersion, PlatformVersion};
 pub mod v0;
 pub mod v1;
 
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub struct StateTransitionCreationOptions {
+    /// The signing options
+    pub signing_options: StateTransitionSigningOptions,
+    pub batch_feature_version: Option<FeatureVersion>,
+    pub method_feature_version: Option<FeatureVersion>,
+    pub base_feature_version: Option<FeatureVersion>,
+}
 impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
     fn all_document_purchases_amount(&self) -> Result<Option<Credits>, ProtocolError> {
         match self {
@@ -87,11 +96,10 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        create_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -109,9 +117,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    create_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             1 => Ok(
@@ -125,9 +131,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    create_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -148,11 +152,10 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        replace_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -169,9 +172,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    replace_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             1 => Ok(
@@ -184,9 +185,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    replace_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -210,11 +209,10 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        transfer_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -232,9 +230,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    transfer_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             1 => Ok(
@@ -248,9 +244,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    transfer_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -273,11 +267,10 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -294,9 +287,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    delete_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             1 => Ok(
@@ -309,9 +300,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    delete_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -334,11 +323,10 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        update_price_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -356,9 +344,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    update_price_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             1 => Ok(
@@ -372,9 +358,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    update_price_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -399,11 +383,10 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        purchase_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -422,9 +405,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    purchase_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             1 => Ok(
@@ -439,9 +420,7 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
                     token_payment_info,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    purchase_feature_version,
-                    base_feature_version,
+                    options,
                 )?,
             ),
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -470,11 +449,10 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -503,9 +481,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
                     user_fee_increase,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    delete_feature_version,
-                    base_feature_version,
+                    options,
                 )
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -530,11 +506,10 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -562,9 +537,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
                     user_fee_increase,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    delete_feature_version,
-                    base_feature_version,
+                    options,
                 )
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -591,11 +564,10 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -626,9 +598,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
                     user_fee_increase,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    delete_feature_version,
-                    base_feature_version,
+                    options,
                 )
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -653,11 +623,10 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -686,9 +655,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
                     user_fee_increase,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    delete_feature_version,
-                    base_feature_version,
+                    options,
                 )
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -713,11 +680,10 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -746,9 +712,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
                     user_fee_increase,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    delete_feature_version,
-                    base_feature_version,
+                    options,
                 )
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -773,11 +737,10 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -806,9 +769,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
                     user_fee_increase,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    delete_feature_version,
-                    base_feature_version,
+                    options,
                 )
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -834,11 +795,10 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -867,9 +827,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
                     user_fee_increase,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    delete_feature_version,
-                    base_feature_version,
+                    options,
                 )
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -895,11 +853,10 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        config_update_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -928,9 +885,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
                     user_fee_increase,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    config_update_feature_version,
-                    base_feature_version,
+                    options,
                 )
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -954,11 +909,10 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        config_update_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -986,9 +940,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
                     user_fee_increase,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    config_update_feature_version,
-                    base_feature_version,
+                    options,
                 )
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -1014,11 +966,10 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        config_update_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -1047,9 +998,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
                     user_fee_increase,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    config_update_feature_version,
-                    base_feature_version,
+                    options,
                 )
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -1075,11 +1024,10 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        config_update_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
-        match batch_feature_version.unwrap_or(
+        let resolved_options = options.unwrap_or_default();
+        match resolved_options.batch_feature_version.unwrap_or(
             platform_version
                 .dpp
                 .state_transition_serialization_versions
@@ -1107,9 +1055,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransition {
                     user_fee_increase,
                     signer,
                     platform_version,
-                    batch_feature_version,
-                    config_update_feature_version,
-                    base_feature_version,
+                    options,
                 )
             }
             version => Err(ProtocolError::UnknownVersionMismatch {

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/mod.rs
@@ -40,8 +40,9 @@ use crate::tokens::{PrivateEncryptedNote, SharedEncryptedNote};
 use crate::ProtocolError;
 #[cfg(feature = "state-transition-signing")]
 use platform_value::Identifier;
+use platform_version::version::FeatureVersion;
 #[cfg(feature = "state-transition-signing")]
-use platform_version::version::{FeatureVersion, PlatformVersion};
+use platform_version::version::PlatformVersion;
 
 pub mod v0;
 pub mod v1;
@@ -54,6 +55,7 @@ pub struct StateTransitionCreationOptions {
     pub method_feature_version: Option<FeatureVersion>,
     pub base_feature_version: Option<FeatureVersion>,
 }
+
 impl DocumentsBatchTransitionMethodsV0 for BatchTransition {
     fn all_document_purchases_amount(&self) -> Result<Option<Credits>, ProtocolError> {
         match self {

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/v0/mod.rs
@@ -127,7 +127,7 @@ pub trait DocumentsBatchTransitionMethodsV0: DocumentsBatchTransitionAccessorsV0
         base_feature_version: Option<FeatureVersion>,
     ) -> Result<StateTransition, ProtocolError>;
 
-    fn contract_based_security_level_requirement(
+    fn combined_security_level_requirement(
         &self,
         get_data_contract_security_level_requirement: impl Fn(
             Identifier,

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/v0/mod.rs
@@ -21,6 +21,7 @@ use platform_value::Identifier;
 use platform_version::version::PlatformVersion;
 use std::convert::TryFrom;
 use crate::state_transition::batch_transition::batched_transition::{BatchedTransition, BatchedTransitionRef};
+#[cfg(feature = "state-transition-signing")]
 use crate::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use crate::state_transition::state_transitions::document::batch_transition::batched_transition::document_transition::DocumentTransitionV0Methods;
 #[cfg(feature = "state-transition-signing")]

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/v0/mod.rs
@@ -18,9 +18,10 @@ use crate::state_transition::StateTransition;
 use crate::ProtocolError;
 use platform_value::Identifier;
 #[cfg(feature = "state-transition-signing")]
-use platform_version::version::{FeatureVersion, PlatformVersion};
+use platform_version::version::PlatformVersion;
 use std::convert::TryFrom;
 use crate::state_transition::batch_transition::batched_transition::{BatchedTransition, BatchedTransitionRef};
+use crate::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use crate::state_transition::state_transitions::document::batch_transition::batched_transition::document_transition::DocumentTransitionV0Methods;
 #[cfg(feature = "state-transition-signing")]
 use crate::tokens::token_payment_info::TokenPaymentInfo;
@@ -38,9 +39,7 @@ pub trait DocumentsBatchTransitionMethodsV0: DocumentsBatchTransitionAccessorsV0
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        create_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     #[cfg(feature = "state-transition-signing")]
@@ -54,9 +53,7 @@ pub trait DocumentsBatchTransitionMethodsV0: DocumentsBatchTransitionAccessorsV0
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        replace_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     #[cfg(feature = "state-transition-signing")]
@@ -70,9 +67,7 @@ pub trait DocumentsBatchTransitionMethodsV0: DocumentsBatchTransitionAccessorsV0
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     #[cfg(feature = "state-transition-signing")]
@@ -87,9 +82,7 @@ pub trait DocumentsBatchTransitionMethodsV0: DocumentsBatchTransitionAccessorsV0
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        transfer_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     #[cfg(feature = "state-transition-signing")]
@@ -104,9 +97,7 @@ pub trait DocumentsBatchTransitionMethodsV0: DocumentsBatchTransitionAccessorsV0
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        update_price_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     #[cfg(feature = "state-transition-signing")]
@@ -122,9 +113,7 @@ pub trait DocumentsBatchTransitionMethodsV0: DocumentsBatchTransitionAccessorsV0
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        purchase_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     fn combined_security_level_requirement(

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/v1/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/v1/mod.rs
@@ -16,6 +16,8 @@ use crate::identity::IdentityPublicKey;
 use crate::prelude::{IdentityNonce, UserFeeIncrease};
 use crate::state_transition::batch_transition::accessors::DocumentsBatchTransitionAccessorsV0;
 #[cfg(feature = "state-transition-signing")]
+use crate::state_transition::batch_transition::methods::StateTransitionCreationOptions;
+#[cfg(feature = "state-transition-signing")]
 use crate::state_transition::StateTransition;
 #[cfg(feature = "state-transition-signing")]
 use crate::tokens::emergency_action::TokenEmergencyAction;
@@ -23,8 +25,6 @@ use crate::tokens::emergency_action::TokenEmergencyAction;
 use crate::tokens::token_pricing_schedule::TokenPricingSchedule;
 #[cfg(feature = "state-transition-signing")]
 use crate::tokens::{PrivateEncryptedNote, SharedEncryptedNote};
-#[cfg(feature = "state-transition-signing")]
-use crate::version::FeatureVersion;
 #[cfg(feature = "state-transition-signing")]
 use crate::ProtocolError;
 #[cfg(feature = "state-transition-signing")]
@@ -75,9 +75,7 @@ pub trait DocumentsBatchTransitionMethodsV1: DocumentsBatchTransitionAccessorsV0
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     /// Creates a `StateTransition` to burn tokens, permanently removing them from circulation.
@@ -109,9 +107,7 @@ pub trait DocumentsBatchTransitionMethodsV1: DocumentsBatchTransitionAccessorsV0
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     /// Creates a `StateTransition` to transfer tokens from one identity to another.
@@ -147,9 +143,7 @@ pub trait DocumentsBatchTransitionMethodsV1: DocumentsBatchTransitionAccessorsV0
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     /// Creates a `StateTransition` to freeze tokens belonging to a specific identity.
@@ -183,9 +177,7 @@ pub trait DocumentsBatchTransitionMethodsV1: DocumentsBatchTransitionAccessorsV0
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     /// Creates a `StateTransition` to unfreeze tokens previously frozen for a specific identity.
@@ -217,9 +209,7 @@ pub trait DocumentsBatchTransitionMethodsV1: DocumentsBatchTransitionAccessorsV0
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     /// Creates a `StateTransition` to destroy previously frozen tokens, removing them permanently from supply.
@@ -251,9 +241,7 @@ pub trait DocumentsBatchTransitionMethodsV1: DocumentsBatchTransitionAccessorsV0
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     /// Creates a `StateTransition` to execute an emergency action for a token.
@@ -288,9 +276,7 @@ pub trait DocumentsBatchTransitionMethodsV1: DocumentsBatchTransitionAccessorsV0
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     /// Creates a `StateTransition` to update the configuration of a token.
@@ -325,9 +311,7 @@ pub trait DocumentsBatchTransitionMethodsV1: DocumentsBatchTransitionAccessorsV0
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        config_update_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     /// Creates a `StateTransition` to claim tokens from a distribution source.
@@ -360,9 +344,7 @@ pub trait DocumentsBatchTransitionMethodsV1: DocumentsBatchTransitionAccessorsV0
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        config_update_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     /// Creates a `StateTransition` to set or update the price of a token for direct purchase.
@@ -397,9 +379,7 @@ pub trait DocumentsBatchTransitionMethodsV1: DocumentsBatchTransitionAccessorsV0
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        config_update_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 
     /// Creates a `StateTransition` to perform a direct purchase of tokens by a user.
@@ -433,8 +413,6 @@ pub trait DocumentsBatchTransitionMethodsV1: DocumentsBatchTransitionAccessorsV0
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         platform_version: &PlatformVersion,
-        batch_feature_version: Option<FeatureVersion>,
-        config_update_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError>;
 }

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v0/v0_methods.rs
@@ -32,10 +32,12 @@ use crate::ProtocolError;
 use platform_value::Identifier;
 #[cfg(feature = "state-transition-signing")]
 use platform_version::version::PlatformVersion;
+#[cfg(feature = "state-transition-signing")]
 use crate::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use crate::state_transition::batch_transition::document_create_transition::v0::v0_methods::DocumentCreateTransitionV0Methods;
 use crate::state_transition::batch_transition::batched_transition::document_purchase_transition::v0::v0_methods::DocumentPurchaseTransitionV0Methods;
 use crate::state_transition::batch_transition::batched_transition::document_transition::DocumentTransition;
+#[cfg(feature = "state-transition-signing")]
 use crate::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use crate::state_transition::batch_transition::resolvers::v0::BatchTransitionResolversV0;
 use crate::state_transition::state_transitions::document::batch_transition::batched_transition::document_transition::DocumentTransitionV0Methods;

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v0/v0_methods.rs
@@ -33,10 +33,11 @@ use crate::ProtocolError;
 #[cfg(feature = "state-transition-signing")]
 use platform_value::Identifier;
 #[cfg(feature = "state-transition-signing")]
-use platform_version::version::{FeatureVersion, PlatformVersion};
+use platform_version::version::PlatformVersion;
 use crate::state_transition::batch_transition::document_create_transition::v0::v0_methods::DocumentCreateTransitionV0Methods;
 use crate::state_transition::batch_transition::batched_transition::document_purchase_transition::v0::v0_methods::DocumentPurchaseTransitionV0Methods;
 use crate::state_transition::batch_transition::batched_transition::document_transition::DocumentTransition;
+use crate::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use crate::state_transition::batch_transition::resolvers::v0::BatchTransitionResolversV0;
 use crate::state_transition::state_transitions::document::batch_transition::batched_transition::document_transition::DocumentTransitionV0Methods;
 #[cfg(feature = "state-transition-signing")]
@@ -90,10 +91,9 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        create_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
+        let resolved_options = options.unwrap_or_default();
         let owner_id = document.owner_id();
         let create_transition = DocumentCreateTransition::from_document(
             document,
@@ -102,8 +102,8 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
             token_payment_info,
             identity_contract_nonce,
             platform_version,
-            create_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV0 {
             owner_id,
@@ -114,10 +114,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }
@@ -132,19 +133,18 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        replace_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let owner_id = document.owner_id();
+        let resolved_options = options.unwrap_or_default();
         let replace_transition = DocumentReplaceTransition::from_document(
             document,
             document_type,
             token_payment_info,
             identity_contract_nonce,
             platform_version,
-            replace_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV0 {
             owner_id,
@@ -155,10 +155,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }
@@ -174,11 +175,10 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        transfer_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let owner_id = document.owner_id();
+        let resolved_options = options.unwrap_or_default();
         let transfer_transition = DocumentTransferTransition::from_document(
             document,
             document_type,
@@ -186,8 +186,8 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
             identity_contract_nonce,
             recipient_owner_id,
             platform_version,
-            transfer_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV0 {
             owner_id,
@@ -198,10 +198,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }
@@ -216,19 +217,18 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let owner_id = document.owner_id();
+        let resolved_options = options.unwrap_or_default();
         let delete_transition = DocumentDeleteTransition::from_document(
             document,
             document_type,
             token_payment_info,
             identity_contract_nonce,
             platform_version,
-            delete_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV0 {
             owner_id,
@@ -239,10 +239,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }
@@ -258,11 +259,10 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        update_price_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let owner_id = document.owner_id();
+        let resolved_options = options.unwrap_or_default();
         let transfer_transition = DocumentUpdatePriceTransition::from_document(
             document,
             document_type,
@@ -270,8 +270,8 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
             token_payment_info,
             identity_contract_nonce,
             platform_version,
-            update_price_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV0 {
             owner_id,
@@ -282,10 +282,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }
@@ -302,10 +303,9 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        purchase_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
+        let resolved_options = options.unwrap_or_default();
         let purchase_transition = DocumentPurchaseTransition::from_document(
             document,
             document_type,
@@ -313,8 +313,8 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
             token_payment_info,
             identity_contract_nonce,
             platform_version,
-            purchase_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV0 {
             owner_id: new_owner_id,
@@ -325,10 +325,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v0/v0_methods.rs
@@ -6,8 +6,6 @@ use crate::document::{Document, DocumentV0Getters};
 use crate::fee::Credits;
 #[cfg(feature = "state-transition-signing")]
 use crate::identity::signer::Signer;
-#[cfg(feature = "state-transition-signing")]
-use crate::identity::SecurityLevel;
 use crate::prelude::IdentityNonce;
 #[cfg(feature = "state-transition-signing")]
 use crate::prelude::IdentityPublicKey;
@@ -34,6 +32,7 @@ use crate::ProtocolError;
 use platform_value::Identifier;
 #[cfg(feature = "state-transition-signing")]
 use platform_version::version::PlatformVersion;
+use crate::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use crate::state_transition::batch_transition::document_create_transition::v0::v0_methods::DocumentCreateTransitionV0Methods;
 use crate::state_transition::batch_transition::batched_transition::document_purchase_transition::v0::v0_methods::DocumentPurchaseTransitionV0Methods;
 use crate::state_transition::batch_transition::batched_transition::document_transition::DocumentTransition;
@@ -114,10 +113,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)
@@ -155,10 +155,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)
@@ -198,10 +199,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)
@@ -239,10 +241,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)
@@ -282,10 +285,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)
@@ -325,10 +329,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v0_methods.rs
@@ -37,9 +37,11 @@ use crate::ProtocolError;
 use platform_value::Identifier;
 #[cfg(feature = "state-transition-signing")]
 use platform_version::version::PlatformVersion;
+#[cfg(feature = "state-transition-signing")]
 use crate::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use crate::state_transition::batch_transition::document_create_transition::v0::v0_methods::DocumentCreateTransitionV0Methods;
 use crate::state_transition::batch_transition::batched_transition::document_purchase_transition::v0::v0_methods::DocumentPurchaseTransitionV0Methods;
+#[cfg(feature = "state-transition-signing")]
 use crate::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use crate::state_transition::batch_transition::resolvers::v0::BatchTransitionResolversV0;
 #[cfg(feature = "state-transition-signing")]

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v0_methods.rs
@@ -5,8 +5,6 @@ use crate::document::{Document, DocumentV0Getters};
 use crate::fee::Credits;
 #[cfg(feature = "state-transition-signing")]
 use crate::identity::signer::Signer;
-#[cfg(feature = "state-transition-signing")]
-use crate::identity::SecurityLevel;
 use crate::prelude::IdentityNonce;
 #[cfg(feature = "state-transition-signing")]
 use crate::prelude::IdentityPublicKey;
@@ -39,6 +37,7 @@ use crate::ProtocolError;
 use platform_value::Identifier;
 #[cfg(feature = "state-transition-signing")]
 use platform_version::version::PlatformVersion;
+use crate::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use crate::state_transition::batch_transition::document_create_transition::v0::v0_methods::DocumentCreateTransitionV0Methods;
 use crate::state_transition::batch_transition::batched_transition::document_purchase_transition::v0::v0_methods::DocumentPurchaseTransitionV0Methods;
 use crate::state_transition::batch_transition::methods::StateTransitionCreationOptions;
@@ -119,10 +118,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)
@@ -160,10 +160,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)
@@ -201,10 +202,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)
@@ -244,10 +246,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)
@@ -287,10 +290,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)
@@ -330,10 +334,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
+        let required_security_level = document_type.security_level_requirement();
         state_transition.sign_external_with_options(
             identity_public_key,
             signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
+            Some(|_, _| Ok(required_security_level)),
             resolved_options.signing_options,
         )?;
         Ok(state_transition)

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v0_methods.rs
@@ -38,9 +38,10 @@ use crate::ProtocolError;
 #[cfg(feature = "state-transition-signing")]
 use platform_value::Identifier;
 #[cfg(feature = "state-transition-signing")]
-use platform_version::version::{FeatureVersion, PlatformVersion};
+use platform_version::version::PlatformVersion;
 use crate::state_transition::batch_transition::document_create_transition::v0::v0_methods::DocumentCreateTransitionV0Methods;
 use crate::state_transition::batch_transition::batched_transition::document_purchase_transition::v0::v0_methods::DocumentPurchaseTransitionV0Methods;
+use crate::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use crate::state_transition::batch_transition::resolvers::v0::BatchTransitionResolversV0;
 #[cfg(feature = "state-transition-signing")]
 use crate::tokens::token_payment_info::TokenPaymentInfo;
@@ -95,11 +96,10 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        create_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let owner_id = document.owner_id();
+        let resolved_options = options.unwrap_or_default();
         let create_transition = DocumentCreateTransition::from_document(
             document,
             document_type,
@@ -107,8 +107,8 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
             token_payment_info,
             identity_contract_nonce,
             platform_version,
-            create_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV1 {
             owner_id,
@@ -119,10 +119,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }
@@ -137,19 +138,18 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        replace_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let owner_id = document.owner_id();
+        let resolved_options = options.unwrap_or_default();
         let replace_transition = DocumentReplaceTransition::from_document(
             document,
             document_type,
             token_payment_info,
             identity_contract_nonce,
             platform_version,
-            replace_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV1 {
             owner_id,
@@ -160,10 +160,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }
@@ -178,19 +179,18 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        delete_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let owner_id = document.owner_id();
+        let resolved_options = options.unwrap_or_default();
         let delete_transition = DocumentDeleteTransition::from_document(
             document,
             document_type,
             token_payment_info,
             identity_contract_nonce,
             platform_version,
-            delete_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV1 {
             owner_id,
@@ -201,10 +201,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }
@@ -220,11 +221,10 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        transfer_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let owner_id = document.owner_id();
+        let resolved_options = options.unwrap_or_default();
         let transfer_transition = DocumentTransferTransition::from_document(
             document,
             document_type,
@@ -232,8 +232,8 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
             identity_contract_nonce,
             recipient_owner_id,
             platform_version,
-            transfer_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV1 {
             owner_id,
@@ -244,10 +244,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }
@@ -263,11 +264,10 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        update_price_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let owner_id = document.owner_id();
+        let resolved_options = options.unwrap_or_default();
         let transfer_transition = DocumentUpdatePriceTransition::from_document(
             document,
             document_type,
@@ -275,8 +275,8 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
             token_payment_info,
             identity_contract_nonce,
             platform_version,
-            update_price_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV1 {
             owner_id,
@@ -287,10 +287,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }
@@ -307,10 +308,9 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
         platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        purchase_feature_version: Option<FeatureVersion>,
-        base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
+        let resolved_options = options.unwrap_or_default();
         let purchase_transition = DocumentPurchaseTransition::from_document(
             document,
             document_type,
@@ -318,8 +318,8 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
             token_payment_info,
             identity_contract_nonce,
             platform_version,
-            purchase_feature_version,
-            base_feature_version,
+            resolved_options.method_feature_version,
+            resolved_options.base_feature_version,
         )?;
         let documents_batch_transition: BatchTransition = BatchTransitionV1 {
             owner_id: new_owner_id,
@@ -330,10 +330,11 @@ impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
+        state_transition.sign_external_with_options(
             identity_public_key,
             signer,
             Some(|_, _| Ok(SecurityLevel::HIGH)),
+            resolved_options.signing_options,
         )?;
         Ok(state_transition)
     }

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v1_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v1_methods.rs
@@ -26,7 +26,7 @@ use crate::ProtocolError;
 #[cfg(feature = "state-transition-signing")]
 use platform_value::Identifier;
 #[cfg(feature = "state-transition-signing")]
-use platform_version::version::{FeatureVersion, PlatformVersion};
+use platform_version::version::PlatformVersion;
 #[cfg(feature = "state-transition-signing")]
 use crate::balances::credits::TokenAmount;
 #[cfg(feature = "state-transition-signing")]
@@ -37,6 +37,7 @@ use crate::data_contract::associated_token::token_distribution_key::TokenDistrib
 use crate::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
 #[cfg(feature = "state-transition-signing")]
 use crate::state_transition::batch_transition::batched_transition::multi_party_action::AllowedAsMultiPartyAction;
+use crate::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use crate::state_transition::batch_transition::methods::v1::DocumentsBatchTransitionMethodsV1;
 #[cfg(feature = "state-transition-signing")]
 use crate::state_transition::batch_transition::token_base_transition::token_base_transition_accessors::TokenBaseTransitionAccessors;
@@ -91,9 +92,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         _platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        _delete_feature_version: Option<FeatureVersion>,
-        _base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let mut mint_transition = TokenMintTransition::V0(TokenMintTransitionV0 {
             base: TokenBaseTransition::V0(TokenBaseTransitionV0 {
@@ -137,11 +136,21 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
-            identity_public_key,
-            signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
-        )?;
+        if let Some(options) = options {
+            state_transition.sign_external_with_options(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                options.signing_options,
+            )?;
+        } else {
+            state_transition.sign_external(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+            )?;
+        }
+
         Ok(state_transition)
     }
 
@@ -159,9 +168,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         _platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        _delete_feature_version: Option<FeatureVersion>,
-        _base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let mut burn_transition = TokenBurnTransition::V0(TokenBurnTransitionV0 {
             base: TokenBaseTransition::V0(TokenBaseTransitionV0 {
@@ -207,11 +214,20 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
 
         // Create the state transition
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
-            identity_public_key,
-            signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
-        )?;
+        if let Some(options) = options {
+            state_transition.sign_external_with_options(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                options.signing_options,
+            )?;
+        } else {
+            state_transition.sign_external(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+            )?;
+        }
 
         Ok(state_transition)
     }
@@ -231,9 +247,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         _platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        _delete_feature_version: Option<FeatureVersion>,
-        _base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         // Create the transfer transition for batch version 1
         let transfer_transition = TokenTransferTransition::V0(TokenTransferTransitionV0 {
@@ -263,11 +277,20 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
 
         // Create the state transition
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
-            identity_public_key,
-            signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
-        )?;
+        if let Some(options) = options {
+            state_transition.sign_external_with_options(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                options.signing_options,
+            )?;
+        } else {
+            state_transition.sign_external(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+            )?;
+        }
 
         Ok(state_transition)
     }
@@ -286,9 +309,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         _platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        _delete_feature_version: Option<FeatureVersion>,
-        _base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let mut freeze_transition = TokenFreezeTransition::V0(TokenFreezeTransitionV0 {
             base: TokenBaseTransition::V0(TokenBaseTransitionV0 {
@@ -332,12 +353,22 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             signature: Default::default(),
         }
         .into();
+
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
-            identity_public_key,
-            signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
-        )?;
+        if let Some(options) = options {
+            state_transition.sign_external_with_options(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                options.signing_options,
+            )?;
+        } else {
+            state_transition.sign_external(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+            )?;
+        }
         Ok(state_transition)
     }
 
@@ -355,9 +386,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         _platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        _delete_feature_version: Option<FeatureVersion>,
-        _base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let mut unfreeze_transition = TokenUnfreezeTransition::V0(TokenUnfreezeTransitionV0 {
             base: TokenBaseTransition::V0(TokenBaseTransitionV0 {
@@ -401,12 +430,22 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             signature: Default::default(),
         }
         .into();
+
         let mut state_transition: StateTransition = documents_batch_transition.into();
-        state_transition.sign_external(
-            identity_public_key,
-            signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
-        )?;
+        if let Some(options) = options {
+            state_transition.sign_external_with_options(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                options.signing_options,
+            )?;
+        } else {
+            state_transition.sign_external(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+            )?;
+        }
         Ok(state_transition)
     }
 
@@ -424,9 +463,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         _platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        _delete_feature_version: Option<FeatureVersion>,
-        _base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let mut destroy_frozen_funds_transition =
             TokenDestroyFrozenFundsTransition::V0(TokenDestroyFrozenFundsTransitionV0 {
@@ -474,11 +511,20 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = batch_transition.into();
-        state_transition.sign_external(
-            identity_public_key,
-            signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
-        )?;
+        if let Some(options) = options {
+            state_transition.sign_external_with_options(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                options.signing_options,
+            )?;
+        } else {
+            state_transition.sign_external(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+            )?;
+        }
         Ok(state_transition)
     }
 
@@ -496,9 +542,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         _platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        _delete_feature_version: Option<FeatureVersion>,
-        _base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let mut emergency_action_transition =
             TokenEmergencyActionTransition::V0(TokenEmergencyActionTransitionV0 {
@@ -544,11 +588,20 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = batch_transition.into();
-        state_transition.sign_external(
-            identity_public_key,
-            signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
-        )?;
+        if let Some(options) = options {
+            state_transition.sign_external_with_options(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                options.signing_options,
+            )?;
+        } else {
+            state_transition.sign_external(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+            )?;
+        }
         Ok(state_transition)
     }
 
@@ -566,9 +619,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         _platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        _config_update_feature_version: Option<FeatureVersion>,
-        _base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let mut config_update_transition =
             TokenConfigUpdateTransition::V0(TokenConfigUpdateTransitionV0 {
@@ -614,11 +665,20 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = batch_transition.into();
-        state_transition.sign_external(
-            identity_public_key,
-            signer,
-            Some(|_, _| Ok(SecurityLevel::CRITICAL)),
-        )?;
+        if let Some(options) = options {
+            state_transition.sign_external_with_options(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                options.signing_options,
+            )?;
+        } else {
+            state_transition.sign_external(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+            )?;
+        }
         Ok(state_transition)
     }
 
@@ -635,9 +695,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         _platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        _config_update_feature_version: Option<FeatureVersion>,
-        _base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let claim_transition = TokenClaimTransition::V0(TokenClaimTransitionV0 {
             base: TokenBaseTransition::V0(TokenBaseTransitionV0 {
@@ -660,11 +718,20 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = batch_transition.into();
-        state_transition.sign_external(
-            identity_public_key,
-            signer,
-            Some(|_, _| Ok(SecurityLevel::CRITICAL)),
-        )?;
+        if let Some(options) = options {
+            state_transition.sign_external_with_options(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                options.signing_options,
+            )?;
+        } else {
+            state_transition.sign_external(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+            )?;
+        }
         Ok(state_transition)
     }
 
@@ -682,9 +749,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         _platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        _config_update_feature_version: Option<FeatureVersion>,
-        _base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let mut change_direct_purchase_price_transition =
             TokenSetPriceForDirectPurchaseTransition::V0(
@@ -735,11 +800,20 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = batch_transition.into();
-        state_transition.sign_external(
-            identity_public_key,
-            signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
-        )?;
+        if let Some(options) = options {
+            state_transition.sign_external_with_options(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                options.signing_options,
+            )?;
+        } else {
+            state_transition.sign_external(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+            )?;
+        }
         Ok(state_transition)
     }
 
@@ -756,9 +830,7 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         user_fee_increase: UserFeeIncrease,
         signer: &S,
         _platform_version: &PlatformVersion,
-        _batch_feature_version: Option<FeatureVersion>,
-        _config_update_feature_version: Option<FeatureVersion>,
-        _base_feature_version: Option<FeatureVersion>,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, ProtocolError> {
         let direct_purchase_transition =
             TokenDirectPurchaseTransition::V0(TokenDirectPurchaseTransitionV0 {
@@ -782,11 +854,20 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
         }
         .into();
         let mut state_transition: StateTransition = batch_transition.into();
-        state_transition.sign_external(
-            identity_public_key,
-            signer,
-            Some(|_, _| Ok(SecurityLevel::HIGH)),
-        )?;
+        if let Some(options) = options {
+            state_transition.sign_external_with_options(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                options.signing_options,
+            )?;
+        } else {
+            state_transition.sign_external(
+                identity_public_key,
+                signer,
+                Some(|_, _| Ok(SecurityLevel::HIGH)),
+            )?;
+        }
         Ok(state_transition)
     }
 }

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v1_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v1_methods.rs
@@ -35,6 +35,7 @@ use crate::data_contract::associated_token::token_distribution_key::TokenDistrib
 use crate::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
 #[cfg(feature = "state-transition-signing")]
 use crate::state_transition::batch_transition::batched_transition::multi_party_action::AllowedAsMultiPartyAction;
+#[cfg(feature = "state-transition-signing")]
 use crate::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use crate::state_transition::batch_transition::methods::v1::DocumentsBatchTransitionMethodsV1;
 #[cfg(feature = "state-transition-signing")]
@@ -67,6 +68,7 @@ use crate::state_transition::batch_transition::token_set_price_for_direct_purcha
 use crate::state_transition::batch_transition::token_transfer_transition::TokenTransferTransitionV0;
 #[cfg(feature = "state-transition-signing")]
 use crate::state_transition::batch_transition::token_unfreeze_transition::TokenUnfreezeTransitionV0;
+#[cfg(feature = "state-transition-signing")]
 use crate::state_transition::GetDataContractSecurityLevelRequirementFn;
 #[cfg(feature = "state-transition-signing")]
 use crate::tokens::emergency_action::TokenEmergencyAction;

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v1_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v1_methods.rs
@@ -3,8 +3,6 @@ use crate::fee::Credits;
 #[cfg(feature = "state-transition-signing")]
 use crate::identity::signer::Signer;
 #[cfg(feature = "state-transition-signing")]
-use crate::identity::SecurityLevel;
-#[cfg(feature = "state-transition-signing")]
 use crate::prelude::IdentityNonce;
 #[cfg(feature = "state-transition-signing")]
 use crate::prelude::IdentityPublicKey;
@@ -69,6 +67,7 @@ use crate::state_transition::batch_transition::token_set_price_for_direct_purcha
 use crate::state_transition::batch_transition::token_transfer_transition::TokenTransferTransitionV0;
 #[cfg(feature = "state-transition-signing")]
 use crate::state_transition::batch_transition::token_unfreeze_transition::TokenUnfreezeTransitionV0;
+use crate::state_transition::GetDataContractSecurityLevelRequirementFn;
 #[cfg(feature = "state-transition-signing")]
 use crate::tokens::emergency_action::TokenEmergencyAction;
 #[cfg(feature = "state-transition-signing")]
@@ -140,14 +139,14 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             state_transition.sign_external_with_options(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
                 options.signing_options,
             )?;
         } else {
             state_transition.sign_external(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
             )?;
         }
 
@@ -218,14 +217,14 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             state_transition.sign_external_with_options(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
                 options.signing_options,
             )?;
         } else {
             state_transition.sign_external(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
             )?;
         }
 
@@ -281,14 +280,14 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             state_transition.sign_external_with_options(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
                 options.signing_options,
             )?;
         } else {
             state_transition.sign_external(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
             )?;
         }
 
@@ -359,14 +358,14 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             state_transition.sign_external_with_options(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
                 options.signing_options,
             )?;
         } else {
             state_transition.sign_external(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
             )?;
         }
         Ok(state_transition)
@@ -436,14 +435,14 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             state_transition.sign_external_with_options(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
                 options.signing_options,
             )?;
         } else {
             state_transition.sign_external(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
             )?;
         }
         Ok(state_transition)
@@ -515,14 +514,14 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             state_transition.sign_external_with_options(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
                 options.signing_options,
             )?;
         } else {
             state_transition.sign_external(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
             )?;
         }
         Ok(state_transition)
@@ -592,14 +591,14 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             state_transition.sign_external_with_options(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
                 options.signing_options,
             )?;
         } else {
             state_transition.sign_external(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
             )?;
         }
         Ok(state_transition)
@@ -669,14 +668,14 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             state_transition.sign_external_with_options(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
                 options.signing_options,
             )?;
         } else {
             state_transition.sign_external(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
             )?;
         }
         Ok(state_transition)
@@ -722,14 +721,14 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             state_transition.sign_external_with_options(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
                 options.signing_options,
             )?;
         } else {
             state_transition.sign_external(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
             )?;
         }
         Ok(state_transition)
@@ -804,14 +803,14 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             state_transition.sign_external_with_options(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
                 options.signing_options,
             )?;
         } else {
             state_transition.sign_external(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
             )?;
         }
         Ok(state_transition)
@@ -858,14 +857,14 @@ impl DocumentsBatchTransitionMethodsV1 for BatchTransitionV1 {
             state_transition.sign_external_with_options(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
                 options.signing_options,
             )?;
         } else {
             state_transition.sign_external(
                 identity_public_key,
                 signer,
-                Some(|_, _| Ok(SecurityLevel::HIGH)),
+                None::<GetDataContractSecurityLevelRequirementFn>,
             )?;
         }
         Ok(state_transition)

--- a/packages/rs-dpp/src/state_transition/traits/state_transition_identity_signed.rs
+++ b/packages/rs-dpp/src/state_transition/traits/state_transition_identity_signed.rs
@@ -16,7 +16,12 @@ use crate::state_transition::errors::WrongPublicKeyPurposeError;
     feature = "state-transition-validation"
 ))]
 use crate::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use crate::state_transition::{StateTransitionLike, StateTransitionSigningOptions};
+use crate::state_transition::StateTransitionLike;
+#[cfg(any(
+    feature = "state-transition-signing",
+    feature = "state-transition-validation"
+))]
+use crate::state_transition::StateTransitionSigningOptions;
 
 #[cfg(any(
     feature = "state-transition-signing",

--- a/packages/rs-dpp/src/state_transition/traits/state_transition_identity_signed.rs
+++ b/packages/rs-dpp/src/state_transition/traits/state_transition_identity_signed.rs
@@ -16,7 +16,7 @@ use crate::state_transition::errors::WrongPublicKeyPurposeError;
     feature = "state-transition-validation"
 ))]
 use crate::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use crate::state_transition::StateTransitionLike;
+use crate::state_transition::{StateTransitionLike, StateTransitionSigningOptions};
 
 #[cfg(any(
     feature = "state-transition-signing",
@@ -44,17 +44,21 @@ pub trait StateTransitionIdentitySigned: StateTransitionLike {
     fn verify_public_key_level_and_purpose(
         &self,
         public_key: &IdentityPublicKey,
+        options: StateTransitionSigningOptions,
     ) -> Result<(), ProtocolError> {
-        if !self.purpose_requirement().contains(&public_key.purpose()) {
+        if !options.allow_signing_with_any_purpose
+            && !self.purpose_requirement().contains(&public_key.purpose())
+        {
             return Err(ProtocolError::WrongPublicKeyPurposeError(
                 WrongPublicKeyPurposeError::new(public_key.purpose(), self.purpose_requirement()),
             ));
         }
 
         // Otherwise, key security level should be less than MASTER but more or equal than required
-        if !self
-            .security_level_requirement(public_key.purpose())
-            .contains(&public_key.security_level())
+        if !options.allow_signing_with_any_security_level
+            && !self
+                .security_level_requirement(public_key.purpose())
+                .contains(&public_key.security_level())
         {
             return Err(ProtocolError::InvalidSignaturePublicKeySecurityLevelError(
                 InvalidSignaturePublicKeySecurityLevelError::new(

--- a/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
@@ -2372,8 +2372,6 @@ mod tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -2391,8 +2389,6 @@ mod tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");

--- a/packages/rs-drive-abci/src/execution/platform_events/block_processing_end_events/tests.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_processing_end_events/tests.rs
@@ -83,8 +83,6 @@ mod refund_tests {
                 signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -191,8 +189,6 @@ mod refund_tests {
                 None,
                 signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -320,8 +316,6 @@ mod refund_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -426,8 +420,6 @@ mod refund_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -537,8 +529,6 @@ mod refund_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -642,8 +632,6 @@ mod refund_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -749,8 +737,6 @@ mod refund_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -855,8 +841,6 @@ mod refund_tests {
                 None,
                 &signer,
                 &platform_version_with_higher_fees,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/advanced_structure/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/advanced_structure/v0/mod.rs
@@ -62,7 +62,7 @@ impl DocumentsBatchStateTransitionStructureValidationV0 for BatchTransition {
         execution_context: &mut StateTransitionExecutionContext,
         platform_version: &PlatformVersion,
     ) -> Result<ConsensusValidationResult<StateTransitionAction>, Error> {
-        let security_levels = action.contract_based_security_level_requirement()?;
+        let security_levels = action.combined_security_level_requirement()?;
 
         let signing_key = identity.loaded_public_keys.get(&self.signature_public_key_id()).ok_or(Error::Execution(ExecutionError::CorruptedCodeExecution("the key must exist for advanced structure validation as we already fetched it during signature validation")))?;
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/creation.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/creation.rs
@@ -99,8 +99,6 @@ mod creation_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -186,8 +184,6 @@ mod creation_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -248,8 +244,6 @@ mod creation_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -357,8 +351,6 @@ mod creation_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -539,8 +531,6 @@ mod creation_tests {
                 &signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -560,8 +550,6 @@ mod creation_tests {
                 None,
                 &signer_2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -583,8 +571,6 @@ mod creation_tests {
                 &signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -603,8 +589,6 @@ mod creation_tests {
                 None,
                 &signer_2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -963,8 +947,6 @@ mod creation_tests {
                 &signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1236,8 +1218,6 @@ mod creation_tests {
                 None,
                 &signer_1,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -1585,8 +1565,6 @@ mod creation_tests {
                 &signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1606,8 +1584,6 @@ mod creation_tests {
                 None,
                 &signer_2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -1629,8 +1605,6 @@ mod creation_tests {
                 &signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1651,8 +1625,6 @@ mod creation_tests {
                 &signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1672,8 +1644,6 @@ mod creation_tests {
                 &signer_2,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1692,8 +1662,6 @@ mod creation_tests {
                 None,
                 &signer_1,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -2132,8 +2100,6 @@ mod creation_tests {
                 &contender_1_signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -2364,8 +2330,6 @@ mod creation_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -2426,8 +2390,6 @@ mod creation_tests {
                 None,
                 &another_identity_signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -2549,8 +2511,6 @@ mod creation_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -2687,8 +2647,6 @@ mod creation_tests {
                 })),
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -2831,8 +2789,6 @@ mod creation_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -2973,8 +2929,6 @@ mod creation_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -3106,8 +3060,6 @@ mod creation_tests {
                 })),
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -3241,8 +3193,6 @@ mod creation_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -3363,8 +3313,6 @@ mod creation_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -3496,8 +3444,6 @@ mod creation_tests {
                 })),
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -3657,8 +3603,6 @@ mod creation_tests {
                 })),
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
@@ -64,8 +64,6 @@ mod deletion_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -107,8 +105,6 @@ mod deletion_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -247,8 +243,6 @@ mod deletion_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -290,8 +284,6 @@ mod deletion_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -413,8 +405,6 @@ mod deletion_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -456,8 +446,6 @@ mod deletion_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -579,8 +567,6 @@ mod deletion_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -622,8 +608,6 @@ mod deletion_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -715,8 +699,6 @@ mod deletion_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -821,8 +803,6 @@ mod deletion_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -886,8 +866,6 @@ mod deletion_tests {
                 })),
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -1002,8 +980,6 @@ mod deletion_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1067,8 +1043,6 @@ mod deletion_tests {
                 })),
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/dpns.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/dpns.rs
@@ -218,8 +218,6 @@ mod dpns_tests {
                 &signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -239,8 +237,6 @@ mod dpns_tests {
                 None,
                 &signer_2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -262,8 +258,6 @@ mod dpns_tests {
                 &signer_3,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -284,8 +278,6 @@ mod dpns_tests {
                 &signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -305,8 +297,6 @@ mod dpns_tests {
                 &signer_2,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -325,8 +315,6 @@ mod dpns_tests {
                 None,
                 &signer_3,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -679,8 +667,6 @@ mod dpns_tests {
                 &signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -700,8 +686,6 @@ mod dpns_tests {
                 None,
                 &signer_2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -723,8 +707,6 @@ mod dpns_tests {
                 &signer_3,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -745,8 +727,6 @@ mod dpns_tests {
                 &signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -766,8 +746,6 @@ mod dpns_tests {
                 &signer_2,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -786,8 +764,6 @@ mod dpns_tests {
                 None,
                 &signer_3,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/nft.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/nft.rs
@@ -53,8 +53,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -123,8 +121,6 @@ mod nft_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the update price");
@@ -213,8 +209,6 @@ mod nft_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -307,8 +301,6 @@ mod nft_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the update price");
@@ -436,8 +428,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -556,8 +546,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition for the update price");
 
@@ -672,8 +660,6 @@ mod nft_tests {
                 None,
                 &recipient_signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the purchase");
@@ -834,8 +820,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -958,8 +942,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1053,8 +1035,6 @@ mod nft_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the update price");
@@ -1182,8 +1162,6 @@ mod nft_tests {
                 None,
                 &recipient_signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the purchase");
@@ -1343,8 +1321,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1467,8 +1443,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition for the update price");
 
@@ -1585,8 +1559,6 @@ mod nft_tests {
                 None,
                 &recipient_signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the purchase");
@@ -1731,8 +1703,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1777,8 +1747,6 @@ mod nft_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the update price");
@@ -1828,8 +1796,6 @@ mod nft_tests {
                 None,
                 &recipient_signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the purchase");
@@ -1926,8 +1892,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1972,8 +1936,6 @@ mod nft_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the update price");
@@ -2023,8 +1985,6 @@ mod nft_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the purchase");
@@ -2126,8 +2086,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -2172,8 +2130,6 @@ mod nft_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the update price");
@@ -2223,8 +2179,6 @@ mod nft_tests {
                 None,
                 &recipient_signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the purchase");
@@ -2336,8 +2290,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition for the purchase");
 
@@ -2432,8 +2384,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -2525,8 +2475,6 @@ mod nft_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the update price");
@@ -2621,8 +2569,6 @@ mod nft_tests {
                 &recipient_signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition for the purchase");
 
@@ -2714,8 +2660,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -2762,8 +2706,6 @@ mod nft_tests {
                 None,
                 &other_identity_signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the update price");
@@ -2915,8 +2857,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -3018,8 +2958,6 @@ mod nft_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition for the update price");
 
@@ -3115,8 +3053,6 @@ mod nft_tests {
                 })),
                 &recipient_signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for the purchase");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/replacement.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/replacement.rs
@@ -67,8 +67,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -110,8 +108,6 @@ mod replacement_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -221,8 +217,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -277,8 +271,6 @@ mod replacement_tests {
                     None,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -569,8 +561,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -612,8 +602,6 @@ mod replacement_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -700,8 +688,6 @@ mod replacement_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -796,8 +782,6 @@ mod replacement_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for transfer");
@@ -905,8 +889,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1009,8 +991,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1074,8 +1054,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1093,8 +1071,6 @@ mod replacement_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -1228,8 +1204,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1297,8 +1271,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1316,8 +1288,6 @@ mod replacement_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -1488,8 +1458,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1557,8 +1525,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1576,8 +1542,6 @@ mod replacement_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -1752,8 +1716,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1821,8 +1783,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1840,8 +1800,6 @@ mod replacement_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -2030,8 +1988,6 @@ mod replacement_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -2082,8 +2038,6 @@ mod replacement_tests {
                 })),
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/transfer.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/transfer.rs
@@ -75,8 +75,6 @@ mod transfer_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -121,8 +119,6 @@ mod transfer_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for transfer");
@@ -231,8 +227,6 @@ mod transfer_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -324,8 +318,6 @@ mod transfer_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for transfer");
@@ -457,8 +449,6 @@ mod transfer_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -550,8 +540,6 @@ mod transfer_tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for transfer");
@@ -703,8 +691,6 @@ mod transfer_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition for transfer");
 
@@ -809,8 +795,6 @@ mod transfer_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -903,8 +887,6 @@ mod transfer_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition for transfer");
 
@@ -971,8 +953,6 @@ mod transfer_tests {
                 None,
                 &recipient_signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -1110,8 +1090,6 @@ mod transfer_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1209,8 +1187,6 @@ mod transfer_tests {
                 })),
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition for transfer");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/direct_selling/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/direct_selling/mod.rs
@@ -57,8 +57,6 @@ mod token_selling_tests {
                 &seller_signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .unwrap();
 
@@ -122,8 +120,6 @@ mod token_selling_tests {
             0,
             &buyer_signer,
             platform_version,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -211,8 +207,6 @@ mod token_selling_tests {
                 &seller_signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .unwrap();
 
@@ -241,8 +235,6 @@ mod token_selling_tests {
             0,
             &buyer_signer,
             platform_version,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -333,8 +325,6 @@ mod token_selling_tests {
                 &seller_signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .unwrap();
 
@@ -362,8 +352,6 @@ mod token_selling_tests {
             0,
             &buyer_signer,
             platform_version,
-            None,
-            None,
             None,
         )
         .unwrap();
@@ -569,8 +557,6 @@ mod token_selling_tests {
                 0,
                 seller_signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .unwrap();

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/distribution/perpetual/block_based.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/distribution/perpetual/block_based.rs
@@ -74,8 +74,6 @@ mod perpetual_distribution_block {
             &signer,
             platform_version,
             None,
-            None,
-            None,
         )
         .expect("expect to create documents batch transition");
 
@@ -141,8 +139,6 @@ mod perpetual_distribution_block {
             0,
             &signer,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -211,8 +207,6 @@ mod perpetual_distribution_block {
             0,
             &signer,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -322,8 +316,6 @@ mod perpetual_distribution_block {
             0,
             &signer,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -444,8 +436,6 @@ mod perpetual_distribution_block {
             0,
             &signer_2,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -2769,8 +2759,6 @@ mod test_suite {
                 0,
                 &self.signer,
                 self.platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/distribution/perpetual/time_based.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/distribution/perpetual/time_based.rs
@@ -71,8 +71,6 @@ mod perpetual_distribution_time {
             &signer,
             platform_version,
             None,
-            None,
-            None,
         )
         .expect("expect to create documents batch transition");
 
@@ -138,8 +136,6 @@ mod perpetual_distribution_time {
             0,
             &signer,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -208,8 +204,6 @@ mod perpetual_distribution_time {
             0,
             &signer,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -320,8 +314,6 @@ mod perpetual_distribution_time {
             0,
             &signer,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -445,8 +437,6 @@ mod perpetual_distribution_time {
             &signer_2,
             platform_version,
             None,
-            None,
-            None,
         )
         .expect("expect to create documents batch transition");
 
@@ -564,8 +554,6 @@ mod perpetual_distribution_time {
             &signer_2,
             platform_version,
             None,
-            None,
-            None,
         )
         .expect("expect to create documents batch transition");
 
@@ -633,8 +621,6 @@ mod perpetual_distribution_time {
             0,
             &signer_2,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -754,8 +740,6 @@ mod perpetual_distribution_time {
             &signer_2,
             platform_version,
             None,
-            None,
-            None,
         )
         .expect("expect to create documents batch transition");
 
@@ -825,8 +809,6 @@ mod perpetual_distribution_time {
             0,
             &signer_2,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -947,8 +929,6 @@ mod perpetual_distribution_time {
             &signer_2,
             platform_version,
             None,
-            None,
-            None,
         )
         .expect("expect to create documents batch transition");
 
@@ -1016,8 +996,6 @@ mod perpetual_distribution_time {
             0,
             &signer_2,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -1138,8 +1116,6 @@ mod perpetual_distribution_time {
             &signer_2,
             platform_version,
             None,
-            None,
-            None,
         )
         .expect("expect to create documents batch transition");
 
@@ -1203,8 +1179,6 @@ mod perpetual_distribution_time {
             0,
             &signer_2,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -1323,8 +1297,6 @@ mod perpetual_distribution_time {
                 0,
                 &signer_2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/distribution/pre_programmed.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/distribution/pre_programmed.rs
@@ -65,8 +65,6 @@ mod pre_programmed_distribution {
             &signer_2,
             platform_version,
             None,
-            None,
-            None,
         )
         .expect("expect to create documents batch transition");
 
@@ -131,8 +129,6 @@ mod pre_programmed_distribution {
             0,
             &signer_2,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -235,8 +231,6 @@ mod pre_programmed_distribution {
             &signer_2,
             platform_version,
             None,
-            None,
-            None,
         )
         .expect("expect to create documents batch transition");
 
@@ -301,8 +295,6 @@ mod pre_programmed_distribution {
             0,
             &signer_2,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -407,8 +399,6 @@ mod pre_programmed_distribution {
             0,
             &signer_2,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -518,8 +508,6 @@ mod pre_programmed_distribution {
             &signer_2,
             platform_version,
             None,
-            None,
-            None,
         )
         .expect("expect to create documents batch transition");
 
@@ -584,8 +572,6 @@ mod pre_programmed_distribution {
             0,
             &signer_2,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -690,8 +676,6 @@ mod pre_programmed_distribution {
             0,
             &signer_2,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");
@@ -811,8 +795,6 @@ mod pre_programmed_distribution {
             0,
             &signer_2,
             platform_version,
-            None,
-            None,
             None,
         )
         .expect("expect to create documents batch transition");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mod.rs
@@ -3177,10 +3177,9 @@ mod token_tests {
         use dpp::state_transition::batch_transition::TokenMintTransition;
         use dpp::data_contract::group::v0::GroupV0;
         use dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
-        use dpp::identity::SecurityLevel;
         use dpp::state_transition::batch_transition::accessors::DocumentsBatchTransitionAccessorsV0;
         use dpp::state_transition::batch_transition::batched_transition::token_transition::TokenTransition;
-        use dpp::state_transition::StateTransition;
+        use dpp::state_transition::{GetDataContractSecurityLevelRequirementFn, StateTransition};
         use dpp::state_transition::batch_transition::batched_transition::BatchedTransitionMutRef;
         use dpp::state_transition::batch_transition::token_base_transition::token_base_transition_accessors::TokenBaseTransitionAccessors;
         use dpp::state_transition::batch_transition::token_base_transition::v0::v0_methods::TokenBaseTransitionV0Methods;
@@ -4186,7 +4185,7 @@ mod token_tests {
             }
 
             token_transfer_transition
-                .sign_external(&key, &signer, None)
+                .sign_external(&key, &signer, None::<GetDataContractSecurityLevelRequirementFn>)
                 .expect("expected to resign transaction");
 
             let token_transfer_serialized_transition = token_transfer_transition

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mod.rs
@@ -4186,7 +4186,7 @@ mod token_tests {
             }
 
             token_transfer_transition
-                .sign_external(&key, &signer, Some(|_, _| Ok(SecurityLevel::HIGH)))
+                .sign_external(&key, &signer, None)
                 .expect("expected to resign transaction");
 
             let token_transfer_serialized_transition = token_transfer_transition

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mod.rs
@@ -4185,7 +4185,11 @@ mod token_tests {
             }
 
             token_transfer_transition
-                .sign_external(&key, &signer, None::<GetDataContractSecurityLevelRequirementFn>)
+                .sign_external(
+                    &key,
+                    &signer,
+                    None::<GetDataContractSecurityLevelRequirementFn>,
+                )
                 .expect("expected to resign transaction");
 
             let token_transfer_serialized_transition = token_transfer_transition

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mod.rs
@@ -76,8 +76,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -163,8 +161,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -253,8 +249,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -348,8 +342,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -437,8 +429,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -531,8 +521,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -620,8 +608,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -720,8 +706,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -818,8 +802,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -910,8 +892,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -1013,8 +993,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -1113,8 +1091,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -1222,8 +1198,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -1335,8 +1309,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -1451,8 +1423,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -1562,8 +1532,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -1638,8 +1606,6 @@ mod token_tests {
                     0,
                     &signer2,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -1760,8 +1726,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -1837,8 +1801,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -1972,8 +1934,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -2048,8 +2008,6 @@ mod token_tests {
                     0,
                     &signer2,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -2130,8 +2088,6 @@ mod token_tests {
                     0,
                     &signer2,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -2266,8 +2222,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -2342,8 +2296,6 @@ mod token_tests {
                     0,
                     &signer2,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -2424,8 +2376,6 @@ mod token_tests {
                     0,
                     &signer3,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -2552,8 +2502,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -2668,8 +2616,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -2744,8 +2690,6 @@ mod token_tests {
                     0,
                     &signer2,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -2884,8 +2828,6 @@ mod token_tests {
                     &signer2,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -2989,8 +2931,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -3075,8 +3015,6 @@ mod token_tests {
                 0,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -3169,8 +3107,6 @@ mod token_tests {
                 0,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -3295,8 +3231,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -3409,8 +3343,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -3495,8 +3427,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -3557,8 +3487,6 @@ mod token_tests {
                 0,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -3670,8 +3598,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -3730,8 +3656,6 @@ mod token_tests {
                 0,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -3808,8 +3732,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -3870,8 +3792,6 @@ mod token_tests {
                 0,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -3972,8 +3892,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -4063,8 +3981,6 @@ mod token_tests {
                 0,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -4191,8 +4107,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -4249,8 +4163,6 @@ mod token_tests {
                 0,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -4391,8 +4303,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -4500,8 +4410,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -4561,8 +4469,6 @@ mod token_tests {
                 0,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -4671,8 +4577,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -4734,8 +4638,6 @@ mod token_tests {
                 0,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -4812,8 +4714,6 @@ mod token_tests {
                 0,
                 &signer2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -4892,8 +4792,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -4955,8 +4853,6 @@ mod token_tests {
                 0,
                 &signer2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -5078,8 +4974,6 @@ mod token_tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -5141,8 +5035,6 @@ mod token_tests {
                 0,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -5265,8 +5157,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -5369,8 +5259,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -5518,8 +5406,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -5631,8 +5517,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -5680,8 +5564,6 @@ mod token_tests {
                     0,
                     &signer_2,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -5788,8 +5670,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -5880,8 +5760,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -5971,8 +5849,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -6079,8 +5955,6 @@ mod token_tests {
                     0,
                     &signer,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -6205,8 +6079,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -6280,8 +6152,6 @@ mod token_tests {
                     0,
                     &signer_2,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -6431,8 +6301,6 @@ mod token_tests {
                     &signer_3,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -6513,8 +6381,6 @@ mod token_tests {
                     0,
                     &signer_4,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -6599,8 +6465,6 @@ mod token_tests {
                     &signer_5,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -6655,8 +6519,6 @@ mod token_tests {
                     0,
                     &signer_5,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -6724,8 +6586,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -6783,8 +6643,6 @@ mod token_tests {
                     0,
                     &signer_2,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -6872,8 +6730,6 @@ mod token_tests {
                     &signer,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -6931,8 +6787,6 @@ mod token_tests {
                     0,
                     &signer_2,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");
@@ -7022,8 +6876,6 @@ mod token_tests {
                     &signer_3,
                     platform_version,
                     None,
-                    None,
-                    None,
                 )
                 .expect("expect to create documents batch transition");
 
@@ -7090,8 +6942,6 @@ mod token_tests {
                     0,
                     &signer_2,
                     platform_version,
-                    None,
-                    None,
                     None,
                 )
                 .expect("expect to create documents batch transition");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
@@ -1111,8 +1111,6 @@ pub(in crate::execution) mod tests {
                 signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1132,8 +1130,6 @@ pub(in crate::execution) mod tests {
                 None,
                 signer_2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -1155,8 +1151,6 @@ pub(in crate::execution) mod tests {
                 signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1175,8 +1169,6 @@ pub(in crate::execution) mod tests {
                 None,
                 signer_2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -1429,8 +1421,6 @@ pub(in crate::execution) mod tests {
                 signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1450,8 +1440,6 @@ pub(in crate::execution) mod tests {
                 None,
                 signer_2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -1473,8 +1461,6 @@ pub(in crate::execution) mod tests {
                 signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1493,8 +1479,6 @@ pub(in crate::execution) mod tests {
                 None,
                 signer_2,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -1655,8 +1639,6 @@ pub(in crate::execution) mod tests {
                 &signer_1,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("expect to create documents batch transition");
 
@@ -1676,8 +1658,6 @@ pub(in crate::execution) mod tests {
                 None,
                 &signer_1,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("expect to create documents batch transition");
@@ -2596,8 +2576,6 @@ pub(in crate::execution) mod tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("batch transition");
 
@@ -2661,8 +2639,6 @@ pub(in crate::execution) mod tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("batch transition");
 
@@ -2725,8 +2701,6 @@ pub(in crate::execution) mod tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("batch transition");
@@ -2873,8 +2847,6 @@ pub(in crate::execution) mod tests {
                 &signer,
                 platform_version,
                 None,
-                None,
-                None,
             )
             .expect("replace");
 
@@ -2940,8 +2912,6 @@ pub(in crate::execution) mod tests {
                 None,
                 &signer,
                 platform_version,
-                None,
-                None,
                 None,
             )
             .expect("delete");

--- a/packages/rs-drive-abci/tests/strategy_tests/token_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/token_tests.rs
@@ -44,12 +44,12 @@ mod tests {
 
         let (mut identity1, keys1) = Identity::random_identity_with_main_keys_with_private_key::<
             Vec<_>,
-        >(2, &mut rng, platform_version)
+        >(3, &mut rng, platform_version)
         .unwrap();
 
         let (mut identity2, keys2) = Identity::random_identity_with_main_keys_with_private_key::<
             Vec<_>,
-        >(2, &mut rng, platform_version)
+        >(3, &mut rng, platform_version)
         .unwrap();
 
         simple_signer.add_keys(keys1);
@@ -194,12 +194,12 @@ mod tests {
 
         let (mut identity1, keys1) = Identity::random_identity_with_main_keys_with_private_key::<
             Vec<_>,
-        >(2, &mut rng, platform_version)
+        >(3, &mut rng, platform_version)
         .unwrap();
 
         let (mut identity2, keys2) = Identity::random_identity_with_main_keys_with_private_key::<
             Vec<_>,
-        >(2, &mut rng, platform_version)
+        >(3, &mut rng, platform_version)
         .unwrap();
 
         simple_signer.add_keys(keys1);

--- a/packages/rs-sdk/src/platform/transition/fungible_tokens/burn.rs
+++ b/packages/rs-sdk/src/platform/transition/fungible_tokens/burn.rs
@@ -9,6 +9,7 @@ use dpp::identity::signer::Signer;
 use dpp::identity::IdentityPublicKey;
 use dpp::prelude::UserFeeIncrease;
 use dpp::state_transition::batch_transition::methods::v1::DocumentsBatchTransitionMethodsV1;
+use dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::calculate_token_id;
@@ -127,6 +128,7 @@ impl<'a> TokenBurnTransitionBuilder<'a> {
         identity_public_key: &IdentityPublicKey,
         signer: &impl Signer,
         platform_version: &PlatformVersion,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, Error> {
         let token_id = Identifier::from(calculate_token_id(
             self.data_contract.id().as_bytes(),
@@ -155,9 +157,7 @@ impl<'a> TokenBurnTransitionBuilder<'a> {
             self.user_fee_increase.unwrap_or_default(),
             signer,
             platform_version,
-            None,
-            None,
-            None,
+            options,
         )?;
 
         Ok(state_transition)

--- a/packages/rs-sdk/src/platform/transition/fungible_tokens/claim.rs
+++ b/packages/rs-sdk/src/platform/transition/fungible_tokens/claim.rs
@@ -8,6 +8,7 @@ use dpp::identity::signer::Signer;
 use dpp::identity::IdentityPublicKey;
 use dpp::prelude::UserFeeIncrease;
 use dpp::state_transition::batch_transition::methods::v1::DocumentsBatchTransitionMethodsV1;
+use dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::calculate_token_id;
@@ -116,6 +117,7 @@ impl<'a> TokenClaimTransitionBuilder<'a> {
         identity_public_key: &IdentityPublicKey,
         signer: &impl Signer,
         platform_version: &PlatformVersion,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, Error> {
         let token_id = Identifier::from(calculate_token_id(
             self.data_contract.id().as_bytes(),
@@ -143,9 +145,7 @@ impl<'a> TokenClaimTransitionBuilder<'a> {
             self.user_fee_increase.unwrap_or_default(),
             signer,
             platform_version,
-            None,
-            None,
-            None,
+            options,
         )?;
 
         Ok(state_transition)

--- a/packages/rs-sdk/src/platform/transition/fungible_tokens/config_update.rs
+++ b/packages/rs-sdk/src/platform/transition/fungible_tokens/config_update.rs
@@ -9,6 +9,7 @@ use dpp::identity::signer::Signer;
 use dpp::identity::IdentityPublicKey;
 use dpp::prelude::UserFeeIncrease;
 use dpp::state_transition::batch_transition::methods::v1::DocumentsBatchTransitionMethodsV1;
+use dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::calculate_token_id;
@@ -121,6 +122,7 @@ impl<'a> TokenConfigUpdateTransitionBuilder<'a> {
         identity_public_key: &IdentityPublicKey,
         signer: &impl Signer,
         platform_version: &PlatformVersion,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, Error> {
         let token_id = Identifier::from(calculate_token_id(
             self.data_contract.id().as_bytes(),
@@ -149,9 +151,7 @@ impl<'a> TokenConfigUpdateTransitionBuilder<'a> {
             self.user_fee_increase.unwrap_or_default(),
             signer,
             platform_version,
-            None,
-            None,
-            None,
+            options,
         )?;
 
         Ok(state_transition)

--- a/packages/rs-sdk/src/platform/transition/fungible_tokens/destroy.rs
+++ b/packages/rs-sdk/src/platform/transition/fungible_tokens/destroy.rs
@@ -8,6 +8,7 @@ use dpp::identity::signer::Signer;
 use dpp::identity::IdentityPublicKey;
 use dpp::prelude::UserFeeIncrease;
 use dpp::state_transition::batch_transition::methods::v1::DocumentsBatchTransitionMethodsV1;
+use dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::calculate_token_id;
@@ -135,6 +136,7 @@ impl<'a> TokenDestroyFrozenFundsTransitionBuilder<'a> {
         identity_public_key: &IdentityPublicKey,
         signer: &impl Signer,
         platform_version: &PlatformVersion,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, Error> {
         let token_id = Identifier::from(calculate_token_id(
             self.data_contract.id().as_bytes(),
@@ -163,9 +165,7 @@ impl<'a> TokenDestroyFrozenFundsTransitionBuilder<'a> {
             self.user_fee_increase.unwrap_or_default(),
             signer,
             platform_version,
-            None,
-            None,
-            None,
+            options,
         )?;
 
         Ok(state_transition)

--- a/packages/rs-sdk/src/platform/transition/fungible_tokens/emergency_action.rs
+++ b/packages/rs-sdk/src/platform/transition/fungible_tokens/emergency_action.rs
@@ -8,6 +8,7 @@ use dpp::identity::signer::Signer;
 use dpp::identity::IdentityPublicKey;
 use dpp::prelude::UserFeeIncrease;
 use dpp::state_transition::batch_transition::methods::v1::DocumentsBatchTransitionMethodsV1;
+use dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::calculate_token_id;
@@ -164,6 +165,7 @@ impl<'a> TokenEmergencyActionTransitionBuilder<'a> {
         identity_public_key: &IdentityPublicKey,
         signer: &impl Signer,
         platform_version: &PlatformVersion,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, Error> {
         let token_id = Identifier::from(calculate_token_id(
             self.data_contract.id().as_bytes(),
@@ -192,9 +194,7 @@ impl<'a> TokenEmergencyActionTransitionBuilder<'a> {
             self.user_fee_increase.unwrap_or_default(),
             signer,
             platform_version,
-            None,
-            None,
-            None,
+            options,
         )?;
 
         Ok(state_transition)

--- a/packages/rs-sdk/src/platform/transition/fungible_tokens/freeze.rs
+++ b/packages/rs-sdk/src/platform/transition/fungible_tokens/freeze.rs
@@ -8,6 +8,7 @@ use dpp::identity::signer::Signer;
 use dpp::identity::IdentityPublicKey;
 use dpp::prelude::UserFeeIncrease;
 use dpp::state_transition::batch_transition::methods::v1::DocumentsBatchTransitionMethodsV1;
+use dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::calculate_token_id;
@@ -135,6 +136,7 @@ impl<'a> TokenFreezeTransitionBuilder<'a> {
         identity_public_key: &IdentityPublicKey,
         signer: &impl Signer,
         platform_version: &PlatformVersion,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, Error> {
         let token_id = Identifier::from(calculate_token_id(
             self.data_contract.id().as_bytes(),
@@ -163,9 +165,7 @@ impl<'a> TokenFreezeTransitionBuilder<'a> {
             self.user_fee_increase.unwrap_or_default(),
             signer,
             platform_version,
-            None,
-            None,
-            None,
+            options,
         )?;
 
         Ok(state_transition)

--- a/packages/rs-sdk/src/platform/transition/fungible_tokens/mint.rs
+++ b/packages/rs-sdk/src/platform/transition/fungible_tokens/mint.rs
@@ -9,6 +9,7 @@ use dpp::identity::signer::Signer;
 use dpp::identity::IdentityPublicKey;
 use dpp::prelude::UserFeeIncrease;
 use dpp::state_transition::batch_transition::methods::v1::DocumentsBatchTransitionMethodsV1;
+use dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::calculate_token_id;
@@ -155,6 +156,7 @@ impl<'a> TokenMintTransitionBuilder<'a> {
         identity_public_key: &IdentityPublicKey,
         signer: &impl Signer,
         platform_version: &PlatformVersion,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, Error> {
         let token_id = Identifier::from(calculate_token_id(
             self.data_contract.id().as_bytes(),
@@ -184,9 +186,7 @@ impl<'a> TokenMintTransitionBuilder<'a> {
             self.user_fee_increase.unwrap_or_default(),
             signer,
             platform_version,
-            None,
-            None,
-            None,
+            options,
         )?;
 
         Ok(state_transition)

--- a/packages/rs-sdk/src/platform/transition/fungible_tokens/transfer.rs
+++ b/packages/rs-sdk/src/platform/transition/fungible_tokens/transfer.rs
@@ -8,6 +8,7 @@ use dpp::identity::signer::Signer;
 use dpp::identity::IdentityPublicKey;
 use dpp::prelude::UserFeeIncrease;
 use dpp::state_transition::batch_transition::methods::v1::DocumentsBatchTransitionMethodsV1;
+use dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::{calculate_token_id, PrivateEncryptedNote, SharedEncryptedNote};
@@ -159,6 +160,7 @@ impl<'a> TokenTransferTransitionBuilder<'a> {
         identity_public_key: &IdentityPublicKey,
         signer: &impl Signer,
         platform_version: &PlatformVersion,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, Error> {
         let token_id = Identifier::from(calculate_token_id(
             self.data_contract.id().as_bytes(),
@@ -189,9 +191,7 @@ impl<'a> TokenTransferTransitionBuilder<'a> {
             self.user_fee_increase.unwrap_or_default(),
             signer,
             platform_version,
-            None,
-            None,
-            None,
+            options,
         )?;
 
         Ok(state_transition)

--- a/packages/rs-sdk/src/platform/transition/fungible_tokens/unfreeze.rs
+++ b/packages/rs-sdk/src/platform/transition/fungible_tokens/unfreeze.rs
@@ -8,6 +8,7 @@ use dpp::identity::signer::Signer;
 use dpp::identity::IdentityPublicKey;
 use dpp::prelude::UserFeeIncrease;
 use dpp::state_transition::batch_transition::methods::v1::DocumentsBatchTransitionMethodsV1;
+use dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::calculate_token_id;
@@ -135,6 +136,7 @@ impl<'a> TokenUnfreezeTransitionBuilder<'a> {
         identity_public_key: &IdentityPublicKey,
         signer: &impl Signer,
         platform_version: &PlatformVersion,
+        options: Option<StateTransitionCreationOptions>,
     ) -> Result<StateTransition, Error> {
         let token_id = Identifier::from(calculate_token_id(
             self.data_contract.id().as_bytes(),
@@ -163,9 +165,7 @@ impl<'a> TokenUnfreezeTransitionBuilder<'a> {
             self.user_fee_increase.unwrap_or_default(),
             signer,
             platform_version,
-            None,
-            None,
-            None,
+            options,
         )?;
 
         Ok(state_transition)

--- a/packages/rs-sdk/src/platform/transition/purchase_document.rs
+++ b/packages/rs-sdk/src/platform/transition/purchase_document.rs
@@ -82,9 +82,7 @@ impl<S: Signer> PurchaseDocument<S> for Document {
             token_payment_info,
             signer,
             sdk.version(),
-            None,
-            None,
-            None,
+            settings.state_transition_creation_options,
         )?;
 
         transition.broadcast(sdk, Some(settings)).await?;

--- a/packages/rs-sdk/src/platform/transition/put_document.rs
+++ b/packages/rs-sdk/src/platform/transition/put_document.rs
@@ -70,9 +70,7 @@ impl<S: Signer> PutDocument<S> for Document {
             None,
             signer,
             sdk.version(),
-            None,
-            None,
-            None,
+            settings.state_transition_creation_options,
         )?;
 
         // response is empty for a broadcast, result comes from the stream wait for state transition result

--- a/packages/rs-sdk/src/platform/transition/put_settings.rs
+++ b/packages/rs-sdk/src/platform/transition/put_settings.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use dpp::prelude::UserFeeIncrease;
+use dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use rs_dapi_client::RequestSettings;
 
 /// The options when putting something to platform
@@ -9,6 +10,7 @@ pub struct PutSettings {
     pub request_settings: RequestSettings,
     pub identity_nonce_stale_time_s: Option<u64>,
     pub user_fee_increase: Option<UserFeeIncrease>,
+    pub state_transition_creation_options: Option<StateTransitionCreationOptions>,
     /// Soft limit of total time to wait for state transition to be executed (included in a block).
     ///
     /// This is an upper limit, and other settings may affect the actual wait time

--- a/packages/rs-sdk/src/platform/transition/transfer_document.rs
+++ b/packages/rs-sdk/src/platform/transition/transfer_document.rs
@@ -78,9 +78,7 @@ impl<S: Signer> TransferDocument<S> for Document {
             token_payment_info,
             signer,
             sdk.version(),
-            None,
-            None,
-            None,
+            settings.state_transition_creation_options,
         )?;
 
         let request = transition.broadcast_request_for_state_transition()?;

--- a/packages/rs-sdk/src/platform/transition/update_price_of_document.rs
+++ b/packages/rs-sdk/src/platform/transition/update_price_of_document.rs
@@ -78,9 +78,7 @@ impl<S: Signer> UpdatePriceOfDocument<S> for Document {
             token_payment_info,
             signer,
             sdk.version(),
-            None,
-            None,
-            None,
+            settings.state_transition_creation_options,
         )?;
 
         // response is empty for a broadcast, result comes from the stream wait for state transition result


### PR DESCRIPTION
## Issue being fixed or feature implemented
This PR addresses an issue where the security level for token transitions was not being correctly set to `CRITICAL` when necessary.
The PR also refactors signing state transitions to allow for signing with invalid security level keys for testing.

## What was done?
- Updated the logic in `DocumentsBatchTransitionMethodsV0` to ensure that all token transitions require a `CRITICAL` security level.
- Modified the test cases to accommodate the changes by increasing the number of keys generated for identities.
- A lot of refactoring.

## How Has This Been Tested?
The changes have been tested by updating the existing test cases in `token_tests.rs` to ensure that the security level is correctly set and that the transitions function as expected.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added ! to the title and described breaking changes in the corresponding section if my code contains any.

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced consolidated state transition creation options to simplify and standardize method signatures across document and token batch transitions.
  - Added configurable signing options allowing flexible security level and purpose checks during state transition signing.
- **Bug Fixes**
  - Enhanced security level requirement handling by combining document and token transition checks for batch actions.
- **Tests**
  - Cleaned up test code by removing redundant optional parameters in batch transition creation calls for clearer and simpler test invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->