### PR TITLE
chore: add wasm-sdk as scope for pr linting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,6 +47,7 @@ jobs:
             bench-suite
             release
             dash-spv
+            wasm-sdk
           requireScope: false
           # Configure additional validation for the subject based on a regex.
           # This example ensures the subject doesn't start with an uppercase character.


### PR DESCRIPTION
## Issue being fixed or feature implemented
PR linting is failing unnecessarily because we haven't added "wasm-sdk" to scope.

## What was done?
Added "wasm-sdk" as valid scope


## How Has This Been Tested?
N/A

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR title validation to include “wasm-sdk” as an allowed scope, aligning CI checks with current naming and reducing false negatives during reviews. This streamlines contributor workflow and improves release notes/changelog categorization. Applies to pull request automation only. No user-facing changes. No runtime impact or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->