### PR TITLE
fix(drive): prevent token transfer to self during document actions

### DIFF
--- a/packages/rs-drive-abci/src/error/execution.rs
+++ b/packages/rs-drive-abci/src/error/execution.rs
@@ -100,6 +100,10 @@ pub enum ExecutionError {
     #[error("corrupted credits not balanced error: {0}")]
     CorruptedCreditsNotBalanced(String),
 
+    /// Corrupted tokens are not balanced.
+    #[error("corrupted tokens not balanced error: {0}")]
+    CorruptedTokensNotBalanced(String),
+
     /// The transaction is not present.
     #[error("transaction not present error: {0}")]
     NotInTransaction(&'static str),

--- a/packages/rs-drive-abci/src/execution/platform_events/tokens/validate_token_aggregated_balance/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/tokens/validate_token_aggregated_balance/v0/mod.rs
@@ -21,8 +21,8 @@ impl<C> Platform<C> {
 
             if !token_balance.ok()? {
                 return Err(Error::Execution(
-                    ExecutionError::CorruptedCreditsNotBalanced(format!(
-                        "credits are not balanced after block execution {:?} off by {}",
+                    ExecutionError::CorruptedTokensNotBalanced(format!(
+                        "tokens are not balanced after block execution {:?} off by {}",
                         token_balance,
                         token_balance
                             .total_identity_token_balances

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/creation.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/creation.rs
@@ -2676,6 +2676,10 @@ mod creation_tests {
         );
 
         platform
+            .validate_token_aggregated_balance(&transaction, platform_version)
+            .expect("expected to validate token aggregated balances");
+
+        platform
             .drive
             .grove
             .commit_transaction(transaction)
@@ -2817,6 +2821,10 @@ mod creation_tests {
         );
 
         platform
+            .validate_token_aggregated_balance(&transaction, platform_version)
+            .expect("expected to validate token aggregated balances");
+
+        platform
             .drive
             .grove
             .commit_transaction(transaction)
@@ -2848,6 +2856,136 @@ mod creation_tests {
 
         // He was paid 10
         assert_eq!(contract_owner_token_balance, Some(10));
+    }
+
+    #[test]
+    fn test_document_creation_paid_with_a_token_transfer_to_ones_self() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let mut rng = StdRng::seed_from_u64(433);
+
+        let platform_state = platform.state.load();
+
+        let (contract_owner_id, signer, key) =
+            setup_identity(&mut platform, 958, dash_to_credits!(0.1));
+
+        let (contract, gold_token_id, _) =
+            create_card_game_internal_token_contract_with_owner_identity_transfer_tokens(
+                &mut platform,
+                contract_owner_id.id(),
+                platform_version,
+            );
+
+        let token_supply = platform
+            .drive
+            .fetch_token_total_supply(gold_token_id.to_buffer(), None, platform_version)
+            .expect("expected to fetch total supply");
+
+        assert_eq!(token_supply, Some(0));
+
+        assert_eq!(contract.tokens().len(), 2);
+
+        add_tokens_to_identity(&mut platform, gold_token_id, contract_owner_id.id(), 15);
+
+        let token_supply = platform
+            .drive
+            .fetch_token_total_supply(gold_token_id.to_buffer(), None, platform_version)
+            .expect("expected to fetch total supply");
+
+        assert_eq!(token_supply, Some(15));
+
+        let card_document_type = contract
+            .document_type_for_name("card")
+            .expect("expected a profile document type");
+
+        let entropy = Bytes32::random_with_rng(&mut rng);
+
+        let mut document = card_document_type
+            .random_document_with_identifier_and_entropy(
+                &mut rng,
+                contract_owner_id.id(),
+                entropy,
+                DocumentFieldFillType::DoNotFillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                platform_version,
+            )
+            .expect("expected a random document");
+
+        document.set("attack", 4.into());
+        document.set("defense", 7.into());
+
+        let documents_batch_create_transition =
+            BatchTransition::new_document_creation_transition_from_document(
+                document.clone(),
+                card_document_type,
+                entropy.0,
+                &key,
+                2,
+                0,
+                Some(TokenPaymentInfo::V0(TokenPaymentInfoV0 {
+                    payment_token_contract_id: None,
+                    token_contract_position: 0,
+                    minimum_token_cost: None,
+                    maximum_token_cost: Some(10),
+                    gas_fees_paid_by: GasFeesPaidBy::DocumentOwner,
+                })),
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+        let documents_batch_create_serialized_transition = documents_batch_create_transition
+            .serialize_to_bytes()
+            .expect("expected documents batch serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![documents_batch_create_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution(_, _)]
+        );
+
+        platform
+            .validate_token_aggregated_balance(&transaction, platform_version)
+            .expect("expected to validate token aggregated balances");
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        let token_balance = platform
+            .drive
+            .fetch_identity_token_balance(
+                gold_token_id.to_buffer(),
+                contract_owner_id.id().to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch token balance");
+
+        // He still has 15
+        assert_eq!(token_balance, Some(15));
     }
 
     #[test]

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_create_transition.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_create_transition.rs
@@ -70,12 +70,15 @@ impl DriveHighLevelBatchOperationConverter for DocumentCreateTransitionAction {
                 if let Some((token_id, effect, cost)) = document_creation_token_cost {
                     match effect {
                         DocumentActionTokenEffect::TransferTokenToContractOwner => {
-                            ops.push(TokenOperation(TokenOperationType::TokenTransfer {
-                                token_id,
-                                sender_id: owner_id,
-                                recipient_id: contract_fetch_info.contract.owner_id(),
-                                amount: cost,
-                            }));
+                            // If we are the owner, no need to send anything
+                            if owner_id != contract_fetch_info.contract.owner_id() {
+                                ops.push(TokenOperation(TokenOperationType::TokenTransfer {
+                                    token_id,
+                                    sender_id: owner_id,
+                                    recipient_id: contract_fetch_info.contract.owner_id(),
+                                    amount: cost,
+                                }));
+                            }
                         }
                         DocumentActionTokenEffect::BurnToken => {
                             ops.push(TokenOperation(TokenOperationType::TokenBurn {

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_delete_transition.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_delete_transition.rs
@@ -61,12 +61,15 @@ impl DriveHighLevelBatchOperationConverter for DocumentDeleteTransitionAction {
                 if let Some((token_id, effect, cost)) = document_deletion_token_cost {
                     match effect {
                         DocumentActionTokenEffect::TransferTokenToContractOwner => {
-                            ops.push(TokenOperation(TokenOperationType::TokenTransfer {
-                                token_id,
-                                sender_id: owner_id,
-                                recipient_id: contract_fetch_info.contract.owner_id(),
-                                amount: cost,
-                            }));
+                            // If we are the owner, no need to send anything
+                            if owner_id != contract_fetch_info.contract.owner_id() {
+                                ops.push(TokenOperation(TokenOperationType::TokenTransfer {
+                                    token_id,
+                                    sender_id: owner_id,
+                                    recipient_id: contract_fetch_info.contract.owner_id(),
+                                    amount: cost,
+                                }));
+                            }
                         }
                         DocumentActionTokenEffect::BurnToken => {
                             ops.push(TokenOperation(TokenOperationType::TokenBurn {

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_purchase_transition.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_purchase_transition.rs
@@ -84,12 +84,15 @@ impl DriveHighLevelBatchOperationConverter for DocumentPurchaseTransitionAction 
                 if let Some((token_id, effect, cost)) = document_purchase_token_cost {
                     match effect {
                         DocumentActionTokenEffect::TransferTokenToContractOwner => {
-                            ops.push(TokenOperation(TokenOperationType::TokenTransfer {
-                                token_id,
-                                sender_id: owner_id,
-                                recipient_id: contract_owner_id,
-                                amount: cost,
-                            }));
+                            // If we are the owner, no need to send anything
+                            if owner_id != contract_owner_id {
+                                ops.push(TokenOperation(TokenOperationType::TokenTransfer {
+                                    token_id,
+                                    sender_id: owner_id,
+                                    recipient_id: contract_owner_id,
+                                    amount: cost,
+                                }));
+                            }
                         }
                         DocumentActionTokenEffect::BurnToken => {
                             ops.push(TokenOperation(TokenOperationType::TokenBurn {

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_replace_transition.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_replace_transition.rs
@@ -71,12 +71,15 @@ impl DriveHighLevelBatchOperationConverter for DocumentReplaceTransitionAction {
                 if let Some((token_id, effect, cost)) = document_replacement_token_cost {
                     match effect {
                         DocumentActionTokenEffect::TransferTokenToContractOwner => {
-                            ops.push(TokenOperation(TokenOperationType::TokenTransfer {
-                                token_id,
-                                sender_id: owner_id,
-                                recipient_id: contract_owner_id,
-                                amount: cost,
-                            }));
+                            // If we are the owner, no need to send anything
+                            if owner_id != contract_owner_id {
+                                ops.push(TokenOperation(TokenOperationType::TokenTransfer {
+                                    token_id,
+                                    sender_id: owner_id,
+                                    recipient_id: contract_owner_id,
+                                    amount: cost,
+                                }));
+                            }
                         }
                         DocumentActionTokenEffect::BurnToken => {
                             ops.push(TokenOperation(TokenOperationType::TokenBurn {

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_transfer_transition.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_transfer_transition.rs
@@ -73,12 +73,15 @@ impl DriveHighLevelBatchOperationConverter for DocumentTransferTransitionAction 
                 if let Some((token_id, effect, cost)) = document_transfer_token_cost {
                     match effect {
                         DocumentActionTokenEffect::TransferTokenToContractOwner => {
-                            ops.push(TokenOperation(TokenOperationType::TokenTransfer {
-                                token_id,
-                                sender_id: owner_id,
-                                recipient_id: contract_owner_id,
-                                amount: cost,
-                            }));
+                            // If we are the owner, no need to send anything
+                            if owner_id != contract_owner_id {
+                                ops.push(TokenOperation(TokenOperationType::TokenTransfer {
+                                    token_id,
+                                    sender_id: owner_id,
+                                    recipient_id: contract_owner_id,
+                                    amount: cost,
+                                }));
+                            }
                         }
                         DocumentActionTokenEffect::BurnToken => {
                             ops.push(TokenOperation(TokenOperationType::TokenBurn {

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_update_price_transition.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_update_price_transition.rs
@@ -66,12 +66,15 @@ impl DriveHighLevelBatchOperationConverter for DocumentUpdatePriceTransitionActi
                 if let Some((token_id, effect, cost)) = document_update_price_token_cost {
                     match effect {
                         DocumentActionTokenEffect::TransferTokenToContractOwner => {
-                            ops.push(TokenOperation(TokenOperationType::TokenTransfer {
-                                token_id,
-                                sender_id: owner_id,
-                                recipient_id: contract_owner_id,
-                                amount: cost,
-                            }));
+                            // If we are the owner, no need to send anything
+                            if owner_id != contract_owner_id {
+                                ops.push(TokenOperation(TokenOperationType::TokenTransfer {
+                                    token_id,
+                                    sender_id: owner_id,
+                                    recipient_id: contract_owner_id,
+                                    amount: cost,
+                                }));
+                            }
                         }
                         DocumentActionTokenEffect::BurnToken => {
                             ops.push(TokenOperation(TokenOperationType::TokenBurn {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Prevent token transfers to the contract owner when the owner is the same as the sender during document actions.

## What was done?
Updated document action transitions to check if the owner is the same as the sender before performing a token transfer. If they are the same, the transfer operation is skipped.

## How Has This Been Tested?
Added tests to ensure that token transfers are not executed when the sender and recipient are the same.

## Breaking Changes
None

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone