### PR TITLE
feat(dpp):! add marketplace rules accessor to token configuration

### DIFF
--- a/packages/rs-dpp/src/data_contract/associated_token/token_configuration/v0/accessors.rs
+++ b/packages/rs-dpp/src/data_contract/associated_token/token_configuration/v0/accessors.rs
@@ -8,6 +8,7 @@ use crate::data_contract::associated_token::token_configuration::v0::{
 use crate::data_contract::associated_token::token_distribution_rules::accessors::v0::TokenDistributionRulesV0Getters;
 use crate::data_contract::associated_token::token_distribution_rules::TokenDistributionRules;
 use crate::data_contract::associated_token::token_keeps_history_rules::TokenKeepsHistoryRules;
+use crate::data_contract::associated_token::token_marketplace_rules::accessors::v0::TokenMarketplaceRulesV0Getters;
 use crate::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
 use crate::data_contract::change_control_rules::ChangeControlRules;
 use crate::data_contract::GroupContractPosition;
@@ -185,6 +186,10 @@ impl TokenConfigurationV0Getters for TokenConfigurationV0 {
                 "distribution_rules.change_direct_purchase_pricing_rules",
                 self.distribution_rules
                     .change_direct_purchase_pricing_rules(),
+            ),
+            (
+                "trade_mode_change_rules",
+                &self.marketplace_rules.trade_mode_change_rules(),
             ),
             ("manual_minting_rules", &self.manual_minting_rules),
             ("manual_burning_rules", &self.manual_burning_rules),


### PR DESCRIPTION
## Issue being fixed or feature implemented
Add support for accessing marketplace rules in the token configuration.

## What was done?
Introduced a new accessor for marketplace rules within the `TokenConfigurationV0Getters` implementation. This includes the addition of `trade_mode_change_rules` to the existing set of rules.

## How Has This Been Tested?
Not tested, but obvious.

## Breaking Changes
Yes

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

  **For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visibility of trade mode change rules for marketplace settings within token configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->