### PR TITLE
fix(wasm-sdk): fix nft transitions

### DIFF
--- a/packages/wasm-sdk/src/state_transitions/documents/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/documents/mod.rs
@@ -965,6 +965,26 @@ impl WasmSdk {
             .map_err(|e| JsValue::from_str(&format!("Failed to fetch document: {}", e)))?
             .ok_or_else(|| JsValue::from_str("Document not found"))?;
         
+        // Get the current revision and increment it
+        let current_revision = document.revision().unwrap_or(0);
+        
+        // Create a modified document with incremented revision for the transfer transition
+        let transfer_document = Document::V0(DocumentV0 {
+            id: document.id(),
+            owner_id: document.owner_id(),
+            properties: document.properties().clone(),
+            revision: Some(current_revision + 1),
+            created_at: document.created_at(),
+            updated_at: document.updated_at(),
+            transferred_at: document.transferred_at(),
+            created_at_block_height: document.created_at_block_height(),
+            updated_at_block_height: document.updated_at_block_height(),
+            transferred_at_block_height: document.transferred_at_block_height(),
+            created_at_core_block_height: document.created_at_core_block_height(),
+            updated_at_core_block_height: document.updated_at_core_block_height(),
+            transferred_at_core_block_height: document.transferred_at_core_block_height(),
+        });
+        
         // Fetch the identity to get the correct key
         let identity = dash_sdk::platform::Identity::fetch(&sdk, owner_identifier)
             .await
@@ -983,7 +1003,7 @@ impl WasmSdk {
         
         // Create a transfer transition
         let transition = BatchTransition::new_document_transfer_transition_from_document(
-            document,
+            transfer_document,
             document_type_ref,
             recipient_identifier,
             matching_key,


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes issues with document state transitions in the WASM SDK where document revisions were not being properly incremented for transfer, purchase, and price update operations, causing validation failures on the platform.

## What was done?
- Fixed document transfer transitions to properly increment the document revision before creating the transition
- Improved document purchase transitions to use a new document instance with incremented revision
- Updated price update transitions to use the dedicated `update_price` method instead of generic replacement
- Ensured all document-modifying transitions correctly handle revision increments to maintain state consistency

There may be a better way to do this, but it's how I was able to get wasm-sdk to produce transitions that actually work.

## How Has This Been Tested?
- Tested document transfer transitions with proper revision increments
- Verified transitions create valid state changes

## Breaking Changes
None

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
