### PR TITLE
refactor: rename token-search-contract to keyword-search-contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "packages/wasm-dpp",
     "packages/withdrawals-contract",
     "packages/token-history-contract",
-    "packages/token-search-contract"
+    "packages/keyword-search-contract"
   ],
   "resolutions": {
     "elliptic": "6.6.1",


### PR DESCRIPTION
## Issue being fixed or feature implemented
The package `token-search-contract` was renamed to `keyword-search-contract` to better reflect its functionality and improve clarity.

## What was done?
The `token-search-contract` package in the `package.json` file has been renamed to `keyword-search-contract`. This change aims to provide a more descriptive name that aligns with the package's purpose.

## How Has This Been Tested?
The change was tested by ensuring that all references to the package name within the codebase were updated accordingly, and the application was run to verify that it functions as expected without any issues.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added ! to the title and described breaking changes in the corresponding section if my code contains any.

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone