### PR TITLE
fix(dashmate): sync max-tx-bytes between tenderdash and drive

### DIFF
--- a/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
+++ b/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
@@ -382,7 +382,7 @@ tx-recv-rate-punish-peer = false
 
 # Maximum size of a single transaction.
 # NOTE: the max size of a tx transmitted over the network is {max-tx-bytes}.
-max-tx-bytes = 50000
+max-tx-bytes = 20480
 
 # Maximum size of a batch of transactions to send to a peer
 # Including space needed by encoding (one varint per transaction).

--- a/packages/rs-platform-version/src/version/system_limits/mod.rs
+++ b/packages/rs-platform-version/src/version/system_limits/mod.rs
@@ -4,6 +4,9 @@ pub mod v1;
 pub struct SystemLimits {
     pub estimated_contract_max_serialized_size: u16,
     pub max_field_value_size: u32,
+    /// Max size of a state transition in bytes.
+    ///
+    /// NOTE: This must be equal to the `max-tx-bytes` in the Tenderdash config
     pub max_state_transition_size: u64,
     pub max_transitions_in_documents_batch: u16,
     pub withdrawal_transactions_per_block_limit: u16,


### PR DESCRIPTION
This pull request includes changes to align system limits between the Rust codebase and the Tenderdash configuration, ensuring consistency in transaction and state transition size limits.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

This pull request includes changes to align system limits between the Rust codebase and the Tenderdash configuration, ensuring consistency in transaction and state transition size limits.


## What was done?
<!--- Describe your changes in detail -->

### Configuration Updates:
* [`packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot`](diffhunk://#diff-ce92fbaefce4688b8c4fdb14c2947ee895a4de6277cb9fc0aa85d66836521ea7L385-R385): Reduced the `max-tx-bytes` (maximum size of a single transaction) from 50,000 to 20,480 bytes in the Tenderdash configuration.

## How Has This Been Tested?

Manually modified Tenderdash config on devnet

## Breaking Changes

None - lower limit from Drive (20480) was enforced anyway.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new limit for the maximum size of a state transition, enhancing system configurability and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->