### PR TITLE
build: update rust to 1.89

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,12 +34,11 @@ members = [
     "packages/token-history-contract",
     "packages/keyword-search-contract",
     "packages/wasm-drive-verify",
-    "packages/dash-platform-balance-checker"
+    "packages/dash-platform-balance-checker",
 ]
 
 exclude = ["packages/wasm-sdk"] # This one is experimental and not ready for use
 
 [workspace.package]
 
-rust-version = "1.85"
-
+rust-version = "1.89"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ this repository may be used on the following networks:
 - Install prerequisites:
   - [node.js](https://nodejs.org/) v20
   - [docker](https://docs.docker.com/get-docker/) v20.10+
-  - [rust](https://www.rust-lang.org/tools/install) v1.85+, with wasm32 target (`rustup target add wasm32-unknown-unknown`)
+  - [rust](https://www.rust-lang.org/tools/install) v1.89+, with wasm32 target (`rustup target add wasm32-unknown-unknown`)
   - [protoc - protobuf compiler](https://github.com/protocolbuffers/protobuf/releases) v27.3+
     - if needed, set PROTOC environment variable to location of `protoc` binary
   - [wasm-bingen toolchain](https://rustwasm.github.io/wasm-bindgen/):

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Rust version the same as in /README.md
-channel = "1.85"
+channel = "1.89"
 
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Issue being fixed or feature implemented

Dashcore v0.40-dev requires newer rust version

## What was done?

Update rust to 1.89


## How Has This Been Tested?

GHA + cargo build

## Breaking Changes

New Rust required to build, but we don't consider it breaking

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the Rust toolchain to version 1.89 across the workspace to ensure consistent builds.
  * Applied a minor formatting tweak (trailing comma) with no functional impact.

* **Documentation**
  * Updated README prerequisites to require Rust 1.89+ for the wasm32 target; commands remain the same.
  * Note: If you build from source, please update your local Rust toolchain to 1.89 to avoid build issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->