### PR TITLE
feat: add checks for authorized action takers in data contract create and update validations

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/basic_structure/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/basic_structure/v0/mod.rs
@@ -10,6 +10,7 @@ use dpp::consensus::ConsensusError;
 use dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
 use dpp::data_contract::associated_token::token_distribution_rules::accessors::v0::TokenDistributionRulesV0Getters;
 use dpp::data_contract::associated_token::token_perpetual_distribution::methods::v0::TokenPerpetualDistributionV0Accessors;
+use dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
 use dpp::data_contract::{TokenContractPosition, INITIAL_DATA_CONTRACT_VERSION};
 use dpp::prelude::DataContract;
 use dpp::state_transition::data_contract_create_transition::accessors::DataContractCreateTransitionAccessorsV0;
@@ -106,6 +107,16 @@ impl DataContractCreateStateTransitionBasicStructureValidationV0 for DataContrac
                 && !token_configuration
                     .distribution_rules()
                     .minting_allow_choosing_destination()
+                && !(token_configuration
+                    .distribution_rules()
+                    .minting_allow_choosing_destination_rules()
+                    .authorized_to_make_change_action_takers()
+                    == &AuthorizedActionTakers::NoOne
+                    && token_configuration
+                        .distribution_rules()
+                        .minting_allow_choosing_destination_rules()
+                        .admin_action_takers()
+                        == &AuthorizedActionTakers::NoOne)
             {
                 return Ok(SimpleConsensusValidationResult::new_with_error(
                     NewTokensDestinationIdentityOptionRequiredError::new(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/basic_structure/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_update/basic_structure/v0/mod.rs
@@ -6,6 +6,7 @@ use dpp::consensus::basic::data_contract::{
 use dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
 use dpp::data_contract::associated_token::token_distribution_rules::accessors::v0::TokenDistributionRulesV0Getters;
 use dpp::data_contract::associated_token::token_perpetual_distribution::methods::v0::TokenPerpetualDistributionV0Accessors;
+use dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
 use dpp::data_contract::TokenContractPosition;
 use dpp::prelude::DataContract;
 use dpp::state_transition::data_contract_update_transition::accessors::DataContractUpdateTransitionAccessorsV0;
@@ -91,6 +92,16 @@ impl DataContractUpdateStateTransitionBasicStructureValidationV0 for DataContrac
                 && !token_configuration
                     .distribution_rules()
                     .minting_allow_choosing_destination()
+                && !(token_configuration
+                    .distribution_rules()
+                    .minting_allow_choosing_destination_rules()
+                    .authorized_to_make_change_action_takers()
+                    == &AuthorizedActionTakers::NoOne
+                    && token_configuration
+                        .distribution_rules()
+                        .minting_allow_choosing_destination_rules()
+                        .admin_action_takers()
+                        == &AuthorizedActionTakers::NoOne)
             {
                 return Ok(SimpleConsensusValidationResult::new_with_error(
                     NewTokensDestinationIdentityOptionRequiredError::new(


### PR DESCRIPTION
## Issue being fixed or feature implemented
Added validation checks for authorized action takers in the data contract creation and update processes to ensure proper handling of minting destination options.

## What was done?
- Introduced checks in both `data_contract_create` and `data_contract_update` validation logic to verify if there are authorized action takers for minting destination rules.
- Updated logic to return an error if both `authorized_to_make_change_action_takers` and `admin_action_takers` are set to `NoOne`.

## How Has This Been Tested?
The changes were validated through existing unit tests covering data contract creation and update scenarios, ensuring that the new checks are appropriately enforced.

## Breaking Changes
None

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added ! to the title and described breaking changes in the corresponding section if my code contains any.

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone