### PR TITLE
fix(dpp): allow changing main control group for token configuration

### DIFF
--- a/packages/rs-dpp/src/data_contract/associated_token/token_configuration/methods/can_apply_token_configuration_item/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/associated_token/token_configuration/methods/can_apply_token_configuration_item/v0/mod.rs
@@ -281,7 +281,15 @@ impl TokenConfigurationV0 {
                     goal,
                 )
             }
-            TokenConfigurationChangeItem::MainControlGroup(_) => false, // Main control group cannot be updated directly
+            TokenConfigurationChangeItem::MainControlGroup(_) => self
+                .main_control_group_can_be_modified
+                .allowed_for_action_taker(
+                    contract_owner_id,
+                    main_group,
+                    groups,
+                    action_taker,
+                    goal,
+                ),
         }
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/config_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/config_update/mod.rs
@@ -791,6 +791,113 @@ mod token_config_update_tests {
                 .unwrap()
                 .expect("expected to commit transaction");
         }
+
+        #[test]
+        fn test_token_config_update_by_owner_changing_main_control_group() {
+            let platform_version = PlatformVersion::latest();
+            let mut platform = TestPlatformBuilder::new()
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(49853);
+
+            let platform_state = platform.state.load();
+
+            let (identity, signer, key) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_2, _, _) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (contract, token_id) = create_token_contract_with_owner_identity(
+                &mut platform,
+                identity.id(),
+                Some(|token_configuration: &mut TokenConfiguration| {
+                    token_configuration.set_main_control_group_can_be_modified(
+                        AuthorizedActionTakers::ContractOwner,
+                    );
+                }),
+                None,
+                Some(
+                    [(
+                        0,
+                        Group::V0(GroupV0 {
+                            members: [(identity.id(), 1), (identity_2.id(), 1)].into(),
+                            required_power: 2,
+                        }),
+                    )]
+                    .into(),
+                ),
+                platform_version,
+            );
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MainControlGroup(Some(0)),
+                None,
+                None,
+                &key,
+                2,
+                0,
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution(_, _)]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch token balance")
+                .expect("expected contract");
+            let updated_token_config = contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert_eq!(updated_token_config.main_control_group(), Some(0));
+        }
     }
 
     mod with_group {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Main control group was not modifiable, which was a bug preventing proper token configuration updates.

## What was done?
Updated the logic in `TokenConfigurationV0` to allow the main control group to be modified by the contract owner if permitted. Added a test to verify that the main control group can now be changed successfully.

## How Has This Been Tested?
A new unit test was created to ensure that the main control group can be updated by the contract owner. The test checks the successful execution of the state transition and verifies that the main control group has been updated correctly.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Main control group of a token contract can now be updated by the contract owner, subject to permissions.
- **Tests**
  - Added a test to verify that the contract owner can successfully change the main control group of a token contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->