### PR TITLE
fix(platform): ensure group action parameters cannot be modified

### DIFF
--- a/packages/rs-dpp/src/errors/consensus/codes.rs
+++ b/packages/rs-dpp/src/errors/consensus/codes.rs
@@ -331,6 +331,7 @@ impl ErrorWithCode for StateError {
             Self::GroupActionDoesNotExistError(_) => 40801,
             Self::GroupActionAlreadyCompletedError(_) => 40802,
             Self::GroupActionAlreadySignedByIdentityError(_) => 40803,
+            Self::ModificationOfGroupActionMainParametersNotPermittedError(_) => 40804,
         }
     }
 }

--- a/packages/rs-dpp/src/errors/consensus/state/group/mod.rs
+++ b/packages/rs-dpp/src/errors/consensus/state/group/mod.rs
@@ -4,9 +4,11 @@ mod group_action_does_not_exist_error;
 mod identity_not_member_of_group_error;
 
 mod identity_for_group_not_found_error;
+mod modification_of_group_action_main_parameters_not_permitted_error;
 
 pub use group_action_already_completed_error::*;
 pub use group_action_already_signed_by_identity_error::*;
 pub use group_action_does_not_exist_error::*;
 pub use identity_for_group_not_found_error::*;
 pub use identity_not_member_of_group_error::*;
+pub use modification_of_group_action_main_parameters_not_permitted_error::*;

--- a/packages/rs-dpp/src/errors/consensus/state/group/modification_of_group_action_main_parameters_not_permitted_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/state/group/modification_of_group_action_main_parameters_not_permitted_error.rs
@@ -1,0 +1,56 @@
+use crate::consensus::state::state_error::StateError;
+use crate::consensus::ConsensusError;
+use crate::ProtocolError;
+use bincode::{Decode, Encode};
+use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
+use thiserror::Error;
+
+#[derive(
+    Error, Debug, Clone, PartialEq, Eq, Encode, Decode, PlatformSerialize, PlatformDeserialize,
+)]
+#[error(
+    "Modification of group action main parameters is not permitted.\n\
+     Changed fields: {changed_internal_fields:?}\n\
+     Original event type: {original}\n\
+     Modified event type: {modified}"
+)]
+#[platform_serialize(unversioned)]
+pub struct ModificationOfGroupActionMainParametersNotPermittedError {
+    original: String,
+    modified: String,
+    changed_internal_fields: Vec<String>,
+}
+
+impl ModificationOfGroupActionMainParametersNotPermittedError {
+    /// Creates a new `ModificationOfGroupActionMainParametersNotPermittedError`.
+    pub fn new(original: String, modified: String, changed_internal_fields: Vec<String>) -> Self {
+        Self {
+            original,
+            modified,
+            changed_internal_fields,
+        }
+    }
+
+    /// Returns a reference to the original group action.
+    pub fn original(&self) -> &String {
+        &self.original
+    }
+
+    /// Returns a reference to the modified group action.
+    pub fn modified(&self) -> &String {
+        &self.modified
+    }
+
+    /// Returns a reference to the changed fields.
+    pub fn changed_internal_fields(&self) -> &Vec<String> {
+        &self.changed_internal_fields
+    }
+}
+
+impl From<ModificationOfGroupActionMainParametersNotPermittedError> for ConsensusError {
+    fn from(err: ModificationOfGroupActionMainParametersNotPermittedError) -> Self {
+        ConsensusError::StateError(
+            StateError::ModificationOfGroupActionMainParametersNotPermittedError(err),
+        )
+    }
+}

--- a/packages/rs-dpp/src/errors/consensus/state/state_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/state/state_error.rs
@@ -34,7 +34,7 @@ use crate::consensus::state::document::document_contest_not_joinable_error::Docu
 use crate::consensus::state::document::document_contest_not_paid_for_error::DocumentContestNotPaidForError;
 use crate::consensus::state::document::document_incorrect_purchase_price_error::DocumentIncorrectPurchasePriceError;
 use crate::consensus::state::document::document_not_for_sale_error::DocumentNotForSaleError;
-use crate::consensus::state::group::{GroupActionAlreadyCompletedError, GroupActionAlreadySignedByIdentityError, GroupActionDoesNotExistError, IdentityMemberOfGroupNotFoundError, IdentityNotMemberOfGroupError};
+use crate::consensus::state::group::{GroupActionAlreadyCompletedError, GroupActionAlreadySignedByIdentityError, GroupActionDoesNotExistError, IdentityMemberOfGroupNotFoundError, IdentityNotMemberOfGroupError, ModificationOfGroupActionMainParametersNotPermittedError};
 use crate::consensus::state::identity::identity_for_token_configuration_not_found_error::IdentityInTokenConfigurationNotFoundError;
 use crate::consensus::state::identity::identity_public_key_already_exists_for_unique_contract_bounds_error::IdentityPublicKeyAlreadyExistsForUniqueContractBoundsError;
 use crate::consensus::state::identity::invalid_identity_contract_nonce_error::InvalidIdentityNonceError;
@@ -305,6 +305,11 @@ pub enum StateError {
 
     #[error(transparent)]
     IdentityMemberOfGroupNotFoundError(IdentityMemberOfGroupNotFoundError),
+
+    #[error(transparent)]
+    ModificationOfGroupActionMainParametersNotPermittedError(
+        ModificationOfGroupActionMainParametersNotPermittedError,
+    ),
 }
 
 impl From<StateError> for ConsensusError {

--- a/packages/rs-dpp/src/group/action_event.rs
+++ b/packages/rs-dpp/src/group/action_event.rs
@@ -11,11 +11,30 @@ pub enum GroupActionEvent {
     TokenEvent(TokenEvent),
 }
 
+use std::fmt;
+
+impl fmt::Display for GroupActionEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GroupActionEvent::TokenEvent(event) => write!(f, "Token event: {}", event),
+        }
+    }
+}
+
 impl GroupActionEvent {
     /// Returns a reference to the public note if the variant includes one.
     pub fn public_note(&self) -> Option<&str> {
         match self {
             GroupActionEvent::TokenEvent(token_event) => token_event.public_note(),
+        }
+    }
+
+    /// Returns a name of the event
+    pub fn event_name(&self) -> String {
+        match self {
+            GroupActionEvent::TokenEvent(token_event) => {
+                format!("Token: {}", token_event.associated_document_type_name())
+            }
         }
     }
 }

--- a/packages/rs-dpp/src/tokens/token_event.rs
+++ b/packages/rs-dpp/src/tokens/token_event.rs
@@ -15,6 +15,7 @@ use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
 use platform_value::Identifier;
 use platform_version::version::PlatformVersion;
 use std::collections::BTreeMap;
+use std::fmt;
 
 pub type TokenEventPublicNote = Option<String>;
 pub type TokenEventSharedEncryptedNote = Option<SharedEncryptedNote>;
@@ -135,6 +136,66 @@ pub enum TokenEvent {
     /// - `TokenAmount`: The amount of tokens purchased.
     /// - `Credits`: The number of credits paid.
     DirectPurchase(TokenAmount, Credits),
+}
+
+impl fmt::Display for TokenEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TokenEvent::Mint(amount, recipient, note) => {
+                write!(f, "Mint {} to {}{}", amount, recipient, format_note(note))
+            }
+            TokenEvent::Burn(amount, note) => {
+                write!(f, "Burn {}{}", amount, format_note(note))
+            }
+            TokenEvent::Freeze(identity, note) => {
+                write!(f, "Freeze {}{}", identity, format_note(note))
+            }
+            TokenEvent::Unfreeze(identity, note) => {
+                write!(f, "Unfreeze {}{}", identity, format_note(note))
+            }
+            TokenEvent::DestroyFrozenFunds(identity, amount, note) => {
+                write!(
+                    f,
+                    "Destroy {} frozen from {}{}",
+                    amount,
+                    identity,
+                    format_note(note)
+                )
+            }
+            TokenEvent::Transfer(to, note, _, _, amount) => {
+                write!(f, "Transfer {} to {}{}", amount, to, format_note(note))
+            }
+            TokenEvent::Claim(recipient, amount, note) => {
+                write!(
+                    f,
+                    "Claim {} by {:?}{}",
+                    amount,
+                    recipient,
+                    format_note(note)
+                )
+            }
+            TokenEvent::EmergencyAction(action, note) => {
+                write!(f, "Emergency action {:?}{}", action, format_note(note))
+            }
+            TokenEvent::ConfigUpdate(change, note) => {
+                write!(f, "Configuration update {:?}{}", change, format_note(note))
+            }
+            TokenEvent::ChangePriceForDirectPurchase(schedule, note) => match schedule {
+                Some(s) => write!(f, "Change price schedule to {:?}{}", s, format_note(note)),
+                None => write!(f, "Disable direct purchase{}", format_note(note)),
+            },
+            TokenEvent::DirectPurchase(amount, credits) => {
+                write!(f, "Direct purchase of {} for {} credits", amount, credits)
+            }
+        }
+    }
+}
+
+fn format_note(note: &Option<String>) -> String {
+    match note {
+        Some(n) => format!(" (note: {})", n),
+        None => String::new(),
+    }
 }
 
 impl TokenEvent {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_burn_transition_action/state_v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_burn_transition_action/state_v0/mod.rs
@@ -1,15 +1,20 @@
 use dpp::block::block_info::BlockInfo;
 use dpp::consensus::ConsensusError;
+use dpp::consensus::state::group::ModificationOfGroupActionMainParametersNotPermittedError;
 use dpp::consensus::state::state_error::StateError;
 use dpp::consensus::state::token::IdentityDoesNotHaveEnoughTokenBalanceError;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::accessors::v1::DataContractV1Getters;
 use dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dpp::group::action_event::GroupActionEvent;
+use dpp::group::group_action::GroupActionAccessors;
 use dpp::prelude::Identifier;
+use dpp::tokens::token_event::TokenEvent;
 use dpp::validation::SimpleConsensusValidationResult;
 use drive::state_transition_action::batch::batched_transition::token_transition::token_burn_transition_action::{TokenBurnTransitionAction, TokenBurnTransitionActionAccessorsV0};
 use dpp::version::PlatformVersion;
 use drive::query::TransactionArg;
+use drive::state_transition_action::batch::batched_transition::token_transition::token_base_transition_action::TokenBaseTransitionActionAccessorsV0;
 use crate::error::Error;
 use crate::execution::types::execution_operation::ValidationOperation;
 use crate::execution::types::state_transition_execution_context::{StateTransitionExecutionContext, StateTransitionExecutionContextMethodsV0};
@@ -67,6 +72,38 @@ impl TokenBurnTransitionActionStateValidationV0 for TokenBurnTransitionAction {
         )?;
         if !validation_result.is_valid() {
             return Ok(validation_result);
+        }
+
+        if let Some(original_group_action) = self.base().original_group_action() {
+            if let GroupActionEvent::TokenEvent(TokenEvent::Burn(old_group_action_amount, _)) =
+                original_group_action.event()
+            {
+                if old_group_action_amount != &self.burn_amount() {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::StateError(
+                            StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                                ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                    original_group_action.event().event_name(),
+                                    "Token: burn".to_string(),
+                                    vec!["burn_amount".to_string()],
+                                ),
+                            ),
+                        ),
+                    ));
+                }
+            } else {
+                return Ok(SimpleConsensusValidationResult::new_with_error(
+                    ConsensusError::StateError(
+                        StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                            ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                original_group_action.event().event_name(),
+                                "Token: burn".to_string(),
+                                vec![],
+                            ),
+                        ),
+                    ),
+                ));
+            }
         }
 
         // We need to verify that we have enough of the token

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_destroy_frozen_funds_transition_action/state_v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_destroy_frozen_funds_transition_action/state_v0/mod.rs
@@ -1,16 +1,21 @@
 use dpp::block::block_info::BlockInfo;
 use dpp::consensus::ConsensusError;
+use dpp::consensus::state::group::ModificationOfGroupActionMainParametersNotPermittedError;
 use dpp::consensus::state::state_error::StateError;
 use dpp::consensus::state::token::IdentityTokenAccountNotFrozenError;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::accessors::v1::DataContractV1Getters;
 use dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dpp::group::action_event::GroupActionEvent;
+use dpp::group::group_action::GroupActionAccessors;
 use dpp::prelude::Identifier;
 use dpp::tokens::info::v0::IdentityTokenInfoV0Accessors;
+use dpp::tokens::token_event::TokenEvent;
 use dpp::validation::SimpleConsensusValidationResult;
 use drive::state_transition_action::batch::batched_transition::token_transition::token_destroy_frozen_funds_transition_action::{TokenDestroyFrozenFundsTransitionAction, TokenDestroyFrozenFundsTransitionActionAccessorsV0};
 use dpp::version::PlatformVersion;
 use drive::query::TransactionArg;
+use drive::state_transition_action::batch::batched_transition::token_transition::token_base_transition_action::TokenBaseTransitionActionAccessorsV0;
 use crate::error::Error;
 use crate::execution::types::execution_operation::ValidationOperation;
 use crate::execution::types::state_transition_execution_context::{StateTransitionExecutionContext, StateTransitionExecutionContextMethodsV0};
@@ -93,6 +98,46 @@ impl TokenDestroyFrozenFundsTransitionActionStateValidationV0
         )?;
         if !validation_result.is_valid() {
             return Ok(validation_result);
+        }
+
+        if let Some(original_group_action) = self.base().original_group_action() {
+            // we shouldn't compare the amount, because that is figured out at the end
+            if let GroupActionEvent::TokenEvent(TokenEvent::DestroyFrozenFunds(
+                destroy_frozen_funds_identifier,
+                _,
+                _,
+            )) = original_group_action.event()
+            {
+                let mut changed_internal_fields = vec![];
+                if destroy_frozen_funds_identifier != &self.frozen_identity_id() {
+                    changed_internal_fields.push("frozen_identity_id".to_string());
+                }
+                if !changed_internal_fields.is_empty() {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::StateError(
+                            StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                                ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                    original_group_action.event().event_name(),
+                                    "Token: destroyFrozenFunds".to_string(),
+                                    changed_internal_fields,
+                                ),
+                            ),
+                        ),
+                    ));
+                }
+            } else {
+                return Ok(SimpleConsensusValidationResult::new_with_error(
+                    ConsensusError::StateError(
+                        StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                            ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                original_group_action.event().event_name(),
+                                "Token: destroyFrozenFunds".to_string(),
+                                vec![],
+                            ),
+                        ),
+                    ),
+                ));
+            }
         }
 
         Ok(SimpleConsensusValidationResult::new())

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_emergency_action_transition_action/state_v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_emergency_action_transition_action/state_v0/mod.rs
@@ -2,16 +2,21 @@ use dpp::block::block_info::BlockInfo;
 use dpp::consensus::state::state_error::StateError;
 use dpp::consensus::state::token::{TokenAlreadyPausedError, TokenNotPausedError};
 use dpp::consensus::ConsensusError;
+use dpp::consensus::state::group::ModificationOfGroupActionMainParametersNotPermittedError;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::accessors::v1::DataContractV1Getters;
 use dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dpp::group::action_event::GroupActionEvent;
+use dpp::group::group_action::GroupActionAccessors;
 use dpp::prelude::Identifier;
 use dpp::tokens::emergency_action::TokenEmergencyAction;
 use dpp::tokens::status::v0::TokenStatusV0Accessors;
+use dpp::tokens::token_event::TokenEvent;
 use dpp::validation::SimpleConsensusValidationResult;
 use drive::state_transition_action::batch::batched_transition::token_transition::token_emergency_action_transition_action::{TokenEmergencyActionTransitionAction, TokenEmergencyActionTransitionActionAccessorsV0};
 use dpp::version::PlatformVersion;
 use drive::query::TransactionArg;
+use drive::state_transition_action::batch::batched_transition::token_transition::token_base_transition_action::TokenBaseTransitionActionAccessorsV0;
 use crate::error::Error;
 use crate::execution::types::execution_operation::ValidationOperation;
 use crate::execution::types::state_transition_execution_context::{StateTransitionExecutionContext, StateTransitionExecutionContextMethodsV0};
@@ -70,6 +75,43 @@ impl TokenEmergencyActionTransitionActionStateValidationV0
         )?;
         if !validation_result.is_valid() {
             return Ok(validation_result);
+        }
+
+        if let Some(original_group_action) = self.base().original_group_action() {
+            // we shouldn't compare the amount, because that is figured out at the end
+            if let GroupActionEvent::TokenEvent(TokenEvent::EmergencyAction(action, _)) =
+                original_group_action.event()
+            {
+                let mut changed_internal_fields = vec![];
+                if action != &self.emergency_action() {
+                    changed_internal_fields.push("emergency_action".to_string());
+                }
+                if !changed_internal_fields.is_empty() {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::StateError(
+                            StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                                ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                    original_group_action.event().event_name(),
+                                    "Token: emergencyAction".to_string(),
+                                    changed_internal_fields,
+                                ),
+                            ),
+                        ),
+                    ));
+                }
+            } else {
+                return Ok(SimpleConsensusValidationResult::new_with_error(
+                    ConsensusError::StateError(
+                        StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                            ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                original_group_action.event().event_name(),
+                                "Token: emergencyAction".to_string(),
+                                vec![],
+                            ),
+                        ),
+                    ),
+                ));
+            }
         }
 
         // Check if we are paused

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_mint_transition_action/state_v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_mint_transition_action/state_v0/mod.rs
@@ -1,13 +1,17 @@
 use dpp::block::block_info::BlockInfo;
 use dpp::consensus::ConsensusError;
+use dpp::consensus::state::group::ModificationOfGroupActionMainParametersNotPermittedError;
 use dpp::consensus::state::identity::RecipientIdentityDoesNotExistError;
 use dpp::consensus::state::state_error::StateError;
 use dpp::consensus::state::token::{IdentityTokenAccountFrozenError, TokenMintPastMaxSupplyError};
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::accessors::v1::DataContractV1Getters;
 use dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dpp::group::action_event::GroupActionEvent;
+use dpp::group::group_action::GroupActionAccessors;
 use dpp::prelude::Identifier;
 use dpp::tokens::info::v0::IdentityTokenInfoV0Accessors;
+use dpp::tokens::token_event::TokenEvent;
 use dpp::validation::SimpleConsensusValidationResult;
 use drive::state_transition_action::batch::batched_transition::token_transition::token_mint_transition_action::{TokenMintTransitionAction, TokenMintTransitionActionAccessorsV0};
 use dpp::version::PlatformVersion;
@@ -70,6 +74,48 @@ impl TokenMintTransitionActionStateValidationV0 for TokenMintTransitionAction {
         )?;
         if !validation_result.is_valid() {
             return Ok(validation_result);
+        }
+
+        if let Some(original_group_action) = self.base().original_group_action() {
+            if let GroupActionEvent::TokenEvent(TokenEvent::Mint(
+                old_group_action_amount,
+                old_group_action_recipient,
+                _,
+            )) = original_group_action.event()
+            {
+                let mut changed_internal_fields = vec![];
+                if old_group_action_amount != &self.mint_amount() {
+                    changed_internal_fields.push("mint_amount".to_string());
+                }
+                if old_group_action_recipient != &self.identity_balance_holder_id() {
+                    changed_internal_fields.push("recipient".to_string());
+                }
+                if !changed_internal_fields.is_empty() {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::StateError(
+                            StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                                ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                    original_group_action.event().event_name(),
+                                    "Token: mint".to_string(),
+                                    changed_internal_fields,
+                                ),
+                            ),
+                        ),
+                    ));
+                }
+            } else {
+                return Ok(SimpleConsensusValidationResult::new_with_error(
+                    ConsensusError::StateError(
+                        StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                            ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                original_group_action.event().event_name(),
+                                "Token: mint".to_string(),
+                                vec![],
+                            ),
+                        ),
+                    ),
+                ));
+            }
         }
 
         if let Some(max_supply) = token_configuration.max_supply() {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_set_price_for_direct_purchase_transition_action/state_v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_set_price_for_direct_purchase_transition_action/state_v0/mod.rs
@@ -1,13 +1,20 @@
 use dpp::block::block_info::BlockInfo;
+use dpp::consensus::ConsensusError;
+use dpp::consensus::state::group::ModificationOfGroupActionMainParametersNotPermittedError;
+use dpp::consensus::state::state_error::StateError;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::accessors::v1::DataContractV1Getters;
 use dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
 use dpp::data_contract::associated_token::token_distribution_rules::accessors::v0::TokenDistributionRulesV0Getters;
+use dpp::group::action_event::GroupActionEvent;
+use dpp::group::group_action::GroupActionAccessors;
 use dpp::prelude::Identifier;
+use dpp::tokens::token_event::TokenEvent;
 use dpp::validation::SimpleConsensusValidationResult;
 use drive::state_transition_action::batch::batched_transition::token_transition::token_set_price_for_direct_purchase_transition_action::{TokenSetPriceForDirectPurchaseTransitionAction, TokenSetPriceForDirectPurchaseTransitionActionAccessorsV0};
 use dpp::version::PlatformVersion;
 use drive::query::TransactionArg;
+use drive::state_transition_action::batch::batched_transition::token_transition::token_base_transition_action::TokenBaseTransitionActionAccessorsV0;
 use crate::error::Error;
 use crate::execution::types::state_transition_execution_context::StateTransitionExecutionContext;
 use crate::execution::validation::state_transition::batch::action_validation::token::token_base_transition_action::TokenBaseTransitionActionValidation;
@@ -67,6 +74,44 @@ impl TokenSetPriceForDirectPurchaseTransitionActionStateValidationV0
         )?;
         if !validation_result.is_valid() {
             return Ok(validation_result);
+        }
+
+        if let Some(original_group_action) = self.base().original_group_action() {
+            if let GroupActionEvent::TokenEvent(TokenEvent::ChangePriceForDirectPurchase(
+                maybe_token_pricing_schedule,
+                _,
+            )) = original_group_action.event()
+            {
+                let mut changed_internal_fields = vec![];
+                if maybe_token_pricing_schedule.as_ref() != self.price() {
+                    changed_internal_fields.push("price".to_string());
+                }
+                if !changed_internal_fields.is_empty() {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::StateError(
+                            StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                                ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                    original_group_action.event().event_name(),
+                                    "Token: directPricing".to_string(),
+                                    changed_internal_fields,
+                                ),
+                            ),
+                        ),
+                    ));
+                }
+            } else {
+                return Ok(SimpleConsensusValidationResult::new_with_error(
+                    ConsensusError::StateError(
+                        StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                            ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                original_group_action.event().event_name(),
+                                "Token: directPricing".to_string(),
+                                vec![],
+                            ),
+                        ),
+                    ),
+                ));
+            }
         }
 
         Ok(SimpleConsensusValidationResult::new())

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_unfreeze_transition_action/state_v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_unfreeze_transition_action/state_v0/mod.rs
@@ -1,16 +1,21 @@
 use dpp::block::block_info::BlockInfo;
 use dpp::consensus::ConsensusError;
+use dpp::consensus::state::group::ModificationOfGroupActionMainParametersNotPermittedError;
 use dpp::consensus::state::state_error::StateError;
 use dpp::consensus::state::token::IdentityTokenAccountNotFrozenError;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::accessors::v1::DataContractV1Getters;
 use dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dpp::group::action_event::GroupActionEvent;
+use dpp::group::group_action::GroupActionAccessors;
 use dpp::prelude::Identifier;
 use dpp::tokens::info::v0::IdentityTokenInfoV0Accessors;
+use dpp::tokens::token_event::TokenEvent;
 use dpp::validation::SimpleConsensusValidationResult;
 use drive::state_transition_action::batch::batched_transition::token_transition::token_unfreeze_transition_action::{TokenUnfreezeTransitionAction, TokenUnfreezeTransitionActionAccessorsV0};
 use dpp::version::PlatformVersion;
 use drive::query::TransactionArg;
+use drive::state_transition_action::batch::batched_transition::token_transition::token_base_transition_action::TokenBaseTransitionActionAccessorsV0;
 use crate::error::Error;
 use crate::execution::types::execution_operation::ValidationOperation;
 use crate::execution::types::state_transition_execution_context::{StateTransitionExecutionContext, StateTransitionExecutionContextMethodsV0};
@@ -67,6 +72,42 @@ impl TokenUnfreezeTransitionActionStateValidationV0 for TokenUnfreezeTransitionA
         )?;
         if !validation_result.is_valid() {
             return Ok(validation_result);
+        }
+
+        if let Some(original_group_action) = self.base().original_group_action() {
+            if let GroupActionEvent::TokenEvent(TokenEvent::Unfreeze(identifier, _)) =
+                original_group_action.event()
+            {
+                let mut changed_internal_fields = vec![];
+                if identifier != &self.frozen_identity_id() {
+                    changed_internal_fields.push("frozen_identity_id".to_string());
+                }
+                if !changed_internal_fields.is_empty() {
+                    return Ok(SimpleConsensusValidationResult::new_with_error(
+                        ConsensusError::StateError(
+                            StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                                ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                    original_group_action.event().event_name(),
+                                    "Token: unfreeze".to_string(),
+                                    changed_internal_fields,
+                                ),
+                            ),
+                        ),
+                    ));
+                }
+            } else {
+                return Ok(SimpleConsensusValidationResult::new_with_error(
+                    ConsensusError::StateError(
+                        StateError::ModificationOfGroupActionMainParametersNotPermittedError(
+                            ModificationOfGroupActionMainParametersNotPermittedError::new(
+                                original_group_action.event().event_name(),
+                                "Token: unfreeze".to_string(),
+                                vec![],
+                            ),
+                        ),
+                    ),
+                ));
+            }
         }
 
         // Then validate that the identity is frozen

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mint/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mint/mod.rs
@@ -2031,6 +2031,237 @@ mod token_mint_tests {
         }
 
         #[test]
+        fn test_token_mint_by_owner_requires_group_other_member_changes_minting_amount() {
+            // We are using a group, and two members need to sign for the event to happen
+            let platform_version = PlatformVersion::latest();
+            let mut platform = TestPlatformBuilder::new()
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(49853);
+
+            let platform_state = platform.state.load();
+
+            let (identity, signer, key) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_2, signer2, key2) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (contract, token_id) = create_token_contract_with_owner_identity(
+                &mut platform,
+                identity.id(),
+                Some(|token_configuration: &mut TokenConfiguration| {
+                    token_configuration
+                        .keeps_history_mut()
+                        .set_keeps_minting_history(true);
+                    token_configuration.set_manual_minting_rules(ChangeControlRules::V0(
+                        ChangeControlRulesV0 {
+                            authorized_to_make_change: AuthorizedActionTakers::Group(0),
+                            admin_action_takers: AuthorizedActionTakers::NoOne,
+                            changing_authorized_action_takers_to_no_one_allowed: false,
+                            changing_admin_action_takers_to_no_one_allowed: false,
+                            self_changing_admin_action_takers_allowed: false,
+                        },
+                    ));
+                }),
+                None,
+                Some(
+                    [(
+                        0,
+                        Group::V0(GroupV0 {
+                            members: [(identity.id(), 1), (identity_2.id(), 1)].into(),
+                            required_power: 2,
+                        }),
+                    )]
+                    .into(),
+                ),
+                platform_version,
+            );
+
+            let token_mint_transition = BatchTransition::new_token_mint_transition(
+                token_id,
+                identity.id(),
+                contract.id(),
+                0,
+                1337,
+                Some(identity.id()),
+                Some("initial note".to_string()),
+                Some(GroupStateTransitionInfoStatus::GroupStateTransitionInfoProposer(0)),
+                &key,
+                2,
+                0,
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let token_mint_serialized_transition = token_mint_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[token_mint_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution(_, _)]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            // Let's verify the proof of the state transition
+
+            let proof = platform
+                .drive
+                .prove_state_transition(&token_mint_transition, None, platform_version)
+                .expect("expect to prove state transition");
+
+            let (_root_hash, result) = Drive::verify_state_transition_was_executed_with_proof(
+                &token_mint_transition,
+                &BlockInfo::default(),
+                proof.data.as_ref().expect("expected data"),
+                &|_| Ok(Some(contract.clone().into())),
+                platform_version,
+            )
+            .unwrap_or_else(|_| {
+                panic!(
+                    "expect to verify state transition proof {}",
+                    hex::encode(proof.data.expect("expected data"))
+                )
+            });
+            assert_matches!(
+                result,
+                StateTransitionProofResult::VerifiedTokenGroupActionWithDocument(power, doc) => {
+                    assert_eq!(power, 1);
+                    assert_eq!(doc, None);
+                }
+            );
+
+            let token_balance = platform
+                .drive
+                .fetch_identity_token_balance(
+                    token_id.to_buffer(),
+                    identity.id().to_buffer(),
+                    None,
+                    platform_version,
+                )
+                .expect("expected to fetch token balance");
+            assert_eq!(token_balance, Some(100000));
+
+            // Now we need to get the second identity to also sign it
+            let action_id = TokenMintTransition::calculate_action_id_with_fields(
+                token_id.as_bytes(),
+                identity.id().as_bytes(),
+                2,
+                1337,
+            );
+
+            let confirm_token_mint_transition = BatchTransition::new_token_mint_transition(
+                token_id,
+                identity_2.id(),
+                contract.id(),
+                0,
+                99999,
+                Some(identity.id()),
+                None,
+                Some(
+                    GroupStateTransitionInfoStatus::GroupStateTransitionInfoOtherSigner(
+                        GroupStateTransitionInfo {
+                            group_contract_position: 0,
+                            action_id,
+                            action_is_proposer: false,
+                        },
+                    ),
+                ),
+                &key2,
+                2,
+                0,
+                &signer2,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let confirm_token_mint_serialized_transition = confirm_token_mint_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[confirm_token_mint_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::PaidConsensusError(
+                    ConsensusError::StateError(
+                        StateError::ModificationOfGroupActionMainParametersNotPermittedError(_)
+                    ),
+                    _
+                )]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let token_balance = platform
+                .drive
+                .fetch_identity_token_balance(
+                    token_id.to_buffer(),
+                    identity.id().to_buffer(),
+                    None,
+                    platform_version,
+                )
+                .expect("expected to fetch token balance");
+            assert_eq!(token_balance, Some(100000));
+
+            let token_balance = platform
+                .drive
+                .fetch_identity_token_balance(
+                    token_id.to_buffer(),
+                    identity_2.id().to_buffer(),
+                    None,
+                    platform_version,
+                )
+                .expect("expected to fetch token balance");
+            assert_eq!(token_balance, None);
+        }
+
+        #[test]
         fn test_token_mint_by_owner_requires_group_resubmitting_causes_error() {
             // We are using a group, and two members need to sign for the event to happen
             let platform_version = PlatformVersion::latest();

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_base_transition_action/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_base_transition_action/mod.rs
@@ -1,6 +1,7 @@
 use derive_more::From;
 use dpp::data_contract::associated_token::token_configuration::TokenConfiguration;
 use dpp::data_contract::TokenContractPosition;
+use dpp::group::group_action::GroupAction;
 use dpp::group::GroupStateTransitionResolvedInfo;
 use dpp::platform_value::Identifier;
 use dpp::prelude::IdentityNonce;
@@ -68,6 +69,12 @@ impl TokenBaseTransitionActionAccessorsV0 for TokenBaseTransitionAction {
     fn store_in_group(&self) -> Option<&GroupStateTransitionResolvedInfo> {
         match self {
             TokenBaseTransitionAction::V0(v0) => v0.store_in_group(),
+        }
+    }
+
+    fn original_group_action(&self) -> Option<&GroupAction> {
+        match self {
+            TokenBaseTransitionAction::V0(v0) => v0.original_group_action(),
         }
     }
 

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_base_transition_action/v0/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_base_transition_action/v0/mod.rs
@@ -116,8 +116,7 @@ impl TokenBaseTransitionActionAccessorsV0 for TokenBaseTransitionActionV0 {
     fn original_group_action(&self) -> Option<&GroupAction> {
         self.store_in_group
             .as_ref()
-            .map(|(_, group_action)| group_action.as_ref())
-            .flatten()
+            .and_then(|(_, group_action)| group_action.as_ref())
     }
 
     fn perform_action(&self) -> bool {

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_base_transition_action/v0/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_base_transition_action/v0/mod.rs
@@ -4,6 +4,7 @@ use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::accessors::v1::DataContractV1Getters;
 use dpp::data_contract::associated_token::token_configuration::TokenConfiguration;
 use dpp::data_contract::TokenContractPosition;
+use dpp::group::group_action::GroupAction;
 use dpp::group::GroupStateTransitionResolvedInfo;
 use dpp::identifier::Identifier;
 use dpp::prelude::IdentityNonce;
@@ -12,6 +13,9 @@ use std::sync::Arc;
 
 /// transformer
 pub mod transformer;
+
+/// A type for the original group action if one exists
+pub type OriginalGroupAction = Option<GroupAction>;
 
 /// Token base transition action v0
 #[derive(Debug, Clone)]
@@ -26,7 +30,7 @@ pub struct TokenBaseTransitionActionV0 {
     pub data_contract: Arc<DataContractFetchInfo>,
     /// Using group multi party rules for authentication
     /// If this is set we should store in group
-    pub store_in_group: Option<GroupStateTransitionResolvedInfo>,
+    pub store_in_group: Option<(GroupStateTransitionResolvedInfo, OriginalGroupAction)>,
     /// Should the action be performed.
     /// This is true if we don't store in group.
     /// And also true if we store in group and with this have enough signatures to perform the action
@@ -58,6 +62,9 @@ pub trait TokenBaseTransitionActionAccessorsV0 {
 
     /// Gets the store_in_group field (optional)
     fn store_in_group(&self) -> Option<&GroupStateTransitionResolvedInfo>;
+
+    /// Gets the original group action if we are in a group action, and we are not the proposer
+    fn original_group_action(&self) -> Option<&GroupAction>;
 
     /// Gets the perform_action field
     fn perform_action(&self) -> bool;
@@ -103,7 +110,14 @@ impl TokenBaseTransitionActionAccessorsV0 for TokenBaseTransitionActionV0 {
     }
 
     fn store_in_group(&self) -> Option<&GroupStateTransitionResolvedInfo> {
-        self.store_in_group.as_ref()
+        self.store_in_group.as_ref().map(|(s, _)| s)
+    }
+
+    fn original_group_action(&self) -> Option<&GroupAction> {
+        self.store_in_group
+            .as_ref()
+            .map(|(_, group_action)| group_action.as_ref())
+            .flatten()
     }
 
     fn perform_action(&self) -> bool {

--- a/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
@@ -76,7 +76,7 @@ use dpp::consensus::state::document::document_contest_not_joinable_error::Docume
 use dpp::consensus::state::document::document_contest_not_paid_for_error::DocumentContestNotPaidForError;
 use dpp::consensus::state::document::document_incorrect_purchase_price_error::DocumentIncorrectPurchasePriceError;
 use dpp::consensus::state::document::document_not_for_sale_error::DocumentNotForSaleError;
-use dpp::consensus::state::group::{GroupActionAlreadyCompletedError, GroupActionAlreadySignedByIdentityError, GroupActionDoesNotExistError, IdentityMemberOfGroupNotFoundError, IdentityNotMemberOfGroupError};
+use dpp::consensus::state::group::{GroupActionAlreadyCompletedError, GroupActionAlreadySignedByIdentityError, GroupActionDoesNotExistError, IdentityMemberOfGroupNotFoundError, IdentityNotMemberOfGroupError, ModificationOfGroupActionMainParametersNotPermittedError};
 use dpp::consensus::state::identity::identity_for_token_configuration_not_found_error::IdentityInTokenConfigurationNotFoundError;
 use dpp::consensus::state::identity::identity_public_key_already_exists_for_unique_contract_bounds_error::IdentityPublicKeyAlreadyExistsForUniqueContractBoundsError;
 use dpp::consensus::state::identity::master_public_key_update_error::MasterPublicKeyUpdateError;
@@ -414,6 +414,10 @@ pub fn from_state_error(state_error: &StateError) -> JsValue {
         }
         StateError::IdentityMemberOfGroupNotFoundError(e) => {
             generic_consensus_error!(IdentityMemberOfGroupNotFoundError, e).into()
+        }
+        StateError::ModificationOfGroupActionMainParametersNotPermittedError(e) => {
+            generic_consensus_error!(ModificationOfGroupActionMainParametersNotPermittedError, e)
+                .into()
         }
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Prevent modification of main parameters in group actions to avoid potential disastrous effects.

## What was done?
Added a new error type `ModificationOfGroupActionMainParametersNotPermittedError` to handle attempts to modify main parameters of group actions. Updated the relevant transition actions to check for parameter modifications and return this error when detected.

## How Has This Been Tested?
Added unit tests to verify that attempts to modify group action parameters trigger the appropriate error. Existing tests were also updated to ensure they account for the new error handling.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new error type preventing unauthorized modifications of main parameters during group token actions.
  - Enhanced validation across token group actions (mint, burn, freeze, unfreeze, destroy frozen funds, config updates, emergency actions, price changes) to enforce immutability of key parameters once initiated.
  - Added standardized string representations for token and group action events to improve readability.

- **Bug Fixes**
  - Improved error handling to precisely detect and report unauthorized changes to main parameters in group actions.

- **Tests**
  - Added extensive tests verifying that group actions cannot be altered mid-process and that unauthorized parameter modifications are properly rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->