### PR TITLE
fix(drive): ignore time based update fields in proof verification of data contract updates

### DIFF
--- a/packages/rs-dpp/src/data_contract/serialized_version/mod.rs
+++ b/packages/rs-dpp/src/data_contract/serialized_version/mod.rs
@@ -130,6 +130,8 @@ impl DataContractInSerializationFormat {
                     && v1_self.document_schemas == v1_other.document_schemas
                     && v1_self.groups == v1_other.groups
                     && v1_self.tokens == v1_other.tokens
+                    && v1_self.keywords == v1_other.keywords
+                    && v1_self.description == v1_other.description
             }
             // Cross-version comparisons return false
             (

--- a/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
@@ -103,7 +103,9 @@ impl Drive {
                 let contract_for_serialization: DataContractInSerializationFormat = contract
                     .clone()
                     .try_into_platform_versioned(platform_version)?;
-                if &contract_for_serialization != data_contract_update.data_contract() {
+                if !contract_for_serialization
+                    .eq_without_auto_fields(data_contract_update.data_contract())
+                {
                     return Err(Error::Proof(ProofError::IncorrectProof(format!("proof of state transition execution did not contain exact expected contract after update with id {}", data_contract_update.data_contract().id()))));
                 }
                 Ok((root_hash, VerifiedDataContract(contract)))


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes the verification of data contract updates by ignoring time based fields that are auto updated during execution.

## What was done?
- Added checks for `keywords` and `description` in the equality comparison of `DataContractInSerializationFormat`.
- Updated the test for data contract updates to include proof generation and verification.
- Adjusted the verification logic in the `Drive` implementation to utilize a more accurate comparison method.

## How Has This Been Tested?
- Unit tests were added to verify that the data contract update can add new tokens and that the state transition proof is correctly verified.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added ! to the title and described breaking changes in the corresponding section if my code contains any.

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved equality checks for data contracts to include the "keywords" and "description" fields, ensuring more accurate comparisons.
  - Verification logic for data contract updates now ignores automatically managed fields, reducing false mismatches during proof validation.

- **Tests**
  - Enhanced tests for data contract updates by adding cryptographic proof generation and verification steps, increasing test coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->