### PR TITLE
chore(platform): add protocol version 10 support

### DIFF
--- a/packages/rs-platform-version/src/version/mod.rs
+++ b/packages/rs-platform-version/src/version/mod.rs
@@ -1,6 +1,6 @@
 mod protocol_version;
 
-use crate::version::v9::PROTOCOL_VERSION_9;
+use crate::version::v10::PROTOCOL_VERSION_10;
 pub use protocol_version::*;
 use std::ops::RangeInclusive;
 
@@ -15,6 +15,7 @@ pub mod patches;
 pub mod system_data_contract_versions;
 mod system_limits;
 pub mod v1;
+pub mod v10;
 pub mod v2;
 pub mod v3;
 pub mod v4;
@@ -28,5 +29,5 @@ pub type ProtocolVersion = u32;
 
 pub const ALL_VERSIONS: RangeInclusive<ProtocolVersion> = 1..=LATEST_VERSION;
 
-pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_9;
+pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_10;
 pub const INITIAL_PROTOCOL_VERSION: ProtocolVersion = 1;

--- a/packages/rs-platform-version/src/version/protocol_version.rs
+++ b/packages/rs-platform-version/src/version/protocol_version.rs
@@ -16,6 +16,7 @@ use std::sync::OnceLock;
 
 use crate::version::consensus_versions::ConsensusVersions;
 use crate::version::system_limits::SystemLimits;
+use crate::version::v10::PLATFORM_V10;
 use crate::version::v2::PLATFORM_V2;
 use crate::version::v3::PLATFORM_V3;
 use crate::version::v4::PLATFORM_V4;
@@ -50,6 +51,7 @@ pub const PLATFORM_VERSIONS: &[PlatformVersion] = &[
     PLATFORM_V7,
     PLATFORM_V8,
     PLATFORM_V9,
+    PLATFORM_V10,
 ];
 
 #[cfg(feature = "mock-versions")]
@@ -58,7 +60,7 @@ pub static PLATFORM_TEST_VERSIONS: OnceLock<Vec<PlatformVersion>> = OnceLock::ne
 #[cfg(feature = "mock-versions")]
 const DEFAULT_PLATFORM_TEST_VERSIONS: &[PlatformVersion] = &[TEST_PLATFORM_V2, TEST_PLATFORM_V3];
 
-pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V9;
+pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V10;
 
 pub const DESIRED_PLATFORM_VERSION: &PlatformVersion = LATEST_PLATFORM_VERSION;
 

--- a/packages/rs-platform-version/src/version/v10.rs
+++ b/packages/rs-platform-version/src/version/v10.rs
@@ -1,0 +1,65 @@
+use crate::version::consensus_versions::ConsensusVersions;
+use crate::version::dpp_versions::dpp_asset_lock_versions::v1::DPP_ASSET_LOCK_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_contract_versions::v2::CONTRACT_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_costs_versions::v1::DPP_COSTS_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_document_versions::v2::DOCUMENT_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_factory_versions::v1::DPP_FACTORY_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_identity_versions::v1::IDENTITY_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_method_versions::v2::DPP_METHOD_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_state_transition_conversion_versions::v2::STATE_TRANSITION_CONVERSION_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_state_transition_method_versions::v1::STATE_TRANSITION_METHOD_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_state_transition_serialization_versions::v2::STATE_TRANSITION_SERIALIZATION_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_state_transition_versions::v2::STATE_TRANSITION_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_token_versions::v1::TOKEN_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_validation_versions::v2::DPP_VALIDATION_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_voting_versions::v2::VOTING_VERSION_V2;
+use crate::version::dpp_versions::DPPVersion;
+use crate::version::drive_abci_versions::drive_abci_method_versions::v6::DRIVE_ABCI_METHOD_VERSIONS_V6;
+use crate::version::drive_abci_versions::drive_abci_query_versions::v1::DRIVE_ABCI_QUERY_VERSIONS_V1;
+use crate::version::drive_abci_versions::drive_abci_structure_versions::v1::DRIVE_ABCI_STRUCTURE_VERSIONS_V1;
+use crate::version::drive_abci_versions::drive_abci_validation_versions::v6::DRIVE_ABCI_VALIDATION_VERSIONS_V6;
+use crate::version::drive_abci_versions::drive_abci_withdrawal_constants::v2::DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2;
+use crate::version::drive_abci_versions::DriveAbciVersion;
+use crate::version::drive_versions::v4::DRIVE_VERSION_V4;
+use crate::version::fee::v2::FEE_VERSION2;
+use crate::version::protocol_version::PlatformVersion;
+use crate::version::system_data_contract_versions::v1::SYSTEM_DATA_CONTRACT_VERSIONS_V1;
+use crate::version::system_limits::v1::SYSTEM_LIMITS_V1;
+use crate::version::ProtocolVersion;
+
+pub const PROTOCOL_VERSION_10: ProtocolVersion = 10;
+
+/// This version was for Platform release 2.1.0
+pub const PLATFORM_V10: PlatformVersion = PlatformVersion {
+    protocol_version: PROTOCOL_VERSION_10,
+    drive: DRIVE_VERSION_V4,
+    drive_abci: DriveAbciVersion {
+        structs: DRIVE_ABCI_STRUCTURE_VERSIONS_V1,
+        methods: DRIVE_ABCI_METHOD_VERSIONS_V6,
+        validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V6,
+        withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2,
+        query: DRIVE_ABCI_QUERY_VERSIONS_V1,
+    },
+    dpp: DPPVersion {
+        costs: DPP_COSTS_VERSIONS_V1,
+        validation: DPP_VALIDATION_VERSIONS_V2,
+        state_transition_serialization_versions: STATE_TRANSITION_SERIALIZATION_VERSIONS_V2,
+        state_transition_conversion_versions: STATE_TRANSITION_CONVERSION_VERSIONS_V2,
+        state_transition_method_versions: STATE_TRANSITION_METHOD_VERSIONS_V1,
+        state_transitions: STATE_TRANSITION_VERSIONS_V2,
+        contract_versions: CONTRACT_VERSIONS_V2,
+        document_versions: DOCUMENT_VERSIONS_V2,
+        identity_versions: IDENTITY_VERSIONS_V1,
+        voting_versions: VOTING_VERSION_V2,
+        token_versions: TOKEN_VERSIONS_V1,
+        asset_lock_versions: DPP_ASSET_LOCK_VERSIONS_V1,
+        methods: DPP_METHOD_VERSIONS_V2,
+        factory_versions: DPP_FACTORY_VERSIONS_V1,
+    },
+    system_data_contracts: SYSTEM_DATA_CONTRACT_VERSIONS_V1,
+    fee_version: FEE_VERSION2,
+    system_limits: SYSTEM_LIMITS_V1,
+    consensus: ConsensusVersions {
+        tenderdash_consensus_version: 1,
+    },
+};


### PR DESCRIPTION
## Issue being fixed or feature implemented
Add support for protocol version 10, including necessary updates to the versioning system.

## What was done?
- Updated the main versioning module to include `PROTOCOL_VERSION_10`.
- Added a new module `v10` to define the specifics of protocol version 10.
- Updated constants to reflect the latest platform version as `PLATFORM_V10` and `LATEST_VERSION`.

## How Has This Been Tested?
Changes have been validated through existing unit tests that cover protocol versioning.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added ! to the title and described breaking changes in the corresponding section if my code contains any.

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for protocol version 10, now recognized as the latest platform version.
  * Added a new module for version 10, consolidating all relevant platform components and versioning.

* **Chores**
  * Updated constants and version references throughout the platform to reflect protocol version 10 as the current standard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->