### PR TITLE
fix(sdk): install wasm-opt from Github instead of apt

### DIFF
--- a/.github/workflows/wasm-sdk-build.yml
+++ b/.github/workflows/wasm-sdk-build.yml
@@ -81,9 +81,23 @@ jobs:
       - name: Install wasm-opt
         run: |
           if ! command -v wasm-opt &> /dev/null; then
-            echo "Installing wasm-opt..."
-            sudo apt-get update
-            sudo apt-get install -y binaryen
+            echo "Installing wasm-opt from GitHub releases..."
+            # Get the latest release version
+            WASM_OPT_VERSION=$(curl -s https://api.github.com/repos/WebAssembly/binaryen/releases/latest | grep -oP '"tag_name": "\K[^"]+')
+            echo "Installing wasm-opt version: $WASM_OPT_VERSION"
+            
+            # Download and extract binaryen
+            curl -L "https://github.com/WebAssembly/binaryen/releases/download/${WASM_OPT_VERSION}/binaryen-${WASM_OPT_VERSION}-x86_64-linux.tar.gz" -o /tmp/binaryen.tar.gz
+            tar -xzf /tmp/binaryen.tar.gz -C /tmp
+            
+            # Move wasm-opt to PATH
+            sudo mv /tmp/binaryen-${WASM_OPT_VERSION}/bin/wasm-opt /usr/local/bin/
+            sudo chmod +x /usr/local/bin/wasm-opt
+            
+            # Clean up
+            rm -rf /tmp/binaryen.tar.gz /tmp/binaryen-${WASM_OPT_VERSION}
+            
+            echo "wasm-opt installed successfully"
           else
             echo "wasm-opt already installed"
           fi

--- a/.github/workflows/wasm-sdk-build.yml
+++ b/.github/workflows/wasm-sdk-build.yml
@@ -86,8 +86,21 @@ jobs:
             WASM_OPT_VERSION=$(curl -s https://api.github.com/repos/WebAssembly/binaryen/releases/latest | grep -oP '"tag_name": "\K[^"]+')
             echo "Installing wasm-opt version: $WASM_OPT_VERSION"
             
+            # Detect architecture
+            ARCH=$(uname -m)
+            if [ "$ARCH" = "x86_64" ]; then
+              BINARYEN_ARCH="x86_64"
+            elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+              BINARYEN_ARCH="arm64"
+            else
+              echo "Unsupported architecture: $ARCH"
+              exit 1
+            fi
+            
+            echo "Detected architecture: $ARCH, using binaryen arch: $BINARYEN_ARCH"
+            
             # Download and extract binaryen
-            curl -L "https://github.com/WebAssembly/binaryen/releases/download/${WASM_OPT_VERSION}/binaryen-${WASM_OPT_VERSION}-x86_64-linux.tar.gz" -o /tmp/binaryen.tar.gz
+            curl -L "https://github.com/WebAssembly/binaryen/releases/download/${WASM_OPT_VERSION}/binaryen-${WASM_OPT_VERSION}-${BINARYEN_ARCH}-linux.tar.gz" -o /tmp/binaryen.tar.gz
             tar -xzf /tmp/binaryen.tar.gz -C /tmp
             
             # Move wasm-opt to PATH

--- a/.github/workflows/wasm-sdk-build.yml
+++ b/.github/workflows/wasm-sdk-build.yml
@@ -91,7 +91,7 @@ jobs:
             if [ "$ARCH" = "x86_64" ]; then
               BINARYEN_ARCH="x86_64"
             elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
-              BINARYEN_ARCH="arm64"
+              BINARYEN_ARCH="aarch64"
             else
               echo "Unsupported architecture: $ARCH"
               exit 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
We are installing wasm-pack from latest release and installing an old version of wasm-opt from the Ubuntu repositories - this is causing version mismatch problems


## What was done?
Install the latest wasm-opt instead of the one from apt


## How Has This Been Tested?
CI - https://github.com/dashpay/platform/actions/runs/16276671946/job/45957134828


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the workflow to install the latest version of `wasm-opt` directly from GitHub releases instead of using the system package manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->