### PR TITLE
feat(platform): add finalized epoch infos query and proof functionality

### DIFF
--- a/packages/dapi-grpc/build.rs
+++ b/packages/dapi-grpc/build.rs
@@ -73,7 +73,7 @@ fn configure_platform(mut platform: MappingConfig) -> MappingConfig {
     // Derive features for versioned messages
     //
     // "GetConsensusParamsRequest" is excluded as this message does not support proofs
-    const VERSIONED_REQUESTS: [&str; 43] = [
+    const VERSIONED_REQUESTS: [&str; 44] = [
         "GetDataContractHistoryRequest",
         "GetDataContractRequest",
         "GetDataContractsRequest",
@@ -117,6 +117,7 @@ fn configure_platform(mut platform: MappingConfig) -> MappingConfig {
         "GetGroupInfosRequest",
         "GetGroupActionsRequest",
         "GetGroupActionSignersRequest",
+        "GetFinalizedEpochInfosRequest",
     ];
 
     // The following responses are excluded as they don't support proofs:
@@ -127,7 +128,7 @@ fn configure_platform(mut platform: MappingConfig) -> MappingConfig {
     // - "GetIdentityByNonUniquePublicKeyHashResponse"
     //
     //  "GetEvonodesProposedEpochBlocksResponse" is used for 2 Requests
-    const VERSIONED_RESPONSES: [&str; 41] = [
+    const VERSIONED_RESPONSES: [&str; 42] = [
         "GetDataContractHistoryResponse",
         "GetDataContractResponse",
         "GetDataContractsResponse",
@@ -169,6 +170,7 @@ fn configure_platform(mut platform: MappingConfig) -> MappingConfig {
         "GetGroupInfosResponse",
         "GetGroupActionsResponse",
         "GetGroupActionSignersResponse",
+        "GetFinalizedEpochInfosResponse",
     ];
 
     check_unique(&VERSIONED_REQUESTS).expect("VERSIONED_REQUESTS");

--- a/packages/dapi-grpc/protos/platform/v0/platform.proto
+++ b/packages/dapi-grpc/protos/platform/v0/platform.proto
@@ -49,6 +49,7 @@ service Platform {
       GetProtocolVersionUpgradeVoteStatusRequest)
       returns (GetProtocolVersionUpgradeVoteStatusResponse);
   rpc getEpochsInfo(GetEpochsInfoRequest) returns (GetEpochsInfoResponse);
+  rpc getFinalizedEpochInfos(GetFinalizedEpochInfosRequest) returns (GetFinalizedEpochInfosResponse);
   // What votes are currently happening for a specific contested index
   rpc getContestedResources(GetContestedResourcesRequest)
       returns (GetContestedResourcesResponse);
@@ -796,6 +797,69 @@ message GetEpochsInfoResponse {
   }
 
   oneof version { GetEpochsInfoResponseV0 v0 = 1; }
+}
+
+message GetFinalizedEpochInfosRequest {
+  message GetFinalizedEpochInfosRequestV0 {
+    uint32 start_epoch_index = 1;          // The starting epoch index
+    bool start_epoch_index_included = 2;   // Whether to include the start epoch
+    uint32 end_epoch_index = 3;            // The ending epoch index  
+    bool end_epoch_index_included = 4;     // Whether to include the end epoch
+    bool prove = 5;                        // Flag to request a proof as the response
+  }
+
+  oneof version { GetFinalizedEpochInfosRequestV0 v0 = 1; }
+}
+
+message GetFinalizedEpochInfosResponse {
+  message GetFinalizedEpochInfosResponseV0 {
+    // FinalizedEpochInfos holds a collection of finalized epoch information entries
+    message FinalizedEpochInfos {
+      repeated FinalizedEpochInfo finalized_epoch_infos = 
+          1; // List of finalized information for each requested epoch
+    }
+
+    // FinalizedEpochInfo represents finalized information about a single epoch
+    message FinalizedEpochInfo {
+      uint32 number = 1; // The number of the epoch
+      uint64 first_block_height = 2
+          [ jstype = JS_STRING ]; // The height of the first block in this epoch
+      uint32 first_core_block_height = 
+          3; // The height of the first Core block in this epoch
+      uint64 first_block_time = 4
+          [ jstype = JS_STRING ]; // The timestamp of the first block (milliseconds)
+      double fee_multiplier = 5;  // The fee multiplier (converted from permille)
+      uint32 protocol_version = 6; // The protocol version for this epoch
+      uint64 total_blocks_in_epoch = 7
+          [ jstype = JS_STRING ]; // Total number of blocks in the epoch
+      uint32 next_epoch_start_core_block_height = 8; // Core block height where next epoch starts
+      uint64 total_processing_fees = 9
+          [ jstype = JS_STRING ]; // Total processing fees collected
+      uint64 total_distributed_storage_fees = 10
+          [ jstype = JS_STRING ]; // Total storage fees distributed
+      uint64 total_created_storage_fees = 11
+          [ jstype = JS_STRING ]; // Total storage fees created
+      uint64 core_block_rewards = 12
+          [ jstype = JS_STRING ]; // Rewards from core blocks
+      repeated BlockProposer block_proposers = 13; // List of block proposers and their counts
+    }
+
+    // BlockProposer represents a block proposer and their block count
+    message BlockProposer {
+      bytes proposer_id = 1; // The proposer's identifier
+      uint32 block_count = 2; // Number of blocks proposed
+    }
+
+    oneof result {
+      FinalizedEpochInfos epochs = 
+          1; // The actual finalized information about the requested epochs
+      Proof proof = 
+          2; // Cryptographic proof of the finalized epoch information, if requested
+    }
+    ResponseMetadata metadata = 3; // Metadata about the blockchain state
+  }
+
+  oneof version { GetFinalizedEpochInfosResponseV0 v0 = 1; }
 }
 
 message GetContestedResourcesRequest {

--- a/packages/rs-dapi-client/src/transport/grpc.rs
+++ b/packages/rs-dapi-client/src/transport/grpc.rs
@@ -311,6 +311,14 @@ impl_transport_request_grpc!(
 );
 
 impl_transport_request_grpc!(
+    platform_proto::GetFinalizedEpochInfosRequest,
+    platform_proto::GetFinalizedEpochInfosResponse,
+    PlatformGrpcClient,
+    RequestSettings::default(),
+    get_finalized_epoch_infos
+);
+
+impl_transport_request_grpc!(
     platform_proto::GetProtocolVersionUpgradeStateRequest,
     platform_proto::GetProtocolVersionUpgradeStateResponse,
     PlatformGrpcClient,

--- a/packages/rs-drive-abci/src/query/service.rs
+++ b/packages/rs-drive-abci/src/query/service.rs
@@ -22,10 +22,11 @@ use dapi_grpc::platform::v0::{
     GetDataContractResponse, GetDataContractsRequest, GetDataContractsResponse,
     GetDocumentsRequest, GetDocumentsResponse, GetEpochsInfoRequest, GetEpochsInfoResponse,
     GetEvonodesProposedEpochBlocksByIdsRequest, GetEvonodesProposedEpochBlocksByRangeRequest,
-    GetEvonodesProposedEpochBlocksResponse, GetGroupActionSignersRequest,
-    GetGroupActionSignersResponse, GetGroupActionsRequest, GetGroupActionsResponse,
-    GetGroupInfoRequest, GetGroupInfoResponse, GetGroupInfosRequest, GetGroupInfosResponse,
-    GetIdentitiesBalancesRequest, GetIdentitiesBalancesResponse, GetIdentitiesContractKeysRequest,
+    GetEvonodesProposedEpochBlocksResponse, GetFinalizedEpochInfosRequest,
+    GetFinalizedEpochInfosResponse, GetGroupActionSignersRequest, GetGroupActionSignersResponse,
+    GetGroupActionsRequest, GetGroupActionsResponse, GetGroupInfoRequest, GetGroupInfoResponse,
+    GetGroupInfosRequest, GetGroupInfosResponse, GetIdentitiesBalancesRequest,
+    GetIdentitiesBalancesResponse, GetIdentitiesContractKeysRequest,
     GetIdentitiesContractKeysResponse, GetIdentitiesTokenBalancesRequest,
     GetIdentitiesTokenBalancesResponse, GetIdentitiesTokenInfosRequest,
     GetIdentitiesTokenInfosResponse, GetIdentityBalanceAndRevisionRequest,
@@ -786,6 +787,18 @@ impl PlatformService for QueryService {
             request,
             Platform::<DefaultCoreRPC>::query_token_perpetual_distribution_last_claim,
             "get_token_perpetual_distribution_last_claim",
+        )
+        .await
+    }
+
+    async fn get_finalized_epoch_infos(
+        &self,
+        request: Request<GetFinalizedEpochInfosRequest>,
+    ) -> Result<Response<GetFinalizedEpochInfosResponse>, Status> {
+        self.handle_blocking_query(
+            request,
+            Platform::<DefaultCoreRPC>::query_finalized_epoch_infos,
+            "get_finalized_epoch_infos",
         )
         .await
     }

--- a/packages/rs-drive-abci/src/query/system/finalized_epoch_infos/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/finalized_epoch_infos/mod.rs
@@ -1,0 +1,65 @@
+use crate::error::query::QueryError;
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::platform_types::platform_state::PlatformState;
+use crate::query::QueryValidationResult;
+
+use dapi_grpc::platform::v0::get_finalized_epoch_infos_request::Version as RequestVersion;
+use dapi_grpc::platform::v0::get_finalized_epoch_infos_response::Version as ResponseVersion;
+use dapi_grpc::platform::v0::{GetFinalizedEpochInfosRequest, GetFinalizedEpochInfosResponse};
+use dpp::version::PlatformVersion;
+
+mod v0;
+
+impl<C> Platform<C> {
+    /// Query finalized epoch information for a given range
+    pub fn query_finalized_epoch_infos(
+        &self,
+        GetFinalizedEpochInfosRequest { version }: GetFinalizedEpochInfosRequest,
+        platform_state: &PlatformState,
+        platform_version: &PlatformVersion,
+    ) -> Result<QueryValidationResult<GetFinalizedEpochInfosResponse>, Error> {
+        let Some(version) = version else {
+            return Ok(QueryValidationResult::new_with_error(
+                QueryError::DecodingError(
+                    "could not decode finalized epoch infos query".to_string(),
+                ),
+            ));
+        };
+
+        let feature_version_bounds = &platform_version
+            .drive_abci
+            .query
+            .system
+            .finalized_epoch_infos;
+
+        let feature_version = match &version {
+            RequestVersion::V0(_) => 0,
+        };
+
+        if !feature_version_bounds.check_version(feature_version) {
+            return Ok(QueryValidationResult::new_with_error(
+                QueryError::UnsupportedQueryVersion(
+                    "finalized_epoch_infos".to_string(),
+                    feature_version_bounds.min_version,
+                    feature_version_bounds.max_version,
+                    platform_version.protocol_version,
+                    feature_version,
+                ),
+            ));
+        }
+
+        match version {
+            RequestVersion::V0(request_v0) => {
+                let result = self.query_finalized_epoch_infos_v0(
+                    request_v0,
+                    platform_state,
+                    platform_version,
+                )?;
+                Ok(result.map(|response_v0| GetFinalizedEpochInfosResponse {
+                    version: Some(ResponseVersion::V0(response_v0)),
+                }))
+            }
+        }
+    }
+}

--- a/packages/rs-drive-abci/src/query/system/finalized_epoch_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/finalized_epoch_infos/v0/mod.rs
@@ -1,0 +1,140 @@
+use crate::error::query::QueryError;
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::platform_types::platform_state::PlatformState;
+use crate::query::QueryValidationResult;
+
+use dapi_grpc::platform::v0::get_finalized_epoch_infos_request::GetFinalizedEpochInfosRequestV0;
+use dapi_grpc::platform::v0::get_finalized_epoch_infos_response::{
+    get_finalized_epoch_infos_response_v0, GetFinalizedEpochInfosResponseV0,
+};
+use dapi_grpc::platform::v0::get_finalized_epoch_infos_response::get_finalized_epoch_infos_response_v0::{BlockProposer, FinalizedEpochInfo, FinalizedEpochInfos};
+use dpp::block::finalized_epoch_info::v0::getters::FinalizedEpochInfoGettersV0;
+use dpp::check_validation_result_with_data;
+use dpp::version::PlatformVersion;
+use dpp::validation::ValidationResult;
+
+impl<C> Platform<C> {
+    pub(super) fn query_finalized_epoch_infos_v0(
+        &self,
+        GetFinalizedEpochInfosRequestV0 {
+            start_epoch_index,
+            start_epoch_index_included,
+            end_epoch_index,
+            end_epoch_index_included,
+            prove,
+        }: GetFinalizedEpochInfosRequestV0,
+        platform_state: &PlatformState,
+        platform_version: &PlatformVersion,
+    ) -> Result<QueryValidationResult<GetFinalizedEpochInfosResponseV0>, Error> {
+        // Validate that epoch indices fit in u16
+        if start_epoch_index > u16::MAX as u32 {
+            return Ok(QueryValidationResult::new_with_error(
+                QueryError::InvalidArgument(format!(
+                    "start_epoch_index {} exceeds maximum value of {}",
+                    start_epoch_index,
+                    u16::MAX
+                )),
+            ));
+        }
+
+        if end_epoch_index > u16::MAX as u32 {
+            return Ok(QueryValidationResult::new_with_error(
+                QueryError::InvalidArgument(format!(
+                    "end_epoch_index {} exceeds maximum value of {}",
+                    end_epoch_index,
+                    u16::MAX
+                )),
+            ));
+        }
+
+        if end_epoch_index == start_epoch_index
+            && (!end_epoch_index_included || !start_epoch_index_included)
+        {
+            return Ok(QueryValidationResult::new_with_error(
+                QueryError::InvalidArgument(
+                    format!("when start_epoch_index equals end_epoch_index ({}), both boundaries must be included to return a result", start_epoch_index),
+                ),
+            ));
+        }
+
+        if prove {
+            let proof = check_validation_result_with_data!(self
+                .drive
+                .prove_finalized_epoch_infos(
+                    start_epoch_index as u16,
+                    start_epoch_index_included,
+                    end_epoch_index as u16,
+                    end_epoch_index_included,
+                    None,
+                    platform_version,
+                )
+                .map_err(QueryError::Drive));
+
+            Ok(QueryValidationResult::new_with_data(
+                GetFinalizedEpochInfosResponseV0 {
+                    result: Some(get_finalized_epoch_infos_response_v0::Result::Proof(
+                        self.response_proof_v0(platform_state, proof),
+                    )),
+                    metadata: Some(self.response_metadata_v0(platform_state)),
+                },
+            ))
+        } else {
+            let finalized_epoch_infos: Vec<_> = check_validation_result_with_data!(self
+                .drive
+                .get_finalized_epoch_infos(
+                    start_epoch_index as u16,
+                    start_epoch_index_included,
+                    end_epoch_index as u16,
+                    end_epoch_index_included,
+                    None,
+                    platform_version,
+                )
+                .map_err(QueryError::Drive));
+
+            let finalized_epoch_infos: Vec<FinalizedEpochInfo> = finalized_epoch_infos
+                .into_iter()
+                .map(|(epoch_index, finalized_info)| {
+                    // Convert the BTreeMap to the proto repeated field format
+                    let block_proposers = finalized_info
+                        .block_proposers()
+                        .iter()
+                        .map(|(id, count)| BlockProposer {
+                            proposer_id: id.to_vec(),
+                            block_count: *count as u32,
+                        })
+                        .collect();
+
+                    FinalizedEpochInfo {
+                        number: epoch_index as u32,
+                        first_block_height: finalized_info.first_block_height(),
+                        first_core_block_height: finalized_info.first_core_block_height(),
+                        first_block_time: finalized_info.first_block_time(),
+                        fee_multiplier: finalized_info.fee_multiplier_permille() as f64 / 1000.0,
+                        protocol_version: finalized_info.protocol_version(),
+                        total_blocks_in_epoch: finalized_info.total_blocks_in_epoch(),
+                        next_epoch_start_core_block_height: finalized_info
+                            .next_epoch_start_core_block_height(),
+                        total_processing_fees: finalized_info.total_processing_fees(),
+                        total_distributed_storage_fees: finalized_info
+                            .total_distributed_storage_fees(),
+                        total_created_storage_fees: finalized_info.total_created_storage_fees(),
+                        core_block_rewards: finalized_info.core_block_rewards(),
+                        block_proposers,
+                    }
+                })
+                .collect();
+
+            Ok(QueryValidationResult::new_with_data(
+                GetFinalizedEpochInfosResponseV0 {
+                    result: Some(get_finalized_epoch_infos_response_v0::Result::Epochs(
+                        FinalizedEpochInfos {
+                            finalized_epoch_infos,
+                        },
+                    )),
+                    metadata: Some(self.response_metadata_v0(platform_state)),
+                },
+            ))
+        }
+    }
+}

--- a/packages/rs-drive-abci/src/query/system/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/mod.rs
@@ -1,5 +1,6 @@
 mod current_quorums_info;
 mod epoch_infos;
+mod finalized_epoch_infos;
 mod path_elements;
 mod status;
 mod total_credits_in_platform;

--- a/packages/rs-drive-proof-verifier/src/types.rs
+++ b/packages/rs-drive-proof-verifier/src/types.rs
@@ -32,7 +32,10 @@ use dpp::voting::vote_polls::contested_document_resource_vote_poll::ContestedDoc
 use dpp::voting::vote_polls::VotePoll;
 use dpp::voting::votes::resource_vote::ResourceVote;
 use dpp::{
-    block::{epoch::EpochIndex, extended_epoch_info::ExtendedEpochInfo},
+    block::{
+        epoch::EpochIndex, extended_epoch_info::ExtendedEpochInfo,
+        finalized_epoch_info::FinalizedEpochInfo,
+    },
     dashcore::ProTxHash,
     document::Document,
     identity::KeyID,
@@ -519,6 +522,9 @@ pub type IdentityBalances = RetrievedObjects<Identifier, Credits>;
 
 /// Collection of epoch information
 pub type ExtendedEpochInfos = RetrievedObjects<EpochIndex, ExtendedEpochInfo>;
+
+/// Collection of finalized epoch information
+pub type FinalizedEpochInfos = RetrievedObjects<EpochIndex, FinalizedEpochInfo>;
 
 /// Results of protocol version upgrade voting.
 ///

--- a/packages/rs-drive/src/drive/credit_pools/epochs/mod.rs
+++ b/packages/rs-drive/src/drive/credit_pools/epochs/mod.rs
@@ -8,16 +8,13 @@ mod get_epochs_infos;
 #[cfg(feature = "server")]
 mod get_epochs_protocol_versions;
 
-#[cfg(any(feature = "server", feature = "verify"))]
 /// Epoch key constants module
 pub mod epoch_key_constants;
-#[cfg(any(feature = "server", feature = "verify"))]
 /// Epochs root tree key constants module
 pub mod epochs_root_tree_key_constants;
 #[cfg(feature = "server")]
 pub mod operations_factory;
 /// Paths module
-#[cfg(any(feature = "server", feature = "verify"))]
 pub mod paths;
 #[cfg(feature = "server")]
 pub mod proposers;
@@ -35,3 +32,8 @@ mod has_epoch_tree_exists;
 
 #[cfg(feature = "server")]
 mod get_finalized_epoch_info;
+#[cfg(feature = "server")]
+mod prove_finalized_epoch_infos;
+
+/// Queries for epochs
+pub mod queries;

--- a/packages/rs-drive/src/drive/credit_pools/epochs/prove_finalized_epoch_infos/mod.rs
+++ b/packages/rs-drive/src/drive/credit_pools/epochs/prove_finalized_epoch_infos/mod.rs
@@ -1,0 +1,44 @@
+mod v0;
+
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+
+use grovedb::TransactionArg;
+
+use dpp::version::PlatformVersion;
+
+impl Drive {
+    /// Prove finalized epoch information for a given range of epochs
+    pub fn prove_finalized_epoch_infos(
+        &self,
+        start_epoch_index: u16,
+        start_epoch_index_included: bool,
+        end_epoch_index: u16,
+        end_epoch_index_included: bool,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Vec<u8>, Error> {
+        match platform_version
+            .drive
+            .methods
+            .credit_pools
+            .epochs
+            .prove_finalized_epoch_infos
+        {
+            0 => self.prove_finalized_epoch_infos_v0(
+                start_epoch_index,
+                start_epoch_index_included,
+                end_epoch_index,
+                end_epoch_index_included,
+                transaction,
+                platform_version,
+            ),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "prove_finalized_epoch_infos".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/credit_pools/epochs/prove_finalized_epoch_infos/v0/mod.rs
+++ b/packages/rs-drive/src/drive/credit_pools/epochs/prove_finalized_epoch_infos/v0/mod.rs
@@ -1,17 +1,13 @@
 use crate::drive::Drive;
-use crate::error::drive::DriveError;
+use crate::error::query::QuerySyntaxError;
 use crate::error::Error;
-use dpp::block::epoch::{EpochIndex, EPOCH_KEY_OFFSET};
-use dpp::block::finalized_epoch_info::FinalizedEpochInfo;
-use dpp::serialization::PlatformDeserializable;
 use dpp::version::PlatformVersion;
-use grovedb::query_result_type::QueryResultType;
 use grovedb::TransactionArg;
 
 impl Drive {
-    /// Retrieves finalized epoch information for a given range of epochs.
+    /// Proves finalized epoch information for a given range of epochs.
     ///
-    /// This method constructs a query over the stored finalized epoch information based on
+    /// This method constructs a proof query over the stored finalized epoch information based on
     /// the epoch indices provided. The query range is determined using:
     ///
     /// - `start_epoch_index` and `end_epoch_index`: the epoch indices (of type `u16`).
@@ -36,11 +32,10 @@ impl Drive {
     ///    - **Both boundaries excluded:** `QueryItem::RangeAfterTo(start_key, end_key)`.
     ///
     /// 3. **Descending Range Query:** If `start_epoch_index > end_epoch_index`, the roles
-    ///    of the keys are reversed and similar range variants are used, with the query’s
+    ///    of the keys are reversed and similar range variants are used, with the query's
     ///    `left_to_right` flag set to `false`.
     ///
-    /// Finally, the query is executed and the results are parsed into a vector of
-    /// `FinalizedEpochInfo`.
+    /// Finally, the query is executed to generate a proof.
     ///
     /// # Parameters
     ///
@@ -53,17 +48,15 @@ impl Drive {
     ///
     /// # Returns
     ///
-    /// A `Result` containing a vector of `FinalizedEpochInfo` on success or an `Error` on failure.
+    /// A `Result` containing a proof as a byte vector on success or an `Error` on failure.
     ///
     /// # Errors
     ///
     /// - Returns a `ProtocolError::Overflow` if an epoch index plus the offset overflows.
     /// - Returns errors from the underlying storage query if the query fails.
-    /// - Returns an empty vector if the range is empty due to exclusion of boundaries.
+    /// - Returns an empty proof if the range is empty due to exclusion of boundaries.
     ///
-    pub(super) fn get_finalized_epoch_infos_v0<
-        T: FromIterator<(EpochIndex, FinalizedEpochInfo)>,
-    >(
+    pub(super) fn prove_finalized_epoch_infos_v0(
         &self,
         start_epoch_index: u16,
         start_epoch_index_included: bool,
@@ -71,7 +64,7 @@ impl Drive {
         end_epoch_index_included: bool,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
-    ) -> Result<T, Error> {
+    ) -> Result<Vec<u8>, Error> {
         let Some(path_query) = Drive::finalized_epoch_infos_query(
             start_epoch_index,
             start_epoch_index_included,
@@ -79,48 +72,16 @@ impl Drive {
             end_epoch_index_included,
         )?
         else {
-            return Ok(T::from_iter(std::iter::empty()));
+            return Err(Error::Query(QuerySyntaxError::NoQueryItems(
+                "the end epoch index is the start epoch index and they are not included",
+            )));
         };
 
-        let results = self
-            .grove_get_path_query(
-                &path_query,
-                transaction,
-                QueryResultType::QueryPathKeyElementTrioResultType,
-                &mut vec![],
-                &platform_version.drive,
-            )?
-            .0;
-
-        results
-            .to_path_key_elements()
-            .into_iter()
-            .map(|(mut path, _, element)| {
-                let epoch_index_vec =
-                    path.pop()
-                        .ok_or(Error::Drive(DriveError::CorruptedDriveState(
-                            "the path must have a last element".to_string(),
-                        )))?;
-
-                let epoch_index_bytes: [u8; 2] =
-                    epoch_index_vec.as_slice().try_into().map_err(|_| {
-                        Error::Drive(DriveError::CorruptedSerialization(
-                            "extended epoch info: item has an invalid length".to_string(),
-                        ))
-                    })?;
-                let epoch_index = EpochIndex::from_be_bytes(epoch_index_bytes)
-                    .checked_sub(EPOCH_KEY_OFFSET)
-                    .ok_or(Error::Drive(DriveError::CorruptedSerialization(
-                        "epoch bytes on disk too small, should be over epoch key offset"
-                            .to_string(),
-                    )))?;
-
-                let item_bytes = element.as_item_bytes()?;
-
-                let epoch_info = FinalizedEpochInfo::deserialize_from_bytes(item_bytes)?;
-
-                Ok((epoch_index, epoch_info))
-            })
-            .collect::<Result<T, Error>>()
+        self.grove_get_proved_path_query(
+            &path_query,
+            transaction,
+            &mut vec![],
+            &platform_version.drive,
+        )
     }
 }

--- a/packages/rs-drive/src/drive/credit_pools/epochs/queries.rs
+++ b/packages/rs-drive/src/drive/credit_pools/epochs/queries.rs
@@ -1,0 +1,100 @@
+use crate::drive::credit_pools::epochs::epoch_key_constants::KEY_FINISHED_EPOCH_INFO;
+use crate::drive::credit_pools::pools_vec_path;
+use crate::drive::Drive;
+use crate::query::{Query, QueryItem};
+use dpp::block::epoch::EPOCH_KEY_OFFSET;
+use dpp::ProtocolError;
+use grovedb::{PathQuery, SizedQuery};
+
+impl Drive {
+    /// Constructs a query for retrieving finalized epoch information within a specified range.
+    ///
+    /// This method builds a `PathQuery` that can be used to query finalized epoch information
+    /// from the storage layer. The query supports flexible range specifications with optional
+    /// inclusion/exclusion of boundaries and automatic handling of ascending/descending order.
+    ///
+    /// # Parameters
+    ///
+    /// - `start_epoch_index`: The starting epoch index for the query range.
+    /// - `start_epoch_index_included`: If `true`, includes the start epoch in the results.
+    /// - `end_epoch_index`: The ending epoch index for the query range.
+    /// - `end_epoch_index_included`: If `true`, includes the end epoch in the results.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(PathQuery)` if a valid query can be constructed, or `None` if:
+    /// - The epoch indices would overflow when adding the internal offset
+    /// - The range is empty (e.g., start equals end but boundaries are excluded)
+    ///
+    /// # Query Behavior
+    ///
+    /// The method automatically determines the query direction:
+    /// - **Ascending**: When `start_epoch_index <= end_epoch_index`
+    /// - **Descending**: When `start_epoch_index > end_epoch_index`
+    ///
+    /// For single epoch queries (start equals end), both boundaries must be included
+    /// to return a result.
+    ///
+    pub fn finalized_epoch_infos_query(
+        start_epoch_index: u16,
+        start_epoch_index_included: bool,
+        end_epoch_index: u16,
+        end_epoch_index_included: bool,
+    ) -> Result<Option<PathQuery>, ProtocolError> {
+        // Compute the start and end keys with the offset.
+        let start_index = start_epoch_index
+            .checked_add(EPOCH_KEY_OFFSET)
+            .ok_or(ProtocolError::Overflow("Stored epoch index too high"))?;
+        let end_index = end_epoch_index
+            .checked_add(EPOCH_KEY_OFFSET)
+            .ok_or(ProtocolError::Overflow("Stored epoch index too high"))?;
+
+        let start_key = start_index.to_be_bytes().to_vec();
+        let end_key = end_index.to_be_bytes().to_vec();
+
+        // Determine if the query should be ascending.
+        let ascending = start_epoch_index <= end_epoch_index;
+
+        // Build the query item based on the range and inclusivity parameters.
+        let query_item = if start_epoch_index == end_epoch_index {
+            // If the start and end are equal, only return a result if both boundaries are included.
+            if start_epoch_index_included && end_epoch_index_included {
+                QueryItem::Key(start_key)
+            } else {
+                // No epochs satisfy the range.
+                return Ok(None);
+            }
+        } else if ascending {
+            // Ascending order: start_epoch_index < end_epoch_index.
+            if start_epoch_index_included && end_epoch_index_included {
+                QueryItem::RangeInclusive(start_key..=end_key)
+            } else if start_epoch_index_included && !end_epoch_index_included {
+                QueryItem::Range(start_key..end_key)
+            } else if !start_epoch_index_included && end_epoch_index_included {
+                QueryItem::RangeAfterToInclusive(start_key..=end_key)
+            } else {
+                QueryItem::RangeAfterTo(start_key..end_key)
+            }
+        } else {
+            // Descending order: start_epoch_index > end_epoch_index.
+            if start_epoch_index_included && end_epoch_index_included {
+                QueryItem::RangeInclusive(end_key..=start_key)
+            } else if start_epoch_index_included && !end_epoch_index_included {
+                QueryItem::Range(end_key..start_key)
+            } else if !start_epoch_index_included && end_epoch_index_included {
+                QueryItem::RangeAfterToInclusive(end_key..=start_key)
+            } else {
+                QueryItem::RangeAfterTo(end_key..start_key)
+            }
+        };
+
+        // Construct the query.
+        let mut query = Query::new_single_query_item(query_item);
+        query.left_to_right = ascending;
+        query.set_subquery_key(KEY_FINISHED_EPOCH_INFO.to_vec());
+        Ok(Some(PathQuery::new(
+            pools_vec_path(),
+            SizedQuery::new(query, None, None),
+        )))
+    }
+}

--- a/packages/rs-drive/src/verify/system/mod.rs
+++ b/packages/rs-drive/src/verify/system/mod.rs
@@ -1,6 +1,7 @@
 mod verify_elements;
 mod verify_epoch_infos;
 mod verify_epoch_proposers;
+mod verify_finalized_epoch_infos;
 mod verify_total_credits_in_system;
 mod verify_upgrade_state;
 mod verify_upgrade_vote_status;

--- a/packages/rs-drive/src/verify/system/verify_finalized_epoch_infos/mod.rs
+++ b/packages/rs-drive/src/verify/system/verify_finalized_epoch_infos/mod.rs
@@ -1,0 +1,65 @@
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use crate::verify::RootHash;
+use dpp::block::epoch::EpochIndex;
+use dpp::block::finalized_epoch_info::FinalizedEpochInfo;
+use dpp::version::PlatformVersion;
+
+mod v0;
+
+impl Drive {
+    /// Verifies a proof containing finalized epoch information for a given range.
+    ///
+    /// # Parameters
+    ///
+    /// - `proof`: A byte slice representing the proof to be verified.
+    /// - `start_epoch_index`: The starting epoch index for the query.
+    /// - `start_epoch_index_included`: If `true`, the epoch at `start_epoch_index` is included.
+    /// - `end_epoch_index`: The ending epoch index for the query.
+    /// - `end_epoch_index_included`: If `true`, the epoch at `end_epoch_index` is included.
+    /// - `platform_version`: The platform version to use for method dispatch.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` with a tuple of `RootHash` and `Vec<(EpochIndex, FinalizedEpochInfo)>`.
+    /// The vector contains verified finalized epoch information.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `Error` if:
+    ///
+    /// - The proof is corrupted.
+    /// - The GroveDb query fails.
+    /// - An epoch index plus the offset overflows.
+    pub fn verify_finalized_epoch_infos(
+        proof: &[u8],
+        start_epoch_index: u16,
+        start_epoch_index_included: bool,
+        end_epoch_index: u16,
+        end_epoch_index_included: bool,
+        platform_version: &PlatformVersion,
+    ) -> Result<(RootHash, Vec<(EpochIndex, FinalizedEpochInfo)>), Error> {
+        match platform_version
+            .drive
+            .methods
+            .verify
+            .system
+            .verify_finalized_epoch_infos
+        {
+            0 => Drive::verify_finalized_epoch_infos_v0(
+                proof,
+                start_epoch_index,
+                start_epoch_index_included,
+                end_epoch_index,
+                end_epoch_index_included,
+                platform_version,
+            ),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "verify_finalized_epoch_infos".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/verify/system/verify_finalized_epoch_infos/v0/mod.rs
+++ b/packages/rs-drive/src/verify/system/verify_finalized_epoch_infos/v0/mod.rs
@@ -1,0 +1,126 @@
+use crate::drive::credit_pools::epochs::epoch_key_constants::KEY_FINISHED_EPOCH_INFO;
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::proof::ProofError;
+use crate::error::query::QuerySyntaxError;
+use crate::error::Error;
+use crate::verify::RootHash;
+use dpp::block::epoch::{EpochIndex, EPOCH_KEY_OFFSET};
+use dpp::block::finalized_epoch_info::FinalizedEpochInfo;
+use dpp::serialization::PlatformDeserializable;
+use grovedb::{Element, GroveDb};
+use platform_version::version::PlatformVersion;
+use std::collections::BTreeMap;
+
+impl Drive {
+    /// Verifies finalized epoch information for a given range of epochs.
+    ///
+    /// # Parameters
+    ///
+    /// - `proof`: A byte slice representing the proof to be verified.
+    /// - `start_epoch_index`: The starting epoch index for the query.
+    /// - `start_epoch_index_included`: If `true`, the epoch at `start_epoch_index` is included.
+    /// - `end_epoch_index`: The ending epoch index for the query.
+    /// - `end_epoch_index_included`: If `true`, the epoch at `end_epoch_index` is included.
+    /// - `platform_version`: The platform version to use for method dispatch.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` with a tuple of `RootHash` and `Vec<(EpochIndex, FinalizedEpochInfo)>`.
+    /// The vector contains verified finalized epoch information.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `Error` if:
+    ///
+    /// - The proof is corrupted.
+    /// - The GroveDb query fails.
+    /// - An epoch index plus the offset overflows.
+    #[inline(always)]
+    pub(super) fn verify_finalized_epoch_infos_v0(
+        proof: &[u8],
+        start_epoch_index: u16,
+        start_epoch_index_included: bool,
+        end_epoch_index: u16,
+        end_epoch_index_included: bool,
+        platform_version: &PlatformVersion,
+    ) -> Result<(RootHash, Vec<(EpochIndex, FinalizedEpochInfo)>), Error> {
+        let Some(path_query) = Drive::finalized_epoch_infos_query(
+            start_epoch_index,
+            start_epoch_index_included,
+            end_epoch_index,
+            end_epoch_index_included,
+        )?
+        else {
+            return Err(Error::Query(QuerySyntaxError::NoQueryItems(
+                "the end epoch index is the start epoch index and they are not included",
+            )));
+        };
+
+        let (root_hash, elements) =
+            GroveDb::verify_query(proof, &path_query, &platform_version.drive.grove_version)?;
+
+        let results = elements.into_iter().fold(
+            BTreeMap::<_, BTreeMap<_, _>>::new(),
+            |mut acc, result_item| {
+                let (path, key, element) = result_item;
+                if path.len() == 2 {
+                    acc.entry(path).or_default().insert(key, element);
+                }
+                acc
+            },
+        );
+
+        // Convert the BTreeMap entries to (EpochIndex, FinalizedEpochInfo)
+        let finalized_epoch_infos = results
+            .into_iter()
+            .filter_map(|(path, inner_map)| {
+                // Extract the epoch index from the path's last component
+                // and adjust by subtracting the EPOCH_KEY_OFFSET
+                let epoch_index_result: Result<EpochIndex, Error> = path
+                    .last()
+                    .ok_or(Error::Proof(ProofError::CorruptedProof(
+                        "finalized epoch info: path can not be empty".to_string(),
+                    )))
+                    .and_then(|epoch_index_vec| {
+                        epoch_index_vec.as_slice().try_into().map_err(|_| {
+                            Error::Proof(ProofError::CorruptedProof(
+                                "finalized epoch info: item has an invalid length".to_string(),
+                            ))
+                        })
+                    })
+                    .and_then(|epoch_index_bytes| {
+                        EpochIndex::from_be_bytes(epoch_index_bytes)
+                            .checked_sub(EPOCH_KEY_OFFSET)
+                            .ok_or(Error::Proof(ProofError::CorruptedProof(
+                                "epoch bytes on disk too small, should be over epoch key offset"
+                                    .to_string(),
+                            )))
+                    });
+
+                let epoch_index = match epoch_index_result {
+                    Ok(value) => value,
+                    Err(e) => return Some(Err(e)),
+                };
+
+                // Get the finalized epoch info element
+                let finalized_epoch_info_element =
+                    inner_map.get(KEY_FINISHED_EPOCH_INFO.as_slice())?;
+
+                let Some(Element::Item(item_bytes, _)) = finalized_epoch_info_element else {
+                    return Some(Err(Error::Drive(DriveError::UnexpectedElementType(
+                        "finalized epoch info must be an item",
+                    ))));
+                };
+
+                // Deserialize the FinalizedEpochInfo
+                match FinalizedEpochInfo::deserialize_from_bytes(item_bytes) {
+                    Ok(epoch_info) => Some(Ok((epoch_index, epoch_info))),
+                    Err(e) => Some(Err(e.into())),
+                }
+            })
+            .collect::<Result<Vec<(EpochIndex, FinalizedEpochInfo)>, Error>>()?;
+
+        Ok((root_hash, finalized_epoch_infos))
+    }
+}

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_query_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_query_versions/mod.rs
@@ -90,4 +90,5 @@ pub struct DriveAbciQuerySystemVersions {
     pub partial_status: FeatureVersionBounds,
     pub path_elements: FeatureVersionBounds,
     pub total_credits_in_platform: FeatureVersionBounds,
+    pub finalized_epoch_infos: FeatureVersionBounds,
 }

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_query_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_query_versions/v1.rs
@@ -218,6 +218,11 @@ pub const DRIVE_ABCI_QUERY_VERSIONS_V1: DriveAbciQueryVersions = DriveAbciQueryV
             max_version: 0,
             default_current_version: 0,
         },
+        finalized_epoch_infos: FeatureVersionBounds {
+            min_version: 0,
+            max_version: 0,
+            default_current_version: 0,
+        },
     },
     group_queries: DriveAbciQueryGroupVersions {
         group_info: FeatureVersionBounds {

--- a/packages/rs-platform-version/src/version/drive_versions/drive_credit_pool_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_credit_pool_method_versions/mod.rs
@@ -14,6 +14,7 @@ pub struct DriveCreditPoolEpochsMethodVersions {
     pub get_epochs_infos: FeatureVersion,
     pub get_epochs_protocol_versions: FeatureVersion,
     pub prove_epochs_infos: FeatureVersion,
+    pub prove_finalized_epoch_infos: FeatureVersion,
     pub get_epoch_fee_multiplier: FeatureVersion,
     pub get_epoch_processing_credits_for_distribution: FeatureVersion,
     pub get_epoch_storage_credits_for_distribution: FeatureVersion,

--- a/packages/rs-platform-version/src/version/drive_versions/drive_credit_pool_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_credit_pool_method_versions/v1.rs
@@ -11,6 +11,7 @@ pub const CREDIT_POOL_METHOD_VERSIONS_V1: DriveCreditPoolMethodVersions =
             get_epochs_infos: 0,
             get_epochs_protocol_versions: 0,
             prove_epochs_infos: 0,
+            prove_finalized_epoch_infos: 0,
             get_epoch_fee_multiplier: 0,
             get_epoch_processing_credits_for_distribution: 0,
             get_epoch_storage_credits_for_distribution: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/mod.rs
@@ -92,6 +92,7 @@ pub struct DriveVerifySystemMethodVersions {
     pub verify_total_credits_in_system: FeatureVersion,
     pub verify_upgrade_state: FeatureVersion,
     pub verify_upgrade_vote_status: FeatureVersion,
+    pub verify_finalized_epoch_infos: FeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/v1.rs
@@ -65,6 +65,7 @@ pub const DRIVE_VERIFY_METHOD_VERSIONS_V1: DriveVerifyMethodVersions = DriveVeri
         verify_total_credits_in_system: 0,
         verify_upgrade_state: 0,
         verify_upgrade_vote_status: 0,
+        verify_finalized_epoch_infos: 0,
     },
     voting: DriveVerifyVoteMethodVersions {
         verify_masternode_vote: 0,

--- a/packages/rs-platform-version/src/version/mocks/v2_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v2_test.rs
@@ -357,6 +357,11 @@ pub const TEST_PLATFORM_V2: PlatformVersion = PlatformVersion {
                     max_version: 0,
                     default_current_version: 0,
                 },
+                finalized_epoch_infos: FeatureVersionBounds {
+                    min_version: 0,
+                    max_version: 0,
+                    default_current_version: 0,
+                },
             },
             group_queries: DriveAbciQueryGroupVersions {
                 group_info: FeatureVersionBounds {

--- a/packages/rs-sdk/src/mock/requests.rs
+++ b/packages/rs-sdk/src/mock/requests.rs
@@ -9,7 +9,7 @@ use dpp::tokens::status::TokenStatus;
 use dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
 use dpp::{
     bincode,
-    block::extended_epoch_info::ExtendedEpochInfo,
+    block::{extended_epoch_info::ExtendedEpochInfo, finalized_epoch_info::FinalizedEpochInfo},
     dashcore::{hashes::Hash as CoreHash, ProTxHash},
     document::{serialization_traits::DocumentCborMethodsV0, Document},
     identifier::Identifier,
@@ -437,6 +437,7 @@ impl_mock_response!(u32);
 impl_mock_response!(u64);
 impl_mock_response!(Vote);
 impl_mock_response!(ExtendedEpochInfo);
+impl_mock_response!(FinalizedEpochInfo);
 impl_mock_response!(ContestedResources);
 impl_mock_response!(IdentityBalanceAndRevision);
 impl_mock_response!(Contenders);

--- a/packages/rs-sdk/src/platform/fetch_many.rs
+++ b/packages/rs-sdk/src/platform/fetch_many.rs
@@ -12,10 +12,10 @@ use dapi_grpc::platform::v0::{
     GetContestedResourceIdentityVotesRequest, GetContestedResourceVoteStateRequest,
     GetContestedResourceVotersForIdentityRequest, GetContestedResourcesRequest,
     GetDataContractsRequest, GetEpochsInfoRequest, GetEvonodesProposedEpochBlocksByIdsRequest,
-    GetEvonodesProposedEpochBlocksByRangeRequest, GetIdentitiesBalancesRequest,
-    GetIdentityKeysRequest, GetPathElementsRequest, GetProtocolVersionUpgradeStateRequest,
-    GetProtocolVersionUpgradeVoteStatusRequest, GetTokenDirectPurchasePricesRequest,
-    GetVotePollsByEndDateRequest, Proof, ResponseMetadata,
+    GetEvonodesProposedEpochBlocksByRangeRequest, GetFinalizedEpochInfosRequest,
+    GetIdentitiesBalancesRequest, GetIdentityKeysRequest, GetPathElementsRequest,
+    GetProtocolVersionUpgradeStateRequest, GetProtocolVersionUpgradeVoteStatusRequest,
+    GetTokenDirectPurchasePricesRequest, GetVotePollsByEndDateRequest, Proof, ResponseMetadata,
 };
 use dashcore_rpc::dashcore::ProTxHash;
 use dpp::identity::KeyID;
@@ -24,7 +24,8 @@ use dpp::util::deserializer::ProtocolVersion;
 use dpp::version::ProtocolVersionVoteCount;
 use dpp::{block::epoch::EpochIndex, prelude::TimestampMillis, voting::vote_polls::VotePoll};
 use dpp::{
-    block::extended_epoch_info::ExtendedEpochInfo, voting::votes::resource_vote::ResourceVote,
+    block::extended_epoch_info::ExtendedEpochInfo, block::finalized_epoch_info::FinalizedEpochInfo,
+    voting::votes::resource_vote::ResourceVote,
 };
 use dpp::{data_contract::DataContract, tokens::token_pricing_schedule::TokenPricingSchedule};
 use dpp::{document::Document, voting::contender_structs::ContenderWithSerializedDocument};
@@ -32,10 +33,10 @@ use drive::grovedb::query_result_type::Key;
 use drive::grovedb::Element;
 use drive_proof_verifier::types::{
     Contenders, ContestedResource, ContestedResources, DataContracts, Elements, ExtendedEpochInfos,
-    IdentityBalances, IdentityPublicKeys, MasternodeProtocolVote, MasternodeProtocolVotes,
-    ProposerBlockCountById, ProposerBlockCountByRange, ProposerBlockCounts,
-    ProtocolVersionUpgrades, ResourceVotesByIdentity, TokenDirectPurchasePrices,
-    VotePollsGroupedByTimestamp, Voter, Voters,
+    FinalizedEpochInfos, IdentityBalances, IdentityPublicKeys, MasternodeProtocolVote,
+    MasternodeProtocolVotes, ProposerBlockCountById, ProposerBlockCountByRange,
+    ProposerBlockCounts, ProtocolVersionUpgrades, ResourceVotesByIdentity,
+    TokenDirectPurchasePrices, VotePollsGroupedByTimestamp, Voter, Voters,
 };
 use drive_proof_verifier::{types::Documents, FromProof};
 use rs_dapi_client::{
@@ -381,6 +382,19 @@ impl FetchMany<KeyID, IdentityPublicKeys> for IdentityPublicKey {
 ///   that allows to specify maximum number of objects to fetch; see also [FetchMany::fetch_many_with_limit()].
 impl FetchMany<EpochIndex, ExtendedEpochInfos> for ExtendedEpochInfo {
     type Request = GetEpochsInfoRequest;
+}
+
+/// Retrieve finalized epochs.
+///
+/// Returns [FinalizedEpochInfos](drive_proof_verifier::types::FinalizedEpochInfos).
+///
+/// ## Supported query types
+///
+/// * [FinalizedEpochQuery](super::types::finalized_epoch::FinalizedEpochQuery) - query that specifies finalized epoch matching criteria
+/// * [`(EpochIndex, EpochIndex)`] - tuple of (start_epoch, end_epoch) indices
+/// * [`LimitQuery<FinalizedEpochQuery>`](super::LimitQuery) - limit query that allows to specify maximum number of objects to fetch
+impl FetchMany<EpochIndex, FinalizedEpochInfos> for FinalizedEpochInfo {
+    type Request = GetFinalizedEpochInfosRequest;
 }
 
 /// Fetch information about number of votes for each protocol version upgrade.

--- a/packages/rs-sdk/src/platform/types.rs
+++ b/packages/rs-sdk/src/platform/types.rs
@@ -1,6 +1,7 @@
 //! Type-specific implementation for various dpp object types to make queries more convenient and intuitive.
 pub mod epoch;
 pub mod evonode;
+pub mod finalized_epoch;
 pub mod identity;
 pub mod proposed_blocks;
 mod total_credits_in_platform;

--- a/packages/rs-sdk/src/platform/types/finalized_epoch.rs
+++ b/packages/rs-sdk/src/platform/types/finalized_epoch.rs
@@ -1,0 +1,73 @@
+//! Finalized epoch related types and helpers
+use crate::platform::{LimitQuery, Query};
+use crate::Error;
+use dapi_grpc::platform::v0::{get_finalized_epoch_infos_request, GetFinalizedEpochInfosRequest};
+use dpp::block::epoch::EpochIndex;
+
+/// Query used to fetch multiple finalized epochs from Platform.
+#[derive(Clone, Debug)]
+pub struct FinalizedEpochQuery {
+    /// Starting epoch index.
+    pub start_epoch_index: EpochIndex,
+    /// Whether to include the start epoch.
+    pub start_epoch_index_included: bool,
+    /// Ending epoch index.
+    pub end_epoch_index: EpochIndex,
+    /// Whether to include the end epoch.
+    pub end_epoch_index_included: bool,
+}
+
+impl Default for FinalizedEpochQuery {
+    fn default() -> Self {
+        Self {
+            start_epoch_index: 0,
+            start_epoch_index_included: true,
+            end_epoch_index: 0,
+            end_epoch_index_included: false,
+        }
+    }
+}
+
+impl From<(EpochIndex, EpochIndex)> for FinalizedEpochQuery {
+    fn from((start, end): (EpochIndex, EpochIndex)) -> Self {
+        Self {
+            start_epoch_index: start,
+            start_epoch_index_included: true,
+            end_epoch_index: end,
+            end_epoch_index_included: true,
+        }
+    }
+}
+
+impl Query<GetFinalizedEpochInfosRequest> for FinalizedEpochQuery {
+    fn query(self, prove: bool) -> Result<GetFinalizedEpochInfosRequest, Error> {
+        if !prove {
+            unimplemented!("queries without proofs are not supported yet");
+        }
+        Ok(GetFinalizedEpochInfosRequest {
+            version: Some(get_finalized_epoch_infos_request::Version::V0(
+                get_finalized_epoch_infos_request::GetFinalizedEpochInfosRequestV0 {
+                    prove,
+                    start_epoch_index: self.start_epoch_index as u32,
+                    start_epoch_index_included: self.start_epoch_index_included,
+                    end_epoch_index: self.end_epoch_index as u32,
+                    end_epoch_index_included: self.end_epoch_index_included,
+                },
+            )),
+        })
+    }
+}
+
+impl Query<GetFinalizedEpochInfosRequest> for (EpochIndex, EpochIndex) {
+    fn query(self, prove: bool) -> Result<GetFinalizedEpochInfosRequest, Error> {
+        FinalizedEpochQuery::from(self).query(prove)
+    }
+}
+
+impl Query<GetFinalizedEpochInfosRequest> for LimitQuery<FinalizedEpochQuery> {
+    fn query(self, prove: bool) -> Result<GetFinalizedEpochInfosRequest, Error> {
+        // For finalized epochs, the limit is handled by the range itself
+        // so we just pass through the query
+        self.query.query(prove)
+    }
+}

--- a/packages/rs-sdk/src/platform/types/finalized_epoch.rs
+++ b/packages/rs-sdk/src/platform/types/finalized_epoch.rs
@@ -1,5 +1,5 @@
 //! Finalized epoch related types and helpers
-use crate::platform::{LimitQuery, Query};
+use crate::platform::Query;
 use crate::Error;
 use dapi_grpc::platform::v0::{get_finalized_epoch_infos_request, GetFinalizedEpochInfosRequest};
 use dpp::block::epoch::EpochIndex;
@@ -23,7 +23,7 @@ impl Default for FinalizedEpochQuery {
             start_epoch_index: 0,
             start_epoch_index_included: true,
             end_epoch_index: 0,
-            end_epoch_index_included: false,
+            end_epoch_index_included: true,
         }
     }
 }
@@ -61,13 +61,5 @@ impl Query<GetFinalizedEpochInfosRequest> for FinalizedEpochQuery {
 impl Query<GetFinalizedEpochInfosRequest> for (EpochIndex, EpochIndex) {
     fn query(self, prove: bool) -> Result<GetFinalizedEpochInfosRequest, Error> {
         FinalizedEpochQuery::from(self).query(prove)
-    }
-}
-
-impl Query<GetFinalizedEpochInfosRequest> for LimitQuery<FinalizedEpochQuery> {
-    fn query(self, prove: bool) -> Result<GetFinalizedEpochInfosRequest, Error> {
-        // For finalized epochs, the limit is handled by the range itself
-        // so we just pass through the query
-        self.query.query(prove)
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
This update introduces the ability to query and prove finalized epoch information within a specified range of epochs.

## What was done?
- Added `GetFinalizedEpochInfosRequest` and `GetFinalizedEpochInfosResponse` messages to the gRPC platform proto.
- Implemented the `get_finalized_epoch_infos` RPC in the `PlatformService`.
- Created query methods to retrieve finalized epoch information, including validation and proof handling.
- Introduced tests to validate the new functionality.
- Added query to SDK.

## How Has This Been Tested?
Unit tests have been added to cover the new query and proof functionalities, ensuring that both successful retrieval and error cases are handled correctly.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API method to retrieve finalized epoch information with optional cryptographic proof.
  - Responses provide detailed epoch data including block heights, protocol versions, fees, and block proposer stats.
  - Added support for generating and verifying cryptographic proofs of finalized epoch information.
  - Enabled querying finalized epochs by specifying inclusive or exclusive epoch ranges.
  - Extended SDK and client libraries to support finalized epoch queries and proof verification.
  - Added structured query types and helpers for finalized epoch range queries.

- **Tests**
  - Added tests validating both proof and non-proof queries for finalized epoch information.

- **Chores**
  - Updated internal platform and Drive versioning to accommodate finalized epoch info features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->