### PR TITLE
ci: tolerate book preview comment permission errors

### DIFF
--- a/.github/workflows/book-preview.yml
+++ b/.github/workflows/book-preview.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 concurrency:
@@ -43,6 +42,8 @@ jobs:
           retention-days: 30
 
       - name: Post preview link
+        # Fork PRs run with a read-only token that cannot post comments
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |
@@ -51,44 +52,36 @@ jobs:
             const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
             const artifactUrl = `${repoUrl}/actions/runs/${runId}`;
 
-            try {
-              const { data: comments } = await github.rest.issues.listComments({
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const marker = '<!-- book-preview -->';
+            const existing = comments.find(c => c.body.includes(marker));
+            const body = [
+              marker,
+              `📖 **Book Preview** built successfully.`,
+              ``,
+              `Download the preview from the [workflow artifacts](${artifactUrl}).`,
+              `To view locally: download the artifact, unzip, and open \`index.html\`.`,
+              ``,
+              `_Updated at ${new Date().toISOString()}_`,
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
+                body,
               });
-
-              const marker = '<!-- book-preview -->';
-              const existing = comments.find(c => c.body.includes(marker));
-              const body = [
-                marker,
-                `📖 **Book Preview** built successfully.`,
-                ``,
-                `Download the preview from the [workflow artifacts](${artifactUrl}).`,
-                `To view locally: download the artifact, unzip, and open \`index.html\`.`,
-                ``,
-                `_Updated at ${new Date().toISOString()}_`,
-              ].join('\n');
-
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body,
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: prNumber,
-                  body,
-                });
-              }
-            } catch (error) {
-              if (error?.status === 403 && String(error?.message ?? '').includes('Resource not accessible by integration')) {
-                core.warning('Skipping book preview PR comment because this workflow token cannot write comments for the event.');
-              } else {
-                throw error;
-              }
             }

--- a/.github/workflows/book-preview.yml
+++ b/.github/workflows/book-preview.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -50,36 +51,44 @@ jobs:
             const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
             const artifactUrl = `${repoUrl}/actions/runs/${runId}`;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-
-            const marker = '<!-- book-preview -->';
-            const existing = comments.find(c => c.body.includes(marker));
-            const body = [
-              marker,
-              `📖 **Book Preview** built successfully.`,
-              ``,
-              `Download the preview from the [workflow artifacts](${artifactUrl}).`,
-              `To view locally: download the artifact, unzip, and open \`index.html\`.`,
-              ``,
-              `_Updated at ${new Date().toISOString()}_`,
-            ].join('\n');
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                body,
               });
+
+              const marker = '<!-- book-preview -->';
+              const existing = comments.find(c => c.body.includes(marker));
+              const body = [
+                marker,
+                `📖 **Book Preview** built successfully.`,
+                ``,
+                `Download the preview from the [workflow artifacts](${artifactUrl}).`,
+                `To view locally: download the artifact, unzip, and open \`index.html\`.`,
+                ``,
+                `_Updated at ${new Date().toISOString()}_`,
+              ].join('\n');
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body,
+                });
+              }
+            } catch (error) {
+              if (error?.status === 403 && String(error?.message ?? '').includes('Resource not accessible by integration')) {
+                core.warning('Skipping book preview PR comment because this workflow token cannot write comments for the event.');
+              } else {
+                throw error;
+              }
             }


### PR DESCRIPTION
# Book preview comment permission handling

## Issue being fixed or feature implemented

The Book Preview workflow can build mdBook successfully and still fail on
fork-style PR runs when the final `actions/github-script` step cannot create or
update a PR comment with the preview artifact link.

This is currently surfacing as red CI on dashpay/platform#3092 even though the
preview build and artifact upload completed.

## What was done?

- Added `issues: write` to the workflow permissions because PR comments use the
  Issues comments API.
- Wrapped the preview-comment create/update logic in a targeted
  `403 Resource not accessible by integration` handler.
- Kept unexpected GitHub API errors failing the workflow so real regressions are
  still visible.

## How Has This Been Tested?

- `python3` YAML parse of `.github/workflows/book-preview.yml` passed.
- `git diff --check` passed.
- Pre-PR code review gate returned `ship` for
  `upstream/v3.1-dev..fix-book-preview-comment-permission`.

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the
  corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

## For repository code-owners and collaborators only

- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview workflow permissions and handling for pull requests from external repositories.
  * Preview links are posted only when supported, reducing failed workflow attempts and permission-related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->