### PR TITLE
feat(platform): only allow token notes when you are the proposer and use proposer notes in historical documents

### DIFF
--- a/packages/rs-dpp/src/errors/consensus/basic/basic_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/basic_error.rs
@@ -88,7 +88,8 @@ use crate::consensus::basic::token::{
     ChoosingTokenMintRecipientNotAllowedError, ContractHasNoTokensError,
     DestinationIdentityForTokenMintingNotSetError, InvalidActionIdError, InvalidTokenAmountError,
     InvalidTokenConfigUpdateNoChangeError, InvalidTokenIdError, InvalidTokenNoteTooBigError,
-    InvalidTokenPositionError, MissingDefaultLocalizationError, TokenTransferToOurselfError,
+    InvalidTokenPositionError, MissingDefaultLocalizationError,
+    TokenNoteOnlyAllowedWhenProposerError, TokenTransferToOurselfError,
 };
 use crate::consensus::basic::unsupported_version_error::UnsupportedVersionError;
 use crate::consensus::basic::value_error::ValueError;
@@ -560,6 +561,9 @@ pub enum BasicError {
 
     #[error(transparent)]
     GroupRequiredPowerIsInvalidError(GroupRequiredPowerIsInvalidError),
+
+    #[error(transparent)]
+    TokenNoteOnlyAllowedWhenProposerError(TokenNoteOnlyAllowedWhenProposerError),
 }
 
 impl From<BasicError> for ConsensusError {

--- a/packages/rs-dpp/src/errors/consensus/basic/token/mod.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/token/mod.rs
@@ -8,6 +8,7 @@ mod invalid_token_id_error;
 mod invalid_token_note_too_big_error;
 mod invalid_token_position_error;
 mod missing_default_localization;
+mod token_note_only_allowed_on_proposer_error;
 mod token_transfer_to_ourselves_error;
 
 pub use choosing_token_mint_recipient_not_allowed_error::*;
@@ -20,4 +21,5 @@ pub use invalid_token_id_error::*;
 pub use invalid_token_note_too_big_error::*;
 pub use invalid_token_position_error::*;
 pub use missing_default_localization::*;
+pub use token_note_only_allowed_on_proposer_error::*;
 pub use token_transfer_to_ourselves_error::*;

--- a/packages/rs-dpp/src/errors/consensus/basic/token/token_note_only_allowed_on_proposer_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/token/token_note_only_allowed_on_proposer_error.rs
@@ -19,6 +19,12 @@ impl TokenNoteOnlyAllowedWhenProposerError {
     }
 }
 
+impl Default for TokenNoteOnlyAllowedWhenProposerError {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<TokenNoteOnlyAllowedWhenProposerError> for ConsensusError {
     fn from(err: TokenNoteOnlyAllowedWhenProposerError) -> Self {
         Self::BasicError(BasicError::TokenNoteOnlyAllowedWhenProposerError(err))

--- a/packages/rs-dpp/src/errors/consensus/basic/token/token_note_only_allowed_on_proposer_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/token/token_note_only_allowed_on_proposer_error.rs
@@ -1,0 +1,26 @@
+use crate::consensus::basic::BasicError;
+use crate::consensus::ConsensusError;
+use crate::ProtocolError;
+use bincode::{Decode, Encode};
+use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
+use thiserror::Error;
+
+#[derive(
+    Error, Debug, Clone, PartialEq, Eq, Encode, Decode, PlatformSerialize, PlatformDeserialize,
+)]
+#[error("Token note is only allowed when the signer is the proposer")]
+#[platform_serialize(unversioned)]
+pub struct TokenNoteOnlyAllowedWhenProposerError;
+
+impl TokenNoteOnlyAllowedWhenProposerError {
+    /// Creates a new `TokenNoteOnlyAllowedWhenProposerError`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl From<TokenNoteOnlyAllowedWhenProposerError> for ConsensusError {
+    fn from(err: TokenNoteOnlyAllowedWhenProposerError) -> Self {
+        Self::BasicError(BasicError::TokenNoteOnlyAllowedWhenProposerError(err))
+    }
+}

--- a/packages/rs-dpp/src/errors/consensus/codes.rs
+++ b/packages/rs-dpp/src/errors/consensus/codes.rs
@@ -160,6 +160,7 @@ impl ErrorWithCode for BasicError {
             Self::InvalidTokenConfigUpdateNoChangeError(_) => 10457,
             Self::InvalidTokenAmountError(_) => 10458,
             Self::InvalidTokenNoteTooBigError(_) => 10459,
+            Self::TokenNoteOnlyAllowedWhenProposerError(_) => 10460,
 
             // Identity Errors: 10500-10599
             Self::DuplicatedIdentityPublicKeyBasicError(_) => 10500,

--- a/packages/rs-dpp/src/group/action_event.rs
+++ b/packages/rs-dpp/src/group/action_event.rs
@@ -10,3 +10,12 @@ use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
 pub enum GroupActionEvent {
     TokenEvent(TokenEvent),
 }
+
+impl GroupActionEvent {
+    /// Returns a reference to the public note if the variant includes one.
+    pub fn public_note(&self) -> Option<&str> {
+        match self {
+            GroupActionEvent::TokenEvent(token_event) => token_event.public_note(),
+        }
+    }
+}

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_burn_transition/validate_structure/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_burn_transition/validate_structure/v0/mod.rs
@@ -1,4 +1,4 @@
-use crate::consensus::basic::token::{InvalidTokenAmountError, InvalidTokenNoteTooBigError};
+use crate::consensus::basic::token::{InvalidTokenAmountError, InvalidTokenNoteTooBigError, TokenNoteOnlyAllowedWhenProposerError};
 use crate::consensus::basic::BasicError;
 use crate::consensus::ConsensusError;
 use crate::data_contract::associated_token::token_perpetual_distribution::distribution_function::MAX_DISTRIBUTION_PARAM;
@@ -7,6 +7,8 @@ use crate::state_transition::batch_transition::TokenBurnTransition;
 use crate::tokens::MAX_TOKEN_NOTE_LEN;
 use crate::validation::SimpleConsensusValidationResult;
 use crate::ProtocolError;
+use crate::state_transition::batch_transition::token_base_transition::token_base_transition_accessors::TokenBaseTransitionAccessors;
+use crate::state_transition::batch_transition::token_base_transition::v0::v0_methods::TokenBaseTransitionV0Methods;
 
 pub(super) trait TokenBurnTransitionActionStructureValidationV0 {
     fn validate_structure_v0(&self) -> Result<SimpleConsensusValidationResult, ProtocolError>;
@@ -32,6 +34,17 @@ impl TokenBurnTransitionActionStructureValidationV0 for TokenBurnTransition {
                         ),
                     )),
                 ));
+            }
+            if let Some(group_state_transition_info) = self.base().using_group_info() {
+                if !group_state_transition_info.action_is_proposer {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::BasicError(
+                            BasicError::TokenNoteOnlyAllowedWhenProposerError(
+                                TokenNoteOnlyAllowedWhenProposerError::new(),
+                            ),
+                        ),
+                    ));
+                }
             }
         }
 

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_config_update_transition/validate_structure/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_config_update_transition/validate_structure/v0/mod.rs
@@ -1,6 +1,4 @@
-use crate::consensus::basic::token::{
-    InvalidTokenConfigUpdateNoChangeError, InvalidTokenNoteTooBigError,
-};
+use crate::consensus::basic::token::{InvalidTokenConfigUpdateNoChangeError, InvalidTokenNoteTooBigError, TokenNoteOnlyAllowedWhenProposerError};
 use crate::consensus::basic::BasicError;
 use crate::consensus::ConsensusError;
 use crate::data_contract::associated_token::token_configuration_item::TokenConfigurationChangeItem;
@@ -9,6 +7,8 @@ use crate::state_transition::batch_transition::TokenConfigUpdateTransition;
 use crate::tokens::MAX_TOKEN_NOTE_LEN;
 use crate::validation::SimpleConsensusValidationResult;
 use crate::ProtocolError;
+use crate::state_transition::batch_transition::token_base_transition::token_base_transition_accessors::TokenBaseTransitionAccessors;
+use crate::state_transition::batch_transition::token_base_transition::v0::v0_methods::TokenBaseTransitionV0Methods;
 
 pub(super) trait TokenConfigUpdateTransitionStructureValidationV0 {
     fn validate_structure_v0(&self) -> Result<SimpleConsensusValidationResult, ProtocolError>;
@@ -37,6 +37,17 @@ impl TokenConfigUpdateTransitionStructureValidationV0 for TokenConfigUpdateTrans
                         ),
                     )),
                 ));
+            }
+            if let Some(group_state_transition_info) = self.base().using_group_info() {
+                if !group_state_transition_info.action_is_proposer {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::BasicError(
+                            BasicError::TokenNoteOnlyAllowedWhenProposerError(
+                                TokenNoteOnlyAllowedWhenProposerError::new(),
+                            ),
+                        ),
+                    ));
+                }
             }
         }
 

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_destroy_frozen_funds_transition/validate_structure/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_destroy_frozen_funds_transition/validate_structure/v0/mod.rs
@@ -2,8 +2,10 @@ use crate::ProtocolError;
 use crate::state_transition::batch_transition::TokenDestroyFrozenFundsTransition;
 use crate::validation::SimpleConsensusValidationResult;
 use crate::consensus::basic::BasicError;
-use crate::consensus::basic::token::InvalidTokenNoteTooBigError;
+use crate::consensus::basic::token::{InvalidTokenNoteTooBigError, TokenNoteOnlyAllowedWhenProposerError};
 use crate::consensus::ConsensusError;
+use crate::state_transition::batch_transition::token_base_transition::token_base_transition_accessors::TokenBaseTransitionAccessors;
+use crate::state_transition::batch_transition::token_base_transition::v0::v0_methods::TokenBaseTransitionV0Methods;
 use crate::state_transition::batch_transition::token_destroy_frozen_funds_transition::v0::v0_methods::TokenDestroyFrozenFundsTransitionV0Methods;
 use crate::tokens::MAX_TOKEN_NOTE_LEN;
 
@@ -23,6 +25,17 @@ impl TokenDestroyFrozenFundsTransitionStructureValidationV0 for TokenDestroyFroz
                         ),
                     )),
                 ));
+            }
+            if let Some(group_state_transition_info) = self.base().using_group_info() {
+                if !group_state_transition_info.action_is_proposer {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::BasicError(
+                            BasicError::TokenNoteOnlyAllowedWhenProposerError(
+                                TokenNoteOnlyAllowedWhenProposerError::new(),
+                            ),
+                        ),
+                    ));
+                }
             }
         }
 

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_emergency_action_transition/validate_structure/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_emergency_action_transition/validate_structure/v0/mod.rs
@@ -1,4 +1,4 @@
-use crate::consensus::basic::token::InvalidTokenNoteTooBigError;
+use crate::consensus::basic::token::{InvalidTokenNoteTooBigError, TokenNoteOnlyAllowedWhenProposerError};
 use crate::consensus::basic::BasicError;
 use crate::consensus::ConsensusError;
 use crate::state_transition::batch_transition::token_emergency_action_transition::v0::v0_methods::TokenEmergencyActionTransitionV0Methods;
@@ -6,6 +6,8 @@ use crate::state_transition::batch_transition::TokenEmergencyActionTransition;
 use crate::tokens::MAX_TOKEN_NOTE_LEN;
 use crate::validation::SimpleConsensusValidationResult;
 use crate::ProtocolError;
+use crate::state_transition::batch_transition::token_base_transition::token_base_transition_accessors::TokenBaseTransitionAccessors;
+use crate::state_transition::batch_transition::token_base_transition::v0::v0_methods::TokenBaseTransitionV0Methods;
 
 pub(super) trait TokenEmergencyActionTransitionStructureValidationV0 {
     fn validate_structure_v0(&self) -> Result<SimpleConsensusValidationResult, ProtocolError>;
@@ -23,6 +25,17 @@ impl TokenEmergencyActionTransitionStructureValidationV0 for TokenEmergencyActio
                         ),
                     )),
                 ));
+            }
+            if let Some(group_state_transition_info) = self.base().using_group_info() {
+                if !group_state_transition_info.action_is_proposer {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::BasicError(
+                            BasicError::TokenNoteOnlyAllowedWhenProposerError(
+                                TokenNoteOnlyAllowedWhenProposerError::new(),
+                            ),
+                        ),
+                    ));
+                }
             }
         }
 

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_freeze_transition/validate_structure/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_freeze_transition/validate_structure/v0/mod.rs
@@ -1,4 +1,4 @@
-use crate::consensus::basic::token::InvalidTokenNoteTooBigError;
+use crate::consensus::basic::token::{InvalidTokenNoteTooBigError, TokenNoteOnlyAllowedWhenProposerError};
 use crate::consensus::basic::BasicError;
 use crate::consensus::ConsensusError;
 use crate::state_transition::batch_transition::token_freeze_transition::v0::v0_methods::TokenFreezeTransitionV0Methods;
@@ -6,6 +6,8 @@ use crate::state_transition::batch_transition::TokenFreezeTransition;
 use crate::tokens::MAX_TOKEN_NOTE_LEN;
 use crate::validation::SimpleConsensusValidationResult;
 use crate::ProtocolError;
+use crate::state_transition::batch_transition::token_base_transition::token_base_transition_accessors::TokenBaseTransitionAccessors;
+use crate::state_transition::batch_transition::token_base_transition::v0::v0_methods::TokenBaseTransitionV0Methods;
 
 pub(super) trait TokenFreezeTransitionStructureValidationV0 {
     fn validate_structure_v0(&self) -> Result<SimpleConsensusValidationResult, ProtocolError>;
@@ -23,6 +25,17 @@ impl TokenFreezeTransitionStructureValidationV0 for TokenFreezeTransition {
                         ),
                     )),
                 ));
+            }
+            if let Some(group_state_transition_info) = self.base().using_group_info() {
+                if !group_state_transition_info.action_is_proposer {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::BasicError(
+                            BasicError::TokenNoteOnlyAllowedWhenProposerError(
+                                TokenNoteOnlyAllowedWhenProposerError::new(),
+                            ),
+                        ),
+                    ));
+                }
             }
         }
 

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_set_price_for_direct_purchase_transition/validate_structure/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_set_price_for_direct_purchase_transition/validate_structure/v0/mod.rs
@@ -1,4 +1,4 @@
-use crate::consensus::basic::token::InvalidTokenNoteTooBigError;
+use crate::consensus::basic::token::{InvalidTokenNoteTooBigError, TokenNoteOnlyAllowedWhenProposerError};
 use crate::consensus::basic::BasicError;
 use crate::consensus::ConsensusError;
 use crate::state_transition::batch_transition::token_set_price_for_direct_purchase_transition::v0::v0_methods::TokenSetPriceForDirectPurchaseTransitionV0Methods;
@@ -6,6 +6,8 @@ use crate::state_transition::batch_transition::TokenSetPriceForDirectPurchaseTra
 use crate::tokens::MAX_TOKEN_NOTE_LEN;
 use crate::validation::SimpleConsensusValidationResult;
 use crate::ProtocolError;
+use crate::state_transition::batch_transition::token_base_transition::token_base_transition_accessors::TokenBaseTransitionAccessors;
+use crate::state_transition::batch_transition::token_base_transition::v0::v0_methods::TokenBaseTransitionV0Methods;
 
 pub(super) trait TokenSetPriceForDirectPurchaseTransitionActionStructureValidationV0 {
     fn validate_structure_v0(&self) -> Result<SimpleConsensusValidationResult, ProtocolError>;
@@ -27,6 +29,17 @@ impl TokenSetPriceForDirectPurchaseTransitionActionStructureValidationV0
                         ),
                     )),
                 ));
+            }
+            if let Some(group_state_transition_info) = self.base().using_group_info() {
+                if !group_state_transition_info.action_is_proposer {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::BasicError(
+                            BasicError::TokenNoteOnlyAllowedWhenProposerError(
+                                TokenNoteOnlyAllowedWhenProposerError::new(),
+                            ),
+                        ),
+                    ));
+                }
             }
         }
         Ok(SimpleConsensusValidationResult::default())

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_unfreeze_transition/validate_structure/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_unfreeze_transition/validate_structure/v0/mod.rs
@@ -1,4 +1,4 @@
-use crate::consensus::basic::token::InvalidTokenNoteTooBigError;
+use crate::consensus::basic::token::{InvalidTokenNoteTooBigError, TokenNoteOnlyAllowedWhenProposerError};
 use crate::consensus::basic::BasicError;
 use crate::consensus::ConsensusError;
 use crate::state_transition::batch_transition::token_unfreeze_transition::v0::v0_methods::TokenUnfreezeTransitionV0Methods;
@@ -6,6 +6,8 @@ use crate::state_transition::batch_transition::TokenUnfreezeTransition;
 use crate::tokens::MAX_TOKEN_NOTE_LEN;
 use crate::validation::SimpleConsensusValidationResult;
 use crate::ProtocolError;
+use crate::state_transition::batch_transition::token_base_transition::token_base_transition_accessors::TokenBaseTransitionAccessors;
+use crate::state_transition::batch_transition::token_base_transition::v0::v0_methods::TokenBaseTransitionV0Methods;
 
 pub(super) trait TokenUnfreezeTransitionStructureValidationV0 {
     fn validate_structure_v0(&self) -> Result<SimpleConsensusValidationResult, ProtocolError>;
@@ -23,6 +25,17 @@ impl TokenUnfreezeTransitionStructureValidationV0 for TokenUnfreezeTransition {
                         ),
                     )),
                 ));
+            }
+            if let Some(group_state_transition_info) = self.base().using_group_info() {
+                if !group_state_transition_info.action_is_proposer {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::BasicError(
+                            BasicError::TokenNoteOnlyAllowedWhenProposerError(
+                                TokenNoteOnlyAllowedWhenProposerError::new(),
+                            ),
+                        ),
+                    ));
+                }
             }
         }
 

--- a/packages/rs-dpp/src/tokens/token_event.rs
+++ b/packages/rs-dpp/src/tokens/token_event.rs
@@ -154,6 +154,23 @@ impl TokenEvent {
         }
     }
 
+    /// Returns a reference to the public note if the variant includes one.
+    pub fn public_note(&self) -> Option<&str> {
+        match self {
+            TokenEvent::Mint(_, _, Some(note))
+            | TokenEvent::Burn(_, Some(note))
+            | TokenEvent::Freeze(_, Some(note))
+            | TokenEvent::Unfreeze(_, Some(note))
+            | TokenEvent::DestroyFrozenFunds(_, _, Some(note))
+            | TokenEvent::Transfer(_, Some(note), _, _, _)
+            | TokenEvent::Claim(_, _, Some(note))
+            | TokenEvent::EmergencyAction(_, Some(note))
+            | TokenEvent::ConfigUpdate(_, Some(note))
+            | TokenEvent::ChangePriceForDirectPurchase(_, Some(note)) => Some(note),
+            _ => None,
+        }
+    }
+
     pub fn associated_document_type<'a>(
         &self,
         token_history_contract: &'a DataContract,

--- a/packages/rs-drive/src/drive/group/fetch/fetch_action_id_signers_power/v0/mod.rs
+++ b/packages/rs-drive/src/drive/group/fetch/fetch_action_id_signers_power/v0/mod.rs
@@ -3,7 +3,7 @@ use crate::drive::Drive;
 use crate::error::Error;
 use crate::fees::op::LowLevelDriveOperation;
 use crate::util::grove_operations::DirectQueryType;
-use crate::util::grove_operations::QueryTarget::{QueryTargetTree, QueryTargetValue};
+use crate::util::grove_operations::QueryTarget::QueryTargetTree;
 use dpp::data_contract::group::GroupSumPower;
 use dpp::data_contract::GroupContractPosition;
 use dpp::identifier::Identifier;

--- a/packages/rs-drive/src/drive/group/fetch/fetch_active_action_info/mod.rs
+++ b/packages/rs-drive/src/drive/group/fetch/fetch_active_action_info/mod.rs
@@ -5,10 +5,8 @@ use crate::fees::op::LowLevelDriveOperation;
 use dpp::data_contract::GroupContractPosition;
 use dpp::group::group_action::GroupAction;
 use dpp::identifier::Identifier;
-use grovedb::batch::KeyInfoPath;
-use grovedb::{EstimatedLayerInformation, TransactionArg};
+use grovedb::TransactionArg;
 use platform_version::version::PlatformVersion;
-use std::collections::HashMap;
 
 mod v0;
 
@@ -84,16 +82,12 @@ impl Drive {
     /// # Errors
     /// - `DriveError::UnknownVersionMismatch`: If the `platform_version` does not match any known versions.
     #[allow(clippy::too_many_arguments)]
-    // TODO: Is not using
-    #[allow(dead_code)]
     pub(crate) fn fetch_active_action_info_and_add_operations(
         &self,
         contract_id: Identifier,
         group_contract_position: GroupContractPosition,
         action_id: Identifier,
-        estimated_costs_only_with_layer_info: &mut Option<
-            HashMap<KeyInfoPath, EstimatedLayerInformation>,
-        >,
+        approximate_without_state_for_costs: bool,
         transaction: TransactionArg,
         drive_operations: &mut Vec<LowLevelDriveOperation>,
         platform_version: &PlatformVersion,
@@ -109,7 +103,7 @@ impl Drive {
                 contract_id,
                 group_contract_position,
                 action_id,
-                estimated_costs_only_with_layer_info,
+                approximate_without_state_for_costs,
                 transaction,
                 drive_operations,
                 platform_version,

--- a/packages/rs-drive/src/drive/group/fetch/fetch_active_action_info/v0/mod.rs
+++ b/packages/rs-drive/src/drive/group/fetch/fetch_active_action_info/v0/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::drive::group::paths::{group_active_action_path, ACTION_INFO_KEY};
 use crate::drive::Drive;
 use crate::error::Error;
@@ -11,8 +9,7 @@ use dpp::group::group_action::GroupAction;
 use dpp::identifier::Identifier;
 use dpp::serialization::PlatformDeserializable;
 use dpp::version::PlatformVersion;
-use grovedb::batch::KeyInfoPath;
-use grovedb::{EstimatedLayerInformation, TransactionArg, TreeType};
+use grovedb::{TransactionArg, TreeType};
 
 impl Drive {
     pub(super) fn fetch_active_action_info_v0(
@@ -46,16 +43,12 @@ impl Drive {
     }
 
     #[allow(clippy::too_many_arguments)]
-    // TODO: Is not using
-    #[allow(dead_code)]
     pub(super) fn fetch_active_action_info_and_add_operations_v0(
         &self,
         contract_id: Identifier,
         group_contract_position: GroupContractPosition,
         action_id: Identifier,
-        estimated_costs_only_with_layer_info: &mut Option<
-            HashMap<KeyInfoPath, EstimatedLayerInformation>,
-        >,
+        approximate_without_state_for_costs: bool,
         transaction: TransactionArg,
         drive_operations: &mut Vec<LowLevelDriveOperation>,
         platform_version: &PlatformVersion,
@@ -69,12 +62,12 @@ impl Drive {
         );
 
         // no estimated_costs_only_with_layer_info, means we want to apply to state
-        let direct_query_type = if estimated_costs_only_with_layer_info.is_none() {
+        let direct_query_type = if !approximate_without_state_for_costs {
             DirectQueryType::StatefulDirectQuery
         } else {
             DirectQueryType::StatelessDirectQuery {
                 in_tree_type: TreeType::NormalTree,
-                query_target: QueryTargetValue(8),
+                query_target: QueryTargetValue(40),
             }
         };
 

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_base_transition_action/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_base_transition_action/transformer.rs
@@ -11,6 +11,9 @@ use crate::error::Error;
 use crate::fees::op::LowLevelDriveOperation;
 use crate::state_transition_action::batch::batched_transition::token_transition::token_base_transition_action::{TokenBaseTransitionAction, TokenBaseTransitionActionV0};
 
+/// A type representing if we need to change the state transition public note to the original group public note
+pub type ChangeToOriginalPublicNote = Option<Option<String>>;
+
 impl TokenBaseTransitionAction {
     /// from base transition with contract lookup
     #[allow(clippy::too_many_arguments)]
@@ -23,7 +26,7 @@ impl TokenBaseTransitionAction {
         drive_operations: &mut Vec<LowLevelDriveOperation>,
         get_data_contract: impl Fn(Identifier) -> Result<Arc<DataContractFetchInfo>, ProtocolError>,
         platform_version: &PlatformVersion,
-    ) -> Result<ConsensusValidationResult<Self>, Error> {
+    ) -> Result<ConsensusValidationResult<(Self, ChangeToOriginalPublicNote)>, Error> {
         match value {
             TokenBaseTransition::V0(v0) => Ok(
                 TokenBaseTransitionActionV0::try_from_base_transition_with_contract_lookup(
@@ -36,7 +39,7 @@ impl TokenBaseTransitionAction {
                     get_data_contract,
                     platform_version,
                 )?
-                .map(|v0| v0.into()),
+                .map(|(v0, change_note)| (v0.into(), change_note)),
             ),
         }
     }
@@ -52,7 +55,7 @@ impl TokenBaseTransitionAction {
         drive_operations: &mut Vec<LowLevelDriveOperation>,
         get_data_contract: impl Fn(Identifier) -> Result<Arc<DataContractFetchInfo>, ProtocolError>,
         platform_version: &PlatformVersion,
-    ) -> Result<ConsensusValidationResult<Self>, Error> {
+    ) -> Result<ConsensusValidationResult<(Self, ChangeToOriginalPublicNote)>, Error> {
         match value {
             TokenBaseTransition::V0(v0) => Ok(
             TokenBaseTransitionActionV0::try_from_borrowed_base_transition_with_contract_lookup(
@@ -64,7 +67,7 @@ impl TokenBaseTransitionAction {
                 drive_operations,
                 get_data_contract,
                 platform_version,
-            )?.map(|v0| v0.into())
+            )?.map(|(v0, change_note)| (v0.into(), change_note)),
             ),
         }
     }

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_burn_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_burn_transition_action/v0/transformer.rs
@@ -88,7 +88,7 @@ impl TokenBurnTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action = BumpIdentityDataContractNonceAction::from_token_base_transition(
@@ -114,7 +114,7 @@ impl TokenBurnTransitionActionV0 {
                 TokenBurnTransitionActionV0 {
                     base: base_action,
                     burn_amount,
-                    public_note,
+                    public_note: change_note.unwrap_or(public_note),
                 }
                 .into(),
             ))
@@ -193,7 +193,7 @@ impl TokenBurnTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action =
@@ -220,7 +220,7 @@ impl TokenBurnTransitionActionV0 {
                 TokenBurnTransitionActionV0 {
                     base: base_action,
                     burn_amount: *burn_amount,
-                    public_note: public_note.clone(),
+                    public_note: change_note.unwrap_or(public_note.clone()),
                 }
                 .into(),
             ))

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_claim_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_claim_transition_action/v0/transformer.rs
@@ -165,7 +165,8 @@ impl TokenClaimTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        // We can not change the note on a claim
+        let (base_action, _change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action =

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_config_update_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_config_update_transition_action/v0/transformer.rs
@@ -88,7 +88,7 @@ impl TokenConfigUpdateTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action = BumpIdentityDataContractNonceAction::from_token_base_transition(
@@ -114,7 +114,7 @@ impl TokenConfigUpdateTransitionActionV0 {
                 TokenConfigUpdateTransitionActionV0 {
                     base: base_action,
                     update_token_configuration_item,
-                    public_note,
+                    public_note: change_note.unwrap_or(public_note),
                 }
                 .into(),
             ))
@@ -197,7 +197,7 @@ impl TokenConfigUpdateTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action =
@@ -224,7 +224,7 @@ impl TokenConfigUpdateTransitionActionV0 {
                 TokenConfigUpdateTransitionActionV0 {
                     base: base_action,
                     update_token_configuration_item: update_token_configuration_item.clone(),
-                    public_note: public_note.clone(),
+                    public_note: change_note.unwrap_or(public_note.clone()),
                 }
                 .into(),
             ))

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_destroy_frozen_funds_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_destroy_frozen_funds_transition_action/v0/transformer.rs
@@ -127,7 +127,7 @@ impl TokenDestroyFrozenFundsTransitionActionV0 {
             ));
         };
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action = BumpIdentityDataContractNonceAction::from_token_base_transition(
@@ -154,7 +154,7 @@ impl TokenDestroyFrozenFundsTransitionActionV0 {
                     base: base_action,
                     frozen_identity_id,
                     amount: token_amount,
-                    public_note,
+                    public_note: change_note.unwrap_or(public_note),
                 }
                 .into(),
             ))
@@ -274,7 +274,7 @@ impl TokenDestroyFrozenFundsTransitionActionV0 {
             ));
         };
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action =
@@ -302,7 +302,7 @@ impl TokenDestroyFrozenFundsTransitionActionV0 {
                     base: base_action,
                     frozen_identity_id: *frozen_identity_id,
                     amount: token_amount,
-                    public_note: public_note.clone(),
+                    public_note: change_note.unwrap_or(public_note.clone()),
                 }
                 .into(),
             ))

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_direct_purchase_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_direct_purchase_transition_action/v0/transformer.rs
@@ -96,7 +96,8 @@ impl TokenDirectPurchaseTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        // We can not change the note on a direct purchase
+        let (base_action, _change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action =

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_emergency_action_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_emergency_action_transition_action/v0/transformer.rs
@@ -87,7 +87,7 @@ impl TokenEmergencyActionTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action = BumpIdentityDataContractNonceAction::from_token_base_transition(
@@ -113,7 +113,7 @@ impl TokenEmergencyActionTransitionActionV0 {
                 TokenEmergencyActionTransitionActionV0 {
                     base: base_action,
                     emergency_action,
-                    public_note,
+                    public_note: change_note.unwrap_or(public_note),
                 }
                 .into(),
             ))
@@ -196,7 +196,7 @@ impl TokenEmergencyActionTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action =
@@ -223,7 +223,7 @@ impl TokenEmergencyActionTransitionActionV0 {
                 TokenEmergencyActionTransitionActionV0 {
                     base: base_action,
                     emergency_action: *emergency_action,
-                    public_note: public_note.clone(),
+                    public_note: change_note.unwrap_or(public_note.clone()),
                 }
                 .into(),
             ))

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_freeze_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_freeze_transition_action/v0/transformer.rs
@@ -87,7 +87,7 @@ impl TokenFreezeTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action = BumpIdentityDataContractNonceAction::from_token_base_transition(
@@ -113,7 +113,7 @@ impl TokenFreezeTransitionActionV0 {
                 TokenFreezeTransitionActionV0 {
                     base: base_action,
                     identity_to_freeze_id,
-                    public_note,
+                    public_note: change_note.unwrap_or(public_note),
                 }
                 .into(),
             ))
@@ -196,7 +196,7 @@ impl TokenFreezeTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action =
@@ -223,7 +223,7 @@ impl TokenFreezeTransitionActionV0 {
                 TokenFreezeTransitionActionV0 {
                     base: base_action,
                     identity_to_freeze_id: *identity_to_freeze_id,
-                    public_note: public_note.clone(),
+                    public_note: change_note.unwrap_or(public_note.clone()),
                 }
                 .into(),
             ))

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_mint_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_mint_transition_action/v0/transformer.rs
@@ -96,7 +96,7 @@ impl TokenMintTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action = BumpIdentityDataContractNonceAction::from_token_base_transition(
@@ -189,7 +189,7 @@ impl TokenMintTransitionActionV0 {
                     base: base_action,
                     mint_amount: amount,
                     identity_balance_holder_id,
-                    public_note,
+                    public_note: change_note.unwrap_or(public_note),
                 }
                 .into(),
             ))
@@ -273,7 +273,7 @@ impl TokenMintTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action =
@@ -367,7 +367,7 @@ impl TokenMintTransitionActionV0 {
                     base: base_action,
                     mint_amount: *amount,
                     identity_balance_holder_id,
-                    public_note: public_note.clone(),
+                    public_note: change_note.unwrap_or(public_note.clone()),
                 }
                 .into(),
             ))

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_set_price_for_direct_purchase_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_set_price_for_direct_purchase_transition_action/v0/transformer.rs
@@ -87,7 +87,7 @@ impl TokenSetPriceForDirectPurchaseTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action = BumpIdentityDataContractNonceAction::from_token_base_transition(
@@ -114,7 +114,7 @@ impl TokenSetPriceForDirectPurchaseTransitionActionV0 {
                     TokenSetPriceForDirectPurchaseTransitionActionV0 {
                         base: base_action,
                         price,
-                        public_note,
+                        public_note: change_note.unwrap_or(public_note),
                     }
                     .into(),
                 ),
@@ -198,7 +198,7 @@ impl TokenSetPriceForDirectPurchaseTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action =
@@ -226,7 +226,7 @@ impl TokenSetPriceForDirectPurchaseTransitionActionV0 {
                     TokenSetPriceForDirectPurchaseTransitionActionV0 {
                         base: base_action,
                         price: price.clone(),
-                        public_note: public_note.clone(),
+                        public_note: change_note.unwrap_or(public_note.clone()),
                     }
                     .into(),
                 ),

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_transfer_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_transfer_transition_action/v0/transformer.rs
@@ -59,17 +59,19 @@ impl TokenTransferTransitionActionV0 {
         let mut drive_operations = vec![];
 
         // Lookup the base action using the base transition data and contract information
-        let base_action = TokenBaseTransitionAction::try_from_base_transition_with_contract_lookup(
-            drive,
-            owner_id,
-            base,
-            approximate_without_state_for_costs,
-            transaction,
-            &mut drive_operations,
-            get_data_contract,
-            platform_version,
-        )?
-        .into_data()?;
+        // There is no change note for transfer tokens
+        let (base_action, _change_note) =
+            TokenBaseTransitionAction::try_from_base_transition_with_contract_lookup(
+                drive,
+                owner_id,
+                base,
+                approximate_without_state_for_costs,
+                transaction,
+                &mut drive_operations,
+                get_data_contract,
+                platform_version,
+            )?
+            .into_data()?;
 
         let fee_result = Drive::calculate_fee(
             None,
@@ -141,7 +143,8 @@ impl TokenTransferTransitionActionV0 {
         let mut drive_operations = vec![];
 
         // Lookup the base action using the borrowed base transition data and contract information
-        let base_action =
+        // We can never change the note
+        let (base_action, _change_note) =
             TokenBaseTransitionAction::try_from_borrowed_base_transition_with_contract_lookup(
                 drive,
                 owner_id,

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_unfreeze_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_unfreeze_transition_action/v0/transformer.rs
@@ -87,7 +87,7 @@ impl TokenUnfreezeTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action = BumpIdentityDataContractNonceAction::from_token_base_transition(
@@ -113,7 +113,7 @@ impl TokenUnfreezeTransitionActionV0 {
                 TokenUnfreezeTransitionActionV0 {
                     base: base_action,
                     frozen_identity_id,
-                    public_note,
+                    public_note: change_note.unwrap_or(public_note),
                 }
                 .into(),
             ))
@@ -196,7 +196,7 @@ impl TokenUnfreezeTransitionActionV0 {
             None,
         )?;
 
-        let base_action = match base_action_validation_result.is_valid() {
+        let (base_action, change_note) = match base_action_validation_result.is_valid() {
             true => base_action_validation_result.into_data()?,
             false => {
                 let bump_action =
@@ -223,7 +223,7 @@ impl TokenUnfreezeTransitionActionV0 {
                 TokenUnfreezeTransitionActionV0 {
                     base: base_action,
                     frozen_identity_id: *frozen_identity_id,
-                    public_note: public_note.clone(),
+                    public_note: change_note.unwrap_or(public_note.clone()),
                 }
                 .into(),
             ))

--- a/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
@@ -363,9 +363,20 @@ impl Drive {
                                 // so we need to ignore them
                                 let ignore_fields = match token_transition {
                                     TokenTransition::DestroyFrozenFunds(_) => {
-                                        Some(vec!["destroyedAmount"])
+                                        Some(vec!["destroyedAmount", "note"])
                                     }
                                     TokenTransition::Claim(_) => Some(vec!["amount"]),
+                                    TokenTransition::Burn(_)
+                                    | TokenTransition::Mint(_)
+                                    | TokenTransition::Freeze(_)
+                                    | TokenTransition::Unfreeze(_)
+                                    | TokenTransition::EmergencyAction(_)
+                                    | TokenTransition::ConfigUpdate(_)
+                                    | TokenTransition::SetPriceForDirectPurchase(_)
+                                        if token_transition.base().using_group_info().is_some() =>
+                                    {
+                                        Some(vec!["note"])
+                                    }
                                     _ => None,
                                 };
 

--- a/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
@@ -66,7 +66,7 @@ use dpp::consensus::basic::document::{ContestedDocumentsTemporarilyNotAllowedErr
 use dpp::consensus::basic::group::GroupActionNotAllowedOnTransitionError;
 use dpp::consensus::basic::identity::{DataContractBoundsNotPresentError, DisablingKeyIdAlsoBeingAddedInSameTransitionError, InvalidIdentityCreditWithdrawalTransitionAmountError, InvalidIdentityUpdateTransitionDisableKeysError, InvalidIdentityUpdateTransitionEmptyError, TooManyMasterPublicKeyError, WithdrawalOutputScriptNotAllowedWhenSigningWithOwnerKeyError};
 use dpp::consensus::basic::overflow_error::OverflowError;
-use dpp::consensus::basic::token::{ChoosingTokenMintRecipientNotAllowedError, ContractHasNoTokensError, DestinationIdentityForTokenMintingNotSetError, InvalidActionIdError, InvalidTokenAmountError, InvalidTokenConfigUpdateNoChangeError, InvalidTokenIdError, InvalidTokenNoteTooBigError, InvalidTokenPositionError, MissingDefaultLocalizationError, TokenTransferToOurselfError};
+use dpp::consensus::basic::token::{ChoosingTokenMintRecipientNotAllowedError, ContractHasNoTokensError, DestinationIdentityForTokenMintingNotSetError, InvalidActionIdError, InvalidTokenAmountError, InvalidTokenConfigUpdateNoChangeError, InvalidTokenIdError, InvalidTokenNoteTooBigError, InvalidTokenPositionError, MissingDefaultLocalizationError, TokenNoteOnlyAllowedWhenProposerError, TokenTransferToOurselfError};
 use dpp::consensus::state::data_contract::data_contract_update_action_not_allowed_error::DataContractUpdateActionNotAllowedError;
 use dpp::consensus::state::data_contract::document_type_update_error::DocumentTypeUpdateError;
 use dpp::consensus::state::document::document_contest_currently_locked_error::DocumentContestCurrentlyLockedError;
@@ -812,6 +812,9 @@ fn from_basic_error(basic_error: &BasicError) -> JsValue {
         }
         BasicError::GroupRequiredPowerIsInvalidError(e) => {
             generic_consensus_error!(GroupRequiredPowerIsInvalidError, e).into()
+        }
+        BasicError::TokenNoteOnlyAllowedWhenProposerError(e) => {
+            generic_consensus_error!(TokenNoteOnlyAllowedWhenProposerError, e).into()
         }
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Added a new error type `TokenNoteOnlyAllowedWhenProposerError` to enforce that only the proposer of a group action can include a note in token transitions.

## What was done?
- Introduced `TokenNoteOnlyAllowedWhenProposerError` to the error handling for token transitions.
- Updated the relevant token transition validation logic to check if the action is being performed by the proposer.
- Modified the code to return the new error when a non-proposer attempts to include a note in their token actions.
- Updated tests to cover the new behavior, ensuring that only the proposer can include a note.

## How Has This Been Tested?
- Added unit tests to verify that the new error is raised correctly when a non-proposer includes a note in their token transitions.
- Existing tests were updated to reflect the changes in validation logic.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added ! to the title and described breaking changes in the corresponding section if my code contains any.

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added stricter validation enforcing token notes only when the action is performed by the proposer in group contexts.
  - Introduced a new error variant for invalid token note usage by non-proposers.
  - Added methods to access public notes from token and group action events.

- **Bug Fixes**
  - Enhanced enforcement of proposer-only token note constraints in group token transitions.

- **Tests**
  - Added tests verifying token note rules during group minting with multiple signers.

- **Refactor**
  - Improved validation and transformation logic to support conditional overrides of public notes.
  - Simplified method signatures and parameters for fetching group action information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->