### PR TITLE
fix(platform)!: load data contracts in their respective versions

### DIFF
--- a/packages/rs-dpp/src/data_contract/config/mod.rs
+++ b/packages/rs-dpp/src/data_contract/config/mod.rs
@@ -30,7 +30,12 @@ impl DataContractConfig {
     pub fn default_for_version(
         platform_version: &PlatformVersion,
     ) -> Result<DataContractConfig, ProtocolError> {
-        match platform_version.dpp.contract_versions.config {
+        match platform_version
+            .dpp
+            .contract_versions
+            .config
+            .default_current_version
+        {
             0 => Ok(DataContractConfigV0::default().into()),
             1 => Ok(DataContractConfigV1::default().into()),
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -41,11 +46,36 @@ impl DataContractConfig {
         }
     }
 
+    /// Adjusts the current `DataContractConfig` to be valid for the provided platform version.
+    ///
+    /// This replaces the internal version with the `default_current_version` defined in the platform version's
+    /// feature bounds for contract config.
+    pub fn config_valid_for_platform_version(
+        self,
+        platform_version: &PlatformVersion,
+    ) -> DataContractConfig {
+        match self {
+            DataContractConfig::V0(v0) => DataContractConfig::V0(v0),
+            DataContractConfig::V1(v1) => {
+                if platform_version.dpp.contract_versions.config.max_version == 0 {
+                    DataContractConfig::V0(v1.into())
+                } else {
+                    self
+                }
+            }
+        }
+    }
+
     pub fn from_value(
         value: Value,
         platform_version: &PlatformVersion,
     ) -> Result<DataContractConfig, ProtocolError> {
-        match platform_version.dpp.contract_versions.config {
+        match platform_version
+            .dpp
+            .contract_versions
+            .config
+            .default_current_version
+        {
             0 => {
                 let config: DataContractConfigV0 = platform_value::from_value(value)?;
                 Ok(config.into())
@@ -85,7 +115,12 @@ impl DataContractConfig {
         contract: &BTreeMap<String, Value>,
         platform_version: &PlatformVersion,
     ) -> Result<DataContractConfig, ProtocolError> {
-        match platform_version.dpp.contract_versions.config {
+        match platform_version
+            .dpp
+            .contract_versions
+            .config
+            .default_current_version
+        {
             0 => Ok(
                 DataContractConfigV0::get_contract_configuration_properties_v0(contract)?.into(),
             ),

--- a/packages/rs-dpp/src/data_contract/config/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/config/v0/mod.rs
@@ -1,4 +1,5 @@
 use crate::data_contract::config;
+use crate::data_contract::config::v1::DataContractConfigV1;
 use crate::data_contract::config::{
     DataContractConfig, DEFAULT_CONTRACT_CAN_BE_DELETED, DEFAULT_CONTRACT_DOCUMENTS_CAN_BE_DELETED,
     DEFAULT_CONTRACT_DOCUMENTS_KEEPS_HISTORY, DEFAULT_CONTRACT_DOCUMENT_MUTABILITY,
@@ -190,5 +191,23 @@ impl DataContractConfigV0 {
             requires_identity_encryption_bounded_key,
             requires_identity_decryption_bounded_key,
         })
+    }
+}
+
+impl From<DataContractConfigV1> for DataContractConfigV0 {
+    fn from(value: DataContractConfigV1) -> Self {
+        DataContractConfigV0 {
+            can_be_deleted: value.can_be_deleted,
+            readonly: value.readonly,
+            keeps_history: value.keeps_history,
+            documents_keep_history_contract_default: value.documents_keep_history_contract_default,
+            documents_mutable_contract_default: value.documents_mutable_contract_default,
+            documents_can_be_deleted_contract_default: value
+                .documents_can_be_deleted_contract_default,
+            requires_identity_encryption_bounded_key: value
+                .requires_identity_encryption_bounded_key,
+            requires_identity_decryption_bounded_key: value
+                .requires_identity_decryption_bounded_key,
+        }
     }
 }

--- a/packages/rs-dpp/src/data_contract/serialized_version/mod.rs
+++ b/packages/rs-dpp/src/data_contract/serialized_version/mod.rs
@@ -17,7 +17,7 @@ use crate::ProtocolError;
 use bincode::{Decode, Encode};
 use derive_more::From;
 use platform_value::{Identifier, Value};
-use platform_version::TryFromPlatformVersioned;
+use platform_version::{IntoPlatformVersioned, TryFromPlatformVersioned};
 use platform_versioning::PlatformVersioned;
 #[cfg(feature = "data-contract-serde-conversion")]
 use serde::{Deserialize, Serialize};
@@ -160,11 +160,13 @@ impl TryFromPlatformVersioned<DataContractV0> for DataContractInSerializationFor
             .default_current_version
         {
             0 => {
-                let v0_format: DataContractInSerializationFormatV0 = DataContract::V0(value).into();
+                let v0_format: DataContractInSerializationFormatV0 =
+                    DataContract::V0(value).into_platform_versioned(platform_version);
                 Ok(v0_format.into())
             }
             1 => {
-                let v1_format: DataContractInSerializationFormatV1 = DataContract::V0(value).into();
+                let v1_format: DataContractInSerializationFormatV1 =
+                    DataContract::V0(value).into_platform_versioned(platform_version);
                 Ok(v1_format.into())
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -191,12 +193,12 @@ impl TryFromPlatformVersioned<&DataContractV0> for DataContractInSerializationFo
         {
             0 => {
                 let v0_format: DataContractInSerializationFormatV0 =
-                    DataContract::V0(value.to_owned()).into();
+                    DataContract::V0(value.to_owned()).into_platform_versioned(platform_version);
                 Ok(v0_format.into())
             }
             1 => {
                 let v1_format: DataContractInSerializationFormatV1 =
-                    DataContract::V0(value.to_owned()).into();
+                    DataContract::V0(value.to_owned()).into_platform_versioned(platform_version);
                 Ok(v1_format.into())
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -222,11 +224,13 @@ impl TryFromPlatformVersioned<DataContractV1> for DataContractInSerializationFor
             .default_current_version
         {
             0 => {
-                let v0_format: DataContractInSerializationFormatV0 = DataContract::V1(value).into();
+                let v0_format: DataContractInSerializationFormatV0 =
+                    DataContract::V1(value).into_platform_versioned(platform_version);
                 Ok(v0_format.into())
             }
             1 => {
-                let v1_format: DataContractInSerializationFormatV1 = DataContract::V1(value).into();
+                let v1_format: DataContractInSerializationFormatV1 =
+                    DataContract::V1(value).into_platform_versioned(platform_version);
                 Ok(v1_format.into())
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -253,12 +257,12 @@ impl TryFromPlatformVersioned<&DataContractV1> for DataContractInSerializationFo
         {
             0 => {
                 let v0_format: DataContractInSerializationFormatV0 =
-                    DataContract::V1(value.to_owned()).into();
+                    DataContract::V1(value.to_owned()).into_platform_versioned(platform_version);
                 Ok(v0_format.into())
             }
             1 => {
                 let v1_format: DataContractInSerializationFormatV1 =
-                    DataContract::V1(value.to_owned()).into();
+                    DataContract::V1(value.to_owned()).into_platform_versioned(platform_version);
                 Ok(v1_format.into())
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -284,11 +288,13 @@ impl TryFromPlatformVersioned<&DataContract> for DataContractInSerializationForm
             .default_current_version
         {
             0 => {
-                let v0_format: DataContractInSerializationFormatV0 = value.clone().into();
+                let v0_format: DataContractInSerializationFormatV0 =
+                    value.clone().into_platform_versioned(platform_version);
                 Ok(v0_format.into())
             }
             1 => {
-                let v1_format: DataContractInSerializationFormatV1 = value.clone().into();
+                let v1_format: DataContractInSerializationFormatV1 =
+                    value.clone().into_platform_versioned(platform_version);
                 Ok(v1_format.into())
             }
             version => Err(ProtocolError::UnknownVersionMismatch {
@@ -314,11 +320,13 @@ impl TryFromPlatformVersioned<DataContract> for DataContractInSerializationForma
             .default_current_version
         {
             0 => {
-                let v0_format: DataContractInSerializationFormatV0 = value.into();
+                let v0_format: DataContractInSerializationFormatV0 =
+                    value.into_platform_versioned(platform_version);
                 Ok(v0_format.into())
             }
             1 => {
-                let v1_format: DataContractInSerializationFormatV1 = value.into();
+                let v1_format: DataContractInSerializationFormatV1 =
+                    value.into_platform_versioned(platform_version);
                 Ok(v1_format.into())
             }
             version => Err(ProtocolError::UnknownVersionMismatch {

--- a/packages/rs-dpp/src/data_contract/serialized_version/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/serialized_version/v0/mod.rs
@@ -7,6 +7,8 @@ use crate::data_contract::v1::DataContractV1;
 use crate::data_contract::{DataContract, DefinitionName, DocumentName};
 use bincode::{Decode, Encode};
 use platform_value::{Identifier, Value};
+use platform_version::version::PlatformVersion;
+use platform_version::FromPlatformVersioned;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -69,6 +71,63 @@ impl From<DataContract> for DataContractInSerializationFormatV0 {
                     document_types,
                     ..
                 } = v1;
+
+                DataContractInSerializationFormatV0 {
+                    id,
+                    config,
+                    version,
+                    owner_id,
+                    document_schemas: document_types
+                        .into_iter()
+                        .map(|(key, document_type)| (key, document_type.schema_owned()))
+                        .collect(),
+                    schema_defs,
+                }
+            }
+        }
+    }
+}
+
+impl FromPlatformVersioned<DataContract> for DataContractInSerializationFormatV0 {
+    fn from_platform_versioned(value: DataContract, platform_version: &PlatformVersion) -> Self {
+        match value {
+            DataContract::V0(v0) => {
+                let DataContractV0 {
+                    id,
+                    config,
+                    version,
+                    owner_id,
+                    schema_defs,
+                    document_types,
+                    ..
+                } = v0;
+
+                let config = config.config_valid_for_platform_version(platform_version);
+
+                DataContractInSerializationFormatV0 {
+                    id,
+                    config,
+                    version,
+                    owner_id,
+                    document_schemas: document_types
+                        .into_iter()
+                        .map(|(key, document_type)| (key, document_type.schema_owned()))
+                        .collect(),
+                    schema_defs,
+                }
+            }
+            DataContract::V1(v1) => {
+                let DataContractV1 {
+                    id,
+                    config,
+                    version,
+                    owner_id,
+                    schema_defs,
+                    document_types,
+                    ..
+                } = v1;
+
+                let config = config.config_valid_for_platform_version(platform_version);
 
                 DataContractInSerializationFormatV0 {
                     id,

--- a/packages/rs-dpp/src/data_contract/serialized_version/v1/mod.rs
+++ b/packages/rs-dpp/src/data_contract/serialized_version/v1/mod.rs
@@ -14,6 +14,8 @@ use crate::identity::TimestampMillis;
 use crate::prelude::BlockHeight;
 use bincode::{Decode, Encode};
 use platform_value::{Identifier, Value};
+use platform_version::version::PlatformVersion;
+use platform_version::FromPlatformVersioned;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -98,6 +100,92 @@ where
                 .map(|key| (key, v))
         })
         .collect()
+}
+
+impl FromPlatformVersioned<DataContract> for DataContractInSerializationFormatV1 {
+    fn from_platform_versioned(value: DataContract, platform_version: &PlatformVersion) -> Self {
+        match value {
+            DataContract::V0(v0) => {
+                let DataContractV0 {
+                    id,
+                    config,
+                    version,
+                    owner_id,
+                    schema_defs,
+                    document_types,
+                    ..
+                } = v0;
+
+                let config = config.config_valid_for_platform_version(platform_version);
+
+                DataContractInSerializationFormatV1 {
+                    id,
+                    config,
+                    version,
+                    owner_id,
+                    schema_defs,
+                    document_schemas: document_types
+                        .into_iter()
+                        .map(|(key, document_type)| (key, document_type.schema_owned()))
+                        .collect(),
+                    created_at: None,
+                    updated_at: None,
+                    created_at_block_height: None,
+                    updated_at_block_height: None,
+                    created_at_epoch: None,
+                    updated_at_epoch: None,
+                    groups: Default::default(),
+                    tokens: Default::default(),
+                    keywords: Default::default(),
+                    description: None,
+                }
+            }
+            DataContract::V1(v1) => {
+                let DataContractV1 {
+                    id,
+                    config,
+                    version,
+                    owner_id,
+                    schema_defs,
+                    document_types,
+                    created_at,
+                    updated_at,
+                    created_at_block_height,
+                    updated_at_block_height,
+                    created_at_epoch,
+                    updated_at_epoch,
+                    groups,
+                    tokens,
+                    keywords,
+                    description,
+                } = v1;
+
+                let config = config.config_valid_for_platform_version(platform_version);
+
+                DataContractInSerializationFormatV1 {
+                    id,
+                    config,
+                    version,
+                    owner_id,
+                    schema_defs,
+                    document_schemas: document_types
+                        .into_iter()
+                        .map(|(key, document_type)| (key, document_type.schema_owned()))
+                        .collect(),
+                    created_at,
+                    updated_at,
+                    created_at_block_height,
+                    updated_at_block_height,
+                    created_at_epoch,
+                    updated_at_epoch,
+                    groups,
+                    tokens,
+                    keywords,
+                    description,
+                }
+            }
+        }
+    }
 }
 
 impl From<DataContract> for DataContractInSerializationFormatV1 {

--- a/packages/rs-dpp/src/system_data_contracts.rs
+++ b/packages/rs-dpp/src/system_data_contracts.rs
@@ -67,6 +67,9 @@ pub fn load_system_data_contracts(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::data_contract::serialized_version::DataContractInSerializationFormat;
+    use crate::serialization::PlatformSerializableWithPlatformVersion;
+    use platform_version::TryIntoPlatformVersioned;
     #[test]
     fn test_load_system_data_contract_v8_vs_v9() {
         let contract_1 = load_system_data_contract(
@@ -80,5 +83,56 @@ mod tests {
         )
         .expect("data_contract");
         assert_ne!(contract_1, contract_2);
+    }
+
+    #[test]
+    fn serialize_withdrawal_contract_v1_vs_v9() {
+        let contract_1 = load_system_data_contract(
+            SystemDataContract::Withdrawals,
+            PlatformVersion::get(1).unwrap(),
+        )
+        .expect("data_contract");
+        let contract_2 = load_system_data_contract(
+            SystemDataContract::Withdrawals,
+            PlatformVersion::get(9).unwrap(),
+        )
+        .expect("data_contract");
+
+        assert_ne!(contract_1, contract_2);
+        let v1_ser: DataContractInSerializationFormat = contract_1
+            .clone()
+            .try_into_platform_versioned(&PlatformVersion::get(1).unwrap())
+            .expect("expected to serialize");
+        let v2_ser: DataContractInSerializationFormat = contract_2
+            .clone()
+            .try_into_platform_versioned(&PlatformVersion::get(1).unwrap())
+            .expect("expected to serialize");
+        assert_eq!(v1_ser, v2_ser);
+
+        let v1_bytes = contract_1
+            .serialize_to_bytes_with_platform_version(&PlatformVersion::get(1).unwrap())
+            .expect("expected to serialize");
+        let v8_bytes = contract_1
+            .serialize_to_bytes_with_platform_version(&PlatformVersion::get(8).unwrap())
+            .expect("expected to serialize");
+        let v9_bytes = contract_1
+            .serialize_to_bytes_with_platform_version(&PlatformVersion::get(9).unwrap())
+            .expect("expected to serialize");
+        assert_eq!(v1_bytes.len(), 1747);
+        assert_eq!(v8_bytes.len(), 1747);
+        assert_eq!(v9_bytes.len(), 1757); // this will still use a config v0 without sized_integer_types
+
+        let v1_bytes = contract_2
+            .serialize_to_bytes_with_platform_version(&PlatformVersion::get(8).unwrap())
+            .expect("expected to serialize");
+        let v8_bytes = contract_2
+            .serialize_to_bytes_with_platform_version(&PlatformVersion::get(8).unwrap())
+            .expect("expected to serialize");
+        let v9_bytes = contract_2
+            .serialize_to_bytes_with_platform_version(&PlatformVersion::get(9).unwrap())
+            .expect("expected to serialize");
+        assert_eq!(v1_bytes.len(), 1747);
+        assert_eq!(v8_bytes.len(), 1747);
+        assert_eq!(v9_bytes.len(), 1758); // this will use a config v1 in serialization with sized_integer_types
     }
 }

--- a/packages/rs-drive-abci/src/main.rs
+++ b/packages/rs-drive-abci/src/main.rs
@@ -470,7 +470,7 @@ mod test {
 
         let platform_version = PlatformVersion::latest();
 
-        let (drive, _) = Drive::open(&path, None, Some(platform_version)).expect("open drive");
+        let (drive, _) = Drive::open(&path, None).expect("open drive");
 
         drive
             .create_initial_state_structure(None, platform_version)

--- a/packages/rs-drive-abci/src/platform_types/platform/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mod.rs
@@ -128,11 +128,8 @@ impl<C> Platform<C> {
     {
         let config = config.unwrap_or(PlatformConfig::default_testnet());
 
-        let (drive, current_platform_version) = Drive::open(
-            path,
-            Some(config.drive.clone()),
-        )
-        .map_err(Error::Drive)?;
+        let (drive, current_platform_version) =
+            Drive::open(path, Some(config.drive.clone())).map_err(Error::Drive)?;
 
         if let Some(platform_version) = current_platform_version {
             let Some(execution_state) =

--- a/packages/rs-drive-abci/src/platform_types/platform/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mod.rs
@@ -131,6 +131,15 @@ impl<C> Platform<C> {
         let (drive, current_platform_version) =
             Drive::open(path, Some(config.drive.clone())).map_err(Error::Drive)?;
 
+        if let Some(initial_protocol_version) = initial_protocol_version {
+            if initial_protocol_version > 1 {
+                drive
+                    .cache
+                    .system_data_contracts
+                    .reload_system_contracts(PlatformVersion::get(initial_protocol_version)?)?;
+            }
+        }
+
         if let Some(platform_version) = current_platform_version {
             let Some(execution_state) =
                 Platform::<C>::fetch_platform_state(&drive, None, platform_version)?
@@ -139,6 +148,12 @@ impl<C> Platform<C> {
                     "execution state should be stored as well as protocol version".to_string(),
                 )));
             };
+            if platform_version.protocol_version > 1 {
+                drive
+                    .cache
+                    .system_data_contracts
+                    .reload_system_contracts(platform_version)?;
+            }
 
             return Platform::open_with_client_saved_state::<P>(
                 drive,

--- a/packages/rs-drive-abci/src/platform_types/platform/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mod.rs
@@ -128,14 +128,9 @@ impl<C> Platform<C> {
     {
         let config = config.unwrap_or(PlatformConfig::default_testnet());
 
-        let default_initial_platform_version = initial_protocol_version
-            .map(PlatformVersion::get)
-            .transpose()?;
-
         let (drive, current_platform_version) = Drive::open(
             path,
             Some(config.drive.clone()),
-            default_initial_platform_version,
         )
         .map_err(Error::Drive)?;
 

--- a/packages/rs-drive/src/cache/system_contracts.rs
+++ b/packages/rs-drive/src/cache/system_contracts.rs
@@ -2,23 +2,69 @@ use crate::error::Error;
 use arc_swap::{ArcSwap, Guard};
 use dpp::data_contract::DataContract;
 use dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
-use platform_version::version::PlatformVersion;
+use platform_version::version::{PlatformVersion, ProtocolVersion};
 use std::sync::Arc;
+
+/// A wrapper around a system [`DataContract`] that tracks its activation version
+/// and allows atomic replacement.
+///
+/// This is used for system data contracts that may be updated over time while
+/// tracking the protocol version from which they are considered active.
+pub struct ActiveSystemDataContract {
+    /// The current active version of the data contract.
+    pub contract: ArcSwap<DataContract>,
+
+    /// The protocol version since which this contract is considered active.
+    #[allow(unused)]
+    pub active_since_protocol_version: ProtocolVersion,
+}
+
+impl ActiveSystemDataContract {
+    /// Atomically replaces the current data contract with a new one.
+    ///
+    /// # Arguments
+    ///
+    /// * `contract` - The new [`DataContract`] to store.
+    pub fn store(&self, contract: DataContract) {
+        self.contract.store(Arc::new(contract));
+    }
+
+    /// Loads the current data contract.
+    ///
+    /// Returns a guard that provides shared access to the current [`DataContract`].
+    /// The guard keeps the contract alive for the duration of the borrow.
+    pub fn load(&self) -> Guard<Arc<DataContract>> {
+        self.contract.load()
+    }
+
+    /// Creates a new [`ActiveSystemDataContract`] with the given contract and activation version.
+    ///
+    /// # Arguments
+    ///
+    /// * `contract` - The initial [`DataContract`] to store.
+    /// * `active_since_protocol_version` - The protocol version from which this contract is considered active.
+    pub fn new(contract: DataContract, active_since_protocol_version: ProtocolVersion) -> Self {
+        ActiveSystemDataContract {
+            contract: ArcSwap::from_pointee(contract),
+            active_since_protocol_version,
+        }
+    }
+}
 
 /// System contracts
 pub struct SystemDataContracts {
     /// Withdrawal contract
-    withdrawals: ArcSwap<DataContract>,
+    withdrawals: ActiveSystemDataContract,
     /// DPNS contract
-    dpns: ArcSwap<DataContract>,
+    dpns: ActiveSystemDataContract,
     /// Dashpay contract
-    dashpay: ArcSwap<DataContract>,
+    dashpay: ActiveSystemDataContract,
     /// Masternode reward shares contract
-    masternode_reward_shares: ArcSwap<DataContract>,
+    masternode_reward_shares: ActiveSystemDataContract,
     /// Token history contract
-    token_history: ArcSwap<DataContract>,
+    token_history: ActiveSystemDataContract,
     /// Search contract
-    keyword_search: ArcSwap<DataContract>,
+    keyword_search: ActiveSystemDataContract,
 }
 
 impl SystemDataContracts {
@@ -43,46 +89,57 @@ impl SystemDataContracts {
         let keyword_search = load_system_data_contract(KeywordSearch, platform_version)?;
 
         // 2. Swap the cached Arcs — each swap is lock-free & O(1).
-        self.withdrawals.store(Arc::new(withdrawals));
-        self.dpns.store(Arc::new(dpns));
-        self.dashpay.store(Arc::new(dashpay));
+        self.withdrawals.store(withdrawals);
+        self.dpns.store(dpns);
+        self.dashpay.store(dashpay);
         self.masternode_reward_shares
-            .store(Arc::new(masternode_reward_shares));
-        self.token_history.store(Arc::new(token_history));
-        self.keyword_search.store(Arc::new(keyword_search));
+            .store(masternode_reward_shares);
+        self.token_history.store(token_history);
+        self.keyword_search.store(keyword_search);
 
         Ok(())
     }
 
     /// load genesis system contracts
-    pub fn load_genesis_system_contracts(
-        platform_version: &PlatformVersion,
-    ) -> Result<Self, Error> {
+    pub fn load_genesis_system_contracts() -> Result<Self, Error> {
+        // We should use the version where the contract became active for each data contract
         Ok(Self {
-            withdrawals: ArcSwap::from_pointee(load_system_data_contract(
-                SystemDataContract::Withdrawals,
-                platform_version,
-            )?),
-            dpns: ArcSwap::from_pointee(load_system_data_contract(
-                SystemDataContract::DPNS,
-                platform_version,
-            )?),
-            dashpay: ArcSwap::from_pointee(load_system_data_contract(
-                SystemDataContract::Dashpay,
-                platform_version,
-            )?),
-            masternode_reward_shares: ArcSwap::from_pointee(load_system_data_contract(
-                SystemDataContract::MasternodeRewards,
-                platform_version,
-            )?),
-            token_history: ArcSwap::from_pointee(load_system_data_contract(
-                SystemDataContract::TokenHistory,
-                platform_version,
-            )?),
-            keyword_search: ArcSwap::from_pointee(load_system_data_contract(
-                SystemDataContract::KeywordSearch,
-                platform_version,
-            )?),
+            withdrawals: ActiveSystemDataContract::new(
+                load_system_data_contract(
+                    SystemDataContract::Withdrawals,
+                    PlatformVersion::first(),
+                )?,
+                1,
+            ),
+            dpns: ActiveSystemDataContract::new(
+                load_system_data_contract(SystemDataContract::DPNS, PlatformVersion::first())?,
+                1,
+            ),
+            dashpay: ActiveSystemDataContract::new(
+                load_system_data_contract(SystemDataContract::Dashpay, PlatformVersion::first())?,
+                1,
+            ),
+            masternode_reward_shares: ActiveSystemDataContract::new(
+                load_system_data_contract(
+                    SystemDataContract::MasternodeRewards,
+                    PlatformVersion::first(),
+                )?,
+                1,
+            ),
+            token_history: ActiveSystemDataContract::new(
+                load_system_data_contract(
+                    SystemDataContract::TokenHistory,
+                    PlatformVersion::first(),
+                )?,
+                9,
+            ),
+            keyword_search: ActiveSystemDataContract::new(
+                load_system_data_contract(
+                    SystemDataContract::KeywordSearch,
+                    PlatformVersion::first(),
+                )?,
+                9,
+            ),
         })
     }
 

--- a/packages/rs-drive/src/drive/credit_pools/epochs/operations_factory.rs
+++ b/packages/rs-drive/src/drive/credit_pools/epochs/operations_factory.rs
@@ -426,7 +426,7 @@ mod tests {
 
         #[test]
         fn test_error_if_fee_pools_not_initialized() {
-            let drive = setup_drive(None, None);
+            let drive = setup_drive(None);
             let transaction = drive.grove.start_transaction();
 
             let platform_version = PlatformVersion::first();

--- a/packages/rs-drive/src/drive/credit_pools/storage_fee_distribution_pool/get_storage_fees_from_distribution_pool/v0/mod.rs
+++ b/packages/rs-drive/src/drive/credit_pools/storage_fee_distribution_pool/get_storage_fees_from_distribution_pool/v0/mod.rs
@@ -52,7 +52,7 @@ mod tests {
 
         #[test]
         fn test_error_if_epoch_is_not_initiated() {
-            let drive = setup_drive(None, None);
+            let drive = setup_drive(None);
             let transaction = drive.grove.start_transaction();
 
             let platform_version = PlatformVersion::first();

--- a/packages/rs-drive/src/drive/credit_pools/unpaid_epoch/get_unpaid_epoch_index/v0/mod.rs
+++ b/packages/rs-drive/src/drive/credit_pools/unpaid_epoch/get_unpaid_epoch_index/v0/mod.rs
@@ -57,7 +57,7 @@ mod tests {
         #[test]
         fn test_error_if_fee_pools_tree_is_not_initiated() {
             let platform_version = PlatformVersion::latest();
-            let drive = setup_drive(None, None);
+            let drive = setup_drive(None);
             let transaction = drive.grove.start_transaction();
 
             let result = drive.get_unpaid_epoch_index_v0(Some(&transaction), platform_version);

--- a/packages/rs-drive/src/drive/document/delete/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/mod.rs
@@ -89,8 +89,7 @@ mod tests {
 
         let platform_version = PlatformVersion::latest();
 
-        let (drive, _) = Drive::open(tmp_dir, None)
-            .expect("expected to open Drive successfully");
+        let (drive, _) = Drive::open(tmp_dir, None).expect("expected to open Drive successfully");
 
         drive
             .create_initial_state_structure(None, platform_version)

--- a/packages/rs-drive/src/drive/document/delete/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/mod.rs
@@ -89,7 +89,7 @@ mod tests {
 
         let platform_version = PlatformVersion::latest();
 
-        let (drive, _) = Drive::open(tmp_dir, None, Some(platform_version))
+        let (drive, _) = Drive::open(tmp_dir, None)
             .expect("expected to open Drive successfully");
 
         drive

--- a/packages/rs-drive/src/drive/document/update/mod.rs
+++ b/packages/rs-drive/src/drive/document/update/mod.rs
@@ -852,7 +852,7 @@ mod tests {
 
         let platform_version = PlatformVersion::latest();
 
-        let drive: Drive = setup_drive(Some(config), None);
+        let drive: Drive = setup_drive(Some(config));
 
         let transaction = if using_transaction {
             Some(drive.grove.start_transaction())
@@ -1159,7 +1159,7 @@ mod tests {
 
         let platform_version = PlatformVersion::latest();
 
-        let drive: Drive = setup_drive(Some(config), None);
+        let drive: Drive = setup_drive(Some(config));
 
         let transaction = if using_transaction {
             Some(drive.grove.start_transaction())
@@ -1366,7 +1366,7 @@ mod tests {
 
         let platform_version = PlatformVersion::latest();
 
-        let drive: Drive = setup_drive(Some(config), None);
+        let drive: Drive = setup_drive(Some(config));
 
         let transaction = if using_transaction {
             Some(drive.grove.start_transaction())
@@ -1709,7 +1709,7 @@ mod tests {
 
         let platform_version = PlatformVersion::latest();
 
-        let drive: Drive = setup_drive(Some(config), None);
+        let drive: Drive = setup_drive(Some(config));
 
         let transaction = if using_transaction {
             Some(drive.grove.start_transaction())

--- a/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/merge_identity_contract_nonce/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/contract_info/identity_contract_nonce/merge_identity_contract_nonce/v0/mod.rs
@@ -304,7 +304,7 @@ mod tests {
     use platform_version::version::PlatformVersion;
 
     fn setup_base_test(contract_id: [u8; 32]) -> (Drive, Identity) {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let transaction = drive.grove.start_transaction();
 
         let platform_version = PlatformVersion::first();

--- a/packages/rs-drive/src/drive/identity/fetch/fetch_by_public_key_hashes/mod.rs
+++ b/packages/rs-drive/src/drive/identity/fetch/fetch_by_public_key_hashes/mod.rs
@@ -22,7 +22,7 @@ mod tests {
 
     #[test]
     fn test_fetch_all_keys_on_identity() {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
 
         let transaction = drive.grove.start_transaction();

--- a/packages/rs-drive/src/drive/identity/insert/add_new_identity/mod.rs
+++ b/packages/rs-drive/src/drive/identity/insert/add_new_identity/mod.rs
@@ -190,7 +190,7 @@ mod tests {
         platform_version: &PlatformVersion,
         expected_fee_result: FeeResult,
     ) {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
 
         let transaction = drive.grove.start_transaction();
 

--- a/packages/rs-drive/src/drive/identity/key/fetch/mod.rs
+++ b/packages/rs-drive/src/drive/identity/key/fetch/mod.rs
@@ -1046,7 +1046,7 @@ mod tests {
 
     #[test]
     fn test_fetch_all_keys_on_identity() {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
 
         let transaction = drive.grove.start_transaction();
@@ -1082,7 +1082,7 @@ mod tests {
 
     #[test]
     fn test_fetch_single_identity_key() {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
 
         let transaction = drive.grove.start_transaction();
 
@@ -1122,7 +1122,7 @@ mod tests {
 
     #[test]
     fn test_fetch_multiple_identity_key() {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
 
         let transaction = drive.grove.start_transaction();
 
@@ -1162,7 +1162,7 @@ mod tests {
 
     #[test]
     fn test_fetch_unknown_identity_key_returns_not_found() {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
 
         let transaction = drive.grove.start_transaction();
 

--- a/packages/rs-drive/src/drive/identity/update/operations/merge_identity_nonce_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/operations/merge_identity_nonce_operations/v0/mod.rs
@@ -177,7 +177,7 @@ mod tests {
     use platform_version::version::PlatformVersion;
 
     fn setup_base_test() -> (Drive, Identity) {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let transaction = drive.grove.start_transaction();
 
         let platform_version = PlatformVersion::first();

--- a/packages/rs-drive/src/drive/identity/withdrawals/document/find_withdrawal_documents_by_status_and_transaction_indices/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/document/find_withdrawal_documents_by_status_and_transaction_indices/v0/mod.rs
@@ -107,7 +107,6 @@ mod tests {
     use dpp::identity::core_script::CoreScript;
     use dpp::platform_value::platform_value;
     use dpp::system_data_contracts::withdrawals_contract::v1::document_types::withdrawal;
-    use dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
     use dpp::tests::fixtures::get_withdrawal_document_fixture;
     use dpp::version::PlatformVersion;
     use dpp::withdrawal::Pooling;

--- a/packages/rs-drive/src/drive/identity/withdrawals/document/find_withdrawal_documents_by_status_and_transaction_indices/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/document/find_withdrawal_documents_by_status_and_transaction_indices/v0/mod.rs
@@ -123,9 +123,7 @@ mod tests {
 
         let platform_version = PlatformVersion::latest();
 
-        let data_contract =
-            load_system_data_contract(SystemDataContract::Withdrawals, platform_version)
-                .expect("to load system data contract");
+        let data_contract = drive.cache.system_data_contracts.load_withdrawals();
 
         setup_system_data_contract(&drive, &data_contract, Some(&transaction));
 

--- a/packages/rs-drive/src/drive/system/genesis_time/mod.rs
+++ b/packages/rs-drive/src/drive/system/genesis_time/mod.rs
@@ -57,7 +57,7 @@ mod tests {
 
         #[test]
         fn should_return_none_if_cache_is_empty_and_start_time_is_not_persisted() {
-            let drive = setup_drive(None, None);
+            let drive = setup_drive(None);
 
             let result = drive
                 .get_genesis_time(None)
@@ -68,7 +68,7 @@ mod tests {
 
         #[test]
         fn should_return_some_if_cache_is_set() {
-            let drive = setup_drive(None, None);
+            let drive = setup_drive(None);
 
             let mut genesis_time_ms_cache = drive.cache.genesis_time_ms.write();
 
@@ -134,7 +134,7 @@ mod tests {
 
         #[test]
         fn should_set_genesis_time_to_cache() {
-            let drive = setup_drive(None, None);
+            let drive = setup_drive(None);
 
             let genesis_time_ms: u64 = 100;
 

--- a/packages/rs-drive/src/open/mod.rs
+++ b/packages/rs-drive/src/open/mod.rs
@@ -19,7 +19,6 @@ impl Drive {
     ///
     /// * `path` - A reference that implements the `AsRef<Path>` trait. This represents the path to the GroveDB.
     /// * `config` - An `Option` which contains `DriveConfig`. If not specified, default configuration is used.
-    /// * `drive_version` - A `DriveVersion` reference that dictates which version of the method to call.
     ///
     /// # Returns
     ///
@@ -28,7 +27,6 @@ impl Drive {
     pub fn open<P: AsRef<Path>>(
         path: P,
         config: Option<DriveConfig>,
-        default_platform_version: Option<&PlatformVersion>,
     ) -> Result<(Self, Option<&'static PlatformVersion>), Error> {
         let config = config.unwrap_or_default();
 
@@ -50,11 +48,6 @@ impl Drive {
             })
             .transpose()?;
 
-        // At this point we don't know the version what we need to process next block or initialize the chain
-        // so version related data should be updated on init chain or on block execution
-        let platform_version = maybe_platform_version
-            .unwrap_or_else(|| default_platform_version.unwrap_or(PlatformVersion::latest()));
-
         let drive = Drive {
             grove,
             config,
@@ -65,9 +58,7 @@ impl Drive {
                 ),
                 genesis_time_ms: parking_lot::RwLock::new(genesis_time_ms),
                 protocol_versions_counter: parking_lot::RwLock::new(ProtocolVersionsCache::new()),
-                system_data_contracts: SystemDataContracts::load_genesis_system_contracts(
-                    platform_version,
-                )?,
+                system_data_contracts: SystemDataContracts::load_genesis_system_contracts()?,
             },
         };
 

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -2321,7 +2321,7 @@ mod tests {
 
         let platform_version = PlatformVersion::latest();
 
-        let (drive, _) = Drive::open(tmp_dir, None, Some(platform_version))
+        let (drive, _) = Drive::open(tmp_dir, None)
             .expect("expected to open Drive successfully");
 
         drive
@@ -2354,7 +2354,7 @@ mod tests {
 
         let platform_version = PlatformVersion::latest();
 
-        let (drive, _) = Drive::open(tmp_dir, None, Some(platform_version))
+        let (drive, _) = Drive::open(tmp_dir, None)
             .expect("expected to open Drive successfully");
 
         drive

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -2321,8 +2321,7 @@ mod tests {
 
         let platform_version = PlatformVersion::latest();
 
-        let (drive, _) = Drive::open(tmp_dir, None)
-            .expect("expected to open Drive successfully");
+        let (drive, _) = Drive::open(tmp_dir, None).expect("expected to open Drive successfully");
 
         drive
             .create_initial_state_structure(None, platform_version)
@@ -2354,8 +2353,7 @@ mod tests {
 
         let platform_version = PlatformVersion::latest();
 
-        let (drive, _) = Drive::open(tmp_dir, None)
-            .expect("expected to open Drive successfully");
+        let (drive, _) = Drive::open(tmp_dir, None).expect("expected to open Drive successfully");
 
         drive
             .create_initial_state_structure(None, platform_version)

--- a/packages/rs-drive/src/util/grove_operations/batch_delete_items_in_path_query/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/batch_delete_items_in_path_query/v0/mod.rs
@@ -143,7 +143,7 @@ mod tests {
     #[test]
     fn test_batch_delete_items_in_path_query_success() {
         // Set up a test drive instance and transaction
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
         let transaction = drive.grove.start_transaction();
 
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn test_batch_delete_items_in_path_query_range_query() {
         // Set up a test drive instance and transaction
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
         let transaction = drive.grove.start_transaction();
 
@@ -379,7 +379,7 @@ mod tests {
     #[test]
     fn test_batch_delete_items_in_path_query_no_elements() {
         // Set up a test drive instance and transaction
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
         let transaction = drive.grove.start_transaction();
 
@@ -455,7 +455,7 @@ mod tests {
     #[test]
     fn test_batch_delete_items_in_path_query_intermediate_path_missing() {
         // Set up a test drive instance and transaction
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
         let transaction = drive.grove.start_transaction();
 
@@ -491,7 +491,7 @@ mod tests {
     #[test]
     fn test_batch_delete_items_in_path_query_stateless_delete() {
         // Set up a test drive instance and transaction
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
         let transaction = drive.grove.start_transaction();
 

--- a/packages/rs-drive/src/util/grove_operations/batch_move/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/batch_move/v0/mod.rs
@@ -131,7 +131,7 @@ mod tests {
     /// Successfully move a single non‑tree item from `root` to `new_root`.
     #[test]
     fn test_batch_move_single_item_success() {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
         let tx = drive.grove.start_transaction();
 
@@ -237,7 +237,7 @@ mod tests {
     /// Attempting to move a missing key should return a PathKeyNotFound error.
     #[test]
     fn test_batch_move_single_item_missing() {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
         let tx = drive.grove.start_transaction();
 
@@ -285,7 +285,7 @@ mod tests {
     /// Moving a subtree (tree element) must fail with NotSupported.
     #[test]
     fn test_batch_move_single_item_tree_error() {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
         let tx = drive.grove.start_transaction();
 

--- a/packages/rs-drive/src/util/grove_operations/batch_move_items_in_path_query/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/batch_move_items_in_path_query/v0/mod.rs
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn test_batch_move_items_in_path_query_success() {
         // Set up a test drive instance and transaction
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
         let transaction = drive.grove.start_transaction();
 
@@ -315,7 +315,7 @@ mod tests {
     #[test]
     fn test_batch_move_items_in_path_query_no_elements() {
         // Set up a test drive instance and transaction
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
         let transaction = drive.grove.start_transaction();
 
@@ -362,7 +362,7 @@ mod tests {
     #[test]
     fn test_batch_move_items_in_path_query_range_query() {
         // Set up a test drive instance and transaction
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
         let platform_version = PlatformVersion::latest();
         let transaction = drive.grove.start_transaction();
 

--- a/packages/rs-drive/src/util/test_helpers/setup.rs
+++ b/packages/rs-drive/src/util/test_helpers/setup.rs
@@ -36,13 +36,10 @@ impl Default for SetupFeePoolsOptions {
 
 #[cfg(feature = "full")]
 /// Sets up Drive using a temporary directory and the optionally given Drive configuration settings.
-pub fn setup_drive(
-    drive_config: Option<DriveConfig>,
-    specific_platform_version: Option<&PlatformVersion>,
-) -> Drive {
+pub fn setup_drive(drive_config: Option<DriveConfig>) -> Drive {
     let tmp_dir = TempDir::new().unwrap();
 
-    let (drive, _) = Drive::open(tmp_dir, drive_config, specific_platform_version)
+    let (drive, _) = Drive::open(tmp_dir, drive_config)
         .expect("should open Drive successfully");
 
     drive
@@ -53,13 +50,10 @@ pub fn setup_drive(
 pub fn setup_drive_with_initial_state_structure(
     specific_platform_version: Option<&PlatformVersion>,
 ) -> Drive {
-    let drive = setup_drive(
-        Some(DriveConfig {
-            batching_consistency_verification: true,
-            ..Default::default()
-        }),
-        specific_platform_version,
-    );
+    let drive = setup_drive(Some(DriveConfig {
+        batching_consistency_verification: true,
+        ..Default::default()
+    }));
 
     let platform_version = specific_platform_version.unwrap_or(PlatformVersion::latest());
     drive

--- a/packages/rs-drive/src/util/test_helpers/setup.rs
+++ b/packages/rs-drive/src/util/test_helpers/setup.rs
@@ -39,8 +39,7 @@ impl Default for SetupFeePoolsOptions {
 pub fn setup_drive(drive_config: Option<DriveConfig>) -> Drive {
     let tmp_dir = TempDir::new().unwrap();
 
-    let (drive, _) = Drive::open(tmp_dir, drive_config)
-        .expect("should open Drive successfully");
+    let (drive, _) = Drive::open(tmp_dir, drive_config).expect("should open Drive successfully");
 
     drive
 }

--- a/packages/rs-drive/tests/deterministic_root_hash.rs
+++ b/packages/rs-drive/tests/deterministic_root_hash.rs
@@ -316,7 +316,7 @@ mod tests {
     /// Runs `test_root_hash_with_batches` 10 times.
     #[test]
     fn test_deterministic_root_hash_with_batches_first_platform_version() {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
 
         let platform_version = PlatformVersion::first();
 
@@ -335,7 +335,7 @@ mod tests {
     /// Runs `test_root_hash_with_batches` 10 times.
     #[test]
     fn test_root_hash_with_batches_for_version() {
-        let drive = setup_drive(None, None);
+        let drive = setup_drive(None);
 
         let db_transaction = drive.grove.start_transaction();
 

--- a/packages/rs-drive/tests/query_tests.rs
+++ b/packages/rs-drive/tests/query_tests.rs
@@ -203,7 +203,7 @@ pub fn setup_family_tests(
 ) -> (Drive, DataContract) {
     let drive_config = DriveConfig::default();
 
-    let drive = setup_drive(Some(drive_config), None);
+    let drive = setup_drive(Some(drive_config));
 
     let db_transaction = drive.grove.start_transaction();
 
@@ -274,7 +274,7 @@ pub fn setup_family_tests(
 pub fn setup_family_tests_with_nulls(count: u32, seed: u64) -> (Drive, DataContract) {
     let drive_config = DriveConfig::default();
 
-    let drive = setup_drive(Some(drive_config), None);
+    let drive = setup_drive(Some(drive_config));
 
     let db_transaction = drive.grove.start_transaction();
 
@@ -346,7 +346,7 @@ pub fn setup_family_tests_with_nulls(count: u32, seed: u64) -> (Drive, DataContr
 pub fn setup_family_tests_only_first_name_index(count: u32, seed: u64) -> (Drive, DataContract) {
     let drive_config = DriveConfig::default();
 
-    let drive = setup_drive(Some(drive_config), None);
+    let drive = setup_drive(Some(drive_config));
 
     let db_transaction = drive.grove.start_transaction();
 
@@ -822,7 +822,7 @@ pub fn setup_dpns_tests_with_batches(
     seed: u64,
     platform_version: &PlatformVersion,
 ) -> (Drive, DataContract) {
-    let drive = setup_drive(Some(DriveConfig::default()), None);
+    let drive = setup_drive(Some(DriveConfig::default()));
 
     let db_transaction = drive.grove.start_transaction();
 
@@ -870,7 +870,7 @@ pub fn setup_withdrawal_tests(
     total_owners: Option<u32>,
     seed: u64,
 ) -> (Drive, DataContract) {
-    let drive = setup_drive(Some(DriveConfig::default()), None);
+    let drive = setup_drive(Some(DriveConfig::default()));
 
     let db_transaction = drive.grove.start_transaction();
 
@@ -918,7 +918,7 @@ pub fn setup_withdrawal_tests(
 #[cfg(feature = "server")]
 /// Sets up the References contract to test queries on.
 pub fn setup_references_tests(_count: u32, _seed: u64) -> (Drive, DataContract) {
-    let drive = setup_drive(Some(DriveConfig::default()), None);
+    let drive = setup_drive(Some(DriveConfig::default()));
 
     let db_transaction = drive.grove.start_transaction();
 
@@ -956,7 +956,7 @@ pub fn setup_references_tests(_count: u32, _seed: u64) -> (Drive, DataContract) 
 #[cfg(feature = "server")]
 /// Sets up and inserts random domain name data to the DPNS contract to test queries on.
 pub fn setup_dpns_tests_label_not_required(count: u32, seed: u64) -> (Drive, DataContract) {
-    let drive = setup_drive(Some(DriveConfig::default()), None);
+    let drive = setup_drive(Some(DriveConfig::default()));
 
     let db_transaction = drive.grove.start_transaction();
 
@@ -995,7 +995,7 @@ pub fn setup_dpns_tests_label_not_required(count: u32, seed: u64) -> (Drive, Dat
 #[cfg(feature = "server")]
 /// Sets up the DPNS contract and inserts data from the given path to test queries on.
 pub fn setup_dpns_test_with_data(path: &str) -> (Drive, DataContract) {
-    let drive = setup_drive(None, None);
+    let drive = setup_drive(None);
 
     let db_transaction = drive.grove.start_transaction();
 

--- a/packages/rs-drive/tests/query_tests_history.rs
+++ b/packages/rs-drive/tests/query_tests_history.rs
@@ -168,7 +168,7 @@ pub fn setup(
     let epoch_change_fee_version_test: Lazy<CachedEpochIndexFeeVersions> =
         Lazy::new(|| BTreeMap::from([(0, FeeVersion::first())]));
 
-    let drive = setup_drive(Some(drive_config), None);
+    let drive = setup_drive(Some(drive_config));
 
     let db_transaction = drive.grove.start_transaction();
 

--- a/packages/rs-platform-version/src/lib.rs
+++ b/packages/rs-platform-version/src/lib.rs
@@ -50,3 +50,30 @@ where
         U::try_from_platform_versioned(self, platform_version)
     }
 }
+
+/// A trait for converting a value of type `T` into `Self` using a provided `PlatformVersion`.
+///
+/// This trait is infallible and guarantees a valid result for supported versions.
+pub trait FromPlatformVersioned<T>: Sized {
+    /// Performs the conversion.
+    fn from_platform_versioned(value: T, platform_version: &PlatformVersion) -> Self;
+}
+
+/// A trait for converting `Self` into another type `T` using a `PlatformVersion`.
+///
+/// This is the infallible counterpart of `TryIntoPlatformVersioned`.
+pub trait IntoPlatformVersioned<T>: Sized {
+    /// Performs the conversion.
+    fn into_platform_versioned(self, platform_version: &PlatformVersion) -> T;
+}
+
+// FromPlatformVersioned implies IntoPlatformVersioned
+impl<T, U> IntoPlatformVersioned<U> for T
+where
+    U: FromPlatformVersioned<T>,
+{
+    #[inline]
+    fn into_platform_versioned(self, platform_version: &PlatformVersion) -> U {
+        U::from_platform_versioned(self, platform_version)
+    }
+}

--- a/packages/rs-platform-version/src/version/dpp_versions/dpp_contract_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions/dpp_contract_versions/mod.rs
@@ -13,7 +13,7 @@ pub struct DPPContractVersions {
     /// This is the structure of the Contract as it is defined for code paths
     pub contract_structure_version: FeatureVersion,
     pub created_data_contract_structure: FeatureVersion,
-    pub config: FeatureVersion,
+    pub config: FeatureVersionBounds,
     pub methods: DataContractMethodVersions,
     pub document_type_versions: DocumentTypeVersions,
 }

--- a/packages/rs-platform-version/src/version/dpp_versions/dpp_contract_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions/dpp_contract_versions/v1.rs
@@ -14,7 +14,11 @@ pub const CONTRACT_VERSIONS_V1: DPPContractVersions = DPPContractVersions {
     },
     contract_structure_version: 0,
     created_data_contract_structure: 0,
-    config: 0,
+    config: FeatureVersionBounds {
+        min_version: 0,
+        max_version: 0,
+        default_current_version: 0,
+    },
     methods: DataContractMethodVersions {
         validate_document: 0,
         validate_update: 0,

--- a/packages/rs-platform-version/src/version/dpp_versions/dpp_contract_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions/dpp_contract_versions/v2.rs
@@ -14,7 +14,11 @@ pub const CONTRACT_VERSIONS_V2: DPPContractVersions = DPPContractVersions {
     },
     contract_structure_version: 1, //changed
     created_data_contract_structure: 0,
-    config: 1, // changed to enable sized integer types
+    config: FeatureVersionBounds {
+        min_version: 0,
+        max_version: 1,
+        default_current_version: 1,
+    }, // changed to enable sized integer types
     methods: DataContractMethodVersions {
         validate_document: 0,
         validate_update: 0,

--- a/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractCreateTransition/DataContractCreateTransition.spec.js
+++ b/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractCreateTransition/DataContractCreateTransition.spec.js
@@ -66,7 +66,7 @@ describe('DataContractCreateTransition', () => {
     it('should return serialized State Transition', () => {
       const result = stateTransition.toBuffer();
       expect(result).to.be.instanceOf(Buffer);
-      expect(result).to.have.lengthOf(2360);
+      expect(result).to.have.lengthOf(2359);
     });
 
     it('should be able to restore contract config from bytes', () => {

--- a/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractUpdateTransition/DataContractUpdateTransition.spec.js
+++ b/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractUpdateTransition/DataContractUpdateTransition.spec.js
@@ -65,7 +65,7 @@ describe('DataContractUpdateTransition', () => {
     it('should return serialized State Transition', () => {
       const result = stateTransition.toBuffer();
       expect(result).to.be.instanceOf(Buffer);
-      expect(result).to.have.lengthOf(2360);
+      expect(result).to.have.lengthOf(2359);
     });
 
     it('should be able to restore contract config from bytes', () => {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes the loading mechanism for data contracts to ensure they are loaded in the version they appear in.

## What was done?
Updated the methods responsible for loading data contracts to respect their versioning. This includes modifications to the `from_platform_versioned` methods and adjustments in the `ActiveSystemDataContract` struct to handle version-specific logic.
Changed it so data contracts would use the correct config structure when serializing. A data contract in V1 serializing to storage structure V0 was using config structure V1, when it should have been using config structure V0. 

## How Has This Been Tested?
Changes were verified through existing unit tests that validate the loading and serialization of data contracts. Additional tests were added to cover edge cases related to version handling.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced version-aware conversion traits to improve compatibility across platform versions.
  - Added support for bounded version ranges in contract configuration, enabling more flexible version management.
  - Enabled platform version-aware data contract serialization with improved config validation.
  - Added method to adjust data contract configurations for platform version compatibility.
  - Added conversion from newer to older data contract config versions for backward compatibility.

- **Refactor**
  - Simplified and unified test setup functions by reducing redundant parameters.
  - Enhanced system contract management with atomic updates and version tracking.
  - Removed explicit platform version arguments in core drive open calls for streamlined initialization.
  - Updated internal contract loading to use new atomic contract wrapper abstraction.
  - Simplified system contract loading by removing platform version parameter.

- **Bug Fixes**
  - Improved serialization logic to ensure consistent contract output across platform versions.

- **Tests**
  - Expanded test coverage for contract serialization and version differences.
  - Added tests comparing serialized withdrawal contracts across platform versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->