### PR TITLE
docs(sdk): updates missing from 2711

### DIFF
--- a/packages/wasm-sdk/AI_REFERENCE.md
+++ b/packages/wasm-sdk/AI_REFERENCE.md
@@ -731,55 +731,29 @@ const result = await sdk.{transition_name}(identityHex, ...params, privateKeyHex
 **Identity Create** - `identityCreate`
 *Create a new identity with initial credits*
 
-Parameters:
-- `assetLockProof` (string, required) - Asset lock proof (hex-encoded JSON)
-- `assetLockProofPrivateKey` (string, required) - Private key for the asset lock proof (WIF format)
-- `publicKeys` (string, required) - JSON array of public keys to add to the identity
+Parameters (in addition to identity/key):
+- `seedPhrase` (textarea, required) - Seed Phrase
+  - Example: `Enter seed phrase (12-24 words) or click Generate`
+- `generateSeedButton` (button, optional) - Generate New Seed
+- `identityIndex` (number, required) - Identity Index
+- `keySelectionMode` (select, required) - Key Selection Mode
+- `keyPreview` (keyPreview, optional) - Keys to be added
 
 Example:
 ```javascript
-// Asset lock proof is a hex-encoded JSON object
-const assetLockProof = "a9147d3b... (hex-encoded)";
-const assetLockProofPrivateKey = "XFfpaSbZq52HPy3WWwe1dXsZMiU1bQn8vQd34HNXkSZThevBWRn1"; // WIF format
-
-// Public keys array with proper key types
-const publicKeys = JSON.stringify([
-  {
-    id: 0,
-    type: 0, // ECDSA_SECP256K1 = 0, BLS12_381 = 1, ECDSA_HASH160 = 2
-    purpose: 0, // AUTHENTICATION = 0, ENCRYPTION = 1, DECRYPTION = 2, TRANSFER = 3, etc.
-    securityLevel: 0, // MASTER = 0, CRITICAL = 1, HIGH = 2, MEDIUM = 3
-    data: "A5GzYHPIolbHkFrp5l+s9IvF2lWMuuuSu3oWZB8vWHNJ", // Base64-encoded public key
-    readOnly: false
-  },
-  {
-    id: 1,
-    type: 0,
-    purpose: 0,
-    securityLevel: 2,
-    data: "AnotherBase64EncodedPublicKeyHere", // Base64-encoded public key
-    readOnly: false
-  }
-]);
-
-const result = await sdk.identityCreate(assetLockProof, assetLockProofPrivateKey, publicKeys);
+const result = await sdk.identityCreate(identityHex, /* params */, privateKeyHex);
 ```
 
 **Identity Top Up** - `identityTopUp`
 *Add credits to an existing identity*
 
-Parameters:
-- `identityId` (string, required) - The identity ID to top up (base58 format)
-- `assetLockProof` (string, required) - Asset lock proof (hex-encoded JSON)
-- `assetLockProofPrivateKey` (string, required) - Private key for the asset lock proof (WIF format)
+Parameters (in addition to identity/key):
+- `identityId` (text, required) - Identity ID
+  - Example: `Enter the identity ID to top up (base58)`
 
 Example:
 ```javascript
-const identityId = "5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5Bk"; // base58
-const assetLockProof = "a9147d3b... (hex-encoded)";
-const assetLockProofPrivateKey = "XFfpaSbZq52HPy3WWwe1dXsZMiU1bQn8vQd34HNXkSZThevBWRn1"; // WIF format
-
-const result = await sdk.identityTopUp(identityId, assetLockProof, assetLockProofPrivateKey);
+const result = await sdk.identityTopUp(identityHex, /* params */, privateKeyHex);
 ```
 
 **Identity Update** - `identityUpdate`
@@ -787,7 +761,7 @@ const result = await sdk.identityTopUp(identityId, assetLockProof, assetLockProo
 
 Parameters (in addition to identity/key):
 - `addPublicKeys` (textarea, optional) - Keys to Add (JSON array)
-  - Example: `[{"type":0,"purpose":0,"securityLevel":2,"data":"base64_encoded_public_key","readOnly":false}]`
+  - Example: `[{"keyType":"ECDSA_HASH160","purpose":"AUTHENTICATION","data":"base64_key_data"}]`
 - `disablePublicKeys` (text, optional) - Key IDs to Disable (comma-separated)
   - Example: `2,3,5`
 

--- a/packages/wasm-sdk/docs.html
+++ b/packages/wasm-sdk/docs.html
@@ -2343,52 +2343,37 @@
             <div class="parameters">
                 <h5>Parameters:</h5>
                 <div class="parameter">
-                    <span class="param-name">Asset Lock Proof</span>
-                    <span class="param-type">string</span>
+                    <span class="param-name">Seed Phrase</span>
+                    <span class="param-type">textarea</span>
                     <span class="param-required">(required)</span>
-                    <br><small>Hex-encoded JSON asset lock proof</small>
+                    <br><small>Example: Enter seed phrase (12-24 words) or click Generate</small>
                 </div>
                 <div class="parameter">
-                    <span class="param-name">Asset Lock Proof Private Key</span>
-                    <span class="param-type">string</span>
-                    <span class="param-required">(required)</span>
-                    <br><small>WIF format private key</small>
+                    <span class="param-name">Generate New Seed</span>
+                    <span class="param-type">button</span>
+                    <span class="param-optional">(optional)</span>
                 </div>
                 <div class="parameter">
-                    <span class="param-name">Public Keys</span>
-                    <span class="param-type">string</span>
+                    <span class="param-name">Identity Index</span>
+                    <span class="param-type">number</span>
                     <span class="param-required">(required)</span>
-                    <br><small>JSON array of public keys</small>
+                </div>
+                <div class="parameter">
+                    <span class="param-name">Key Selection Mode</span>
+                    <span class="param-type">select</span>
+                    <span class="param-required">(required)</span>
+                    <br><small>Options: Default (Recommended), Advanced</small>
+                </div>
+                <div class="parameter">
+                    <span class="param-name">Keys to be added</span>
+                    <span class="param-type">keyPreview</span>
+                    <span class="param-optional">(optional)</span>
                 </div>
             </div>
             
             <div class="example-container">
                 <h5>Example</h5>
-                <div class="example-code">// Asset lock proof is a hex-encoded JSON object
-const assetLockProof = "a9147d3b... (hex-encoded)";
-const assetLockProofPrivateKey = "XFfpaSbZq52HPy3WWwe1dXsZMiU1bQn8vQd34HNXkSZThevBWRn1"; // WIF format
-
-// Public keys array with proper key types
-const publicKeys = JSON.stringify([
-  {
-    id: 0,
-    type: 0, // ECDSA_SECP256K1 = 0, BLS12_381 = 1, ECDSA_HASH160 = 2
-    purpose: 0, // AUTHENTICATION = 0, ENCRYPTION = 1, DECRYPTION = 2, TRANSFER = 3, etc.
-    securityLevel: 0, // MASTER = 0, CRITICAL = 1, HIGH = 2, MEDIUM = 3
-    data: "A5GzYHPIolbHkFrp5l+s9IvF2lWMuuuSu3oWZB8vWHNJ", // Base64-encoded public key
-    readOnly: false
-  },
-  {
-    id: 1,
-    type: 0,
-    purpose: 0,
-    securityLevel: 2,
-    data: "AnotherBase64EncodedPublicKeyHere", // Base64-encoded public key
-    readOnly: false
-  }
-]);
-
-const result = await sdk.identityCreate(assetLockProof, assetLockProofPrivateKey, publicKeys);</div>            </div>
+                <div class="example-code">const result = await sdk.identityCreate(identityHex, /* params */, privateKeyHex);</div>            </div>
         </div>
         <div class="operation">
             <h4 id="transition-identityTopUp">Identity Top Up</h4>
@@ -2398,30 +2383,15 @@ const result = await sdk.identityCreate(assetLockProof, assetLockProofPrivateKey
                 <h5>Parameters:</h5>
                 <div class="parameter">
                     <span class="param-name">Identity ID</span>
-                    <span class="param-type">string</span>
+                    <span class="param-type">text</span>
                     <span class="param-required">(required)</span>
-                    <br><small>Base58 format identity ID</small>
+                    <br><small>Example: Enter the identity ID to top up (base58)</small>
                 </div>
-                <div class="parameter">
-                    <span class="param-name">Asset Lock Proof</span>
-                    <span class="param-type">string</span>
-                    <span class="param-required">(required)</span>
-                    <br><small>Hex-encoded JSON asset lock proof</small>
-                </div>
-                <div class="parameter">
-                    <span class="param-name">Asset Lock Proof Private Key</span>
-                    <span class="param-type">string</span>
-                    <span class="param-required">(required)</span>
-                    <br><small>WIF format private key</small>
             </div>
             
             <div class="example-container">
                 <h5>Example</h5>
-                <div class="example-code">const identityId = "5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5Bk"; // base58
-const assetLockProof = "a9147d3b... (hex-encoded)";
-const assetLockProofPrivateKey = "XFfpaSbZq52HPy3WWwe1dXsZMiU1bQn8vQd34HNXkSZThevBWRn1"; // WIF format
-
-const result = await sdk.identityTopUp(identityId, assetLockProof, assetLockProofPrivateKey);</div>            </div>
+                <div class="example-code">const result = await sdk.identityTopUp(identityHex, /* params */, privateKeyHex);</div>            </div>
         </div>
         <div class="operation">
             <h4 id="transition-identityUpdate">Identity Update</h4>


### PR DESCRIPTION
## Issue being fixed or feature implemented
The following output files are updated when running generate_docs.py after #2711 was merged

## What was done?
Ran `generate_docs.py`

## How Has This Been Tested?
Not tested

## Breaking Changes
N/A

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated identity-related state transition documentation to reflect simplified parameters and usage examples.
  * Replaced asset lock proof and private key references with seed phrase and key management options in identity creation and top-up instructions.
  * Improved example formats for identity updates and other transitions for clarity and ease of use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->