### PR TITLE
fix(wasm-sdk): include groups and tokens in data contract serialization

### DIFF
--- a/packages/wasm-sdk/src/dpp.rs
+++ b/packages/wasm-sdk/src/dpp.rs
@@ -295,11 +295,18 @@ impl IdentityWasm {
 // }
 
 #[wasm_bindgen]
-pub struct DataContractWasm(DataContract);
+pub struct DataContractWasm(DataContract, &'static PlatformVersion);
+
+impl DataContractWasm {
+    pub fn new(data_contract: DataContract, platform_version: &'static PlatformVersion) -> Self {
+        Self(data_contract, platform_version)
+    }
+}
 
 impl From<DataContract> for DataContractWasm {
     fn from(value: DataContract) -> Self {
-        Self(value)
+        // Use first version as fallback for backward compatibility
+        Self(value, PlatformVersion::first())
     }
 }
 
@@ -311,9 +318,7 @@ impl DataContractWasm {
 
     #[wasm_bindgen(js_name=toJSON)]
     pub fn to_json(&self) -> Result<JsValue, WasmSdkError> {
-        let platform_version = PlatformVersion::first();
-
-        let json = self.0.to_json(platform_version).map_err(|e| {
+        let json = self.0.to_json(self.1).map_err(|e| {
             WasmSdkError::serialization(format!(
                 "failed to convert data contract convert to json: {}",
                 e

--- a/packages/wasm-sdk/src/queries/data_contract.rs
+++ b/packages/wasm-sdk/src/queries/data_contract.rs
@@ -36,10 +36,12 @@ impl WasmSdk {
         )
         .map_err(|e| WasmSdkError::invalid_argument(format!("Invalid data contract ID: {}", e)))?;
 
-        DataContract::fetch_by_identifier(self.as_ref(), id)
+        let contract = DataContract::fetch_by_identifier(self.as_ref(), id)
             .await?
-            .ok_or_else(|| WasmSdkError::not_found("Data contract not found"))
-            .map(Into::into)
+            .ok_or_else(|| WasmSdkError::not_found("Data contract not found"))?;
+
+        let platform_version = dash_sdk::dpp::version::PlatformVersion::get(self.version()).unwrap();
+        Ok(DataContractWasm::new(contract, platform_version))
     }
 
     #[wasm_bindgen(js_name = "getDataContractWithProofInfo")]

--- a/packages/wasm-sdk/src/verify.rs
+++ b/packages/wasm-sdk/src/verify.rs
@@ -122,7 +122,7 @@ pub async fn verify_data_contract() -> Option<DataContractWasm> {
     )
     .expect("parse proof");
 
-    response.map(DataContractWasm::from)
+    response.map(|contract| DataContractWasm::new(contract, PlatformVersion::latest()))
 }
 
 #[wasm_bindgen(js_name = "verifyDocuments")]


### PR DESCRIPTION
## Issue being fixed or feature implemented

The wasm-sdk was not returning `groups` and `tokens` fields when fetching data contracts that define tokens, making it impossible to properly work with token contracts through the SDK.

## What was done?

Fixed the data contract serialization in wasm-sdk to use the SDK's platform version instead of hardcoded `PlatformVersion::first()`. This ensures that contracts are serialized using the V1 format which includes `groups` and `tokens` fields when the platform version supports it.

**Changes made:**
- Modified `DataContractWasm` struct to store the platform version reference
- Updated `to_json()` method to use the stored platform version 
- Fixed all DataContractWasm instantiation points to pass the correct platform version

## How Has This Been Tested?

- Successfully built the wasm-sdk with the changes
- Verified that the build completes without errors
- The fix ensures backward compatibility by falling back to `PlatformVersion::first()` when needed

## Breaking Changes

None - This is a backward-compatible fix that preserves existing behavior while enabling proper serialization for newer platform versions.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone