### PR TITLE
refactor(sdk): set group info for config update transition

### DIFF
--- a/packages/rs-sdk/src/platform/transition/fungible_tokens/config_update.rs
+++ b/packages/rs-sdk/src/platform/transition/fungible_tokens/config_update.rs
@@ -46,7 +46,6 @@ impl<'a> TokenConfigUpdateTransitionBuilder<'a> {
         token_position: TokenContractPosition,
         owner_id: Identifier,
         update_token_configuration_item: TokenConfigurationChangeItem,
-        using_group_info: Option<GroupStateTransitionInfoStatus>,
     ) -> Self {
         // TODO: Validate token position
 
@@ -56,7 +55,7 @@ impl<'a> TokenConfigUpdateTransitionBuilder<'a> {
             owner_id,
             update_token_configuration_item,
             public_note: None,
-            using_group_info,
+            using_group_info: None,
             settings: None,
             user_fee_increase: None,
         }

--- a/packages/rs-sdk/src/platform/transition/fungible_tokens/config_update.rs
+++ b/packages/rs-sdk/src/platform/transition/fungible_tokens/config_update.rs
@@ -90,6 +90,23 @@ impl<'a> TokenConfigUpdateTransitionBuilder<'a> {
         self
     }
 
+    /// Adds group information to the token config update transition
+    ///
+    /// # Arguments
+    ///
+    /// * `group_info` - The group information to add
+    ///
+    /// # Returns
+    ///
+    /// * `Self` - The updated builder
+    pub fn with_using_group_info(mut self, group_info: GroupStateTransitionInfoStatus) -> Self {
+        self.using_group_info = Some(group_info);
+
+        // TODO: Simplify group actions automatically find position if group action is required
+
+        self
+    }
+
     /// Adds settings to the token config_update transition
     ///
     /// # Arguments


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Group info was handled different in config update than other rs-sdk transition builders.

## What was done?
<!--- Describe your changes in detail -->
Removed using_group_info from the builder constructor, and add with_using_group_info function.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the token configuration update process with a new option for specifying group information during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->