### PR TITLE
fix(platform): consensus error for invalid group position, config update won't allow group action if group action is not required, and tests

### DIFF
--- a/packages/rs-dpp/src/data_contract/accessors/mod.rs
+++ b/packages/rs-dpp/src/data_contract/accessors/mod.rs
@@ -173,16 +173,6 @@ impl DataContractV0Setters for DataContract {
 /// Implementing DataContractV1Getters for DataContract
 impl DataContractV1Getters for DataContract {
     /// Returns a reference to the groups map.
-    fn group(&self, position: GroupContractPosition) -> Result<&Group, ProtocolError> {
-        match self {
-            DataContract::V0(_) => Err(ProtocolError::GroupNotFound(
-                "There can not be a group in v0 data contracts".to_string(),
-            )),
-            DataContract::V1(v1) => v1.group(position),
-        }
-    }
-
-    /// Returns a reference to the groups map.
     fn groups(&self) -> &BTreeMap<GroupContractPosition, Group> {
         match self {
             DataContract::V0(_) => &EMPTY_GROUPS,

--- a/packages/rs-dpp/src/data_contract/accessors/v1/mod.rs
+++ b/packages/rs-dpp/src/data_contract/accessors/v1/mod.rs
@@ -10,9 +10,6 @@ use platform_value::Identifier;
 use std::collections::BTreeMap;
 
 pub trait DataContractV1Getters: DataContractV0Getters {
-    /// Gets a group at a certain position.
-    fn group(&self, position: GroupContractPosition) -> Result<&Group, ProtocolError>;
-
     /// Returns a reference to the groups map.
     fn groups(&self) -> &BTreeMap<GroupContractPosition, Group>;
 

--- a/packages/rs-dpp/src/data_contract/change_control_rules/authorized_action_takers.rs
+++ b/packages/rs-dpp/src/data_contract/change_control_rules/authorized_action_takers.rs
@@ -46,18 +46,34 @@ impl AuthorizedActionTakers {
             AuthorizedActionTakers::NoOne => false,
 
             // Only the contract owner is allowed
-            AuthorizedActionTakers::ContractOwner => match action_taker {
-                ActionTaker::SingleIdentity(action_taker) => action_taker == contract_owner_id,
-                ActionTaker::SpecifiedIdentities(action_takers) => {
-                    action_takers.contains(contract_owner_id)
+            AuthorizedActionTakers::ContractOwner => {
+                if goal == ActionGoal::ActionParticipation {
+                    false
+                } else {
+                    match action_taker {
+                        ActionTaker::SingleIdentity(action_taker) => {
+                            action_taker == contract_owner_id
+                        }
+                        ActionTaker::SpecifiedIdentities(action_takers) => {
+                            action_takers.contains(contract_owner_id)
+                        }
+                    }
                 }
-            },
+            }
 
             // Only an identity is allowed
-            AuthorizedActionTakers::Identity(identity) => match action_taker {
-                ActionTaker::SingleIdentity(action_taker) => action_taker == identity,
-                ActionTaker::SpecifiedIdentities(action_takers) => action_takers.contains(identity),
-            },
+            AuthorizedActionTakers::Identity(identity) => {
+                if goal == ActionGoal::ActionParticipation {
+                    false
+                } else {
+                    match action_taker {
+                        ActionTaker::SingleIdentity(action_taker) => action_taker == identity,
+                        ActionTaker::SpecifiedIdentities(action_takers) => {
+                            action_takers.contains(identity)
+                        }
+                    }
+                }
+            }
 
             // MainGroup allows multiparty actions with specific power requirements
             AuthorizedActionTakers::MainGroup => {

--- a/packages/rs-dpp/src/data_contract/v1/accessors/mod.rs
+++ b/packages/rs-dpp/src/data_contract/v1/accessors/mod.rs
@@ -136,16 +136,6 @@ impl DataContractV0Setters for DataContractV1 {
 }
 
 impl DataContractV1Getters for DataContractV1 {
-    fn group(&self, position: GroupContractPosition) -> Result<&Group, ProtocolError> {
-        self.groups
-            .get(&position)
-            .ok_or(ProtocolError::GroupNotFound(format!(
-                "Group not found in contract {} at position {}",
-                self.id(),
-                position
-            )))
-    }
-
     fn groups(&self) -> &BTreeMap<GroupContractPosition, Group> {
         &self.groups
     }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/config_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/config_update/mod.rs
@@ -796,6 +796,7 @@ mod token_config_update_tests {
     mod with_group {
         use super::*;
         use dpp::data_contract::associated_token::token_configuration_localization::v0::TokenConfigurationLocalizationV0;
+        use dpp::data_contract::associated_token::token_distribution_rules::accessors::v0::TokenDistributionRulesV0Getters;
 
         #[test]
         fn test_token_config_update_by_group_member_changing_total_max_supply_not_using_group_gives_error(
@@ -1106,6 +1107,854 @@ mod token_config_update_tests {
                 .expected_token_configuration(0)
                 .expect("expected token configuration");
             assert_eq!(updated_token_config.max_supply(), Some(1000000));
+        }
+
+        #[test]
+        fn test_token_config_update_by_group_member_changing_minting_destination_group() {
+            let platform_version = PlatformVersion::latest();
+            let mut platform = TestPlatformBuilder::new()
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(49853);
+
+            let platform_state = platform.state.load();
+
+            let (identity, signer, key) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_2, signer_2, key_2) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_3, _, _) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_4, _, _) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (contract, token_id) = create_token_contract_with_owner_identity(
+                &mut platform,
+                identity.id(),
+                Some(|token_configuration: &mut TokenConfiguration| {
+                    token_configuration
+                        .distribution_rules_mut()
+                        .set_minting_allow_choosing_destination(false);
+                    token_configuration
+                        .distribution_rules_mut()
+                        .set_minting_allow_choosing_destination_rules(ChangeControlRules::V0(
+                            ChangeControlRulesV0 {
+                                authorized_to_make_change: AuthorizedActionTakers::Group(1),
+                                admin_action_takers: AuthorizedActionTakers::Group(0),
+                                changing_authorized_action_takers_to_no_one_allowed: false,
+                                changing_admin_action_takers_to_no_one_allowed: false,
+                                self_changing_admin_action_takers_allowed: false,
+                            },
+                        ));
+                }),
+                None,
+                Some(
+                    [
+                        (
+                            0,
+                            Group::V0(GroupV0 {
+                                members: [(identity.id(), 1), (identity_2.id(), 1)].into(),
+                                required_power: 2,
+                            }),
+                        ),
+                        (
+                            1,
+                            Group::V0(GroupV0 {
+                                members: [(identity_3.id(), 1), (identity_4.id(), 1)].into(),
+                                required_power: 2,
+                            }),
+                        ),
+                    ]
+                    .into(),
+                ),
+                platform_version,
+            );
+
+            let action_id = TokenConfigUpdateTransition::calculate_action_id_with_fields(
+                token_id.as_bytes(),
+                identity.id().as_bytes(),
+                2,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestinationControlGroup(
+                    AuthorizedActionTakers::Group(0),
+                )
+                .u8_item_index(),
+            );
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestinationControlGroup(
+                    AuthorizedActionTakers::Group(0),
+                ),
+                None,
+                Some(GroupStateTransitionInfoStatus::GroupStateTransitionInfoProposer(0)),
+                &key,
+                2,
+                0,
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution(_, _)]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let new_contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch token balance")
+                .expect("expected contract");
+            let updated_token_config = new_contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert_eq!(
+                updated_token_config
+                    .distribution_rules()
+                    .minting_allow_choosing_destination_rules()
+                    .authorized_to_make_change_action_takers(),
+                &AuthorizedActionTakers::Group(1)
+            );
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity_2.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestinationControlGroup(
+                    AuthorizedActionTakers::Group(0),
+                ),
+                None,
+                Some(
+                    GroupStateTransitionInfoStatus::GroupStateTransitionInfoOtherSigner(
+                        GroupStateTransitionInfo {
+                            group_contract_position: 0,
+                            action_id,
+                            action_is_proposer: false,
+                        },
+                    ),
+                ),
+                &key_2,
+                2,
+                0,
+                &signer_2,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution(_, _)]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let new_contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch token balance")
+                .expect("expected contract");
+            let updated_token_config = new_contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert_eq!(
+                updated_token_config
+                    .distribution_rules()
+                    .minting_allow_choosing_destination_rules()
+                    .authorized_to_make_change_action_takers(),
+                &AuthorizedActionTakers::Group(0)
+            );
+
+            // now that we are group 0 as the group that can make the change, let's make the change to allow minting to choose the destination
+
+            let action_id = TokenConfigUpdateTransition::calculate_action_id_with_fields(
+                token_id.as_bytes(),
+                identity.id().as_bytes(),
+                3,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestination(true).u8_item_index(),
+            );
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestination(true),
+                None,
+                Some(GroupStateTransitionInfoStatus::GroupStateTransitionInfoProposer(0)),
+                &key,
+                3,
+                0,
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution(_, _)]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let new_contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch token balance")
+                .expect("expected contract");
+            let updated_token_config = new_contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert!(!updated_token_config
+                .distribution_rules()
+                .minting_allow_choosing_destination());
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity_2.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestination(true),
+                None,
+                Some(
+                    GroupStateTransitionInfoStatus::GroupStateTransitionInfoOtherSigner(
+                        GroupStateTransitionInfo {
+                            group_contract_position: 0,
+                            action_id,
+                            action_is_proposer: false,
+                        },
+                    ),
+                ),
+                &key_2,
+                3,
+                0,
+                &signer_2,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution(_, _)]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let new_contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch token balance")
+                .expect("expected contract");
+            let updated_token_config = new_contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert!(updated_token_config
+                .distribution_rules()
+                .minting_allow_choosing_destination());
+        }
+
+        #[test]
+        fn test_token_config_update_by_group_member_changing_minting_admin_group() {
+            let platform_version = PlatformVersion::latest();
+            let mut platform = TestPlatformBuilder::new()
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(49853);
+
+            let platform_state = platform.state.load();
+
+            let (identity, signer, key) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_2, signer_2, key_2) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_3, signer_3, key_3) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_4, signer_4, key_4) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (contract, token_id) = create_token_contract_with_owner_identity(
+                &mut platform,
+                identity.id(),
+                Some(|token_configuration: &mut TokenConfiguration| {
+                    token_configuration
+                        .distribution_rules_mut()
+                        .set_minting_allow_choosing_destination_rules(ChangeControlRules::V0(
+                            ChangeControlRulesV0 {
+                                authorized_to_make_change: AuthorizedActionTakers::Group(1),
+                                admin_action_takers: AuthorizedActionTakers::Group(0),
+                                changing_authorized_action_takers_to_no_one_allowed: false,
+                                changing_admin_action_takers_to_no_one_allowed: false,
+                                self_changing_admin_action_takers_allowed: true,
+                            },
+                        ));
+                }),
+                None,
+                Some(
+                    [
+                        (
+                            0,
+                            Group::V0(GroupV0 {
+                                members: [(identity.id(), 1), (identity_2.id(), 1)].into(),
+                                required_power: 2,
+                            }),
+                        ),
+                        (
+                            1,
+                            Group::V0(GroupV0 {
+                                members: [(identity_3.id(), 1), (identity_4.id(), 1)].into(),
+                                required_power: 2,
+                            }),
+                        ),
+                        (
+                            2,
+                            Group::V0(GroupV0 {
+                                members: [(identity.id(), 1), (identity_4.id(), 1)].into(),
+                                required_power: 2,
+                            }),
+                        ),
+                    ]
+                    .into(),
+                ),
+                platform_version,
+            );
+
+            let action_id = TokenConfigUpdateTransition::calculate_action_id_with_fields(
+                token_id.as_bytes(),
+                identity.id().as_bytes(),
+                2,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestinationAdminGroup(
+                    AuthorizedActionTakers::Group(1),
+                )
+                .u8_item_index(),
+            );
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestinationAdminGroup(
+                    AuthorizedActionTakers::Group(1),
+                ),
+                None,
+                Some(GroupStateTransitionInfoStatus::GroupStateTransitionInfoProposer(0)),
+                &key,
+                2,
+                0,
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution(_, _)]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let new_contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch token balance")
+                .expect("expected contract");
+            let updated_token_config = new_contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert_eq!(
+                updated_token_config
+                    .distribution_rules()
+                    .minting_allow_choosing_destination_rules()
+                    .admin_action_takers(),
+                &AuthorizedActionTakers::Group(0)
+            );
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity_2.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestinationAdminGroup(
+                    AuthorizedActionTakers::Group(1),
+                ),
+                None,
+                Some(
+                    GroupStateTransitionInfoStatus::GroupStateTransitionInfoOtherSigner(
+                        GroupStateTransitionInfo {
+                            group_contract_position: 0,
+                            action_id,
+                            action_is_proposer: false,
+                        },
+                    ),
+                ),
+                &key_2,
+                2,
+                0,
+                &signer_2,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution(_, _)]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let new_contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch token balance")
+                .expect("expected contract");
+            let updated_token_config = new_contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert_eq!(
+                updated_token_config
+                    .distribution_rules()
+                    .minting_allow_choosing_destination_rules()
+                    .admin_action_takers(),
+                &AuthorizedActionTakers::Group(1)
+            );
+
+            // The admin group has changed to 1, let's try to do an action with admin group as 0.
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestinationControlGroup(
+                    AuthorizedActionTakers::Group(2),
+                ),
+                None,
+                Some(GroupStateTransitionInfoStatus::GroupStateTransitionInfoProposer(0)),
+                &key,
+                3,
+                0,
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            // It should fail because the authorized group to do this action is now 1
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [PaidConsensusError(
+                    ConsensusError::StateError(StateError::UnauthorizedTokenActionError(_)),
+                    _
+                )]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            // Let's try doing this action with group 1
+
+            let action_id = TokenConfigUpdateTransition::calculate_action_id_with_fields(
+                token_id.as_bytes(),
+                identity_3.id().as_bytes(),
+                2,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestinationControlGroup(
+                    AuthorizedActionTakers::Group(2),
+                )
+                .u8_item_index(),
+            );
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity_3.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestinationControlGroup(
+                    AuthorizedActionTakers::Group(2),
+                ),
+                None,
+                Some(GroupStateTransitionInfoStatus::GroupStateTransitionInfoProposer(1)),
+                &key_3,
+                2,
+                0,
+                &signer_3,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution(_, _)]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let new_contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch token balance")
+                .expect("expected contract");
+            let updated_token_config = new_contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert_eq!(
+                updated_token_config
+                    .distribution_rules()
+                    .minting_allow_choosing_destination_rules()
+                    .authorized_to_make_change_action_takers(),
+                &AuthorizedActionTakers::Group(1)
+            );
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity_4.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MintingAllowChoosingDestinationControlGroup(
+                    AuthorizedActionTakers::Group(2),
+                ),
+                None,
+                Some(
+                    GroupStateTransitionInfoStatus::GroupStateTransitionInfoOtherSigner(
+                        GroupStateTransitionInfo {
+                            group_contract_position: 1,
+                            action_id,
+                            action_is_proposer: false,
+                        },
+                    ),
+                ),
+                &key_4,
+                2,
+                0,
+                &signer_4,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution(_, _)]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let new_contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch token balance")
+                .expect("expected contract");
+            let updated_token_config = new_contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert_eq!(
+                updated_token_config
+                    .distribution_rules()
+                    .minting_allow_choosing_destination_rules()
+                    .authorized_to_make_change_action_takers(),
+                &AuthorizedActionTakers::Group(2)
+            );
         }
 
         #[test]
@@ -1878,6 +2727,122 @@ mod token_config_update_tests {
                 .commit_transaction(transaction)
                 .unwrap()
                 .expect("expected to commit transaction");
+        }
+
+        #[test]
+        fn test_token_config_update_as_group_member_but_group_not_needed() {
+            let platform_version = PlatformVersion::latest();
+            let mut platform = TestPlatformBuilder::new()
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(49853);
+
+            let platform_state = platform.state.load();
+
+            let (identity, signer, key) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_2, _, _) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (contract, token_id) = create_token_contract_with_owner_identity(
+                &mut platform,
+                identity.id(),
+                Some(|token_configuration: &mut TokenConfiguration| {
+                    token_configuration.set_max_supply_change_rules(ChangeControlRules::V0(
+                        ChangeControlRulesV0 {
+                            authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                            admin_action_takers: AuthorizedActionTakers::NoOne,
+                            changing_authorized_action_takers_to_no_one_allowed: false,
+                            changing_admin_action_takers_to_no_one_allowed: false,
+                            self_changing_admin_action_takers_allowed: false,
+                        },
+                    ));
+                }),
+                None,
+                Some(
+                    [(
+                        0,
+                        Group::V0(GroupV0 {
+                            members: [(identity.id(), 1), (identity_2.id(), 1)].into(),
+                            required_power: 2,
+                        }),
+                    )]
+                    .into(),
+                ),
+                platform_version,
+            );
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MaxSupply(Some(1000000)),
+                None,
+                Some(GroupStateTransitionInfoStatus::GroupStateTransitionInfoProposer(0)),
+                &key,
+                2,
+                0,
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [PaidConsensusError(
+                    ConsensusError::StateError(StateError::UnauthorizedTokenActionError(_)),
+                    _
+                )]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch token balance")
+                .expect("expected contract");
+            let updated_token_config = contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert_eq!(updated_token_config.max_supply(), None);
         }
     }
 }


### PR DESCRIPTION
## What was done?
- Removed the `group` method from `DataContractV1Getters` and `DataContract` because it was redundant with `expected_group` method.
- Updated the `AuthorizedActionTakers` logic to prevent unauthorized access when doing an update config.
- Return a consensus error and not an internal error for invalid group positions in the token transitions.
- Added tests to verify the behavior when group access is not required and when unauthorized actions are attempted.

## How Has This Been Tested?
- Comprehensive unit tests were added to cover various scenarios, including unauthorized access attempts and proper group validation.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for invalid group positions during token state transitions, providing clearer error messages when a group is not found.

- **Tests**
  - Added comprehensive tests for group-based authorization in token configuration updates, minting, and direct selling scenarios.
  - Tests now verify correct enforcement of group and owner permissions, including unauthorized action error handling for invalid group usage.

- **Refactor**
  - Simplified contract accessor interfaces by removing the explicit group lookup method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->