### PR TITLE
fix(wasm-sdk): enable proofs for getContestedResourceVotersForIdentity

### DIFF
--- a/packages/wasm-sdk/test/ui-automation/tests/query-execution.spec.js
+++ b/packages/wasm-sdk/test/ui-automation/tests/query-execution.spec.js
@@ -829,7 +829,7 @@ test.describe('WASM SDK Query Execution Tests', () => {
       },
       { 
         name: 'getContestedResourceVotersForIdentity', 
-        hasProofSupport: false, // Not working
+        hasProofSupport: true,
         needsParameters: true,
         validateFn: (result) => {
           expect(() => JSON.parse(result)).not.toThrow();


### PR DESCRIPTION
## Issue being fixed or feature implemented

Add support for the `index_values` parameter to the contested resource voters query in the WASM SDK to enable proofs for that query.

  ## What was done?
- Added `index_values` parameter to `get_contested_resource_voters_for_identity_with_proof_info` function
- Implemented proper serialization of index values using bincode for compatibility with the underlying query system
- Updated UI automation tests to enable proof support for the `getContestedResourceVotersForIdentity` query

## How Has This Been Tested?

- Updated existing UI automation test suite to verify the new parameter functionality
- Tested proof generation with index values through the automated test framework
- Manual verification through the WASM SDK web interface

## Breaking Changes

None - this is a backward compatible addition that adds an optional parameter to enhance query capabilities.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support to provide index values when querying contested-resource voters, enabling targeted filtering instead of querying all resources.
  * Improved input validation with clear errors when index values are not strings.
  * Response format remains unchanged and continues to include proof information.

* **Tests**
  * Enabled proof-info test path for the contested-resource voters query to increase coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->