### PR TITLE
feat(sdk)!: make document state transition entropy optional, will do a replace if revision is not 1.

### DIFF
--- a/packages/rs-sdk/src/platform/transition/put_document.rs
+++ b/packages/rs-sdk/src/platform/transition/put_document.rs
@@ -2,9 +2,11 @@ use super::broadcast::BroadcastStateTransition;
 use super::waitable::Waitable;
 use crate::platform::transition::put_settings::PutSettings;
 use crate::{Error, Sdk};
+use dpp::dashcore::secp256k1::rand::rngs::StdRng;
+use dpp::dashcore::secp256k1::rand::{Rng, SeedableRng};
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dpp::data_contract::document_type::DocumentType;
-use dpp::document::{Document, DocumentV0Getters};
+use dpp::document::{Document, DocumentV0Getters, DocumentV0Setters, INITIAL_REVISION};
 use dpp::identity::signer::Signer;
 use dpp::identity::IdentityPublicKey;
 use dpp::state_transition::batch_transition::methods::v0::DocumentsBatchTransitionMethodsV0;
@@ -22,7 +24,7 @@ pub trait PutDocument<S: Signer>: Waitable {
         &self,
         sdk: &Sdk,
         document_type: DocumentType,
-        document_state_transition_entropy: [u8; 32],
+        document_state_transition_entropy: Option<[u8; 32]>,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
@@ -35,7 +37,7 @@ pub trait PutDocument<S: Signer>: Waitable {
         &self,
         sdk: &Sdk,
         document_type: DocumentType,
-        document_state_transition_entropy: [u8; 32],
+        document_state_transition_entropy: Option<[u8; 32]>,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
@@ -49,7 +51,7 @@ impl<S: Signer> PutDocument<S> for Document {
         &self,
         sdk: &Sdk,
         document_type: DocumentType,
-        document_state_transition_entropy: [u8; 32],
+        document_state_transition_entropy: Option<[u8; 32]>,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,
@@ -65,19 +67,48 @@ impl<S: Signer> PutDocument<S> for Document {
             .await?;
 
         let settings = settings.unwrap_or_default();
-
-        let transition = BatchTransition::new_document_creation_transition_from_document(
-            self.clone(),
-            document_type.as_ref(),
-            document_state_transition_entropy,
-            &identity_public_key,
-            new_identity_contract_nonce,
-            settings.user_fee_increase.unwrap_or_default(),
-            token_payment_info,
-            signer,
-            sdk.version(),
-            settings.state_transition_creation_options,
-        )?;
+        let transition = if self.revision().is_some()
+            && self.revision().unwrap() != INITIAL_REVISION
+        {
+            BatchTransition::new_document_replacement_transition_from_document(
+                self.clone(),
+                document_type.as_ref(),
+                &identity_public_key,
+                new_identity_contract_nonce,
+                settings.user_fee_increase.unwrap_or_default(),
+                token_payment_info,
+                signer,
+                sdk.version(),
+                settings.state_transition_creation_options,
+            )
+        } else {
+            let (document, document_state_transition_entropy) = document_state_transition_entropy
+                .map(|entropy| (self.clone(), entropy))
+                .unwrap_or_else(|| {
+                    let mut rng = StdRng::from_entropy();
+                    let mut document = self.clone();
+                    let entropy = rng.gen::<[u8; 32]>();
+                    document.set_id(Document::generate_document_id_v0(
+                        &document_type.data_contract_id(),
+                        &document.owner_id(),
+                        document_type.name(),
+                        entropy.as_slice(),
+                    ));
+                    (document, entropy)
+                });
+            BatchTransition::new_document_creation_transition_from_document(
+                document,
+                document_type.as_ref(),
+                document_state_transition_entropy,
+                &identity_public_key,
+                new_identity_contract_nonce,
+                settings.user_fee_increase.unwrap_or_default(),
+                token_payment_info,
+                signer,
+                sdk.version(),
+                settings.state_transition_creation_options,
+            )
+        }?;
 
         // response is empty for a broadcast, result comes from the stream wait for state transition result
         transition.broadcast(sdk, Some(settings)).await?;
@@ -88,7 +119,7 @@ impl<S: Signer> PutDocument<S> for Document {
         &self,
         sdk: &Sdk,
         document_type: DocumentType,
-        document_state_transition_entropy: [u8; 32],
+        document_state_transition_entropy: Option<[u8; 32]>,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
         signer: &S,


### PR DESCRIPTION
## Issue being fixed or feature implemented
This update allows the `document_state_transition_entropy` parameter to be optional, improving flexibility in document state transitions.

## What was done?
- Changed `document_state_transition_entropy` from a required `[u8; 32]` array to an `Option<[u8; 32]>`.
- Updated logic to handle cases where entropy is not provided, generating it randomly when necessary.
- Modified the document creation and replacement transition methods to accommodate the new optional parameter.

## How Has This Been Tested?
The changes were tested through existing unit tests that cover document state transitions, ensuring that both the creation and replacement scenarios function correctly with and without the entropy parameter.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added ! to the title and described breaking changes in the corresponding section if my code contains any.

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved document creation and replacement process by allowing optional entropy input; if not provided, entropy is generated automatically.
- **Refactor**
  - Updated document handling to distinguish between creation and replacement based on document revision, streamlining the transition process for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->