### PR TITLE
feat(dashmate): allow configuring zmq using dashmate

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -105,6 +105,10 @@ export default function getBaseConfigFactory() {
           },
           allowIps: ['127.0.0.1', '172.16.0.0/12', '192.168.0.0/16'],
         },
+        zmq: {
+          host: '127.0.0.1',
+          port: 29998,
+        },
         spork: {
           address: null,
           privateKey: null,

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1096,6 +1096,16 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
           });
         return configFile;
       },
+      '2.0.2': (configFile) => {
+        Object.entries(configFile.configs)
+          .forEach(([, options]) => {
+            // Add ZMQ configuration if it doesn't exist
+            if (!options.core.zmq) {
+              options.core.zmq = base.get('core.zmq');
+            }
+          });
+        return configFile;
+      },
     };
   }
 

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1096,7 +1096,7 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
           });
         return configFile;
       },
-      '2.0.2': (configFile) => {
+      '2.1.0-dev.1': (configFile) => {
         Object.entries(configFile.configs)
           .forEach(([, options]) => {
             // Add ZMQ configuration if it doesn't exist

--- a/packages/dashmate/docker-compose.yml
+++ b/packages/dashmate/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     ports:
       - ${CORE_P2P_HOST:?err}:${CORE_P2P_PORT:?err}:${CORE_P2P_PORT:?err}
       - ${CORE_RPC_HOST:?err}:${CORE_RPC_PORT:?err}:${CORE_RPC_PORT:?err}
+      - ${CORE_ZMQ_HOST:?err}:${CORE_ZMQ_PORT:?err}:${CORE_ZMQ_PORT:?err}
     volumes:
       - core_data:/home/dash
       - ${DASHMATE_HOME_DIR:?err}/${CONFIG_NAME:?err}/core/dash.conf:/home/dash/.dashcore/dash.conf:ro
@@ -146,7 +147,7 @@ services:
       - DASHCORE_RPC_USER=dapi
       - DASHCORE_RPC_PASS=${CORE_RPC_USERS_DAPI_PASSWORD:?err}
       - DASHCORE_ZMQ_HOST=core
-      - DASHCORE_ZMQ_PORT=29998
+      - DASHCORE_ZMQ_PORT=${CORE_ZMQ_PORT:?err}
       - NETWORK=${NETWORK:?err}
       - TENDERMINT_RPC_HOST=drive_tenderdash
       - TENDERMINT_RPC_PORT=${PLATFORM_DRIVE_TENDERDASH_RPC_PORT:?err}
@@ -178,7 +179,7 @@ services:
       - DASHCORE_RPC_USER=dapi
       - DASHCORE_RPC_PASS=${CORE_RPC_USERS_DAPI_PASSWORD:?err}
       - DASHCORE_ZMQ_HOST=core
-      - DASHCORE_ZMQ_PORT=29998
+      - DASHCORE_ZMQ_PORT=${CORE_ZMQ_PORT:?err}
       - NETWORK=${NETWORK:?err}
       - TENDERMINT_RPC_HOST=drive_tenderdash
       - TENDERMINT_RPC_PORT=26657

--- a/packages/dashmate/docs/config/core.md
+++ b/packages/dashmate/docs/config/core.md
@@ -67,6 +67,27 @@ Each user has:
 - `whitelist`: List of allowed RPC methods (null means all methods)
 - `lowPriority`: Whether the user's requests have low priority and processed in a separate low priority RPC queue
 
+## ZMQ
+
+The `core.zmq` section configures the ZeroMQ notification interface, which provides real-time notifications for blockchain events.
+
+| Option | Description | Default | Example |
+|--------|-------------|---------|---------|
+| `core.zmq.port` | Port for ZMQ notifications | `29998` | `30998` |
+| `core.zmq.host` | Host binding for Docker port mapping | `127.0.0.1` | `0.0.0.0` |
+
+ZMQ settings control real-time blockchain event notifications:
+- ZMQ provides low-latency notifications for blocks, transactions, and other blockchain events
+- **host**: Controls Docker port exposure:
+  - `127.0.0.1`: ZMQ port exposed only on localhost (local machine access)
+  - `0.0.0.0`: ZMQ port exposed on all interfaces (public internet access - use with caution)
+- **port**: The port number for ZMQ notifications
+- DAPI uses ZMQ to receive real-time blockchain data for streaming to clients
+- ZMQ notifications include raw transactions, blocks, instantlocks, and chainlocks
+- ZMQ is always enabled in Dash Core as it's used by internal components
+
+**Security Note**: Be cautious when setting `host` to `0.0.0.0` as it makes ZMQ publicly accessible.
+
 ## Sporks
 
 The `core.spork` section configures spork functionality. Sporks are a governance mechanism in Dash that allow network parameters to be changed without requiring a node software update.

--- a/packages/dashmate/docs/services/core.md
+++ b/packages/dashmate/docs/services/core.md
@@ -33,6 +33,7 @@ Core exposes P2P and RPC ports for communication with other services. It also pr
 |----------------------|--------------|---------------|---------------------|----------------------|------------------|
 | **Core**             | P2P          | 9999          | `core.p2p.port`     | 0.0.0.0 (all)        | `core.p2p.host`  |
 |                      | RPC          | 9998          | `core.rpc.port`     | 127.0.0.1 (local)    | `core.rpc.host`  |
+|                      | ZMQ          | 29998         | `core.zmq.port`     | 127.0.0.1 (local)    | `core.zmq.host`  |
 | **Insight API/UI**   | HTTP         | 3001          | `core.insight.port` | 127.0.0.1 (local)    | (fixed)           |
 
 To interact with Core RPC use `dashmate core cli` command.

--- a/packages/dashmate/docs/services/index.md
+++ b/packages/dashmate/docs/services/index.md
@@ -73,8 +73,17 @@ Dashmate runs and orchestrate Dash Platform components:
 | Type                | Ports                                                        | Default Host Binding |
 |---------------------|--------------------------------------------------------------|---------------------|
 | **Public-facing**   | Core P2P (9999)<br>Tenderdash P2P (26656)<br>Gateway API (443) | 0.0.0.0 (all)       |
+| **Configurable**    | Core ZMQ (29998)                                             | configurable (see below) |
 | **Localhost-only**  | Core RPC (9998)<br>Insight UI (3001)<br>Dashmate Helper (9100)<br>Drive ABCI Metrics (29090)<br>Drive Debug Tools (6669, 8083)<br>Tenderdash RPC (26657)<br>Tenderdash Metrics (26660)<br>Tenderdash Debug (6060)<br>Gateway Metrics (9090)<br>Gateway Admin (9901)<br>Rate Limiter Metrics (9102) | 127.0.0.1 (local)   |
-| **Internal only**   | Core ZMQ (29998)<br>Drive ABCI (26658)<br>Drive gRPC (26670)<br>DAPI JSON-RPC (3004)<br>DAPI gRPC (3005)<br>DAPI Streams (3006)<br>Rate Limiter gRPC (8081)<br>Rate Limiter StatsD (9125)<br>Rate Limiter Redis (6379) | (not exposed)       |
+| **Internal only**   | Drive ABCI (26658)<br>Drive gRPC (26670)<br>DAPI JSON-RPC (3004)<br>DAPI gRPC (3005)<br>DAPI Streams (3006)<br>Rate Limiter gRPC (8081)<br>Rate Limiter StatsD (9125)<br>Rate Limiter Redis (6379) | (not exposed)       |
+
+#### Core ZMQ Exposure Configuration
+
+The Core ZMQ port (29998) exposure is configurable via `core.zmq.host`:
+- **`host: '127.0.0.1'`** (default): ZMQ port exposed on localhost only
+- **`host: '0.0.0.0'`**: ZMQ port exposed on all interfaces (use with caution)
+
+ZMQ is always enabled in Dash Core as it's used by internal components like DAPI.
 
 ### Port Security Notes
 

--- a/packages/dashmate/src/config/configJsonSchema.js
+++ b/packages/dashmate/src/config/configJsonSchema.js
@@ -307,6 +307,19 @@ export default {
           required: ['host', 'port', 'users', 'allowIps'],
           additionalProperties: false,
         },
+        zmq: {
+          type: 'object',
+          properties: {
+            host: {
+              $ref: '#/definitions/host',
+            },
+            port: {
+              $ref: '#/definitions/port',
+            },
+          },
+          required: ['host', 'port'],
+          additionalProperties: false,
+        },
         spork: {
           type: 'object',
           properties: {
@@ -475,7 +488,7 @@ export default {
             + ' `core.masternode.enable`, and `core.insight.enabled` add indexes dynamically',
         },
       },
-      required: ['docker', 'p2p', 'rpc', 'spork', 'masternode', 'miner', 'devnet', 'log',
+      required: ['docker', 'p2p', 'rpc', 'zmq', 'spork', 'masternode', 'miner', 'devnet', 'log',
         'indexes', 'insight'],
       additionalProperties: false,
     },

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -2,8 +2,8 @@ import { Listr } from 'listr2';
 import {
   PRESET_LOCAL,
 } from '../../../constants.js';
-import generateTenderdashNodeKey from '../../../tenderdash/generateTenderdashNodeKey.js';
 import deriveTenderdashNodeId from '../../../tenderdash/deriveTenderdashNodeId.js';
+import generateTenderdashNodeKey from '../../../tenderdash/generateTenderdashNodeKey.js';
 import generateRandomString from '../../../util/generateRandomString.js';
 
 /**
@@ -124,6 +124,7 @@ export default function setupLocalPresetTaskFactory(
                 config.set('group', 'local');
                 config.set('core.p2p.port', config.get('core.p2p.port') + (i * 100));
                 config.set('core.rpc.port', config.get('core.rpc.port') + (i * 100));
+                config.set('core.zmq.port', config.get('core.zmq.port') + (i * 100));
 
                 Object.values(config.get('core.rpc.users')).forEach((options) => {
                   // eslint-disable-next-line no-param-reassign

--- a/packages/dashmate/templates/core/dash.conf.dot
+++ b/packages/dashmate/templates/core/dash.conf.dot
@@ -70,13 +70,13 @@ spentindex=1
 {{?}}
 
 # ZeroMQ notifications
-zmqpubrawtx=tcp://0.0.0.0:29998
-zmqpubrawtxlock=tcp://0.0.0.0:29998
-zmqpubrawblock=tcp://0.0.0.0:29998
-zmqpubhashblock=tcp://0.0.0.0:29998
-zmqpubrawchainlocksig=tcp://0.0.0.0:29998
-zmqpubrawchainlock=tcp://0.0.0.0:29998
-zmqpubrawtxlocksig=tcp://0.0.0.0:29998
+zmqpubrawtx=tcp://0.0.0.0:{{=it.core.zmq.port}}
+zmqpubrawtxlock=tcp://0.0.0.0:{{=it.core.zmq.port}}
+zmqpubrawblock=tcp://0.0.0.0:{{=it.core.zmq.port}}
+zmqpubhashblock=tcp://0.0.0.0:{{=it.core.zmq.port}}
+zmqpubrawchainlocksig=tcp://0.0.0.0:{{=it.core.zmq.port}}
+zmqpubrawchainlock=tcp://0.0.0.0:{{=it.core.zmq.port}}
+zmqpubrawtxlocksig=tcp://0.0.0.0:{{=it.core.zmq.port}}
 
 {{? it.core.masternode.enable === true}}
 masternodeblsprivkey={{=it.core.masternode.operator.privateKey}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented


To use dash-evo-tool  with a local network, we need to expose zeromq.


## What was done?


Added config option `core.zmq` to control how zeromq is exposed.


## How Has This Been Tested?

GHA

## Breaking Changes

New config is needed, but migrations are done.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ZeroMQ (ZMQ) interface options (`host` and `port`) to the Core service configuration, allowing customization of real-time blockchain event notifications.
  * ZMQ port can now be individually set for each local node, supporting multi-node setups.

* **Bug Fixes**
  * Ensured consistent and configurable ZMQ port usage across services via environment variables.

* **Documentation**
  * Updated documentation to describe ZMQ configuration options, port exposure, and usage within the Core service and Dashmate.
  * Clarified how to configure and secure the ZMQ interface, including security considerations for public exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->