### PR TITLE
fix(dpp): historical document type name for token direct pricing

### DIFF
--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_transition.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/token_transition.rs
@@ -347,7 +347,7 @@ impl TokenTransitionV0Methods for TokenTransition {
             TokenTransition::ConfigUpdate(_) => "configUpdate",
             TokenTransition::Claim(_) => "claim",
             TokenTransition::DirectPurchase(_) => "directPurchase",
-            TokenTransition::SetPriceForDirectPurchase(_) => "setPriceForDirectPurchase",
+            TokenTransition::SetPriceForDirectPurchase(_) => "directPricing",
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The historical_document_type_name getter had the wrong name for directPricing transition


## What was done?
<!--- Describe your changes in detail -->
Changed the name returned by the function for token set price transition.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the historical document type name for direct purchase price setting to "directPricing" for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->