### PR TITLE
test(drive): add test for invalid owner on document delete

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
@@ -1226,14 +1226,13 @@ mod deletion_tests {
             .commit_transaction(transaction)
             .unwrap()
             .expect("expected to commit transaction");
-        
+
         assert_matches!(
             processing_result.execution_results().as_slice(),
-            [PaidConsensusError(ConsensusError::StateError(
-                StateError::DocumentOwnerIdMismatchError(_)
-            ),
-                    _
-                )]
+            [PaidConsensusError(
+                ConsensusError::StateError(StateError::DocumentOwnerIdMismatchError(_)),
+                _
+            )]
         );
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
@@ -3,10 +3,8 @@ use super::*;
 mod deletion_tests {
     use super::*;
     use crate::execution::validation::state_transition::tests::create_card_game_internal_token_contract_with_owner_identity_burn_tokens;
-    use dpp::consensus::signature::SignatureError;
     use dpp::tokens::token_payment_info::v0::TokenPaymentInfoV0;
     use dpp::tokens::token_payment_info::TokenPaymentInfo;
-    use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult::UnpaidConsensusError;
 
     #[test]
     fn test_document_delete_on_document_type_that_is_mutable_and_can_be_deleted() {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
@@ -3,8 +3,10 @@ use super::*;
 mod deletion_tests {
     use super::*;
     use crate::execution::validation::state_transition::tests::create_card_game_internal_token_contract_with_owner_identity_burn_tokens;
+    use dpp::consensus::signature::SignatureError;
     use dpp::tokens::token_payment_info::v0::TokenPaymentInfoV0;
     use dpp::tokens::token_payment_info::TokenPaymentInfo;
+    use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult::UnpaidConsensusError;
 
     #[test]
     fn test_document_delete_on_document_type_that_is_mutable_and_can_be_deleted() {
@@ -1095,5 +1097,144 @@ mod deletion_tests {
 
         // He still has no token balance of the gas token
         assert_eq!(token_balance, None);
+    }
+
+    #[test]
+    fn test_document_deletion_where_we_are_not_the_owner() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let mut rng = StdRng::seed_from_u64(433);
+
+        let platform_state = platform.state.load();
+
+        let (identity, signer, key) = setup_identity(&mut platform, 958, dash_to_credits!(0.1));
+
+        let (_other_identity, other_signer, other_key) =
+            setup_identity(&mut platform, 495, dash_to_credits!(0.1));
+
+        let dpns = platform.drive.cache.system_data_contracts.load_dpns();
+        let dpns_contract = dpns.clone();
+
+        let preorder_document_type = dpns_contract
+            .document_type_for_name("preorder")
+            .expect("expected a profile document type");
+
+        assert!(preorder_document_type.documents_can_be_deleted());
+
+        let entropy = Bytes32::random_with_rng(&mut rng);
+
+        let document = preorder_document_type
+            .random_document_with_identifier_and_entropy(
+                &mut rng,
+                identity.id(),
+                entropy,
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                platform_version,
+            )
+            .expect("expected a random document");
+
+        let mut altered_document = document.clone();
+
+        altered_document.set_revision(Some(1));
+
+        let documents_batch_create_transition =
+            BatchTransition::new_document_creation_transition_from_document(
+                document,
+                preorder_document_type,
+                entropy.0,
+                &key,
+                2,
+                0,
+                None,
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+        let documents_batch_create_serialized_transition = documents_batch_create_transition
+            .serialize_to_bytes()
+            .expect("expected documents batch serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![documents_batch_create_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.valid_count(), 1);
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        let documents_batch_deletion_transition =
+            BatchTransition::new_document_deletion_transition_from_document(
+                altered_document,
+                preorder_document_type,
+                &other_key,
+                3,
+                0,
+                None,
+                &other_signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create documents batch transition");
+
+        let documents_batch_deletion_serialized_transition = documents_batch_deletion_transition
+            .serialize_to_bytes()
+            .expect("expected documents batch serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![documents_batch_deletion_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        assert_eq!(processing_result.invalid_unpaid_count(), 1);
+        assert_eq!(processing_result.invalid_paid_count(), 0);
+        assert_eq!(processing_result.valid_count(), 0);
+
+        // Check the error message
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [UnpaidConsensusError(ConsensusError::SignatureError(
+                SignatureError::InvalidStateTransitionSignatureError(_)
+            ))]
+        );
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Errors could potentially be handled better when trying to delete a document where we're not the owner. Normally, you will get an invalid nonce error, but if you are able to somehow find out or guess the correct nonce, you will get invalid signature error. I feel like we should get an error that you are not the owner in any case.

## What was done?
<!--- Describe your changes in detail -->
Added a test to demonstrate the invalid signature error in the case a non-owner is attempting to delete a document and the nonce is input correctly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It is a test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new test to verify that document deletion attempts by non-owners are correctly rejected due to ownership mismatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->