### PR TITLE
fix: resolve grovedb error during signing group action finalization

### DIFF
--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/accessors/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/accessors/mod.rs
@@ -93,4 +93,24 @@ impl DocumentsBatchTransitionAccessorsV0 for BatchTransition {
                 .map(|batch_transition| batch_transition.borrow_as_mut()),
         }
     }
+
+    fn contains_document_transition(&self) -> bool {
+        match self {
+            BatchTransition::V0(_) => true,
+            BatchTransition::V1(v1) => v1
+                .transitions
+                .iter()
+                .any(|transition| matches!(transition, BatchedTransition::Document(_))),
+        }
+    }
+
+    fn contains_token_transition(&self) -> bool {
+        match self {
+            BatchTransition::V0(_) => false,
+            BatchTransition::V1(v1) => v1
+                .transitions
+                .iter()
+                .any(|transition| matches!(transition, BatchedTransition::Token(_))),
+        }
+    }
 }

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/accessors/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/accessors/v0/mod.rs
@@ -16,4 +16,6 @@ pub trait DocumentsBatchTransitionAccessorsV0 {
     fn first_transition(&self) -> Option<BatchedTransitionRef>;
 
     fn first_transition_mut(&mut self) -> Option<BatchedTransitionMutRef>;
+    fn contains_document_transition(&self) -> bool;
+    fn contains_token_transition(&self) -> bool;
 }

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v0/v0_methods.rs
@@ -78,6 +78,14 @@ impl DocumentsBatchTransitionAccessorsV0 for BatchTransitionV0 {
             .first_mut()
             .map(BatchedTransitionMutRef::Document)
     }
+
+    fn contains_document_transition(&self) -> bool {
+        true
+    }
+
+    fn contains_token_transition(&self) -> bool {
+        false
+    }
 }
 
 impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV0 {

--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/v1/v0_methods.rs
@@ -83,6 +83,18 @@ impl DocumentsBatchTransitionAccessorsV0 for BatchTransitionV1 {
             .first_mut()
             .map(|transition| transition.borrow_as_mut())
     }
+
+    fn contains_document_transition(&self) -> bool {
+        self.transitions
+            .iter()
+            .any(|transition| matches!(transition, BatchedTransition::Document(_)))
+    }
+
+    fn contains_token_transition(&self) -> bool {
+        self.transitions
+            .iter()
+            .any(|transition| matches!(transition, BatchedTransition::Token(_)))
+    }
 }
 
 impl DocumentsBatchTransitionMethodsV0 for BatchTransitionV1 {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mint/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/mint/mod.rs
@@ -1093,6 +1093,8 @@ mod token_mint_tests {
 
     mod token_mint_tests_authorization_scenarios {
         use super::*;
+        use crate::execution::check_tx::CheckTxLevel;
+        use crate::platform_types::platform::PlatformRef;
         use dpp::data_contract::associated_token::token_keeps_history_rules::accessors::v0::TokenKeepsHistoryRulesV0Setters;
         use dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
         use dpp::data_contract::change_control_rules::v0::ChangeControlRulesV0;
@@ -2330,6 +2332,24 @@ mod token_mint_tests {
                 .serialize_to_bytes()
                 .expect("expected documents batch serialized state transition");
 
+            let platform_ref = PlatformRef {
+                drive: &platform.drive,
+                state: &platform_state,
+                config: &platform.config,
+                core_rpc: &platform.core_rpc,
+            };
+
+            let validation_result = platform
+                .check_tx(
+                    &token_mint_serialized_transition,
+                    CheckTxLevel::FirstTimeCheck,
+                    &platform_ref,
+                    platform_version,
+                )
+                .expect("expected to be able to check tx");
+
+            assert_eq!(validation_result.errors.as_slice(), &[]);
+
             let transaction = platform.drive.grove.start_transaction();
 
             let processing_result = platform
@@ -2405,6 +2425,17 @@ mod token_mint_tests {
             let confirm_token_mint_serialized_transition = confirm_token_mint_transition
                 .serialize_to_bytes()
                 .expect("expected documents batch serialized state transition");
+
+            let validation_result = platform
+                .check_tx(
+                    &confirm_token_mint_serialized_transition,
+                    CheckTxLevel::FirstTimeCheck,
+                    &platform_ref,
+                    platform_version,
+                )
+                .expect("expected to be able to check tx");
+
+            assert_eq!(validation_result.errors.as_slice(), &[]);
 
             let transaction = platform.drive.grove.start_transaction();
 
@@ -2980,6 +3011,24 @@ mod token_mint_tests {
             let confirm_token_mint_serialized_transition = confirm_token_mint_transition
                 .serialize_to_bytes()
                 .expect("expected documents batch serialized state transition");
+
+            let platform_ref = PlatformRef {
+                drive: &platform.drive,
+                state: &platform_state,
+                config: &platform.config,
+                core_rpc: &platform.core_rpc,
+            };
+
+            let validation_result = platform
+                .check_tx(
+                    &confirm_token_mint_serialized_transition,
+                    CheckTxLevel::FirstTimeCheck,
+                    &platform_ref,
+                    platform_version,
+                )
+                .expect("expected to be able to check tx");
+
+            assert_eq!(validation_result.errors.as_slice(), &[]);
 
             let transaction = platform.drive.grove.start_transaction();
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixed a grovedb error that occurred during the finalization of signing group actions.

## What was done?
Modified the logic that checks the state during signing group action finalization to avoid the grovedb error. Instead of performing a state check, the implementation now approximates the state, which resolves the issue.

## How Has This Been Tested?
The changes have been tested by running existing tests and validating that the signing group action finalization no longer triggers the grovedb error.

## Breaking Changes
None

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone