### PR TITLE
fix(dashmate): consensus params in dashmate different than on testnet

### DIFF
--- a/packages/dashmate/configs/defaults/getTestnetConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getTestnetConfigFactory.js
@@ -1,8 +1,8 @@
 import lodash from 'lodash';
+import Config from '../../src/config/Config.js';
 import {
   NETWORK_TESTNET,
 } from '../../src/constants.js';
-import Config from '../../src/config/Config.js';
 
 const { merge: lodashMerge } = lodash;
 /**
@@ -116,8 +116,38 @@ export default function getTestnetConfigFactory(homeDir, getBaseConfig) {
               chain_id: 'dash-testnet-51',
               validator_quorum_type: 6,
               consensus_params: {
+                block: {
+                  max_bytes: '2097152',
+                  max_gas: '57631392000',
+                },
+                evidence: {
+                  max_age_num_blocks: '100000',
+                  max_age_duration: '172800000000000',
+                  max_bytes: '512000',
+                },
+                validator: {
+                  pub_key_types: [
+                    'bls12381',
+                  ],
+                },
                 version: {
                   app_version: '1',
+                  consensus: '0',
+                },
+                synchrony: {
+                  precision: '500000000',
+                  message_delay: '32000000000',
+                },
+                timeout: {
+                  propose: '30000000000',
+                  propose_delta: '1000000000',
+                  vote: '2000000000',
+                  vote_delta: '500000000',
+                  commit: '0',
+                  bypass_commit_timeout: false,
+                },
+                abci: {
+                  recheck_tx: true,
                 },
               },
             },

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -554,7 +554,7 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
         Object.entries(configFile.configs)
           .forEach(([name, options]) => {
             if (options.network === NETWORK_TESTNET && name !== 'base') {
-              options.platform.drive.tenderdash.genesis = testnet.get('platform.drive.tenderdash.genesis');
+              options.platform.drive.tenderdash.genesis = lodash.cloneDeep(testnet.get('platform.drive.tenderdash.genesis'));
             }
 
             const defaultConfig = getDefaultConfigByNameOrGroup(name, options.group);
@@ -758,7 +758,7 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
             options.core.devnet.llmq = base.get('core.devnet.llmq');
 
             if (options.network === NETWORK_TESTNET) {
-              options.platform.drive.tenderdash.genesis = testnet.get('platform.drive.tenderdash.genesis');
+              options.platform.drive.tenderdash.genesis = lodash.cloneDeep(testnet.get('platform.drive.tenderdash.genesis'));
             }
           });
         return configFile;
@@ -784,7 +784,7 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
         Object.entries(configFile.configs)
           .forEach(([, options]) => {
             if (options.network === NETWORK_TESTNET) {
-              options.platform.drive.tenderdash.genesis = testnet.get('platform.drive.tenderdash.genesis');
+              options.platform.drive.tenderdash.genesis = lodash.cloneDeep(testnet.get('platform.drive.tenderdash.genesis'));
             }
 
             // Update tenderdash image
@@ -1093,6 +1093,15 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
 
             options.platform.drive.abci.docker.image = 'dashpay/drive:2';
             options.platform.dapi.api.docker.image = 'dashpay/dapi:2';
+          });
+        return configFile;
+      },
+      '2.0.2-rc.1': (configFile) => {
+        Object.entries(configFile.configs)
+          .forEach(([name, options]) => {
+            if (options.network === NETWORK_TESTNET && name !== 'base') {
+              options.platform.drive.tenderdash.genesis.consensus_params = lodash.cloneDeep(testnet.get('platform.drive.tenderdash.genesis.consensus_params'));
+            }
           });
         return configFile;
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Newly provisioned testnet nodes have wrong genesis.json.

## What was done?

Fetched consensus params from testnet with `curl 0:36657/consensus_params?height=1|jq` and added them to testnet config.

## How Has This Been Tested?

On a local VM.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the testnet configuration with detailed consensus parameters covering block size, evidence limits, validator keys, timing, and ABCI settings.
  - Introduced an automatic migration to update testnet genesis configurations during upgrades, ensuring configuration consistency.
- **Bug Fixes**
  - Updated keyword search contract ID and owner ID bytes to resolve related issues.
- **Version Updates**
  - Incremented package versions across multiple components to 2.0.1 for improved consistency and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->