### PR TITLE
feat(wasm-sdk): auto-generate entropy for document creation when not provided

### DIFF
--- a/packages/js-evo-sdk/src/documents/facade.ts
+++ b/packages/js-evo-sdk/src/documents/facade.ts
@@ -38,7 +38,7 @@ export class DocumentsFacade {
     return w.getDocumentWithProofInfo(contractId, type, documentId);
   }
 
-  async create(options: wasm.DocumentCreateOptions): Promise<void> {
+  async create(options: wasm.DocumentCreateOptions): Promise<wasm.Document> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.documentCreate(options);
   }

--- a/packages/js-evo-sdk/tests/unit/facades/documents.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/documents.spec.ts
@@ -54,7 +54,7 @@ describe('DocumentsFacade', () => {
     });
 
     // Stub transition methods
-    documentCreateStub = this.sinon.stub(wasmSdk, 'documentCreate').resolves();
+    documentCreateStub = this.sinon.stub(wasmSdk, 'documentCreate').resolves(document);
     documentReplaceStub = this.sinon.stub(wasmSdk, 'documentReplace').resolves();
     documentDeleteStub = this.sinon.stub(wasmSdk, 'documentDelete').resolves();
     documentTransferStub = this.sinon.stub(wasmSdk, 'documentTransfer').resolves();
@@ -126,9 +126,10 @@ describe('DocumentsFacade', () => {
         tokenPaymentInfo,
       };
 
-      await client.documents.create(options);
+      const result = await client.documents.create(options);
 
       expect(documentCreateStub).to.be.calledOnceWithExactly(options);
+      expect(result).to.equal(document);
     });
   });
 

--- a/packages/wasm-sdk/src/state_transitions/document.rs
+++ b/packages/wasm-sdk/src/state_transitions/document.rs
@@ -51,7 +51,8 @@ export interface DocumentCreateOptions {
   /**
    * The document to create.
    * Use `new Document(...)` or `Document.fromJSON(...)` to construct it.
-   * Must include dataContractId, documentTypeName, ownerId, and entropy.
+   * Must include dataContractId, documentTypeName, and ownerId.
+   * Entropy is optional - if not set, it will be auto-generated.
    */
   document: Document;
 
@@ -108,19 +109,23 @@ impl WasmSdk {
         let contract_id: Identifier = document_wasm.get_data_contract_id().into();
         let document_type_name = document_wasm.get_document_type_name();
 
-        // Get entropy from document
-        let entropy = document_wasm.get_entropy().ok_or_else(|| {
-            WasmSdkError::invalid_argument("Document must have entropy set for creation")
-        })?;
-
-        if entropy.len() != 32 {
-            return Err(WasmSdkError::invalid_argument(
-                "Document entropy must be exactly 32 bytes",
-            ));
-        }
-
-        let mut entropy_array = [0u8; 32];
-        entropy_array.copy_from_slice(&entropy);
+        // Get entropy from document, or generate if not set
+        let entropy_array = match document_wasm.get_entropy() {
+            Some(entropy) if entropy.len() == 32 => {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&entropy);
+                arr
+            }
+            _ => {
+                // Auto-generate entropy if not provided
+                use dash_sdk::dpp::util::entropy_generator::{
+                    DefaultEntropyGenerator, EntropyGenerator,
+                };
+                DefaultEntropyGenerator.generate().map_err(|e| {
+                    WasmSdkError::generic(format!("Failed to generate entropy: {}", e))
+                })?
+            }
+        };
 
         // Extract identity key from options
         let identity_key_wasm =

--- a/packages/wasm-sdk/src/state_transitions/document.rs
+++ b/packages/wasm-sdk/src/state_transitions/document.rs
@@ -109,23 +109,16 @@ impl WasmSdk {
         let contract_id: Identifier = document_wasm.get_data_contract_id().into();
         let document_type_name = document_wasm.get_document_type_name();
 
-        // Get entropy from document, or generate if not set
-        let entropy_array = match document_wasm.get_entropy() {
-            Some(entropy) if entropy.len() == 32 => {
+        // Get entropy from document if set, otherwise let rs-sdk generate it
+        let entropy = document_wasm.get_entropy().and_then(|e| {
+            if e.len() == 32 {
                 let mut arr = [0u8; 32];
-                arr.copy_from_slice(&entropy);
-                arr
+                arr.copy_from_slice(&e);
+                Some(arr)
+            } else {
+                None
             }
-            _ => {
-                // Auto-generate entropy if not provided
-                use dash_sdk::dpp::util::entropy_generator::{
-                    DefaultEntropyGenerator, EntropyGenerator,
-                };
-                DefaultEntropyGenerator.generate().map_err(|e| {
-                    WasmSdkError::generic(format!("Failed to generate entropy: {}", e))
-                })?
-            }
-        };
+        });
 
         // Extract identity key from options
         let identity_key_wasm =
@@ -149,7 +142,7 @@ impl WasmSdk {
             .put_to_platform_and_wait_for_response(
                 self.inner_sdk(),
                 document_type,
-                Some(entropy_array),
+                entropy,
                 identity_key,
                 None, // token_payment_info
                 &signer,

--- a/packages/wasm-sdk/src/state_transitions/document.rs
+++ b/packages/wasm-sdk/src/state_transitions/document.rs
@@ -164,23 +164,16 @@ impl WasmSdk {
         let contract_id: Identifier = document_wasm.data_contract_id().into();
         let document_type_name = document_wasm.document_type_name();
 
-        // Get entropy from document, or generate if not set
-        let entropy_array = match document_wasm.entropy() {
-            Some(entropy) if entropy.len() == 32 => {
+        // Get entropy from document if set, otherwise let rs-sdk generate it
+        let entropy = document_wasm.entropy().and_then(|e| {
+            if e.len() == 32 {
                 let mut arr = [0u8; 32];
-                arr.copy_from_slice(&entropy);
-                arr
+                arr.copy_from_slice(&e);
+                Some(arr)
+            } else {
+                None
             }
-            _ => {
-                // Auto-generate entropy if not provided
-                use dash_sdk::dpp::util::entropy_generator::{
-                    DefaultEntropyGenerator, EntropyGenerator,
-                };
-                DefaultEntropyGenerator.generate().map_err(|e| {
-                    WasmSdkError::generic(format!("Failed to generate entropy: {}", e))
-                })?
-            }
-        };
+        });
 
         // Extract identity key from options
         let identity_key_wasm = IdentityPublicKeyWasm::try_from_options(&options, "identityKey")?;
@@ -205,7 +198,7 @@ impl WasmSdk {
             .put_to_platform_and_wait_for_response(
                 self.inner_sdk(),
                 document_type,
-                Some(entropy_array),
+                entropy,
                 identity_key,
                 token_payment_info,
                 &signer,

--- a/packages/wasm-sdk/src/state_transitions/document.rs
+++ b/packages/wasm-sdk/src/state_transitions/document.rs
@@ -8,11 +8,11 @@ use crate::settings::PutSettingsInput;
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::data_contract::document_type::DocumentType;
 use dash_sdk::dpp::document::{Document, DocumentV0Getters, DocumentV0Setters};
-use dash_sdk::dpp::util::entropy_generator::{DefaultEntropyGenerator, EntropyGenerator};
 use dash_sdk::dpp::fee::Credits;
 use dash_sdk::dpp::identity::IdentityPublicKey;
 use dash_sdk::dpp::platform_value::Identifier;
 use dash_sdk::dpp::tokens::token_payment_info::TokenPaymentInfo;
+use dash_sdk::dpp::util::entropy_generator::{DefaultEntropyGenerator, EntropyGenerator};
 use dash_sdk::platform::documents::transitions::DocumentDeleteTransitionBuilder;
 use dash_sdk::platform::transition::purchase_document::PurchaseDocument;
 use dash_sdk::platform::transition::put_document::PutDocument;
@@ -179,9 +179,9 @@ impl WasmSdk {
                 WasmSdkError::invalid_argument("Document entropy must be exactly 32 bytes")
             })?,
             None => {
-                let entropy = DefaultEntropyGenerator
-                    .generate()
-                    .map_err(|e| WasmSdkError::generic(format!("Failed to generate entropy: {e}")))?;
+                let entropy = DefaultEntropyGenerator.generate().map_err(|e| {
+                    WasmSdkError::generic(format!("Failed to generate entropy: {e}"))
+                })?;
                 let new_id = Document::generate_document_id_v0(
                     &contract_id,
                     &document.owner_id(),

--- a/packages/wasm-sdk/src/state_transitions/document.rs
+++ b/packages/wasm-sdk/src/state_transitions/document.rs
@@ -7,7 +7,8 @@ use crate::sdk::WasmSdk;
 use crate::settings::PutSettingsInput;
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::data_contract::document_type::DocumentType;
-use dash_sdk::dpp::document::{Document, DocumentV0Getters};
+use dash_sdk::dpp::document::{Document, DocumentV0Getters, DocumentV0Setters};
+use dash_sdk::dpp::util::entropy_generator::{DefaultEntropyGenerator, EntropyGenerator};
 use dash_sdk::dpp::fee::Credits;
 use dash_sdk::dpp::identity::IdentityPublicKey;
 use dash_sdk::dpp::platform_value::Identifier;
@@ -102,11 +103,10 @@ const DOCUMENT_CREATE_OPTIONS_TS: &'static str = r#"
 export interface DocumentCreateOptions {
   /**
    * The document to create.
-   * Use `new Document(...)` to construct it (the constructor auto-generates
-   * entropy and the matching document id). Must include dataContractId,
-   * documentTypeName, ownerId, and entropy. When constructing via
-   * `fromObject` / `fromJSON` / `fromBytes`, supply `$entropy` explicitly
-   * along with an `$id` derived from it.
+   * Use `new Document(...)` or `Document.fromJSON(...)` to construct it.
+   * Must include dataContractId, documentTypeName, and ownerId.
+   * Entropy is optional - if not set, it will be auto-generated and the
+   * returned Document will reflect the on-chain id derived from it.
    */
   document: Document;
 
@@ -152,34 +152,46 @@ impl WasmSdk {
     /// 4. Broadcasts and waits for confirmation
     ///
     /// @param options - Creation options including document, identity key, and signer
-    /// @returns Promise that resolves when the document is created
+    /// @returns Promise that resolves to the created Document. When entropy was
+    ///   auto-generated, the returned Document carries the on-chain id derived
+    ///   from it — callers should use this returned Document (not the input)
+    ///   for subsequent replace/delete/fetch.
     #[wasm_bindgen(js_name = "documentCreate")]
     pub async fn document_create(
         &self,
         options: DocumentCreateOptionsJs,
-    ) -> Result<(), WasmSdkError> {
+    ) -> Result<DocumentWasm, WasmSdkError> {
         // Extract document from options
         let document_wasm = DocumentWasm::try_from_options(&options, "document")?;
-        let document: Document = document_wasm.clone().into();
+        let mut document: Document = document_wasm.clone().into();
 
         // Get metadata from document
         let contract_id: Identifier = document_wasm.data_contract_id().into();
         let document_type_name = document_wasm.document_type_name();
 
-        // Require explicit entropy from the caller. If we let rs-sdk auto-generate it, it would
-        // also rewrite the document id (see PutDocument::put_to_platform), and that updated id is
-        // not surfaced back through this wrapper's `Result<(), _>` return — the JS-side Document
-        // would silently retain an id that doesn't match what was committed on-chain.
-        let entropy_bytes = document_wasm.entropy().ok_or_else(|| {
-            WasmSdkError::invalid_argument(
-                "Document must have entropy set for creation. Construct the document with \
-                 `new Document(...)` (which auto-generates entropy) or supply `$entropy` \
-                 explicitly when using fromObject/fromJSON/fromBytes.",
-            )
-        })?;
-        let entropy: [u8; 32] = entropy_bytes.as_slice().try_into().map_err(|_| {
-            WasmSdkError::invalid_argument("Document entropy must be exactly 32 bytes")
-        })?;
+        // Resolve entropy and document id locally so we can surface both back to JS.
+        // If the caller supplied entropy, trust their (entropy, id) pair as-is.
+        // If not, generate fresh entropy and recompute the id to match — mirroring
+        // what rs-sdk would do internally on a None, but without the id getting
+        // lost across the FFI boundary (see PutDocument::put_to_platform).
+        let entropy: [u8; 32] = match document_wasm.entropy() {
+            Some(bytes) => bytes.as_slice().try_into().map_err(|_| {
+                WasmSdkError::invalid_argument("Document entropy must be exactly 32 bytes")
+            })?,
+            None => {
+                let entropy = DefaultEntropyGenerator
+                    .generate()
+                    .map_err(|e| WasmSdkError::generic(format!("Failed to generate entropy: {e}")))?;
+                let new_id = Document::generate_document_id_v0(
+                    &contract_id,
+                    &document.owner_id(),
+                    &document_type_name,
+                    entropy.as_slice(),
+                );
+                document.set_id(new_id);
+                entropy
+            }
+        };
 
         // Extract identity key from options
         let identity_key_wasm = IdentityPublicKeyWasm::try_from_options(&options, "identityKey")?;
@@ -199,8 +211,9 @@ impl WasmSdk {
             try_from_options_optional::<PutSettingsInput>(&options, "settings")?.map(Into::into);
         let token_payment_info = try_from_options_optional_token_payment_info(&options)?;
 
-        // Use PutDocument trait for creation
-        document
+        // Use PutDocument trait for creation. Passing Some(entropy) on the creation branch
+        // makes rs-sdk use our document (and id) as-is rather than rewriting it.
+        let created = document
             .put_to_platform_and_wait_for_response(
                 self.inner_sdk(),
                 document_type,
@@ -212,7 +225,12 @@ impl WasmSdk {
             )
             .await?;
 
-        Ok(())
+        Ok(DocumentWasm::new(
+            created,
+            contract_id,
+            document_type_name,
+            Some(entropy),
+        ))
     }
 }
 

--- a/packages/wasm-sdk/src/state_transitions/document.rs
+++ b/packages/wasm-sdk/src/state_transitions/document.rs
@@ -102,9 +102,11 @@ const DOCUMENT_CREATE_OPTIONS_TS: &'static str = r#"
 export interface DocumentCreateOptions {
   /**
    * The document to create.
-   * Use `new Document(...)` or `Document.fromJSON(...)` to construct it.
-   * Must include dataContractId, documentTypeName, and ownerId.
-   * Entropy is optional - if not set, it will be auto-generated.
+   * Use `new Document(...)` to construct it (the constructor auto-generates
+   * entropy and the matching document id). Must include dataContractId,
+   * documentTypeName, ownerId, and entropy. When constructing via
+   * `fromObject` / `fromJSON` / `fromBytes`, supply `$entropy` explicitly
+   * along with an `$id` derived from it.
    */
   document: Document;
 
@@ -164,16 +166,20 @@ impl WasmSdk {
         let contract_id: Identifier = document_wasm.data_contract_id().into();
         let document_type_name = document_wasm.document_type_name();
 
-        // Get entropy from document if set, otherwise let rs-sdk generate it
-        let entropy = document_wasm.entropy().and_then(|e| {
-            if e.len() == 32 {
-                let mut arr = [0u8; 32];
-                arr.copy_from_slice(&e);
-                Some(arr)
-            } else {
-                None
-            }
-        });
+        // Require explicit entropy from the caller. If we let rs-sdk auto-generate it, it would
+        // also rewrite the document id (see PutDocument::put_to_platform), and that updated id is
+        // not surfaced back through this wrapper's `Result<(), _>` return — the JS-side Document
+        // would silently retain an id that doesn't match what was committed on-chain.
+        let entropy_bytes = document_wasm.entropy().ok_or_else(|| {
+            WasmSdkError::invalid_argument(
+                "Document must have entropy set for creation. Construct the document with \
+                 `new Document(...)` (which auto-generates entropy) or supply `$entropy` \
+                 explicitly when using fromObject/fromJSON/fromBytes.",
+            )
+        })?;
+        let entropy: [u8; 32] = entropy_bytes.as_slice().try_into().map_err(|_| {
+            WasmSdkError::invalid_argument("Document entropy must be exactly 32 bytes")
+        })?;
 
         // Extract identity key from options
         let identity_key_wasm = IdentityPublicKeyWasm::try_from_options(&options, "identityKey")?;
@@ -198,7 +204,7 @@ impl WasmSdk {
             .put_to_platform_and_wait_for_response(
                 self.inner_sdk(),
                 document_type,
-                entropy,
+                Some(entropy),
                 identity_key,
                 token_payment_info,
                 &signer,

--- a/packages/wasm-sdk/src/state_transitions/document.rs
+++ b/packages/wasm-sdk/src/state_transitions/document.rs
@@ -103,7 +103,8 @@ export interface DocumentCreateOptions {
   /**
    * The document to create.
    * Use `new Document(...)` or `Document.fromJSON(...)` to construct it.
-   * Must include dataContractId, documentTypeName, ownerId, and entropy.
+   * Must include dataContractId, documentTypeName, and ownerId.
+   * Entropy is optional - if not set, it will be auto-generated.
    */
   document: Document;
 
@@ -163,19 +164,23 @@ impl WasmSdk {
         let contract_id: Identifier = document_wasm.data_contract_id().into();
         let document_type_name = document_wasm.document_type_name();
 
-        // Get entropy from document
-        let entropy = document_wasm.entropy().ok_or_else(|| {
-            WasmSdkError::invalid_argument("Document must have entropy set for creation")
-        })?;
-
-        if entropy.len() != 32 {
-            return Err(WasmSdkError::invalid_argument(
-                "Document entropy must be exactly 32 bytes",
-            ));
-        }
-
-        let mut entropy_array = [0u8; 32];
-        entropy_array.copy_from_slice(&entropy);
+        // Get entropy from document, or generate if not set
+        let entropy_array = match document_wasm.entropy() {
+            Some(entropy) if entropy.len() == 32 => {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&entropy);
+                arr
+            }
+            _ => {
+                // Auto-generate entropy if not provided
+                use dash_sdk::dpp::util::entropy_generator::{
+                    DefaultEntropyGenerator, EntropyGenerator,
+                };
+                DefaultEntropyGenerator.generate().map_err(|e| {
+                    WasmSdkError::generic(format!("Failed to generate entropy: {}", e))
+                })?
+            }
+        };
 
         // Extract identity key from options
         let identity_key_wasm = IdentityPublicKeyWasm::try_from_options(&options, "identityKey")?;


### PR DESCRIPTION
## Issue being fixed or feature implemented

When creating documents via `sdk.documentCreate()`, the SDK threw an error if the Document didn't have entropy set: "Document must have entropy set for creation". 

While entropy has always been required for document creation, there's an inconsistency in the Document API: the `Document` constructor auto-generates entropy, but `Document.fromObject()`, `Document.fromJSON()`, and `Document.fromBytes()` do not. This creates confusion for SDK consumers who might expect consistent behavior across all document creation methods.

## What was done?

Modified `document_create` in `packages/wasm-sdk/src/state_transitions/document.rs` to pass `None` to rs-sdk when entropy is not set on the Document, instead of throwing an error.

The rs-sdk `PutDocument` trait already handles optional entropy correctly - when `None` is passed, it:
1. Generates new entropy using `StdRng::from_entropy()`
2. Regenerates the document ID based on that entropy

This delegates entropy handling to the lowest level (rs-sdk) where it's already properly implemented, making entropy effectively optional at all higher layers.

Also updated the `DocumentCreateOptions` TypeScript interface comment in the same file to reflect that entropy is now optional.

## How Has This Been Tested?

- `cargo check -p wasm-sdk` passes
- `cargo fmt -p wasm-sdk` applied

## Breaking Changes

None. This change makes the API more lenient by accepting documents without entropy set.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed