### PR TITLE
feat(wasm-sdk)!: remove unused key_id parameters from state transitions

### DIFF
--- a/packages/wasm-sdk/AI_REFERENCE.md
+++ b/packages/wasm-sdk/AI_REFERENCE.md
@@ -1097,7 +1097,6 @@ Parameters (in addition to identity/key):
 - `tokenPosition` (number, required) - Token Contract Position
 - `amount` (text, required) - Amount to Purchase
 - `totalAgreedPrice` (text, optional) - Total Agreed Price (in credits) - Optional, fetches from pricing schedule if not provided
-- `keyId` (number, required) - Key ID (for signing)
 
 Example:
 ```javascript
@@ -1175,7 +1174,7 @@ const result = await sdk.tokenUnfreeze(identityHex, /* params */, privateKeyHex)
 Parameters (in addition to identity/key):
 - `contractId` (text, required) - Data Contract ID
 - `tokenPosition` (number, required) - Token Contract Position
-- `identityId` (text, required) - Identity ID whose frozen tokens to destroy
+- `frozenIdentityId` (text, required) - Identity ID whose frozen tokens to destroy
 - `publicNote` (text, optional) - Public Note
 
 Example:

--- a/packages/wasm-sdk/api-definitions.json
+++ b/packages/wasm-sdk/api-definitions.json
@@ -1875,12 +1875,6 @@
               "type": "text",
               "label": "Total Agreed Price (in credits) - Optional, fetches from pricing schedule if not provided",
               "required": false
-            },
-            {
-              "name": "keyId",
-              "type": "number",
-              "label": "Key ID (for signing)",
-              "required": true
             }
           ]
         },

--- a/packages/wasm-sdk/docs.html
+++ b/packages/wasm-sdk/docs.html
@@ -2639,11 +2639,6 @@ const result = await sdk.identityTopUp(identityId, assetLockProof, assetLockProo
                     <span class="param-type">text</span>
                     <span class="param-optional">(optional)</span>
                 </div>
-                <div class="parameter">
-                    <span class="param-name">Key ID (for signing)</span>
-                    <span class="param-type">number</span>
-                    <span class="param-required">(required)</span>
-                </div>
             </div>
             
             <div class="example-container">

--- a/packages/wasm-sdk/docs_manifest.json
+++ b/packages/wasm-sdk/docs_manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-09-02T17:31:30.731295+00:00",
+  "generated_at": "2025-09-03T20:55:56.075308+00:00",
   "queries": {
     "getIdentity": {
       "category": "identity",

--- a/packages/wasm-sdk/index.html
+++ b/packages/wasm-sdk/index.html
@@ -3296,8 +3296,7 @@ ${indentStr}]`;
             identityId,
             JSON.stringify(documentData),
             BigInt(loadedDocumentRevision),
-            privateKey,
-            0 // key_id - using 0 as default
+            privateKey
           );
           
           // Pass the result object directly to displayResult
@@ -3314,8 +3313,7 @@ ${indentStr}]`;
             values.documentType,
             values.documentId,
             identityId,
-            privateKey,
-            0 // key_id - using 0 as default
+            privateKey
           );
           
           // Pass the result object directly to displayResult
@@ -3329,8 +3327,7 @@ ${indentStr}]`;
             values.documentId,
             identityId,
             values.recipientId,
-            privateKey,
-            0 // key_id - using 0 as default
+            privateKey
           );
           
           // Pass the result object directly to displayResult
@@ -3344,8 +3341,7 @@ ${indentStr}]`;
             values.documentId,
             identityId,
             BigInt(values.price || 0), // price in credits, 0 to remove price
-            privateKey,
-            0 // key_id - using 0 as default
+            privateKey
           );
           
           // Pass the result object directly to displayResult
@@ -3478,8 +3474,7 @@ ${indentStr}]`;
             values.documentId,
             identityId,
             BigInt(values.price),
-            privateKey,
-            0 // key_id - using 0 as default
+            privateKey
           );
           
           // Pass the result object directly to displayResult

--- a/packages/wasm-sdk/src/state_transitions/documents/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/documents/mod.rs
@@ -508,7 +508,6 @@ impl WasmSdk {
     /// * `document_data` - The new document data as a JSON string
     /// * `revision` - The current revision of the document
     /// * `private_key_wif` - The private key in WIF format for signing
-    /// * `key_id` - The key ID to use for signing
     ///
     /// # Returns
     ///
@@ -523,7 +522,6 @@ impl WasmSdk {
         document_data: String,
         revision: u64,
         private_key_wif: String,
-        _key_id: u32,
     ) -> Result<JsValue, JsValue> {
         let sdk = self.inner_clone();
         
@@ -794,7 +792,6 @@ impl WasmSdk {
     /// * `document_id` - The ID of the document to delete
     /// * `owner_id` - The identity ID of the document owner
     /// * `private_key_wif` - The private key in WIF format for signing
-    /// * `key_id` - The key ID to use for signing
     ///
     /// # Returns
     ///
@@ -807,7 +804,6 @@ impl WasmSdk {
         document_id: String,
         owner_id: String,
         private_key_wif: String,
-        _key_id: u32,
     ) -> Result<JsValue, JsValue> {
         let sdk = self.inner_clone();
         
@@ -921,7 +917,6 @@ impl WasmSdk {
     /// * `owner_id` - The current owner's identity ID
     /// * `recipient_id` - The new owner's identity ID
     /// * `private_key_wif` - The private key in WIF format for signing
-    /// * `key_id` - The key ID to use for signing
     ///
     /// # Returns
     ///
@@ -935,7 +930,6 @@ impl WasmSdk {
         owner_id: String,
         recipient_id: String,
         private_key_wif: String,
-        _key_id: u32,
     ) -> Result<JsValue, JsValue> {
         let sdk = self.inner_clone();
         
@@ -1056,7 +1050,6 @@ impl WasmSdk {
     /// * `buyer_id` - The buyer's identity ID
     /// * `price` - The purchase price in credits
     /// * `private_key_wif` - The private key in WIF format for signing
-    /// * `key_id` - The key ID to use for signing
     ///
     /// # Returns
     ///
@@ -1070,7 +1063,6 @@ impl WasmSdk {
         buyer_id: String,
         price: u64,
         private_key_wif: String,
-        key_id: u32,
     ) -> Result<JsValue, JsValue> {
         let sdk = self.inner_clone();
         
@@ -1222,7 +1214,6 @@ impl WasmSdk {
     /// * `owner_id` - The owner's identity ID
     /// * `price` - The price in credits (0 to remove price)
     /// * `private_key_wif` - The private key in WIF format for signing
-    /// * `key_id` - The key ID to use for signing
     ///
     /// # Returns
     ///
@@ -1236,7 +1227,6 @@ impl WasmSdk {
         owner_id: String,
         price: u64,
         private_key_wif: String,
-        key_id: u32,
     ) -> Result<JsValue, JsValue> {
         let sdk = self.inner_clone();
         

--- a/packages/wasm-sdk/test/ui-automation/fixtures/test-data.js
+++ b/packages/wasm-sdk/test/ui-automation/fixtures/test-data.js
@@ -772,7 +772,6 @@ const testData = {
             tokenPosition: 0,
             amount: "1",
             totalAgreedPrice: "10",
-            keyId: 0,
             description: "Direct purchase of tokens at configured price"
           }
         ]


### PR DESCRIPTION
## Issue being fixed or feature implemented
Remove unused parameters from state transitions.

## What was done?
- Removed unused _key_id parameters from 5 document state transition functions (document_replace, document_delete,
document_transfer, document_purchase, document_set_price)
- Removed keyId parameter from tokenDirectPurchase state transition
- Updated JavaScript bindings in index.html to remove hardcoded 0 values for key_id
- Updated test fixtures to remove the unused keyId field
- Regenerated documentation to reflect the API changes

## How Has This Been Tested?
Locally via playwright tests

## Breaking Changes
This is technically a breaking change for the WASM SDK API but it only removes parameters that were never functional. The SDK continues to work correctly by automatically determining the appropriate key for signing operations.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
