### PR TITLE
refactor(dapi,dpp)!: move dapi-client and Identifier off Buffer to Uint8Array

### DIFF
--- a/packages/js-dapi-client/README.md
+++ b/packages/js-dapi-client/README.md
@@ -27,6 +27,33 @@ hosted on Dash masternodes.
 npm install @dashevo/dapi-client
 ```
 
+### Browser usage
+
+Response objects expose byte-valued fields as `Uint8Array` (not Node `Buffer`).
+You can convert via `DAPIClient.bytes`:
+
+```javascript
+const DAPIClient = require('@dashevo/dapi-client');
+const { bytesToHex, hexToBytes } = DAPIClient.bytes;
+
+const hex = bytesToHex(proof.getQuorumHash());
+```
+
+A small number of internal code paths still construct `Buffer` instances —
+notably `BlockHeadersProvider` (uses `dashcore-lib.BlockHeader` for SPV
+parsing) and the `Identifier` constructor inside wasm-dpp. Node has `Buffer` built in;
+browser bundlers (Vite, esbuild, webpack 5) typically auto-shim it when the
+`buffer` package is installed, or you can polyfill explicitly:
+
+```javascript
+import { Buffer } from 'buffer';
+globalThis.Buffer = Buffer;
+```
+
+This requirement will go away once `dashcore-lib`'s `BufferReader` accepts
+`Uint8Array` directly. Until then, browser consumers must ensure a `Buffer`
+global is reachable at runtime.
+
 ## Usage
 
 ### Basic

--- a/packages/js-dapi-client/README.md
+++ b/packages/js-dapi-client/README.md
@@ -50,9 +50,11 @@ import { Buffer } from 'buffer';
 globalThis.Buffer = Buffer;
 ```
 
-This requirement will go away once `dashcore-lib`'s `BufferReader` accepts
-`Uint8Array` directly. Until then, browser consumers must ensure a `Buffer`
-global is reachable at runtime.
+This requirement will go away once
+[dashpay/dashcore-lib#315](https://github.com/dashpay/dashcore-lib/pull/315)
+(widening `BufferReader` to accept `Uint8Array`) lands and is picked up here.
+Until then, browser consumers must ensure a `Buffer` global is reachable at
+runtime.
 
 ## Usage
 

--- a/packages/js-dapi-client/lib/SimplifiedMasternodeListProvider/SimplifiedMasternodeListProvider.js
+++ b/packages/js-dapi-client/lib/SimplifiedMasternodeListProvider/SimplifiedMasternodeListProvider.js
@@ -3,6 +3,7 @@ const SimplifiedMNListDiff = require('@dashevo/dashcore-lib/lib/deterministicmnl
 const cbor = require('cbor');
 
 const logger = require('../logger');
+const { bytesToHex } = require('../utils/bytes');
 
 class SimplifiedMasternodeListProvider {
   /**
@@ -100,11 +101,11 @@ class SimplifiedMasternodeListProvider {
 
         let simplifiedMNListDiff;
         let simplifiedMNListDiffObject;
-        let simplifiedMNListDiffBuffer;
+        let simplifiedMNListDiffBytes;
         try {
-          simplifiedMNListDiffBuffer = Buffer.from(response.getMasternodeListDiff_asU8());
+          simplifiedMNListDiffBytes = new Uint8Array(response.getMasternodeListDiff_asU8());
 
-          simplifiedMNListDiffObject = cbor.decodeFirstSync(simplifiedMNListDiffBuffer);
+          simplifiedMNListDiffObject = cbor.decodeFirstSync(simplifiedMNListDiffBytes);
 
           simplifiedMNListDiff = new SimplifiedMNListDiff(
             simplifiedMNListDiffObject,
@@ -118,7 +119,7 @@ class SimplifiedMasternodeListProvider {
               network: this.options.network,
               error: e,
               simplifiedMNListDiffObject,
-              simplifiedMNListDiffBytes: simplifiedMNListDiffBuffer.toString('hex'),
+              simplifiedMNListDiffBytes: bytesToHex(simplifiedMNListDiffBytes),
             },
           );
 

--- a/packages/js-dapi-client/lib/SimplifiedMasternodeListProvider/SimplifiedMasternodeListProvider.js
+++ b/packages/js-dapi-client/lib/SimplifiedMasternodeListProvider/SimplifiedMasternodeListProvider.js
@@ -112,6 +112,12 @@ class SimplifiedMasternodeListProvider {
             this.options.network,
           );
         } catch (e) {
+          // Guard against bytesToHex throwing (and masking the real error)
+          // if simplifiedMNListDiffBytes is undefined because the failure
+          // happened before line 106 assigned it.
+          const diffBytesHex = simplifiedMNListDiffBytes instanceof Uint8Array
+            ? bytesToHex(simplifiedMNListDiffBytes)
+            : null;
           this.logger.warn(
             `Can't parse masternode list diff: ${e.message}`,
             {
@@ -119,7 +125,7 @@ class SimplifiedMasternodeListProvider {
               network: this.options.network,
               error: e,
               simplifiedMNListDiffObject,
-              simplifiedMNListDiffBytes: bytesToHex(simplifiedMNListDiffBytes),
+              simplifiedMNListDiffBytes: diffBytesHex,
             },
           );
 

--- a/packages/js-dapi-client/lib/index.js
+++ b/packages/js-dapi-client/lib/index.js
@@ -2,11 +2,13 @@ const DAPIClient = require('./DAPIClient');
 
 const NotFoundError = require('./transport/GrpcTransport/errors/NotFoundError');
 const BlockHeadersProvider = require('./BlockHeadersProvider/BlockHeadersProvider');
+const bytes = require('./utils/bytes');
 
 DAPIClient.Errors = {
   NotFoundError,
 };
 
 DAPIClient.BlockHeadersProvider = BlockHeadersProvider;
+DAPIClient.bytes = bytes;
 
 module.exports = DAPIClient;

--- a/packages/js-dapi-client/lib/methods/core/getBlockByHashFactory.js
+++ b/packages/js-dapi-client/lib/methods/core/getBlockByHashFactory.js
@@ -15,7 +15,7 @@ function getBlockByHashFactory(grpcTransport) {
    * @typedef {getBlockByHash}
    * @param {string} hash
    * @param {DAPIClientOptions} [options]
-   * @returns {Promise<null|Buffer>}
+   * @returns {Promise<null|Uint8Array>}
    */
   async function getBlockByHash(hash, options = {}) {
     const getBlockRequest = new GetBlockRequest();
@@ -29,7 +29,7 @@ function getBlockByHashFactory(grpcTransport) {
     );
     const blockBinaryArray = response.getBlock();
 
-    return Buffer.from(blockBinaryArray);
+    return new Uint8Array(blockBinaryArray);
   }
 
   return getBlockByHash;

--- a/packages/js-dapi-client/lib/methods/core/getBlockByHeightFactory.js
+++ b/packages/js-dapi-client/lib/methods/core/getBlockByHeightFactory.js
@@ -15,7 +15,7 @@ function getBlockByHeightFactory(grpcTransport) {
    * @typedef {getBlockByHeight}
    * @param {number} height
    * @param {DAPIClientOptions} [options]
-   * @returns {Promise<null|Buffer>}
+   * @returns {Promise<null|Uint8Array>}
    */
   async function getBlockByHeight(height, options = {}) {
     const getBlockRequest = new GetBlockRequest();
@@ -30,7 +30,7 @@ function getBlockByHeightFactory(grpcTransport) {
 
     const blockBinaryArray = response.getBlock();
 
-    return Buffer.from(blockBinaryArray);
+    return new Uint8Array(blockBinaryArray);
   }
 
   return getBlockByHeight;

--- a/packages/js-dapi-client/lib/methods/core/getBlockchainStatusFactory.js
+++ b/packages/js-dapi-client/lib/methods/core/getBlockchainStatusFactory.js
@@ -29,18 +29,18 @@ function getBlockchainStatusFactory(grpcTransport) {
 
     const responseObject = response.toObject();
 
-    // Respond with Buffers instead of base64 for binary fields
+    // Respond with Uint8Arrays instead of base64 for binary fields
 
     if (response.getChain()) {
       if (response.getChain()
         .getBestBlockHash()) {
-        responseObject.chain.bestBlockHash = Buffer.from(response.getChain()
+        responseObject.chain.bestBlockHash = new Uint8Array(response.getChain()
           .getBestBlockHash());
       }
 
       if (response.getChain()
         .getChainWork()) {
-        responseObject.chain.chainWork = Buffer.from(response.getChain()
+        responseObject.chain.chainWork = new Uint8Array(response.getChain()
           .getChainWork());
       }
     }

--- a/packages/js-dapi-client/lib/methods/core/getMasternodeStatusFactory.js
+++ b/packages/js-dapi-client/lib/methods/core/getMasternodeStatusFactory.js
@@ -5,6 +5,7 @@ const {
     CorePromiseClient,
   },
 } = require('@dashevo/dapi-grpc');
+const { base64ToBytes } = require('../../utils/bytes');
 
 /**
  * @param {GrpcTransport} grpcTransport
@@ -34,7 +35,7 @@ function getMasternodeStatusFactory(grpcTransport) {
     responseObject.status = Object.keys(GetMasternodeStatusResponse.Status)
       .find((key) => GetMasternodeStatusResponse.Status[key] === responseObject.status);
 
-    responseObject.proTxHash = Buffer.from(responseObject.proTxHash, 'base64');
+    responseObject.proTxHash = base64ToBytes(responseObject.proTxHash);
 
     return responseObject;
   }

--- a/packages/js-dapi-client/lib/methods/core/getTransaction/GetTransactionResponse.js
+++ b/packages/js-dapi-client/lib/methods/core/getTransaction/GetTransactionResponse.js
@@ -4,8 +4,8 @@ class GetTransactionResponse {
   /**
    *
    * @param {object} properties
-   * @param {Buffer} properties.transaction
-   * @param {Buffer} properties.blockHash
+   * @param {Uint8Array} properties.transaction
+   * @param {Uint8Array} properties.blockHash
    * @param {number} properties.height
    * @param {number} properties.confirmations
    * @param {boolean} properties.isInstantLocked
@@ -22,7 +22,7 @@ class GetTransactionResponse {
 
   /**
    * Get transaction
-   * @returns {Buffer}
+   * @returns {Uint8Array}
    */
   getTransaction() {
     return this.transaction;
@@ -30,7 +30,7 @@ class GetTransactionResponse {
 
   /**
    * Get block hash
-   * @returns {Buffer}
+   * @returns {Uint8Array}
    */
   getBlockHash() {
     return this.blockHash;
@@ -75,8 +75,8 @@ class GetTransactionResponse {
     }
 
     return new GetTransactionResponse({
-      transaction: Buffer.from(transactionBinaryArray),
-      blockHash: Buffer.from(proto.getBlockHash()),
+      transaction: new Uint8Array(transactionBinaryArray),
+      blockHash: new Uint8Array(proto.getBlockHash()),
       height: proto.getHeight(),
       confirmations: proto.getConfirmations(),
       isInstantLocked: proto.getIsInstantLocked(),

--- a/packages/js-dapi-client/lib/methods/core/getTransaction/GetTransactionResponse.js
+++ b/packages/js-dapi-client/lib/methods/core/getTransaction/GetTransactionResponse.js
@@ -75,8 +75,11 @@ class GetTransactionResponse {
     }
 
     return new GetTransactionResponse({
-      transaction: new Uint8Array(transactionBinaryArray),
-      blockHash: new Uint8Array(proto.getBlockHash()),
+      // Use _asU8 so we get bytes regardless of the underlying protobuf
+      // representation (grpc-js: Uint8Array; grpc-web: base64 string).
+      // new Uint8Array(string) does NOT base64-decode, silently losing bytes.
+      transaction: proto.getTransaction_asU8(),
+      blockHash: proto.getBlockHash_asU8(),
       height: proto.getHeight(),
       confirmations: proto.getConfirmations(),
       isInstantLocked: proto.getIsInstantLocked(),

--- a/packages/js-dapi-client/lib/methods/core/subscribeToBlockHeadersWithChainLocksFactory.js
+++ b/packages/js-dapi-client/lib/methods/core/subscribeToBlockHeadersWithChainLocksFactory.js
@@ -6,6 +6,7 @@ const {
 } = require('@dashevo/dapi-grpc');
 
 const DAPIClientError = require('../../errors/DAPIClientError');
+const { hexToBytes } = require('../../utils/bytes');
 
 /**
  * @param {GrpcTransport} grpcTransport
@@ -41,7 +42,7 @@ function subscribeToBlockHeadersWithChainLocksFactory(grpcTransport) {
 
     if (options.fromBlockHash) {
       request.setFromBlockHash(
-        Buffer.from(options.fromBlockHash, 'hex'),
+        hexToBytes(options.fromBlockHash),
       );
     }
 

--- a/packages/js-dapi-client/lib/methods/core/subscribeToTransactionsWithProofsFactory.js
+++ b/packages/js-dapi-client/lib/methods/core/subscribeToTransactionsWithProofsFactory.js
@@ -7,6 +7,7 @@ const {
 } = require('@dashevo/dapi-grpc');
 
 const DAPIClientError = require('../../errors/DAPIClientError');
+const { hexToBytes } = require('../../utils/bytes');
 
 /**
  * @param {GrpcTransport} grpcTransport
@@ -65,7 +66,7 @@ function subscribeToTransactionsWithProofsFactory(grpcTransport) {
 
     if (options.fromBlockHash) {
       request.setFromBlockHash(
-        Buffer.from(options.fromBlockHash, 'hex'),
+        hexToBytes(options.fromBlockHash),
       );
     }
 

--- a/packages/js-dapi-client/lib/methods/platform/getDataContract/GetDataContractResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getDataContract/GetDataContractResponse.js
@@ -3,7 +3,7 @@ const InvalidResponseError = require('../response/errors/InvalidResponseError');
 
 class GetDataContractResponse extends AbstractResponse {
   /**
-   * @param {Buffer} dataContract
+   * @param {Uint8Array} dataContract
    * @param {Metadata} metadata
    * @param {Proof} [proof]
    */
@@ -14,7 +14,7 @@ class GetDataContractResponse extends AbstractResponse {
   }
 
   /**
-   * @returns {Buffer}
+   * @returns {Uint8Array}
    */
   getDataContract() {
     return this.dataContract;
@@ -33,7 +33,7 @@ class GetDataContractResponse extends AbstractResponse {
     }
 
     return new GetDataContractResponse(
-      Buffer.from(dataContract),
+      new Uint8Array(dataContract),
       metadata,
       proof,
     );

--- a/packages/js-dapi-client/lib/methods/platform/getDataContract/getDataContractFactory.js
+++ b/packages/js-dapi-client/lib/methods/platform/getDataContract/getDataContractFactory.js
@@ -16,7 +16,7 @@ function getDataContractFactory(grpcTransport) {
   /**
    * Fetch Data Contract by id
    * @typedef {getDataContract}
-   * @param {Buffer} contractId
+   * @param {Uint8Array} contractId
    * @param {DAPIClientOptions & {prove: boolean}} [options]
    * @returns {Promise<GetDataContractResponse>}
    */
@@ -24,12 +24,12 @@ function getDataContractFactory(grpcTransport) {
     const { GetDataContractRequestV0 } = GetDataContractRequest;
     const getDataContractRequest = new GetDataContractRequest();
 
-    // need to convert objects inherited from Buffer to pure buffer as google protobuf
+    // need to convert objects inherited from Uint8Array to pure Uint8Array as google protobuf
     // doesn't support extended buffers
     // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
-    if (Buffer.isBuffer(contractId)) {
+    if (contractId instanceof Uint8Array) {
       // eslint-disable-next-line no-param-reassign
-      contractId = Buffer.from(contractId);
+      contractId = new Uint8Array(contractId);
     }
 
     getDataContractRequest.setV0(

--- a/packages/js-dapi-client/lib/methods/platform/getDataContractHistory/getDataContractHistoryFactory.js
+++ b/packages/js-dapi-client/lib/methods/platform/getDataContractHistory/getDataContractHistoryFactory.js
@@ -17,7 +17,7 @@ function getDataContractHistoryFactory(grpcTransport) {
   /**
    * Fetch Data Contract by id
    * @typedef {getDataContractHistory}
-   * @param {Buffer} contractId
+   * @param {Uint8Array} contractId
    * @param {bigint} [startAtMs]
    * @param {number} [limit]
    * @param {number} [offset]
@@ -34,12 +34,12 @@ function getDataContractHistoryFactory(grpcTransport) {
     const { GetDataContractHistoryRequestV0 } = GetDataContractHistoryRequest;
     const getDataContractHistoryRequest = new GetDataContractHistoryRequest();
 
-    // need to convert objects inherited from Buffer to pure buffer as google protobuf
+    // need to convert objects inherited from Uint8Array to pure Uint8Array as google protobuf
     // doesn't support extended buffers
     // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
-    if (Buffer.isBuffer(contractId)) {
+    if (contractId instanceof Uint8Array) {
       // eslint-disable-next-line no-param-reassign
-      contractId = Buffer.from(contractId);
+      contractId = new Uint8Array(contractId);
     }
 
     getDataContractHistoryRequest.setV0(

--- a/packages/js-dapi-client/lib/methods/platform/getDocuments/GetDocumentsResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getDocuments/GetDocumentsResponse.js
@@ -2,7 +2,7 @@ const AbstractResponse = require('../response/AbstractResponse');
 
 class GetDocumentsResponse extends AbstractResponse {
   /**
-   * @param {Buffer[]} documents
+   * @param {Uint8Array[]} documents
    * @param {Metadata} metadata
    * @param {Proof} [proof]
    */
@@ -13,7 +13,7 @@ class GetDocumentsResponse extends AbstractResponse {
   }
 
   /**
-   * @returns {Buffer[]}
+   * @returns {Uint8Array[]}
    */
   getDocuments() {
     return this.documents;
@@ -30,7 +30,7 @@ class GetDocumentsResponse extends AbstractResponse {
 
     return new GetDocumentsResponse(
       documents !== undefined
-        ? documents.getDocumentsList().map((document) => Buffer.from(document)) : [],
+        ? documents.getDocumentsList().map((document) => new Uint8Array(document)) : [],
       metadata,
       proof,
     );

--- a/packages/js-dapi-client/lib/methods/platform/getDocuments/getDocumentsFactory.js
+++ b/packages/js-dapi-client/lib/methods/platform/getDocuments/getDocumentsFactory.js
@@ -18,7 +18,7 @@ function getDocumentsFactory(grpcTransport) {
   /**
    * Fetch Documents from Drive
    * @typedef {getDocuments}
-   * @param {Buffer} contractId - Data Contract ID
+   * @param {Uint8Array} contractId - Data Contract ID
    * @param {string} type - Document type
    * @param {DAPIClientOptions & getDocumentsOptions & {prove: boolean}} [options]
    * @returns {Promise<GetDocumentsResponse>}
@@ -44,15 +44,16 @@ function getDocumentsFactory(grpcTransport) {
 
     const { GetDocumentsRequestV0 } = GetDocumentsRequest;
     const getDocumentsRequest = new GetDocumentsRequest();
-    // need to convert Identifier to pure buffer as google protobuf doesn't support extended buffers
+    // need to convert Identifier to pure Uint8Array as google protobuf doesn't support
+    // extended buffers
     // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
 
-    // need to convert objects inherited from Buffer to pure buffer as google protobuf
+    // need to convert objects inherited from Uint8Array to pure Uint8Array as google protobuf
     // doesn't support extended buffers
     // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
-    if (Buffer.isBuffer(contractId)) {
+    if (contractId instanceof Uint8Array) {
       // eslint-disable-next-line no-param-reassign
-      contractId = Buffer.from(contractId);
+      contractId = new Uint8Array(contractId);
     }
 
     getDocumentsRequest.setV0(

--- a/packages/js-dapi-client/lib/methods/platform/getIdentitiesContractKeys/GetIdentitiesContractKeysResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentitiesContractKeys/GetIdentitiesContractKeysResponse.js
@@ -34,8 +34,7 @@ class GetIdentitiesContractKeysResponse extends AbstractResponse {
       const keysEntries = identitiesKeys.getEntriesList();
 
       identitiesKeysMap = keysEntries.reduce((acc, entry) => {
-        // wasm-dpp Identifier.from requires Node Buffer (not plain Uint8Array)
-        const identityId = Identifier.from(Buffer.from(entry.getIdentityId())).toString();
+        const identityId = Identifier.from(entry.getIdentityId()).toString();
         if (!acc[identityId]) {
           acc[identityId] = {};
         }

--- a/packages/js-dapi-client/lib/methods/platform/getIdentitiesContractKeys/GetIdentitiesContractKeysResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentitiesContractKeys/GetIdentitiesContractKeysResponse.js
@@ -34,6 +34,7 @@ class GetIdentitiesContractKeysResponse extends AbstractResponse {
       const keysEntries = identitiesKeys.getEntriesList();
 
       identitiesKeysMap = keysEntries.reduce((acc, entry) => {
+        // wasm-dpp Identifier.from requires Node Buffer (not plain Uint8Array)
         const identityId = Identifier.from(Buffer.from(entry.getIdentityId())).toString();
         if (!acc[identityId]) {
           acc[identityId] = {};

--- a/packages/js-dapi-client/lib/methods/platform/getIdentitiesContractKeys/getIdentitiesContractKeysFactory.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentitiesContractKeys/getIdentitiesContractKeysFactory.js
@@ -17,8 +17,8 @@ function getIdentitiesContractKeysFactory(grpcTransport) {
   /**
    * Fetch the identities by public key hashes
    * @typedef {getIdentitiesContractKeys}
-   * @param {Buffer[]} identitiesIds
-   * @param {Buffer} contractId
+   * @param {Uint8Array[]} identitiesIds
+   * @param {Uint8Array} contractId
    * @param {IdentityPublicKey.PURPOSES[]} keyPurposes
    * @param {string | null} documentTypeName
    * @param {DAPIClientOptions & {prove: boolean}} [options]
@@ -36,17 +36,16 @@ function getIdentitiesContractKeysFactory(grpcTransport) {
 
     // eslint-disable-next-line no-param-reassign
     identitiesIds = identitiesIds.map((id) => {
-      if (Buffer.isBuffer(id)) {
-        // eslint-disable-next-line no-param-reassign
-        id = Buffer.from(id);
+      if (id instanceof Uint8Array) {
+        return new Uint8Array(id);
       }
 
       return id;
     });
 
-    if (Buffer.isBuffer(contractId)) {
+    if (contractId instanceof Uint8Array) {
       // eslint-disable-next-line no-param-reassign
-      contractId = Buffer.from(contractId);
+      contractId = new Uint8Array(contractId);
     }
 
     getIdentitiesContractKeysRequest.setV0(

--- a/packages/js-dapi-client/lib/methods/platform/getIdentity/GetIdentityResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentity/GetIdentityResponse.js
@@ -3,7 +3,7 @@ const InvalidResponseError = require('../response/errors/InvalidResponseError');
 
 class GetIdentityResponse extends AbstractResponse {
   /**
-   * @param {Buffer} identity
+   * @param {Uint8Array} identity
    * @param {Metadata} metadata
    * @param {Proof} [proof]
    */
@@ -14,7 +14,7 @@ class GetIdentityResponse extends AbstractResponse {
   }
 
   /**
-   * @returns {Buffer}
+   * @returns {Uint8Array}
    */
   getIdentity() {
     return this.identity;
@@ -33,7 +33,7 @@ class GetIdentityResponse extends AbstractResponse {
     }
 
     return new GetIdentityResponse(
-      Buffer.from(proto.getV0().getIdentity()),
+      new Uint8Array(proto.getV0().getIdentity()),
       metadata,
       proof,
     );

--- a/packages/js-dapi-client/lib/methods/platform/getIdentity/GetIdentityResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentity/GetIdentityResponse.js
@@ -33,7 +33,10 @@ class GetIdentityResponse extends AbstractResponse {
     }
 
     return new GetIdentityResponse(
-      new Uint8Array(proto.getV0().getIdentity()),
+      // Use _asU8 so we get bytes regardless of the underlying protobuf
+      // representation (grpc-js: Uint8Array; grpc-web: base64 string).
+      // new Uint8Array(string) does NOT base64-decode, silently losing bytes.
+      proto.getV0().getIdentity_asU8(),
       metadata,
       proof,
     );

--- a/packages/js-dapi-client/lib/methods/platform/getIdentity/getIdentityFactory.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentity/getIdentityFactory.js
@@ -16,19 +16,19 @@ function getIdentityFactory(grpcTransport) {
   /**
    * Fetch the identity by id
    * @typedef {getIdentity}
-   * @param {Buffer} id
+   * @param {Uint8Array} id
    * @param {DAPIClientOptions & {prove: boolean}} [options]
    * @returns {Promise<GetIdentityResponse>}
    */
   async function getIdentity(id, options = {}) {
     const { GetIdentityRequestV0 } = GetIdentityRequest;
     const getIdentityRequest = new GetIdentityRequest();
-    // need to convert objects inherited from Buffer to pure buffer as google protobuf
+    // need to convert objects inherited from Uint8Array to pure Uint8Array as google protobuf
     // doesn't support extended buffers
     // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
-    if (Buffer.isBuffer(id)) {
+    if (id instanceof Uint8Array) {
       // eslint-disable-next-line no-param-reassign
-      id = Buffer.from(id);
+      id = new Uint8Array(id);
     }
 
     getIdentityRequest.setV0(

--- a/packages/js-dapi-client/lib/methods/platform/getIdentityBalance/getIdentityBalanceFactory.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentityBalance/getIdentityBalanceFactory.js
@@ -16,19 +16,19 @@ function getIdentityBalanceFactory(grpcTransport) {
   /**
    * Fetch the identity balance by id
    * @typedef {getIdentityBalance}
-   * @param {Buffer} id
+   * @param {Uint8Array} id
    * @param {DAPIClientOptions & {prove: boolean}} [options]
    * @returns {Promise<GetIdentityBalanceResponse>}
    */
   async function getIdentityBalance(id, options = {}) {
     const { GetIdentityBalanceRequestV0 } = GetIdentityBalanceRequest;
     const getIdentityBalanceRequest = new GetIdentityBalanceRequest();
-    // need to convert objects inherited from Buffer to pure buffer as google protobuf
+    // need to convert objects inherited from Uint8Array to pure Uint8Array as google protobuf
     // doesn't support extended buffers
     // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
-    if (Buffer.isBuffer(id)) {
+    if (id instanceof Uint8Array) {
       // eslint-disable-next-line no-param-reassign
-      id = Buffer.from(id);
+      id = new Uint8Array(id);
     }
 
     getIdentityBalanceRequest.setV0(

--- a/packages/js-dapi-client/lib/methods/platform/getIdentityByPublicKeyHash/GetIdentityByPublicKeyHashResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentityByPublicKeyHash/GetIdentityByPublicKeyHashResponse.js
@@ -2,8 +2,7 @@ const AbstractResponse = require('../response/AbstractResponse');
 
 class GetIdentityByPublicKeyHashResponse extends AbstractResponse {
   /**
-   * @param {Uint8Array} identities
-   * @param identity
+   * @param {Uint8Array} identity
    * @param {Metadata} metadata
    * @param {Proof} [proof]
    */
@@ -14,7 +13,7 @@ class GetIdentityByPublicKeyHashResponse extends AbstractResponse {
   }
 
   /**
-   * @returns {Uint8Array[]}
+   * @returns {Uint8Array}
    */
   getIdentity() {
     return this.identity;

--- a/packages/js-dapi-client/lib/methods/platform/getIdentityByPublicKeyHash/GetIdentityByPublicKeyHashResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentityByPublicKeyHash/GetIdentityByPublicKeyHashResponse.js
@@ -26,10 +26,11 @@ class GetIdentityByPublicKeyHashResponse extends AbstractResponse {
   static createFromProto(proto) {
     const { metadata, proof } = AbstractResponse.createMetadataAndProofFromProto(proto);
 
-    const identity = proto.getV0().getIdentity();
-
     return new GetIdentityByPublicKeyHashResponse(
-      new Uint8Array(identity),
+      // Use _asU8 so we get bytes regardless of the underlying protobuf
+      // representation (grpc-js: Uint8Array; grpc-web: base64 string).
+      // new Uint8Array(string) does NOT base64-decode, silently losing bytes.
+      proto.getV0().getIdentity_asU8(),
       metadata,
       proof,
     );

--- a/packages/js-dapi-client/lib/methods/platform/getIdentityByPublicKeyHash/GetIdentityByPublicKeyHashResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentityByPublicKeyHash/GetIdentityByPublicKeyHashResponse.js
@@ -2,7 +2,7 @@ const AbstractResponse = require('../response/AbstractResponse');
 
 class GetIdentityByPublicKeyHashResponse extends AbstractResponse {
   /**
-   * @param {Buffer} identities
+   * @param {Uint8Array} identities
    * @param identity
    * @param {Metadata} metadata
    * @param {Proof} [proof]
@@ -14,7 +14,7 @@ class GetIdentityByPublicKeyHashResponse extends AbstractResponse {
   }
 
   /**
-   * @returns {Buffer[]}
+   * @returns {Uint8Array[]}
    */
   getIdentity() {
     return this.identity;
@@ -30,7 +30,7 @@ class GetIdentityByPublicKeyHashResponse extends AbstractResponse {
     const identity = proto.getV0().getIdentity();
 
     return new GetIdentityByPublicKeyHashResponse(
-      Buffer.from(identity),
+      new Uint8Array(identity),
       metadata,
       proof,
     );

--- a/packages/js-dapi-client/lib/methods/platform/getIdentityContractNonce/getIdentityContractNonceFactory.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentityContractNonce/getIdentityContractNonceFactory.js
@@ -16,8 +16,8 @@ function getIdentityContractNonceFactory(grpcTransport) {
   /**
    * Fetch the version upgrade votes status
    * @typedef {getIdentityContractNonce}
-   * @param {Buffer} identityId
-   * @param {Buffer} contractId
+   * @param {Uint8Array} identityId
+   * @param {Uint8Array} contractId
    * @param {DAPIClientOptions & {prove: boolean}} [options]
    * @returns {Promise<GetIdentityContractNonceResponse>}
    */
@@ -29,14 +29,14 @@ function getIdentityContractNonceFactory(grpcTransport) {
     // eslint-disable-next-line max-len
     const getIdentityContractNonceRequest = new GetIdentityContractNonceRequest();
 
-    if (Buffer.isBuffer(identityId)) {
+    if (identityId instanceof Uint8Array) {
       // eslint-disable-next-line no-param-reassign
-      identityId = Buffer.from(identityId);
+      identityId = new Uint8Array(identityId);
     }
 
-    if (Buffer.isBuffer(contractId)) {
+    if (contractId instanceof Uint8Array) {
       // eslint-disable-next-line no-param-reassign
-      contractId = Buffer.from(contractId);
+      contractId = new Uint8Array(contractId);
     }
 
     getIdentityContractNonceRequest.setV0(

--- a/packages/js-dapi-client/lib/methods/platform/getIdentityKeys/getIdentityKeysFactory.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentityKeys/getIdentityKeysFactory.js
@@ -23,16 +23,16 @@ function getIdentityKeysFactory(grpcTransport) {
   /**
    * Fetch the version upgrade votes status
    * @typedef {getIdentityKeys}
-   * @param {Buffer} identityId
+   * @param {Uint8Array} identityId
    * @param {number[]=} keyIds
    * @param {number} limit
    * @param {DAPIClientOptions & {prove: boolean}} [options]
    * @returns {Promise<GetIdentityKeysResponse>}
    */
   async function getIdentityKeys(identityId, keyIds, limit = 100, options = {}) {
-    if (Buffer.isBuffer(identityId)) {
+    if (identityId instanceof Uint8Array) {
       // eslint-disable-next-line no-param-reassign
-      identityId = Buffer.from(identityId);
+      identityId = new Uint8Array(identityId);
     }
 
     const getIdentityKeysRequest = new GetIdentityKeysRequest();

--- a/packages/js-dapi-client/lib/methods/platform/getIdentityNonce/getIdentityNonceFactory.js
+++ b/packages/js-dapi-client/lib/methods/platform/getIdentityNonce/getIdentityNonceFactory.js
@@ -16,7 +16,7 @@ function getIdentityNonceFactory(grpcTransport) {
   /**
    * Fetch the version upgrade votes status
    * @typedef {getIdentityNonce}
-   * @param {Buffer} identityId
+   * @param {Uint8Array} identityId
    * @param {DAPIClientOptions & {prove: boolean}} [options]
    * @returns {Promise<GetIdentityNonceResponse>}
    */
@@ -28,9 +28,9 @@ function getIdentityNonceFactory(grpcTransport) {
     // eslint-disable-next-line max-len
     const getIdentityNonceRequest = new GetIdentityNonceRequest();
 
-    if (Buffer.isBuffer(identityId)) {
+    if (identityId instanceof Uint8Array) {
       // eslint-disable-next-line no-param-reassign
-      identityId = Buffer.from(identityId);
+      identityId = new Uint8Array(identityId);
     }
 
     getIdentityNonceRequest.setV0(

--- a/packages/js-dapi-client/lib/methods/platform/getProtocolVersionUpgradeVoteStatus/GetProtocolVersionUpgradeVoteStatusResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getProtocolVersionUpgradeVoteStatus/GetProtocolVersionUpgradeVoteStatusResponse.js
@@ -1,6 +1,7 @@
 const AbstractResponse = require('../response/AbstractResponse');
 const VersionSignal = require('./VersionSignal');
 const InvalidResponseError = require('../response/errors/InvalidResponseError');
+const { bytesToHex } = require('../../../utils/bytes');
 
 class GetProtocolVersionUpgradeVoteStatusResponse extends AbstractResponse {
   /**
@@ -40,7 +41,7 @@ class GetProtocolVersionUpgradeVoteStatusResponse extends AbstractResponse {
     const versionSignalsList = versions && versions.getVersionSignalsList();
     if (versionSignalsList) {
       versionSignals = versionSignalsList.map((versionSignal) => new VersionSignal(
-        Buffer.from(versionSignal.getProTxHash()).toString('hex'),
+        bytesToHex(new Uint8Array(versionSignal.getProTxHash())),
         versionSignal.getVersion(),
       ));
     }

--- a/packages/js-dapi-client/lib/methods/platform/getProtocolVersionUpgradeVoteStatus/GetProtocolVersionUpgradeVoteStatusResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getProtocolVersionUpgradeVoteStatus/GetProtocolVersionUpgradeVoteStatusResponse.js
@@ -41,7 +41,11 @@ class GetProtocolVersionUpgradeVoteStatusResponse extends AbstractResponse {
     const versionSignalsList = versions && versions.getVersionSignalsList();
     if (versionSignalsList) {
       versionSignals = versionSignalsList.map((versionSignal) => new VersionSignal(
-        bytesToHex(new Uint8Array(versionSignal.getProTxHash())),
+        // Use _asU8 so we get bytes regardless of the underlying protobuf
+        // representation (grpc-js: Uint8Array; grpc-web: base64 string).
+        // The default getter would yield the base64 string under grpc-web,
+        // and new Uint8Array(string) does NOT base64-decode it.
+        bytesToHex(versionSignal.getProTxHash_asU8()),
         versionSignal.getVersion(),
       ));
     }

--- a/packages/js-dapi-client/lib/methods/platform/getProtocolVersionUpgradeVoteStatus/getProtocolVersionUpgradeVoteStatusFactory.js
+++ b/packages/js-dapi-client/lib/methods/platform/getProtocolVersionUpgradeVoteStatus/getProtocolVersionUpgradeVoteStatusFactory.js
@@ -7,6 +7,7 @@ const {
 
 const GetProtocolVersionUpgradeVoteStatusResponse = require('./GetProtocolVersionUpgradeVoteStatusResponse');
 const InvalidResponseError = require('../response/errors/InvalidResponseError');
+const { hexToBytes } = require('../../../utils/bytes');
 
 /**
  * @param {GrpcTransport} grpcTransport
@@ -31,7 +32,7 @@ function getProtocolVersionUpgradeVoteStatusFactory(grpcTransport) {
 
     getProtocolVersionUpgradeVoteStatusRequest.setV0(
       new GetProtocolVersionUpgradeVoteStatusRequestV0()
-        .setStartProTxHash(Buffer.from(startProTxHash, 'hex'))
+        .setStartProTxHash(hexToBytes(startProTxHash))
         .setCount(count)
         .setProve(!!options.prove),
     );

--- a/packages/js-dapi-client/lib/methods/platform/getStatus/GetStatusResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getStatus/GetStatusResponse.js
@@ -4,6 +4,7 @@ const ChainStatus = require('./ChainStatus');
 const TimeStatus = require('./TimeStatus');
 const StateSyncStatus = require('./StateSyncStatus');
 const NetworkStatus = require('./NetworkStatus');
+const { bytesToHex } = require('../../../utils/bytes');
 
 class GetStatusResponse {
   /**
@@ -92,17 +93,17 @@ class GetStatusResponse {
       driveNextEpochProtocol,
     );
 
-    const nodeId = Buffer.from(v0.getNode().getId()).toString('hex');
-    const proTxHash = Buffer.from(v0.getNode().getProTxHash()).toString('hex');
+    const nodeId = bytesToHex(new Uint8Array(v0.getNode().getId()));
+    const proTxHash = bytesToHex(new Uint8Array(v0.getNode().getProTxHash()));
 
     const node = new NodeStatus(nodeId, proTxHash);
 
     const catchingUp = v0.getChain().getCatchingUp();
-    const latestBlockHash = Buffer.from(v0.getChain().getLatestBlockHash()).toString('hex');
-    const latestAppHash = Buffer.from(v0.getChain().getLatestAppHash()).toString('hex');
+    const latestBlockHash = bytesToHex(new Uint8Array(v0.getChain().getLatestBlockHash()));
+    const latestAppHash = bytesToHex(new Uint8Array(v0.getChain().getLatestAppHash()));
     const latestBlockHeight = BigInt(v0.getChain().getLatestBlockHeight());
-    const earliestBlockHash = Buffer.from(v0.getChain().getEarliestBlockHash()).toString('hex');
-    const earliestAppHash = Buffer.from(v0.getChain().getEarliestAppHash()).toString('hex');
+    const earliestBlockHash = bytesToHex(new Uint8Array(v0.getChain().getEarliestBlockHash()));
+    const earliestAppHash = bytesToHex(new Uint8Array(v0.getChain().getEarliestAppHash()));
     const earliestBlockHeight = BigInt(v0.getChain().getEarliestBlockHeight());
     const maxPeerBlockHeight = BigInt(v0.getChain().getMaxPeerBlockHeight());
     const coreChainLockedHeight = v0.getChain().getCoreChainLockedHeight();

--- a/packages/js-dapi-client/lib/methods/platform/getStatus/GetStatusResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getStatus/GetStatusResponse.js
@@ -93,17 +93,20 @@ class GetStatusResponse {
       driveNextEpochProtocol,
     );
 
-    const nodeId = bytesToHex(new Uint8Array(v0.getNode().getId()));
-    const proTxHash = bytesToHex(new Uint8Array(v0.getNode().getProTxHash()));
+    // Use _asU8 so we get bytes regardless of the underlying protobuf
+    // representation (grpc-js: Uint8Array; grpc-web: base64 string).
+    // new Uint8Array(string) does NOT base64-decode, silently losing bytes.
+    const nodeId = bytesToHex(v0.getNode().getId_asU8());
+    const proTxHash = bytesToHex(v0.getNode().getProTxHash_asU8());
 
     const node = new NodeStatus(nodeId, proTxHash);
 
     const catchingUp = v0.getChain().getCatchingUp();
-    const latestBlockHash = bytesToHex(new Uint8Array(v0.getChain().getLatestBlockHash()));
-    const latestAppHash = bytesToHex(new Uint8Array(v0.getChain().getLatestAppHash()));
+    const latestBlockHash = bytesToHex(v0.getChain().getLatestBlockHash_asU8());
+    const latestAppHash = bytesToHex(v0.getChain().getLatestAppHash_asU8());
     const latestBlockHeight = BigInt(v0.getChain().getLatestBlockHeight());
-    const earliestBlockHash = bytesToHex(new Uint8Array(v0.getChain().getEarliestBlockHash()));
-    const earliestAppHash = bytesToHex(new Uint8Array(v0.getChain().getEarliestAppHash()));
+    const earliestBlockHash = bytesToHex(v0.getChain().getEarliestBlockHash_asU8());
+    const earliestAppHash = bytesToHex(v0.getChain().getEarliestAppHash_asU8());
     const earliestBlockHeight = BigInt(v0.getChain().getEarliestBlockHeight());
     const maxPeerBlockHeight = BigInt(v0.getChain().getMaxPeerBlockHeight());
     const coreChainLockedHeight = v0.getChain().getCoreChainLockedHeight();

--- a/packages/js-dapi-client/lib/methods/platform/response/Proof.js
+++ b/packages/js-dapi-client/lib/methods/platform/response/Proof.js
@@ -47,10 +47,13 @@ class Proof {
    * @returns {Proof}
    */
   static createFromProto(proofProto) {
+    // Use _asU8 so we get bytes regardless of the underlying protobuf
+    // representation (grpc-js: Uint8Array; grpc-web: base64 string).
+    // new Uint8Array(string) does NOT base64-decode, silently losing bytes.
     return new Proof({
-      merkleProof: new Uint8Array(proofProto.getGrovedbProof()),
-      quorumHash: new Uint8Array(proofProto.getQuorumHash()),
-      signature: new Uint8Array(proofProto.getSignature()),
+      merkleProof: proofProto.getGrovedbProof_asU8(),
+      quorumHash: proofProto.getQuorumHash_asU8(),
+      signature: proofProto.getSignature_asU8(),
       round: proofProto.getRound(),
     });
   }

--- a/packages/js-dapi-client/lib/methods/platform/response/Proof.js
+++ b/packages/js-dapi-client/lib/methods/platform/response/Proof.js
@@ -1,9 +1,9 @@
 class Proof {
   /**
    * @param {object} properties
-   * @param {Buffer} properties.merkleProof
-   * @param {Buffer} properties.quorumHash
-   * @param {Buffer} properties.signature
+   * @param {Uint8Array} properties.merkleProof
+   * @param {Uint8Array} properties.quorumHash
+   * @param {Uint8Array} properties.signature
    * @param {number} properties.round
    */
   constructor(properties) {
@@ -14,21 +14,21 @@ class Proof {
   }
 
   /**
-   * @returns {Buffer}
+   * @returns {Uint8Array}
    */
   getGrovedbProof() {
     return this.merkleProof;
   }
 
   /**
-   * @returns {Buffer}
+   * @returns {Uint8Array}
    */
   getQuorumHash() {
     return this.quorumHash;
   }
 
   /**
-   * @returns {Buffer}
+   * @returns {Uint8Array}
    */
   getSignature() {
     return this.signature;
@@ -48,9 +48,9 @@ class Proof {
    */
   static createFromProto(proofProto) {
     return new Proof({
-      merkleProof: Buffer.from(proofProto.getGrovedbProof()),
-      quorumHash: Buffer.from(proofProto.getQuorumHash()),
-      signature: Buffer.from(proofProto.getSignature()),
+      merkleProof: new Uint8Array(proofProto.getGrovedbProof()),
+      quorumHash: new Uint8Array(proofProto.getQuorumHash()),
+      signature: new Uint8Array(proofProto.getSignature()),
       round: proofProto.getRound(),
     });
   }

--- a/packages/js-dapi-client/lib/methods/platform/waitForStateTransitionResult/WaitForStateTransitionResultResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/waitForStateTransitionResult/WaitForStateTransitionResultResponse.js
@@ -38,7 +38,10 @@ class WaitForStateTransitionResultResponse extends AbstractResponse {
       let data;
 
       if (proto.getV0().getError().getData()) {
-        data = new Uint8Array(proto.getV0().getError().getData());
+        // Use _asU8 so we get bytes regardless of the underlying protobuf
+        // representation (grpc-js: Uint8Array; grpc-web: base64 string).
+        // new Uint8Array(string) does NOT base64-decode, silently losing bytes.
+        data = proto.getV0().getError().getData_asU8();
       }
 
       error = new ErrorResult(

--- a/packages/js-dapi-client/lib/methods/platform/waitForStateTransitionResult/WaitForStateTransitionResultResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/waitForStateTransitionResult/WaitForStateTransitionResultResponse.js
@@ -38,7 +38,7 @@ class WaitForStateTransitionResultResponse extends AbstractResponse {
       let data;
 
       if (proto.getV0().getError().getData()) {
-        data = Buffer.from(proto.getV0().getError().getData());
+        data = new Uint8Array(proto.getV0().getError().getData());
       }
 
       error = new ErrorResult(

--- a/packages/js-dapi-client/lib/test/fixtures/getProofFixture.js
+++ b/packages/js-dapi-client/lib/test/fixtures/getProofFixture.js
@@ -1,15 +1,17 @@
+const { hexToBytes, base64ToBytes } = require('../../utils/bytes');
+
 /**
  * @returns {{
- *   merkleProof: Buffer,
- *   signature: Buffer,
- *   quorumHash: Buffer
+ *   merkleProof: Uint8Array,
+ *   signature: Uint8Array,
+ *   quorumHash: Uint8Array
  * }}
  */
 function getProofFixture() {
   return {
-    quorumHash: Buffer.from('AQEBAQEBAQEBAQEB', 'base64'),
-    signature: Buffer.from('AgICAgICAgICAgIC', 'base64'),
-    merkleProof: Buffer.from('0100000001f0faf5f55674905a68eba1be2f946e667c1cb5010101', 'hex'),
+    quorumHash: base64ToBytes('AQEBAQEBAQEBAQEB'),
+    signature: base64ToBytes('AgICAgICAgICAgIC'),
+    merkleProof: hexToBytes('0100000001f0faf5f55674905a68eba1be2f946e667c1cb5010101'),
     round: 42,
   };
 }

--- a/packages/js-dapi-client/lib/test/fixtures/getStatusFixture.js
+++ b/packages/js-dapi-client/lib/test/fixtures/getStatusFixture.js
@@ -1,3 +1,5 @@
+const { base64ToBytes } = require('../../utils/bytes');
+
 /**
  *
  */
@@ -22,16 +24,16 @@ function getStatusFixture() {
       },
     },
     node: {
-      id: new Uint8Array(Buffer.from('QbMI9zfKnjn2e1UxWJAxmKiMUW4=', 'base64')),
-      proTxHash: new Uint8Array(Buffer.from('s7V0hXG2D+mtEScV1qUXJdblpSqcOvX9NqFyTPUNhi8=', 'base64')),
+      id: base64ToBytes('QbMI9zfKnjn2e1UxWJAxmKiMUW4='),
+      proTxHash: base64ToBytes('s7V0hXG2D+mtEScV1qUXJdblpSqcOvX9NqFyTPUNhi8='),
     },
     chain: {
       catchingUp: false,
-      latestBlockHash: new Uint8Array(Buffer.from('mVDwGtY2oJSaLLgv3WpLp2dFDyFEtqhD4z1gl2OJceY=', 'base64')),
-      latestAppHash: new Uint8Array(Buffer.from('jHgEBK8aZ74TUKcUGN58EFzUNvNsLboOgYe6eH/JetU=', 'base64')),
+      latestBlockHash: base64ToBytes('mVDwGtY2oJSaLLgv3WpLp2dFDyFEtqhD4z1gl2OJceY='),
+      latestAppHash: base64ToBytes('jHgEBK8aZ74TUKcUGN58EFzUNvNsLboOgYe6eH/JetU='),
       latestBlockHeight: '94461',
-      earliestBlockHash: new Uint8Array(Buffer.from('CPoCwn7AOQujAeT8fj1+rbNQyBk+PmKgk2iXBuOiC/o=', 'base64')),
-      earliestAppHash: new Uint8Array(Buffer.from('vwzLnKBxugGubmegwJD5eAPSbVbWddzVExeBy8rI7I8=', 'base64')),
+      earliestBlockHash: base64ToBytes('CPoCwn7AOQujAeT8fj1+rbNQyBk+PmKgk2iXBuOiC/o='),
+      earliestAppHash: base64ToBytes('vwzLnKBxugGubmegwJD5eAPSbVbWddzVExeBy8rI7I8='),
       earliestBlockHeight: '1',
       maxPeerBlockHeight: '94461',
       coreChainLockedHeight: 1187358,

--- a/packages/js-dapi-client/lib/test/mocks/mockHeadersChain.js
+++ b/packages/js-dapi-client/lib/test/mocks/mockHeadersChain.js
@@ -1,6 +1,7 @@
 const X11 = require('wasm-x11-hash');
 const { BlockHeader, configure } = require('@dashevo/dashcore-lib');
 const { genesis } = require('@dashevo/dash-spv');
+const { hexToBytes } = require('../../utils/bytes');
 
 const getRoot = (network) => {
   switch (network) {
@@ -38,8 +39,8 @@ const mockHeadersChain = async (network, length, root) => {
   for (let i = 0; i < length - 1; i += 1) {
     const header = new BlockHeader({
       version: prevHeader.version,
-      prevHash: Buffer.from(prevHeader.hash, 'hex').reverse(),
-      merkleRoot: Buffer.alloc(32),
+      prevHash: hexToBytes(prevHeader.hash).reverse(),
+      merkleRoot: new Uint8Array(32),
       time: prevHeader.time + BLOCK_TIME,
       bits: prevHeader.bits,
       nonce: 3861367235,

--- a/packages/js-dapi-client/lib/transport/GrpcTransport/createGrpcTransportError.js
+++ b/packages/js-dapi-client/lib/transport/GrpcTransport/createGrpcTransportError.js
@@ -14,6 +14,7 @@ const ServerError = require('../errors/response/ServerError');
 const InvalidRequestError = require('../errors/response/InvalidRequestError');
 const InvalidRequestDPPError = require('../errors/response/InvalidRequestDPPError');
 const InternalServerError = require('./errors/InternalServerError');
+const { base64ToBytes } = require('../../utils/bytes');
 
 const INVALID_REQUEST_CODES = [
   GrpcErrorCodes.INVALID_ARGUMENT,
@@ -57,10 +58,13 @@ async function createGrpcTransportError(grpcError, dapiAddress) {
 
   const metadata = parseMetadata(grpcError.metadata) || {};
 
-  // Error data
+  // Error data — grpc-js passes raw bytes; grpc-web passes a base64 string.
+  // Original Buffer.from(x, 'base64') silently passed through bytes; reproduce that.
   const driveErrorData = metadata['drive-error-data-bin'];
   if (driveErrorData) {
-    const encodedData = Buffer.from(driveErrorData, 'base64');
+    const encodedData = typeof driveErrorData === 'string'
+      ? base64ToBytes(driveErrorData)
+      : new Uint8Array(driveErrorData);
     data = cbor.decode(encodedData);
   }
 
@@ -70,10 +74,12 @@ async function createGrpcTransportError(grpcError, dapiAddress) {
     code = Number(driveErrorCode);
   }
 
-  // Error stack
+  // Error stack — same dual-format handling as driveErrorData above.
   const driveErrorStack = metadata['stack-bin'];
   if (driveErrorStack) {
-    const encodedStack = Buffer.from(driveErrorStack, 'base64');
+    const encodedStack = typeof driveErrorStack === 'string'
+      ? base64ToBytes(driveErrorStack)
+      : new Uint8Array(driveErrorStack);
     data.stack = cbor.decode(encodedStack);
   }
 
@@ -124,7 +130,10 @@ async function createGrpcTransportError(grpcError, dapiAddress) {
       throw new Error(`Can't deserialize consensus error ${code}: serialized data is missing`);
     }
 
-    const consensusErrorBytes = Buffer.from(consensusErrorString, 'base64');
+    // grpc-js passes raw bytes; grpc-web passes a base64 string. Handle both.
+    const consensusErrorBytes = typeof consensusErrorString === 'string'
+      ? base64ToBytes(consensusErrorString)
+      : new Uint8Array(consensusErrorString);
     const consensusError = deserializeConsensusError(consensusErrorBytes);
 
     delete data.serializedError;

--- a/packages/js-dapi-client/lib/utils/bytes.js
+++ b/packages/js-dapi-client/lib/utils/bytes.js
@@ -1,0 +1,63 @@
+function hexToBytes(hex) {
+  if (typeof hex !== 'string') {
+    throw new TypeError('hex must be a string');
+  }
+  if (hex.length % 2 !== 0) {
+    throw new Error('hex must have even length');
+  }
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+function bytesToHex(bytes) {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function base64ToBytes(b64) {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) {
+    out[i] = bin.charCodeAt(i);
+  }
+  return out;
+}
+
+function bytesToBase64(bytes) {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    bin += String.fromCharCode(bytes[i]);
+  }
+  return btoa(bin);
+}
+
+function concatBytes(arrays) {
+  let total = 0;
+  for (const a of arrays) total += a.length;
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const a of arrays) {
+    out.set(a, offset);
+    offset += a.length;
+  }
+  return out;
+}
+
+function bytesEqual(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+module.exports = {
+  hexToBytes,
+  bytesToHex,
+  base64ToBytes,
+  bytesToBase64,
+  concatBytes,
+  bytesEqual,
+};

--- a/packages/js-dapi-client/lib/utils/bytes.js
+++ b/packages/js-dapi-client/lib/utils/bytes.js
@@ -1,3 +1,13 @@
+// Lightweight byte utilities used in place of Node Buffer methods on the
+// public surface. Inputs that look like bytes are required to be Uint8Array
+// (Buffer extends Uint8Array, so existing Buffer callers continue to work).
+
+function assertBytes(value, name) {
+  if (!(value instanceof Uint8Array)) {
+    throw new TypeError(`${name} must be a Uint8Array`);
+  }
+}
+
 function hexToBytes(hex) {
   if (typeof hex !== 'string') {
     throw new TypeError('hex must be a string');
@@ -5,18 +15,25 @@ function hexToBytes(hex) {
   if (hex.length % 2 !== 0) {
     throw new Error('hex must have even length');
   }
+  if (/[^0-9a-fA-F]/.test(hex)) {
+    throw new Error('hex contains non-hex characters');
+  }
   const out = new Uint8Array(hex.length / 2);
   for (let i = 0; i < out.length; i += 1) {
-    out[i] = parseInt(hex.substr(i * 2, 2), 16);
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
   }
   return out;
 }
 
 function bytesToHex(bytes) {
+  assertBytes(bytes, 'bytes');
   return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 function base64ToBytes(b64) {
+  if (typeof b64 !== 'string') {
+    throw new TypeError('b64 must be a string');
+  }
   const bin = atob(b64);
   const out = new Uint8Array(bin.length);
   for (let i = 0; i < bin.length; i += 1) {
@@ -26,6 +43,7 @@ function base64ToBytes(b64) {
 }
 
 function bytesToBase64(bytes) {
+  assertBytes(bytes, 'bytes');
   let bin = '';
   for (let i = 0; i < bytes.length; i += 1) {
     bin += String.fromCharCode(bytes[i]);
@@ -34,6 +52,10 @@ function bytesToBase64(bytes) {
 }
 
 function concatBytes(arrays) {
+  if (!Array.isArray(arrays)) {
+    throw new TypeError('concatBytes expects an array');
+  }
+  arrays.forEach((a, i) => assertBytes(a, `arrays[${i}]`));
   let total = 0;
   for (const a of arrays) total += a.length;
   const out = new Uint8Array(total);
@@ -46,6 +68,8 @@ function concatBytes(arrays) {
 }
 
 function bytesEqual(a, b) {
+  assertBytes(a, 'a');
+  assertBytes(b, 'b');
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i += 1) {
     if (a[i] !== b[i]) return false;

--- a/packages/js-dapi-client/test/integration/methods/core/CoreMethodsFacade.spec.js
+++ b/packages/js-dapi-client/test/integration/methods/core/CoreMethodsFacade.spec.js
@@ -36,7 +36,7 @@ describe('CoreMethodsFacade', () => {
       response.setTransactionId('4f46066bd50cc2684484407696b7949e82bd906ea92c040f59a97cba47ed8176');
       grpcTransportMock.request.resolves(response);
 
-      const transaction = Buffer.from('transaction');
+      const transaction = new TextEncoder().encode('transaction');
       await coreMethods.broadcastTransaction(transaction);
 
       expect(grpcTransportMock.request).to.be.calledOnce();
@@ -57,7 +57,7 @@ describe('CoreMethodsFacade', () => {
 
   describe('#getBlockByHash', () => {
     it('should get block by hash', async () => {
-      const block = Buffer.from('block');
+      const block = new TextEncoder().encode('block');
       const response = new GetBlockResponse();
       response.setBlock(block);
       grpcTransportMock.request.resolves(response);
@@ -70,7 +70,7 @@ describe('CoreMethodsFacade', () => {
 
   describe('#getBlockByHeight', () => {
     it('should get block by height', async () => {
-      const block = Buffer.from('block');
+      const block = new TextEncoder().encode('block');
       const response = new GetBlockResponse();
       response.setBlock(block);
       grpcTransportMock.request.resolves(response);
@@ -124,10 +124,10 @@ describe('CoreMethodsFacade', () => {
 
   describe('#getTransaction', () => {
     it('should get transaction', async () => {
-      const transaction = Buffer.from('transaction');
+      const transaction = new TextEncoder().encode('transaction');
       const response = new GetTransactionResponse();
       response.setTransaction(transaction);
-      response.setBlockHash(Buffer.from('blockHash'));
+      response.setBlockHash(new TextEncoder().encode('blockHash'));
       response.setHeight(1);
       response.setConfirmations(2);
 

--- a/packages/js-dapi-client/test/integration/methods/platform/PlatformMethodsFacade.spec.js
+++ b/packages/js-dapi-client/test/integration/methods/platform/PlatformMethodsFacade.spec.js
@@ -151,7 +151,7 @@ describe('PlatformMethodsFacade', () => {
           .setIdentitiesKeys(new IdentitiesKeys()
             .setEntriesList([
               new IdentityKeys()
-                .setIdentityId(new Uint8Array(identityFixture.getId().toBuffer()))
+                .setIdentityId(identityFixture.getId().toBytes())
                 .setKeysList([
                   new PurposeKeys()
                     .setPurpose(KeyPurpose.ENCRYPTION)

--- a/packages/js-dapi-client/test/integration/methods/platform/PlatformMethodsFacade.spec.js
+++ b/packages/js-dapi-client/test/integration/methods/platform/PlatformMethodsFacade.spec.js
@@ -296,7 +296,7 @@ describe('PlatformMethodsFacade', () => {
 
       grpcTransportMock.request.resolves(response);
 
-      await platformMethods.getIdentityNonce(new Uint8Array(32), new Uint8Array(32));
+      await platformMethods.getIdentityNonce(new Uint8Array(32), {});
 
       expect(grpcTransportMock.request).to.be.calledOnce();
     });

--- a/packages/js-dapi-client/test/integration/methods/platform/PlatformMethodsFacade.spec.js
+++ b/packages/js-dapi-client/test/integration/methods/platform/PlatformMethodsFacade.spec.js
@@ -25,6 +25,7 @@ const getDataContractFixture = require('@dashevo/wasm-dpp/lib/test/fixtures/getD
 const getIdentityFixture = require('@dashevo/wasm-dpp/lib/test/fixtures/getIdentityFixture');
 
 const PlatformMethodsFacade = require('../../../../lib/methods/platform/PlatformMethodsFacade');
+const { hexToBytes, bytesToHex } = require('../../../../lib/utils/bytes');
 
 const { WaitForStateTransitionResultResponseV0 } = WaitForStateTransitionResultResponse;
 const { GetIdentityResponseV0 } = GetIdentityResponse;
@@ -164,8 +165,8 @@ describe('PlatformMethodsFacade', () => {
       grpcTransportMock.request.resolves(response);
 
       await platformMethods.getIdentitiesContractKeys([
-        Buffer.alloc(32).fill(1),
-      ], Buffer.alloc(32).fill(2), [KeyPurpose.ENCRYPTION]);
+        new Uint8Array(32).fill(1),
+      ], new Uint8Array(32).fill(2), [KeyPurpose.ENCRYPTION]);
 
       expect(grpcTransportMock.request).to.be.calledOnce();
     });
@@ -182,7 +183,7 @@ describe('PlatformMethodsFacade', () => {
       grpcTransportMock.request.resolves(response);
 
       await platformMethods.waitForStateTransitionResult(
-        Buffer.from('6f49655a2906852a38e473dd47574fb70b8b7c4e5cee9ea8e7da3f07b970c421', 'hex'),
+        hexToBytes('6f49655a2906852a38e473dd47574fb70b8b7c4e5cee9ea8e7da3f07b970c421'),
         false,
       );
 
@@ -218,8 +219,8 @@ describe('PlatformMethodsFacade', () => {
 
   describe('#getProtocolVersionUpgradeVoteStatus', () => {
     it('should get version upgrade votes status', async () => {
-      const startProTxHash = Buffer.alloc(32).fill('a').toString('hex');
-      const proTxHash = Buffer.alloc(32).fill('b').toString('hex');
+      const startProTxHash = bytesToHex(new Uint8Array(32).fill(0x61));
+      const proTxHash = bytesToHex(new Uint8Array(32).fill(0x62));
 
       const { VersionSignal, VersionSignals } = GetProtocolVersionUpgradeVoteStatusResponseV0;
 
@@ -277,7 +278,7 @@ describe('PlatformMethodsFacade', () => {
 
       grpcTransportMock.request.resolves(response);
 
-      await platformMethods.getIdentityContractNonce(Buffer.alloc(32), Buffer.alloc(32));
+      await platformMethods.getIdentityContractNonce(new Uint8Array(32), new Uint8Array(32));
 
       expect(grpcTransportMock.request).to.be.calledOnce();
     });
@@ -295,7 +296,7 @@ describe('PlatformMethodsFacade', () => {
 
       grpcTransportMock.request.resolves(response);
 
-      await platformMethods.getIdentityNonce(Buffer.alloc(32), Buffer.alloc(32));
+      await platformMethods.getIdentityNonce(new Uint8Array(32), new Uint8Array(32));
 
       expect(grpcTransportMock.request).to.be.calledOnce();
     });
@@ -309,13 +310,13 @@ describe('PlatformMethodsFacade', () => {
 
       response.setV0(
         new GetIdentityKeysResponseV0()
-          .setKeys(new Keys().setKeysBytesList([Buffer.alloc(41), Buffer.alloc(46)]))
+          .setKeys(new Keys().setKeysBytesList([new Uint8Array(41), new Uint8Array(46)]))
           .setMetadata(new ResponseMetadata()),
       );
 
       grpcTransportMock.request.resolves(response);
 
-      await platformMethods.getIdentityKeys(Buffer.alloc(32), [0, 1], 100, {});
+      await platformMethods.getIdentityKeys(new Uint8Array(32), [0, 1], 100, {});
 
       expect(grpcTransportMock.request).to.be.calledOnce();
     });

--- a/packages/js-dapi-client/test/unit/methods/core/broadcastTransactionFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/core/broadcastTransactionFactory.spec.js
@@ -25,7 +25,7 @@ describe('broadcastTransactionFactory', () => {
       grpcTransportMock,
     );
 
-    transaction = Buffer.from('transaction');
+    transaction = new TextEncoder().encode('transaction');
     id = '4f46066bd50cc2684484407696b7949e82bd906ea92c040f59a97cba47ed8176';
   });
 

--- a/packages/js-dapi-client/test/unit/methods/core/getBlockByHashFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/core/getBlockByHashFactory.spec.js
@@ -14,7 +14,7 @@ describe('getBlockByHashFactory', () => {
   let block;
 
   beforeEach(function beforeEach() {
-    block = Buffer.from('block');
+    block = new TextEncoder().encode('block');
     const response = new GetBlockResponse();
     response.setBlock(block);
 
@@ -36,7 +36,7 @@ describe('getBlockByHashFactory', () => {
     const request = new GetBlockRequest();
     request.setHash(hash);
 
-    expect(result).to.be.instanceof(Buffer);
+    expect(result).to.be.instanceof(Uint8Array);
     expect(result).to.deep.equal(block);
     expect(grpcTransportMock.request).to.be.calledOnceWithExactly(
       CorePromiseClient,

--- a/packages/js-dapi-client/test/unit/methods/core/getBlockByHeightFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/core/getBlockByHeightFactory.spec.js
@@ -14,7 +14,7 @@ describe('getBlockByHeightFactory', () => {
   let block;
 
   beforeEach(function beforeEach() {
-    block = Buffer.from('block');
+    block = new TextEncoder().encode('block');
     const response = new GetBlockResponse();
     response.setBlock(block);
 
@@ -36,7 +36,7 @@ describe('getBlockByHeightFactory', () => {
     const request = new GetBlockRequest();
     request.setHeight(height);
 
-    expect(result).to.be.instanceof(Buffer);
+    expect(result).to.be.instanceof(Uint8Array);
     expect(result).to.deep.equal(block);
     expect(grpcTransportMock.request).to.be.calledOnceWithExactly(
       CorePromiseClient,

--- a/packages/js-dapi-client/test/unit/methods/core/getBlockchainStatusFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/core/getBlockchainStatusFactory.spec.js
@@ -7,6 +7,7 @@ const {
 } = require('@dashevo/dapi-grpc');
 
 const getBlockchainStatusFactory = require('../../../../lib/methods/core/getBlockchainStatusFactory');
+const { base64ToBytes } = require('../../../../lib/utils/bytes');
 
 describe('getBlockchainStatusFactory', () => {
   let getBlockchainStatus;
@@ -25,7 +26,7 @@ describe('getBlockchainStatusFactory', () => {
     response.setStatus(GetBlockchainStatusResponse.Status.READY);
 
     const chain = new GetBlockchainStatusResponse.Chain();
-    chain.setBestBlockHash(Buffer.from('bestBlockHash'));
+    chain.setBestBlockHash(new TextEncoder().encode('bestBlockHash'));
 
     response.setChain(chain);
 
@@ -53,7 +54,8 @@ describe('getBlockchainStatusFactory', () => {
       status: 'READY',
     };
 
-    expectedResult.chain.bestBlockHash = Buffer.from(expectedResult.chain.bestBlockHash, 'base64');
+    // toObject returns bestBlockHash as base64 string; production code converts to Uint8Array
+    expectedResult.chain.bestBlockHash = base64ToBytes(expectedResult.chain.bestBlockHash);
 
     expect(result).to.deep.equal(expectedResult);
   });

--- a/packages/js-dapi-client/test/unit/methods/core/getMasternodeStatusFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/core/getMasternodeStatusFactory.spec.js
@@ -45,7 +45,7 @@ describe('getMasternodeStatusFactory', () => {
 
     const expectedResult = {
       ...response.toObject(),
-      proTxHash: Buffer.alloc(0),
+      proTxHash: new Uint8Array(0),
       status: 'READY',
     };
 

--- a/packages/js-dapi-client/test/unit/methods/core/getTransaction/GetTransactionResponse.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/core/getTransaction/GetTransactionResponse.spec.js
@@ -13,8 +13,8 @@ describe('GetTransactionResponse', () => {
 
   beforeEach(() => {
     response = {
-      transaction: Buffer.from('transaction'),
-      blockHash: Buffer.from('blockHash'),
+      transaction: new TextEncoder().encode('transaction'),
+      blockHash: new TextEncoder().encode('blockHash'),
       height: 10,
       confirmations: 42,
       instantLocked: true,
@@ -72,8 +72,8 @@ describe('GetTransactionResponse', () => {
     const instance = GetTransactionResponse.createFromProto(proto);
 
     expect(instance).to.be.an.instanceOf(GetTransactionResponse);
-    expect(instance.transaction).to.deep.equal(Buffer.from(proto.getTransaction()));
-    expect(instance.blockHash).to.deep.equal(Buffer.from(proto.getBlockHash()));
+    expect(instance.transaction).to.deep.equal(new Uint8Array(proto.getTransaction()));
+    expect(instance.blockHash).to.deep.equal(new Uint8Array(proto.getBlockHash()));
     expect(instance.height).to.deep.equal(proto.getHeight());
     expect(instance.confirmations).to.deep.equal(proto.getConfirmations());
     expect(instance.instantLocked).to.deep.equal(proto.getIsInstantLocked());

--- a/packages/js-dapi-client/test/unit/methods/core/getTransaction/getTransactionFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/core/getTransaction/getTransactionFactory.spec.js
@@ -20,8 +20,8 @@ describe('getTransactionFactory', () => {
   let isInstantLocked;
 
   beforeEach(function beforeEach() {
-    transaction = Buffer.from('transaction');
-    blockHash = Buffer.from('blockHash');
+    transaction = new TextEncoder().encode('transaction');
+    blockHash = new TextEncoder().encode('blockHash');
     height = 42;
     confirmations = 3;
     isChainLocked = true;

--- a/packages/js-dapi-client/test/unit/methods/core/subscribeToBlockHeadersWithChainLocksFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/core/subscribeToBlockHeadersWithChainLocksFactory.spec.js
@@ -9,6 +9,7 @@ const { EventEmitter } = require('events');
 const subscribeToBlockHeadersWithChainLocksFactory = require('../../../../lib/methods/core/subscribeToBlockHeadersWithChainLocksFactory');
 
 const DAPIClientError = require('../../../../lib/errors/DAPIClientError');
+const { hexToBytes } = require('../../../../lib/utils/bytes');
 
 describe('subscribeToBlockHeadersWithChainLocks', () => {
   let subscribeToBlockHeadersWithChainLocks;
@@ -50,7 +51,7 @@ describe('subscribeToBlockHeadersWithChainLocks', () => {
     const request = new BlockHeadersWithChainLocksRequest();
 
     request.setFromBlockHeight(1);
-    request.setFromBlockHash(Buffer.from(options.fromBlockHash, 'hex'));
+    request.setFromBlockHash(hexToBytes(options.fromBlockHash));
     request.setCount(options.count);
 
     expect(grpcTransportMock.request).to.be.calledWith(

--- a/packages/js-dapi-client/test/unit/methods/core/subscribeToTransactionsWithProofsFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/core/subscribeToTransactionsWithProofsFactory.spec.js
@@ -13,6 +13,7 @@ const { EventEmitter } = require('events');
 const subscribeToTransactionsWithProofsFactory = require('../../../../lib/methods/core/subscribeToTransactionsWithProofsFactory');
 
 const DAPIClientError = require('../../../../lib/errors/DAPIClientError');
+const { hexToBytes } = require('../../../../lib/utils/bytes');
 
 describe('subscribeToTransactionsWithProofsFactory', () => {
   let subscribeToTransactionsWithProofs;
@@ -54,7 +55,7 @@ describe('subscribeToTransactionsWithProofsFactory', () => {
     request.setBloomFilter(bloomFilterMessage);
     request.setFromBlockHeight(options.fromBlockHeight);
     request.setCount(options.count);
-    request.setFromBlockHash(Buffer.from(options.fromBlockHash, 'hex'));
+    request.setFromBlockHash(hexToBytes(options.fromBlockHash));
 
     expect(grpcTransportMock.request).to.be.calledOnceWithExactly(
       CorePromiseClient,

--- a/packages/js-dapi-client/test/unit/methods/platform/getDataContract/GetDataContractResponse.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getDataContract/GetDataContractResponse.spec.js
@@ -41,7 +41,7 @@ describe('GetDataContractResponse', () => {
 
   it('should return proof', () => {
     getDataContractResponse = new GetDataContractResponseClass(
-      Buffer.alloc(0),
+      new Uint8Array(0),
       new Metadata(metadataFixture),
       new Proof(proofFixture),
     );
@@ -49,7 +49,7 @@ describe('GetDataContractResponse', () => {
     const dataContract = getDataContractResponse.getDataContract();
     const proof = getDataContractResponse.getProof();
 
-    expect(dataContract).to.deep.equal(Buffer.alloc(0));
+    expect(dataContract).to.deep.equal(new Uint8Array(0));
     expect(proof).to.be.an.instanceOf(Proof);
     expect(proof.getGrovedbProof()).to.deep.equal(proofFixture.merkleProof);
     expect(proof.getQuorumHash()).to.deep.equal(proofFixture.quorumHash);
@@ -113,7 +113,7 @@ describe('GetDataContractResponse', () => {
 
     getDataContractResponse = GetDataContractResponseClass.createFromProto(proto);
     expect(getDataContractResponse).to.be.an.instanceOf(GetDataContractResponseClass);
-    expect(getDataContractResponse.getDataContract()).to.deep.equal(Buffer.alloc(0));
+    expect(getDataContractResponse.getDataContract()).to.deep.equal(new Uint8Array(0));
 
     expect(getDataContractResponse.getMetadata().getHeight())
       .to.deep.equal(BigInt(metadataFixture.height));

--- a/packages/js-dapi-client/test/unit/methods/platform/getDataContract/getDataContractFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getDataContract/getDataContractFactory.spec.js
@@ -118,7 +118,7 @@ describe('getDataContractFactory', () => {
       options,
     ]);
 
-    expect(result.getDataContract()).to.deep.equal(Buffer.alloc(0));
+    expect(result.getDataContract()).to.deep.equal(new Uint8Array(0));
 
     expect(result.getProof()).to.be.an.instanceOf(ProofClass);
     expect(result.getProof().getGrovedbProof()).to.deep.equal(proofFixture.merkleProof);
@@ -146,7 +146,7 @@ describe('getDataContractFactory', () => {
     const request = new GetDataContractRequest();
     request.setV0(
       new GetDataContractRequestV0()
-        .setId(contractId.toBuffer())
+        .setId(new Uint8Array(contractId.toBuffer()))
         .setProve(false),
     );
 

--- a/packages/js-dapi-client/test/unit/methods/platform/getDataContract/getDataContractFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getDataContract/getDataContractFactory.spec.js
@@ -146,7 +146,7 @@ describe('getDataContractFactory', () => {
     const request = new GetDataContractRequest();
     request.setV0(
       new GetDataContractRequestV0()
-        .setId(new Uint8Array(contractId.toBuffer()))
+        .setId(contractId.toBytes())
         .setProve(false),
     );
 

--- a/packages/js-dapi-client/test/unit/methods/platform/getDataContractHistory/getDataContractHistoryFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getDataContractHistory/getDataContractHistoryFactory.spec.js
@@ -190,7 +190,7 @@ describe('getDataContractHistoryFactory', () => {
     const request = new GetDataContractHistoryRequest();
     request.setV0(
       new GetDataContractHistoryRequestV0()
-        .setId(contractId.toBuffer())
+        .setId(new Uint8Array(contractId.toBuffer()))
         .setLimit(new UInt32Value([10]))
         .setOffset(new UInt32Value([0]))
         .setStartAtMs('0')

--- a/packages/js-dapi-client/test/unit/methods/platform/getDataContractHistory/getDataContractHistoryFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getDataContractHistory/getDataContractHistoryFactory.spec.js
@@ -102,7 +102,7 @@ describe('getDataContractHistoryFactory', () => {
   });
 
   it('should return data contract history', async () => {
-    const contractId = dataContractFixture.getId().toBuffer();
+    const contractId = dataContractFixture.getId().toBytes();
     const result = await getDataContractHistory(contractId, BigInt(0), 10, 0, options);
 
     const { GetDataContractHistoryRequestV0 } = GetDataContractHistoryRequest;
@@ -141,7 +141,7 @@ describe('getDataContractHistoryFactory', () => {
     response.getV0().setProof(proof);
     response.getV0().setDataContractHistory(undefined);
 
-    const contractId = dataContractFixture.getId().toBuffer();
+    const contractId = dataContractFixture.getId().toBytes();
     const result = await getDataContractHistory(contractId, BigInt(0), 10, 0, options);
 
     const { GetDataContractHistoryRequestV0 } = GetDataContractHistoryRequest;
@@ -190,7 +190,7 @@ describe('getDataContractHistoryFactory', () => {
     const request = new GetDataContractHistoryRequest();
     request.setV0(
       new GetDataContractHistoryRequestV0()
-        .setId(new Uint8Array(contractId.toBuffer()))
+        .setId(contractId.toBytes())
         .setLimit(new UInt32Value([10]))
         .setOffset(new UInt32Value([0]))
         .setStartAtMs('0')

--- a/packages/js-dapi-client/test/unit/methods/platform/getDocuments/GetDocumentsResponse.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getDocuments/GetDocumentsResponse.spec.js
@@ -28,7 +28,7 @@ describe('GetDocumentsResponse', () => {
     proofFixture = getProofFixture();
 
     serializedDocuments = documentsFixture
-      .map((document) => Buffer.from(JSON.stringify(document)));
+      .map((document) => new TextEncoder().encode(JSON.stringify(document)));
 
     const { GetDocumentsResponseV0 } = GetDocumentsResponse;
     proto = new GetDocumentsResponse();

--- a/packages/js-dapi-client/test/unit/methods/platform/getDocuments/getDocumentsFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getDocuments/getDocumentsFactory.spec.js
@@ -53,7 +53,7 @@ describe('getDocumentsFactory', () => {
 
     documentsFixture = await getDocumentsFixture();
     serializedDocuments = documentsFixture
-      .map((document) => Buffer.from(JSON.stringify(document)));
+      .map((document) => new TextEncoder().encode(JSON.stringify(document)));
 
     const metadata = new ResponseMetadata();
     metadata.setHeight(metadataFixture.height);
@@ -91,7 +91,7 @@ describe('getDocumentsFactory', () => {
     const request = new GetDocumentsRequest();
     request.setV0(
       new GetDocumentsRequestV0()
-        .setDataContractId(contractIdBuffer)
+        .setDataContractId(new Uint8Array(contractIdBuffer))
         .setDocumentType(type)
         .setLimit(options.limit)
         .setWhere(cbor.encode(options.where))
@@ -132,7 +132,7 @@ describe('getDocumentsFactory', () => {
     const request = new GetDocumentsRequest();
     request.setV0(
       new GetDocumentsRequestV0()
-        .setDataContractId(contractIdBuffer)
+        .setDataContractId(new Uint8Array(contractIdBuffer))
         .setDocumentType(type)
         .setLimit(options.limit)
         .setWhere(cbor.encode(options.where))
@@ -174,7 +174,7 @@ describe('getDocumentsFactory', () => {
     const request = new GetDocumentsRequest();
     request.setV0(
       new GetDocumentsRequestV0()
-        .setDataContractId(contractIdBuffer)
+        .setDataContractId(new Uint8Array(contractIdBuffer))
         .setDocumentType(type)
         .setLimit(options.limit)
         .setWhere(cbor.encode(options.where))

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentitiesContractKeys/GetIdentitiesContractKeysResponse.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentitiesContractKeys/GetIdentitiesContractKeysResponse.spec.js
@@ -50,7 +50,7 @@ describe('GetIdentitiesContractKeysResponse', () => {
         .setIdentitiesKeys(new IdentitiesKeys()
           .setEntriesList([
             new IdentityKeys()
-              .setIdentityId(new Uint8Array(identityFixtureA.getId().toBuffer()))
+              .setIdentityId(identityFixtureA.getId().toBytes())
               .setKeysList([
                 new PurposeKeys()
                   .setPurpose(KeyPurpose.ENCRYPTION)
@@ -58,7 +58,7 @@ describe('GetIdentitiesContractKeysResponse', () => {
                     .map((key) => new Uint8Array(key.toBuffer()))),
               ]),
             new IdentityKeys()
-              .setIdentityId(new Uint8Array(identityFixtureB.getId().toBuffer()))
+              .setIdentityId(identityFixtureB.getId().toBytes())
               .setKeysList([
                 new PurposeKeys()
                   .setPurpose(KeyPurpose.DECRYPTION)

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentitiesContractKeys/getIdentitiesContractKeysFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentitiesContractKeys/getIdentitiesContractKeysFactory.spec.js
@@ -61,7 +61,7 @@ describe('getIdentitiesContractKeysFactory', () => {
         .setIdentitiesKeys(new IdentitiesKeys()
           .setEntriesList([
             new IdentityKeys()
-              .setIdentityId(new Uint8Array(identityFixtureA.getId().toBuffer()))
+              .setIdentityId(identityFixtureA.getId().toBytes())
               .setKeysList([
                 new PurposeKeys()
                   .setPurpose(KeyPurpose.ENCRYPTION)
@@ -69,7 +69,7 @@ describe('getIdentitiesContractKeysFactory', () => {
                     .map((key) => new Uint8Array(key.toBuffer()))),
               ]),
             new IdentityKeys()
-              .setIdentityId(new Uint8Array(identityFixtureB.getId().toBuffer()))
+              .setIdentityId(identityFixtureB.getId().toBytes())
               .setKeysList([
                 new PurposeKeys()
                   .setPurpose(KeyPurpose.DECRYPTION)

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentitiesContractKeys/getIdentitiesContractKeysFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentitiesContractKeys/getIdentitiesContractKeysFactory.spec.js
@@ -113,9 +113,9 @@ describe('getIdentitiesContractKeysFactory', () => {
         new GetIdentitiesContractKeysRequestV0()
           .setProve(!!options.prove)
           .setIdentitiesIdsList(
-            [Buffer.from(identityFixtureA.getId()), Buffer.from(identityFixtureB.getId())],
+            [new Uint8Array(identityFixtureA.getId()), new Uint8Array(identityFixtureB.getId())],
           )
-          .setContractId(Buffer.from(contractId))
+          .setContractId(new Uint8Array(contractId))
           .setPurposesList([KeyPurpose.ENCRYPTION, KeyPurpose.DECRYPTION])
           .setDocumentTypeName('contactRequest'),
       );

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentity/GetIdentityResponse.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentity/GetIdentityResponse.spec.js
@@ -58,7 +58,7 @@ describe('GetIdentityResponse', () => {
 
   it('should return proof', () => {
     getIdentityResponse = new GetIdentityResponseClass(
-      Buffer.alloc(0),
+      new Uint8Array(0),
       new Metadata(metadataFixture),
       new Proof(proofFixture),
     );
@@ -66,7 +66,7 @@ describe('GetIdentityResponse', () => {
     const identity = getIdentityResponse.getIdentity();
     const proof = getIdentityResponse.getProof();
 
-    expect(identity).to.deep.equal(Buffer.alloc(0));
+    expect(identity).to.deep.equal(new Uint8Array(0));
     expect(proof).to.be.an.instanceOf(Proof);
     expect(proof.getGrovedbProof()).to.deep.equal(proofFixture.merkleProof);
     expect(proof.getQuorumHash()).to.deep.equal(proofFixture.quorumHash);
@@ -104,7 +104,7 @@ describe('GetIdentityResponse', () => {
 
     getIdentityResponse = GetIdentityResponseClass.createFromProto(proto);
 
-    expect(getIdentityResponse.getIdentity()).to.deep.equal(Buffer.alloc(0));
+    expect(getIdentityResponse.getIdentity()).to.deep.equal(new Uint8Array(0));
 
     expect(getIdentityResponse.getMetadata().getHeight())
       .to.deep.equal(BigInt(metadataFixture.height));

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentity/getIdentityFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentity/getIdentityFactory.spec.js
@@ -72,7 +72,7 @@ describe('getIdentityFactory', () => {
     const request = new GetIdentityRequest();
     request.setV0(
       new GetIdentityRequestV0()
-        .setId(identityId.toBuffer())
+        .setId(new Uint8Array(identityId.toBuffer()))
         .setProve(false),
     );
 
@@ -107,7 +107,7 @@ describe('getIdentityFactory', () => {
     const request = new GetIdentityRequest();
     request.setV0(
       new GetIdentityRequestV0()
-        .setId(identityId.toBuffer())
+        .setId(new Uint8Array(identityId.toBuffer()))
         .setProve(true),
     );
 
@@ -118,7 +118,7 @@ describe('getIdentityFactory', () => {
       options,
     );
 
-    expect(result.getIdentity()).to.deep.equal(Buffer.alloc(0));
+    expect(result.getIdentity()).to.deep.equal(new Uint8Array(0));
 
     expect(result.getMetadata().getHeight())
       .to.deep.equal(BigInt(metadataFixture.height));
@@ -145,7 +145,7 @@ describe('getIdentityFactory', () => {
     const request = new GetIdentityRequest();
     request.setV0(
       new GetIdentityRequestV0()
-        .setId(identityId.toBuffer())
+        .setId(new Uint8Array(identityId.toBuffer()))
         .setProve(false),
     );
 

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentity/getIdentityFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentity/getIdentityFactory.spec.js
@@ -72,7 +72,7 @@ describe('getIdentityFactory', () => {
     const request = new GetIdentityRequest();
     request.setV0(
       new GetIdentityRequestV0()
-        .setId(new Uint8Array(identityId.toBuffer()))
+        .setId(identityId.toBytes())
         .setProve(false),
     );
 
@@ -107,7 +107,7 @@ describe('getIdentityFactory', () => {
     const request = new GetIdentityRequest();
     request.setV0(
       new GetIdentityRequestV0()
-        .setId(new Uint8Array(identityId.toBuffer()))
+        .setId(identityId.toBytes())
         .setProve(true),
     );
 
@@ -145,7 +145,7 @@ describe('getIdentityFactory', () => {
     const request = new GetIdentityRequest();
     request.setV0(
       new GetIdentityRequestV0()
-        .setId(new Uint8Array(identityId.toBuffer()))
+        .setId(identityId.toBytes())
         .setProve(false),
     );
 

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityBalance/getIdentityBalanceFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityBalance/getIdentityBalanceFactory.spec.js
@@ -29,7 +29,7 @@ describe('getIdentityBalanceFactory', () => {
   beforeEach(async function beforeEach() {
     balance = BigInt(1337);
 
-    identityId = Buffer.alloc(32).fill(0);
+    identityId = new Uint8Array(32);
 
     metadataFixture = getMetadataFixture();
     proofFixture = getProofFixture();

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityByPublicKeyHash/GetIdentityByPublicKeyHashResponse.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityByPublicKeyHash/GetIdentityByPublicKeyHashResponse.spec.js
@@ -118,7 +118,7 @@ describe('GetIdentityByPublicKeyHashResponse', () => {
     expect(getIdentityResponse).to.be.an.instanceOf(
       GetIdentityByPublicKeyHashResponseClass,
     );
-    expect(getIdentityResponse.getIdentity()).to.deep.equal(Buffer.alloc(0));
+    expect(getIdentityResponse.getIdentity()).to.deep.equal(new Uint8Array(0));
 
     expect(getIdentityResponse.getMetadata().getHeight())
       .to.deep.equal(BigInt(metadataFixture.height));

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityByPublicKeyHash/getIdentityByPublicKeyHashFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityByPublicKeyHash/getIdentityByPublicKeyHashFactory.spec.js
@@ -121,7 +121,7 @@ describe('getIdentityByPublicKeyHashFactory', () => {
       request,
       options,
     );
-    expect(result.getIdentity()).to.deep.equal(Buffer.alloc(0));
+    expect(result.getIdentity()).to.deep.equal(new Uint8Array(0));
 
     expect(result.getMetadata().getHeight())
       .to.deep.equal(BigInt(metadataFixture.height));

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityContractNonce/GetIdentityContractNonce.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityContractNonce/GetIdentityContractNonce.spec.js
@@ -56,7 +56,7 @@ describe('GetIdentityContractNonceResponse', () => {
 
   it('should return proof', () => {
     getIdentityContractNonceResponse = new GetIdentityContractNonceResponseClass(
-      new Uint8Array(0),
+      BigInt(0),
       new Metadata(metadataFixture),
       new Proof(proofFixture),
     );
@@ -64,7 +64,7 @@ describe('GetIdentityContractNonceResponse', () => {
     const identityContractNonce = getIdentityContractNonceResponse.getIdentityContractNonce();
     const proof = getIdentityContractNonceResponse.getProof();
 
-    expect(identityContractNonce).to.deep.equal(new Uint8Array(0));
+    expect(identityContractNonce).to.deep.equal(BigInt(0));
     expect(proof).to.be.an.instanceOf(Proof);
     expect(proof.getGrovedbProof()).to.deep.equal(proofFixture.merkleProof);
     expect(proof.getQuorumHash()).to.deep.equal(proofFixture.quorumHash);

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityContractNonce/GetIdentityContractNonce.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityContractNonce/GetIdentityContractNonce.spec.js
@@ -56,7 +56,7 @@ describe('GetIdentityContractNonceResponse', () => {
 
   it('should return proof', () => {
     getIdentityContractNonceResponse = new GetIdentityContractNonceResponseClass(
-      Buffer.alloc(0),
+      new Uint8Array(0),
       new Metadata(metadataFixture),
       new Proof(proofFixture),
     );
@@ -64,7 +64,7 @@ describe('GetIdentityContractNonceResponse', () => {
     const identityContractNonce = getIdentityContractNonceResponse.getIdentityContractNonce();
     const proof = getIdentityContractNonceResponse.getProof();
 
-    expect(identityContractNonce).to.deep.equal(Buffer.alloc(0));
+    expect(identityContractNonce).to.deep.equal(new Uint8Array(0));
     expect(proof).to.be.an.instanceOf(Proof);
     expect(proof.getGrovedbProof()).to.deep.equal(proofFixture.merkleProof);
     expect(proof.getQuorumHash()).to.deep.equal(proofFixture.quorumHash);

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityContractNonce/getIdentityContractNonceFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityContractNonce/getIdentityContractNonceFactory.spec.js
@@ -27,8 +27,8 @@ describe('getIdentityContractNonceFactory', () => {
 
   beforeEach(async function beforeEach() {
     nonce = BigInt(1);
-    identityId = Buffer.alloc(32).fill(0);
-    contractId = Buffer.alloc(32).fill(1);
+    identityId = new Uint8Array(32);
+    contractId = new Uint8Array(32).fill(1);
 
     metadataFixture = getMetadataFixture();
     proofFixture = getProofFixture();

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityKeys/GetIdentityKeys.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityKeys/GetIdentityKeys.spec.js
@@ -22,7 +22,7 @@ describe('GetIdentityKeysResponse', () => {
 
   beforeEach(async () => {
     metadataFixture = getMetadataFixture();
-    keys = [Buffer.alloc(41).fill(1), Buffer.alloc(48).fill(2), Buffer.alloc(55).fill(3)];
+    keys = [new Uint8Array(41).fill(1), new Uint8Array(48).fill(2), new Uint8Array(55).fill(3)];
     proofFixture = getProofFixture();
 
     const { GetIdentityKeysResponseV0 } = GetIdentityKeysResponse;
@@ -58,7 +58,7 @@ describe('GetIdentityKeysResponse', () => {
 
   it('should return proof', () => {
     getIdentityKeysResponse = new GetIdentityKeysResponseClass(
-      Buffer.alloc(0),
+      new Uint8Array(0),
       new Metadata(metadataFixture),
       new Proof(proofFixture),
     );
@@ -66,7 +66,7 @@ describe('GetIdentityKeysResponse', () => {
     const identityKeys = getIdentityKeysResponse.getIdentityKeys();
     const proof = getIdentityKeysResponse.getProof();
 
-    expect(identityKeys).to.deep.equal(Buffer.alloc(0));
+    expect(identityKeys).to.deep.equal(new Uint8Array(0));
     expect(proof).to.be.an.instanceOf(Proof);
     expect(proof.getGrovedbProof()).to.deep.equal(proofFixture.merkleProof);
     expect(proof.getQuorumHash()).to.deep.equal(proofFixture.quorumHash);

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityKeys/GetIdentityKeys.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityKeys/GetIdentityKeys.spec.js
@@ -58,7 +58,7 @@ describe('GetIdentityKeysResponse', () => {
 
   it('should return proof', () => {
     getIdentityKeysResponse = new GetIdentityKeysResponseClass(
-      new Uint8Array(0),
+      [],
       new Metadata(metadataFixture),
       new Proof(proofFixture),
     );
@@ -66,7 +66,7 @@ describe('GetIdentityKeysResponse', () => {
     const identityKeys = getIdentityKeysResponse.getIdentityKeys();
     const proof = getIdentityKeysResponse.getProof();
 
-    expect(identityKeys).to.deep.equal(new Uint8Array(0));
+    expect(identityKeys).to.deep.equal([]);
     expect(proof).to.be.an.instanceOf(Proof);
     expect(proof.getGrovedbProof()).to.deep.equal(proofFixture.merkleProof);
     expect(proof.getQuorumHash()).to.deep.equal(proofFixture.quorumHash);

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityKeys/getIdentityKeysFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityKeys/getIdentityKeysFactory.spec.js
@@ -35,11 +35,11 @@ describe('getIdentityKeysFactory', () => {
   let proofResponse;
 
   beforeEach(async function beforeEach() {
-    keys = [Buffer.alloc(41), Buffer.alloc(46)];
+    keys = [new Uint8Array(41), new Uint8Array(46)];
     keyIds = [0, 1];
     limit = 100;
 
-    identityId = Buffer.alloc(32).fill(0);
+    identityId = new Uint8Array(32);
 
     metadataFixture = getMetadataFixture();
     proofFixture = getProofFixture();

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityNonce/GetIdentityNonce.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityNonce/GetIdentityNonce.spec.js
@@ -56,7 +56,7 @@ describe('GetIdentityNonceResponse', () => {
 
   it('should return proof', () => {
     getIdentityNonceResponse = new GetIdentityNonceResponseClass(
-      Buffer.alloc(0),
+      new Uint8Array(0),
       new Metadata(metadataFixture),
       new Proof(proofFixture),
     );
@@ -64,7 +64,7 @@ describe('GetIdentityNonceResponse', () => {
     const IdentityNonce = getIdentityNonceResponse.getIdentityNonce();
     const proof = getIdentityNonceResponse.getProof();
 
-    expect(IdentityNonce).to.deep.equal(Buffer.alloc(0));
+    expect(IdentityNonce).to.deep.equal(new Uint8Array(0));
     expect(proof).to.be.an.instanceOf(Proof);
     expect(proof.getGrovedbProof()).to.deep.equal(proofFixture.merkleProof);
     expect(proof.getQuorumHash()).to.deep.equal(proofFixture.quorumHash);

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityNonce/GetIdentityNonce.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityNonce/GetIdentityNonce.spec.js
@@ -56,7 +56,7 @@ describe('GetIdentityNonceResponse', () => {
 
   it('should return proof', () => {
     getIdentityNonceResponse = new GetIdentityNonceResponseClass(
-      new Uint8Array(0),
+      BigInt(0),
       new Metadata(metadataFixture),
       new Proof(proofFixture),
     );
@@ -64,7 +64,7 @@ describe('GetIdentityNonceResponse', () => {
     const IdentityNonce = getIdentityNonceResponse.getIdentityNonce();
     const proof = getIdentityNonceResponse.getProof();
 
-    expect(IdentityNonce).to.deep.equal(new Uint8Array(0));
+    expect(IdentityNonce).to.deep.equal(BigInt(0));
     expect(proof).to.be.an.instanceOf(Proof);
     expect(proof.getGrovedbProof()).to.deep.equal(proofFixture.merkleProof);
     expect(proof.getQuorumHash()).to.deep.equal(proofFixture.quorumHash);

--- a/packages/js-dapi-client/test/unit/methods/platform/getIdentityNonce/getIdentityNonceFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getIdentityNonce/getIdentityNonceFactory.spec.js
@@ -26,7 +26,7 @@ describe('getIdentityNonceFactory', () => {
 
   beforeEach(async function beforeEach() {
     nonce = BigInt(1);
-    identityId = Buffer.alloc(32).fill(0);
+    identityId = new Uint8Array(32);
 
     metadataFixture = getMetadataFixture();
     proofFixture = getProofFixture();

--- a/packages/js-dapi-client/test/unit/methods/platform/getProtocolVersionUpgradeVoteStatus/GetProtocolVersionUpgradeVoteStatusResponse.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getProtocolVersionUpgradeVoteStatus/GetProtocolVersionUpgradeVoteStatusResponse.spec.js
@@ -13,6 +13,7 @@ const InvalidResponseError = require('../../../../../lib/methods/platform/respon
 const getProofFixture = require('../../../../../lib/test/fixtures/getProofFixture');
 const Proof = require('../../../../../lib/methods/platform/response/Proof');
 const Metadata = require('../../../../../lib/methods/platform/response/Metadata');
+const { bytesToHex, hexToBytes } = require('../../../../../lib/utils/bytes');
 
 describe('GetProtocolVersionUpgradeVoteStatusResponse', () => {
   let getProtocolVersionUpgradeVoteStatus;
@@ -23,7 +24,7 @@ describe('GetProtocolVersionUpgradeVoteStatusResponse', () => {
 
   beforeEach(async () => {
     metadataFixture = getMetadataFixture();
-    versionSignalFixture = new VersionSignalClass(Buffer.alloc(32).toString('hex'), 1);
+    versionSignalFixture = new VersionSignalClass(bytesToHex(new Uint8Array(32)), 1);
     proofFixture = getProofFixture();
 
     const {
@@ -42,7 +43,7 @@ describe('GetProtocolVersionUpgradeVoteStatusResponse', () => {
       new GetProtocolVersionUpgradeVoteStatusResponseV0()
         .setVersions(new VersionSignals()
           .setVersionSignalsList([new VersionSignal()
-            .setProTxHash(Buffer.from(versionSignalFixture.getProTxHash(), 'hex'))
+            .setProTxHash(hexToBytes(versionSignalFixture.getProTxHash()))
             .setVersion(versionSignalFixture.getVersion()),
           ]))
         .setMetadata(metadata),
@@ -125,9 +126,9 @@ describe('GetProtocolVersionUpgradeVoteStatusResponse', () => {
 
     const proof = getProtocolVersionUpgradeVoteStatus.getProof();
     expect(proof).to.be.an.instanceOf(Proof);
-    expect(proof.getGrovedbProof()).to.deep.equal(proofFixture.merkleProof);
-    expect(proof.getQuorumHash()).to.deep.equal(proofFixture.quorumHash);
-    expect(proof.getSignature()).to.deep.equal(proofFixture.signature);
+    expect(proof.getGrovedbProof()).to.deep.equal(new Uint8Array(proofFixture.merkleProof));
+    expect(proof.getQuorumHash()).to.deep.equal(new Uint8Array(proofFixture.quorumHash));
+    expect(proof.getSignature()).to.deep.equal(new Uint8Array(proofFixture.signature));
     expect(proof.getRound()).to.deep.equal(proofFixture.round);
   });
 

--- a/packages/js-dapi-client/test/unit/methods/platform/getProtocolVersionUpgradeVoteStatus/getProtocolVersionUpgradeVoteStatusFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getProtocolVersionUpgradeVoteStatus/getProtocolVersionUpgradeVoteStatusFactory.spec.js
@@ -13,6 +13,7 @@ const VersionSignal = require('../../../../../lib/methods/platform/getProtocolVe
 const getMetadataFixture = require('../../../../../lib/test/fixtures/getMetadataFixture');
 const getProofFixture = require('../../../../../lib/test/fixtures/getProofFixture');
 const Proof = require('../../../../../lib/methods/platform/response/Proof');
+const { bytesToHex, hexToBytes } = require('../../../../../lib/utils/bytes');
 
 describe('getProtocolVersionUpgradeVoteStatusFactory', () => {
   let grpcTransportMock;
@@ -26,8 +27,8 @@ describe('getProtocolVersionUpgradeVoteStatusFactory', () => {
   let startProTxHash;
 
   beforeEach(async function beforeEach() {
-    startProTxHash = Buffer.alloc(32).fill('a').toString('hex');
-    versionSignalFixture = new VersionSignal(Buffer.alloc(32).toString('hex'), 1);
+    startProTxHash = bytesToHex(new Uint8Array(32).fill(0x61));
+    versionSignalFixture = new VersionSignal(bytesToHex(new Uint8Array(32)), 1);
 
     metadataFixture = getMetadataFixture();
     proofFixture = getProofFixture();
@@ -50,7 +51,7 @@ describe('getProtocolVersionUpgradeVoteStatusFactory', () => {
       new GetProtocolVersionUpgradeVoteStatusResponseV0()
         .setVersions(new VersionSignals()
           .setVersionSignalsList([new VersionSignalProto()
-            .setProTxHash(Buffer.from(versionSignalFixture.getProTxHash(), 'hex'))
+            .setProTxHash(hexToBytes(versionSignalFixture.getProTxHash()))
             .setVersion(versionSignalFixture.getVersion())]))
         .setMetadata(metadata),
     );
@@ -84,7 +85,7 @@ describe('getProtocolVersionUpgradeVoteStatusFactory', () => {
     const request = new GetProtocolVersionUpgradeVoteStatusRequest();
     request.setV0(
       new GetProtocolVersionUpgradeVoteStatusRequestV0()
-        .setStartProTxHash(Buffer.from(startProTxHash, 'hex'))
+        .setStartProTxHash(hexToBytes(startProTxHash))
         .setCount(1)
         .setProve(!!options.prove),
     );
@@ -124,7 +125,7 @@ describe('getProtocolVersionUpgradeVoteStatusFactory', () => {
     const request = new GetProtocolVersionUpgradeVoteStatusRequest();
     request.setV0(
       new GetProtocolVersionUpgradeVoteStatusRequestV0()
-        .setStartProTxHash(Buffer.from(startProTxHash, 'hex'))
+        .setStartProTxHash(hexToBytes(startProTxHash))
         .setCount(1)
         .setProve(!!options.ascending),
     );
@@ -148,9 +149,9 @@ describe('getProtocolVersionUpgradeVoteStatusFactory', () => {
       .to.deep.equal(metadataFixture.protocolVersion);
 
     expect(result.getProof()).to.be.an.instanceOf(Proof);
-    expect(result.getProof().getGrovedbProof()).to.deep.equal(proofFixture.merkleProof);
-    expect(result.getProof().getQuorumHash()).to.deep.equal(proofFixture.quorumHash);
-    expect(result.getProof().getSignature()).to.deep.equal(proofFixture.signature);
+    expect(result.getProof().getGrovedbProof()).to.deep.equal(new Uint8Array(proofFixture.merkleProof));
+    expect(result.getProof().getQuorumHash()).to.deep.equal(new Uint8Array(proofFixture.quorumHash));
+    expect(result.getProof().getSignature()).to.deep.equal(new Uint8Array(proofFixture.signature));
     expect(result.getProof().getRound()).to.deep.equal(proofFixture.round);
   });
 
@@ -165,7 +166,7 @@ describe('getProtocolVersionUpgradeVoteStatusFactory', () => {
     const request = new GetProtocolVersionUpgradeVoteStatusRequest();
     request.setV0(
       new GetProtocolVersionUpgradeVoteStatusRequestV0()
-        .setStartProTxHash(Buffer.from(startProTxHash, 'hex'))
+        .setStartProTxHash(hexToBytes(startProTxHash))
         .setCount(1)
         .setProve(!!options.ascending),
     );

--- a/packages/js-dapi-client/test/unit/methods/platform/getStatus/GetStatusResponse.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getStatus/GetStatusResponse.spec.js
@@ -12,6 +12,7 @@ const ChainStatus = require('../../../../../lib/methods/platform/getStatus/Chain
 const NetworkStatus = require('../../../../../lib/methods/platform/getStatus/NetworkStatus');
 const StateSyncStatus = require('../../../../../lib/methods/platform/getStatus/StateSyncStatus');
 const TimeStatus = require('../../../../../lib/methods/platform/getStatus/TimeStatus');
+const { bytesToHex } = require('../../../../../lib/utils/bytes');
 
 describe('GetStatusResponse', () => {
   let getStatusResponse;
@@ -90,17 +91,17 @@ describe('GetStatusResponse', () => {
     );
 
     const node = new NodeStatus(
-      Buffer.from(statusFixture.node.id).toString('hex'),
-      Buffer.from(statusFixture.node.proTxHash).toString('hex'),
+      bytesToHex(statusFixture.node.id),
+      bytesToHex(statusFixture.node.proTxHash),
     );
 
     const chain = new ChainStatus(
       statusFixture.chain.catchingUp,
-      Buffer.from(statusFixture.chain.latestBlockHash).toString('hex'),
-      Buffer.from(statusFixture.chain.latestAppHash).toString('hex'),
+      bytesToHex(statusFixture.chain.latestBlockHash),
+      bytesToHex(statusFixture.chain.latestAppHash),
       BigInt(statusFixture.chain.latestBlockHeight),
-      Buffer.from(statusFixture.chain.earliestBlockHash).toString('hex'),
-      Buffer.from(statusFixture.chain.earliestAppHash).toString('hex'),
+      bytesToHex(statusFixture.chain.earliestBlockHash),
+      bytesToHex(statusFixture.chain.earliestAppHash),
       BigInt(statusFixture.chain.earliestBlockHeight),
       BigInt(statusFixture.chain.maxPeerBlockHeight),
       statusFixture.chain.coreChainLockedHeight,
@@ -219,22 +220,22 @@ describe('GetStatusResponse', () => {
       .to.equal(statusFixture.version.protocol.drive.nextEpoch);
 
     expect(nodeStatus).to.be.an.instanceOf(NodeStatus);
-    expect(nodeStatus.getNodeId()).to.equal(Buffer.from(statusFixture.node.id).toString('hex'));
-    expect(nodeStatus.getProTxHash()).to.equal(Buffer.from(statusFixture.node.proTxHash).toString('hex'));
+    expect(nodeStatus.getNodeId()).to.equal(bytesToHex(statusFixture.node.id));
+    expect(nodeStatus.getProTxHash()).to.equal(bytesToHex(statusFixture.node.proTxHash));
 
     expect(chainStatus).to.be.an.instanceOf(ChainStatus);
     expect(chainStatus.isCatchingUp())
       .to.equal(statusFixture.chain.catchingUp);
     expect(chainStatus.getLatestBlockHash())
-      .to.equal(Buffer.from(statusFixture.chain.latestBlockHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.latestBlockHash));
     expect(chainStatus.getLatestAppHash())
-      .to.equal(Buffer.from(statusFixture.chain.latestAppHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.latestAppHash));
     expect(chainStatus.getLatestBlockHeight())
       .to.equal(BigInt(statusFixture.chain.latestBlockHeight));
     expect(chainStatus.getEarliestBlockHash())
-      .to.equal(Buffer.from(statusFixture.chain.earliestBlockHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.earliestBlockHash));
     expect(chainStatus.getEarliestAppHash())
-      .to.equal(Buffer.from(statusFixture.chain.earliestAppHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.earliestAppHash));
     expect(chainStatus.getEarliestBlockHeight())
       .to.equal(BigInt(statusFixture.chain.earliestBlockHeight));
     expect(chainStatus.getMaxPeerBlockHeight())
@@ -297,22 +298,22 @@ describe('GetStatusResponse', () => {
       .to.equal(statusFixture.version.protocol.drive.latest);
 
     expect(nodeStatus).to.be.an.instanceOf(NodeStatus);
-    expect(nodeStatus.getNodeId()).to.equal(Buffer.from(statusFixture.node.id).toString('hex'));
-    expect(nodeStatus.getProTxHash()).to.equal(Buffer.from(statusFixture.node.proTxHash).toString('hex'));
+    expect(nodeStatus.getNodeId()).to.equal(bytesToHex(statusFixture.node.id));
+    expect(nodeStatus.getProTxHash()).to.equal(bytesToHex(statusFixture.node.proTxHash));
 
     expect(chainStatus).to.be.an.instanceOf(ChainStatus);
     expect(chainStatus.isCatchingUp())
       .to.equal(statusFixture.chain.catchingUp);
     expect(chainStatus.getLatestBlockHash())
-      .to.equal(Buffer.from(statusFixture.chain.latestBlockHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.latestBlockHash));
     expect(chainStatus.getLatestAppHash())
-      .to.equal(Buffer.from(statusFixture.chain.latestAppHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.latestAppHash));
     expect(chainStatus.getLatestBlockHeight())
       .to.equal(BigInt(statusFixture.chain.latestBlockHeight));
     expect(chainStatus.getEarliestBlockHash())
-      .to.equal(Buffer.from(statusFixture.chain.earliestBlockHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.earliestBlockHash));
     expect(chainStatus.getEarliestAppHash())
-      .to.equal(Buffer.from(statusFixture.chain.earliestAppHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.earliestAppHash));
     expect(chainStatus.getEarliestBlockHeight())
       .to.equal(BigInt(statusFixture.chain.earliestBlockHeight));
     expect(chainStatus.getMaxPeerBlockHeight())

--- a/packages/js-dapi-client/test/unit/methods/platform/getStatus/getStatusFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getStatus/getStatusFactory.spec.js
@@ -14,6 +14,7 @@ const ChainStatus = require('../../../../../lib/methods/platform/getStatus/Chain
 const NetworkStatus = require('../../../../../lib/methods/platform/getStatus/NetworkStatus');
 const StateSyncStatus = require('../../../../../lib/methods/platform/getStatus/StateSyncStatus');
 const TimeStatus = require('../../../../../lib/methods/platform/getStatus/TimeStatus');
+const { bytesToHex } = require('../../../../../lib/utils/bytes');
 
 describe('getStatusFactory', () => {
   let grpcTransportMock;
@@ -131,22 +132,22 @@ describe('getStatusFactory', () => {
       .to.equal(statusFixture.version.protocol.drive.nextEpoch);
 
     expect(nodeStatus).to.be.an.instanceOf(NodeStatus);
-    expect(nodeStatus.getNodeId()).to.equal(Buffer.from(statusFixture.node.id).toString('hex'));
-    expect(nodeStatus.getProTxHash()).to.equal(Buffer.from(statusFixture.node.proTxHash).toString('hex'));
+    expect(nodeStatus.getNodeId()).to.equal(bytesToHex(statusFixture.node.id));
+    expect(nodeStatus.getProTxHash()).to.equal(bytesToHex(statusFixture.node.proTxHash));
 
     expect(chainStatus).to.be.an.instanceOf(ChainStatus);
     expect(chainStatus.isCatchingUp())
       .to.equal(statusFixture.chain.catchingUp);
     expect(chainStatus.getLatestBlockHash())
-      .to.equal(Buffer.from(statusFixture.chain.latestBlockHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.latestBlockHash));
     expect(chainStatus.getLatestAppHash())
-      .to.equal(Buffer.from(statusFixture.chain.latestAppHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.latestAppHash));
     expect(chainStatus.getLatestBlockHeight())
       .to.equal(BigInt(statusFixture.chain.latestBlockHeight));
     expect(chainStatus.getEarliestBlockHash())
-      .to.equal(Buffer.from(statusFixture.chain.earliestBlockHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.earliestBlockHash));
     expect(chainStatus.getEarliestAppHash())
-      .to.equal(Buffer.from(statusFixture.chain.earliestAppHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.earliestAppHash));
     expect(chainStatus.getEarliestBlockHeight())
       .to.equal(BigInt(statusFixture.chain.earliestBlockHeight));
     expect(chainStatus.getMaxPeerBlockHeight())
@@ -227,22 +228,22 @@ describe('getStatusFactory', () => {
       .to.equal(statusFixture.version.protocol.drive.latest);
 
     expect(nodeStatus).to.be.an.instanceOf(NodeStatus);
-    expect(nodeStatus.getNodeId()).to.equal(Buffer.from(statusFixture.node.id).toString('hex'));
+    expect(nodeStatus.getNodeId()).to.equal(bytesToHex(statusFixture.node.id));
     expect(nodeStatus.getProTxHash()).to.be.null();
 
     expect(chainStatus).to.be.an.instanceOf(ChainStatus);
     expect(chainStatus.isCatchingUp())
       .to.equal(statusFixture.chain.catchingUp);
     expect(chainStatus.getLatestBlockHash())
-      .to.equal(Buffer.from(statusFixture.chain.latestBlockHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.latestBlockHash));
     expect(chainStatus.getLatestAppHash())
-      .to.equal(Buffer.from(statusFixture.chain.latestAppHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.latestAppHash));
     expect(chainStatus.getLatestBlockHeight())
       .to.equal(BigInt(statusFixture.chain.latestBlockHeight));
     expect(chainStatus.getEarliestBlockHash())
-      .to.equal(Buffer.from(statusFixture.chain.earliestBlockHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.earliestBlockHash));
     expect(chainStatus.getEarliestAppHash())
-      .to.equal(Buffer.from(statusFixture.chain.earliestAppHash).toString('hex'));
+      .to.equal(bytesToHex(statusFixture.chain.earliestAppHash));
     expect(chainStatus.getEarliestBlockHeight())
       .to.equal(BigInt(statusFixture.chain.earliestBlockHeight));
     expect(chainStatus.getMaxPeerBlockHeight())

--- a/packages/js-dapi-client/test/unit/methods/platform/waitForStateTransitionResult/waitForStateTransitionResultFactory.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/waitForStateTransitionResult/waitForStateTransitionResultFactory.spec.js
@@ -13,6 +13,8 @@ const cbor = require('cbor');
 const waitForStateTransitionResultFactory = require('../../../../../lib/methods/platform/waitForStateTransitionResult/waitForStateTransitionResultFactory');
 const getMetadataFixture = require('../../../../../lib/test/fixtures/getMetadataFixture');
 
+const encoder = new TextEncoder();
+
 describe('waitForStateTransitionResultFactory', () => {
   let grpcTransportMock;
   let options;
@@ -22,7 +24,7 @@ describe('waitForStateTransitionResultFactory', () => {
   let metadataFixture;
 
   beforeEach(function beforeEach() {
-    hash = Buffer.from('hash');
+    hash = encoder.encode('hash');
     metadataFixture = getMetadataFixture();
 
     const metadata = new ResponseMetadata();
@@ -86,9 +88,9 @@ describe('waitForStateTransitionResultFactory', () => {
   it('should return response with proof', async () => {
     const proof = new Proof();
 
-    proof.setGrovedbProof(Buffer.from('merkleProof'));
-    proof.setQuorumHash(Buffer.from('quorumHash'));
-    proof.setSignature(Buffer.from('signature'));
+    proof.setGrovedbProof(encoder.encode('merkleProof'));
+    proof.setQuorumHash(encoder.encode('quorumHash'));
+    proof.setSignature(encoder.encode('signature'));
     proof.setRound(42);
 
     response.getV0().setProof(proof);
@@ -108,14 +110,14 @@ describe('waitForStateTransitionResultFactory', () => {
 
     expect(result.getError()).to.equal(undefined);
     expect(result.getProof()).to.be.deep.equal({
-      merkleProof: Buffer.from('merkleProof'),
-      quorumHash: Buffer.from('quorumHash'),
-      signature: Buffer.from('signature'),
+      merkleProof: encoder.encode('merkleProof'),
+      quorumHash: encoder.encode('quorumHash'),
+      signature: encoder.encode('signature'),
       round: 42,
     });
-    expect(result.getProof().getSignature()).to.deep.equal(Buffer.from('signature'));
-    expect(result.getProof().getGrovedbProof()).to.deep.equal(Buffer.from('merkleProof'));
-    expect(result.getProof().getQuorumHash()).to.deep.equal(Buffer.from('quorumHash'));
+    expect(result.getProof().getSignature()).to.deep.equal(encoder.encode('signature'));
+    expect(result.getProof().getGrovedbProof()).to.deep.equal(encoder.encode('merkleProof'));
+    expect(result.getProof().getQuorumHash()).to.deep.equal(encoder.encode('quorumHash'));
     expect(result.getProof().getRound()).to.deep.equal(42);
 
     const { WaitForStateTransitionResultRequestV0 } = WaitForStateTransitionResultRequest;
@@ -161,7 +163,7 @@ describe('waitForStateTransitionResultFactory', () => {
     expect(result.getError()).to.be.deep.equal({
       code: 2,
       message: 'Some error',
-      data: Buffer.from(data),
+      data: new Uint8Array(data),
     });
 
     const { WaitForStateTransitionResultRequestV0 } = WaitForStateTransitionResultRequest;

--- a/packages/wallet-lib/src/plugins/Workers/IdentitySyncWorker.js
+++ b/packages/wallet-lib/src/plugins/Workers/IdentitySyncWorker.js
@@ -92,11 +92,11 @@ class IdentitySyncWorker extends Worker {
         }
       }
 
-      // If it's not an undefined and not a buffer or Identifier (which inherits Buffer),
-      // this method will loop forever.
-      // This check prevents this from happening
-      if (!Buffer.isBuffer(identityBuffer)) {
-        throw new Error(`Expected identity id to be a Buffer or undefined, got ${identityBuffer}`);
+      // If it's not undefined and not bytes (Uint8Array, which Buffer and
+      // Identifier both extend), this method will loop forever.
+      // This check prevents this from happening.
+      if (!(identityBuffer instanceof Uint8Array)) {
+        throw new Error(`Expected identity id to be bytes or undefined, got ${identityBuffer}`);
       }
 
       // reset gap counter if we got an identity

--- a/packages/wallet-lib/src/transport/DAPIClientTransport/methods/getTransaction.js
+++ b/packages/wallet-lib/src/transport/DAPIClientTransport/methods/getTransaction.js
@@ -22,7 +22,9 @@ module.exports = async function getTransaction(txid) {
 
     return {
       transaction: new Transaction(response.getTransaction()),
-      blockHash: response.getBlockHash().toString('hex'),
+      // dapi-client returns blockHash as a plain Uint8Array, whose toString()
+      // ignores the encoding argument. Wrap to Buffer to get hex semantics.
+      blockHash: Buffer.from(response.getBlockHash()).toString('hex'),
       height,
       instantLocked,
       chainLocked,

--- a/packages/wallet-lib/src/transport/DAPIClientTransport/methods/getTransaction.js
+++ b/packages/wallet-lib/src/transport/DAPIClientTransport/methods/getTransaction.js
@@ -21,7 +21,10 @@ module.exports = async function getTransaction(txid) {
     } = response;
 
     return {
-      transaction: new Transaction(response.getTransaction()),
+      // dapi-client returns the raw transaction as a plain Uint8Array, but
+      // dashcore-lib's Transaction reader relies on Buffer methods. Wrap to
+      // Buffer here, consistent with the other raw-transaction call sites.
+      transaction: new Transaction(Buffer.from(response.getTransaction())),
       // dapi-client returns blockHash as a plain Uint8Array, whose toString()
       // ignores the encoding argument. Wrap to Buffer to get hex semantics.
       blockHash: Buffer.from(response.getBlockHash()).toString('hex'),

--- a/packages/wallet-lib/src/transport/Transport.d.ts
+++ b/packages/wallet-lib/src/transport/Transport.d.ts
@@ -20,7 +20,7 @@ export declare interface Transport {
 
     getBlockHeaderByHeight(height: number): Promise<BlockHeader>
 
-    getIdentityByPublicKeyHash(publicKeyHash: Buffer): Promise<Buffer[]>
+    getIdentityByPublicKeyHash(publicKeyHash: Uint8Array): Promise<Uint8Array>
 
     getBlockchainStatus(): Promise<object>
 

--- a/packages/wasm-dpp/lib/identifier/Identifier.ts
+++ b/packages/wasm-dpp/lib/identifier/Identifier.ts
@@ -1,55 +1,102 @@
 import bs58 from 'bs58';
 import IdentifierError from './errors/IdentifierError';
 
-// Buffer extending is not a trivial thing:
+// Buffer extending is not a trivial thing — Identifier used to be a Buffer
+// subclass. As of this revision, Identifier extends Uint8Array directly so it
+// can be constructed and used in environments without a Buffer polyfill.
+// The Buffer-returning toBuffer() method is retained as a deprecated shim
+// for backward compatibility; it requires Buffer to exist at call time but
+// no longer at module load.
 // * https://github.com/nodejs/node/commit/651a5b51eb838e8e23a5b94ba34e8e06630a004a
 // * https://github.com/nodejs/node/issues/4701
 // * https://github.com/nodejs/help/issues/1300
 // * https://github.com/nodejs/node/issues/2882
 
 type CborEncoder = {
-    pushAny: (buffer: Buffer) => void;
+    pushAny: (bytes: Uint8Array) => void;
 }
 
-type IdentifierEncoding = BufferEncoding | 'base58';
+// Encodings accepted by toString(). 'hex' decoding is not supported by from()
+// because there is no precedent for it on the public surface and bs58/base64
+// already cover the user-facing identifier formats.
+type IdentifierStringEncoding = 'base58' | 'base64' | 'hex';
+type IdentifierFromEncoding = 'base58' | 'base64';
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    out += bytes[i].toString(16).padStart(2, '0');
+  }
+  return out;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    bin += String.fromCharCode(bytes[i]);
+  }
+  return btoa(bin);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) {
+    out[i] = bin.charCodeAt(i);
+  }
+  return out;
+}
 
 /**
- * @param {Uint8Array} buffer
+ * @param {Uint8Array} bytes
  * @returns {Identifier}
  * @constructor
  */
 export class Identifier {
   static MEDIA_TYPE = 'application/x.dash.dpp.identifier';
 
-  constructor(buffer: Uint8Array | Identifier) {
+  constructor(bytes: Uint8Array | Identifier) {
     // Accept both Node Buffer and plain Uint8Array. Buffer extends Uint8Array,
     // so an instanceof Uint8Array check matches both — existing Buffer callers
     // continue to work unchanged.
-    if (!(buffer instanceof Uint8Array)) {
+    if (!(bytes instanceof Uint8Array)) {
       throw new IdentifierError('Identifier expects Uint8Array');
     }
 
-    if (buffer.length !== 32) {
+    if (bytes.length !== 32) {
       throw new IdentifierError('Identifier must be 32 long');
     }
 
-    const patchedBuffer = Buffer.from(buffer);
+    // Copy into a fresh Uint8Array so callers cannot mutate the underlying
+    // bytes after construction, then patch the prototype so the result is
+    // an Identifier instance.
+    const patched = new Uint8Array(bytes);
 
-    Object.setPrototypeOf(patchedBuffer, Identifier.prototype);
+    Object.setPrototypeOf(patched, Identifier.prototype);
 
     // noinspection JSValidateTypes
     // @ts-ignore
-    return patchedBuffer;
+    return patched;
+  }
+
+  /**
+   * Convert to a plain Uint8Array (copy)
+   *
+   * @return {Uint8Array}
+   */
+  toBytes(): Uint8Array {
+    return new Uint8Array(this as unknown as Uint8Array);
   }
 
   /**
    * Convert to Buffer
    *
+   * @deprecated Prefer toBytes(). This method requires the `Buffer` global
+   *   to exist at call time and is retained only for backward compatibility.
    * @return {Buffer}
    */
   toBuffer(): Buffer {
-    // @ts-ignore
-    return Buffer.from(this);
+    return Buffer.from(this as unknown as Uint8Array);
   }
 
   /**
@@ -59,7 +106,7 @@ export class Identifier {
    * @return {boolean}
    */
   encodeCBOR(encoder: CborEncoder): boolean {
-    encoder.pushAny(this.toBuffer());
+    encoder.pushAny(this.toBytes());
 
     return true;
   }
@@ -79,56 +126,82 @@ export class Identifier {
    * @param {string} [encoding=base58]
    * @return {string}
    */
-  toString(encoding: IdentifierEncoding = 'base58'): string {
+  toString(encoding: IdentifierStringEncoding = 'base58'): string {
+    const bytes = this.toBytes();
     if (encoding === 'base58') {
-      return bs58.encode(this.toBuffer());
+      return bs58.encode(bytes);
     }
-
-    return this.toBuffer().toString(encoding);
+    if (encoding === 'base64') {
+      return bytesToBase64(bytes);
+    }
+    if (encoding === 'hex') {
+      return bytesToHex(bytes);
+    }
+    throw new IdentifierError(`Unsupported encoding: ${encoding}`);
   }
 
   /**
-   * Compare to another Identifier
-   * @param other
+   * Compare to another Identifier or Uint8Array
+   *
+   * @param {Identifier | Uint8Array} other
    */
   equals(other: Identifier | Uint8Array): boolean {
-    // @ts-ignore
-    return this.toBuffer().equals(Buffer.from(other));
+    if (!(other instanceof Uint8Array)) {
+      return false;
+    }
+    if (other.length !== this.length) {
+      return false;
+    }
+    for (let i = 0; i < this.length; i += 1) {
+      // @ts-ignore — Identifier is a Uint8Array at runtime
+      if (this[i] !== other[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**
-   * Create Identifier from buffer or encoded string
+   * Create Identifier from bytes or encoded string
    *
-   * @param {string|Uint8Array|Identifier} value
-   * @param {string} encoding
+   * @param {string | Uint8Array | Identifier} value
+   * @param {string} [encoding] — when value is a string, one of 'base58' (default) or 'base64'
    * @return {Identifier}
    */
-  static from(value: string | Uint8Array | Identifier, encoding: string = undefined): Identifier {
-    let buffer;
+  static from(value: string | Uint8Array | Identifier, encoding?: IdentifierFromEncoding): Identifier {
+    let bytes;
 
     if (typeof value === 'string') {
-      if (encoding === undefined) {
-        // eslint-disable-next-line no-param-reassign
-        encoding = 'base58';
-      }
+      const effectiveEncoding = encoding === undefined ? 'base58' : encoding;
 
-      if (encoding === 'base58') {
-        buffer = bs58.decode(value);
+      if (effectiveEncoding === 'base58') {
+        // bs58.decode returns a Uint8Array (currently backed by Buffer via
+        // safe-buffer, which transitively requires a Buffer polyfill in
+        // browsers; once bs58 is replaced with a Uint8Array-native base58
+        // library, that transitive dependency goes away).
+        bytes = bs58.decode(value);
+      } else if (effectiveEncoding === 'base64') {
+        bytes = base64ToBytes(value);
       } else {
-        buffer = Buffer.from(value, 'base64');
+        throw new IdentifierError(`Unsupported encoding for string input: ${effectiveEncoding}`);
       }
     } else {
       if (encoding !== undefined) {
         throw new IdentifierError('encoding accepted only with type string');
       }
 
-      buffer = value;
+      bytes = value;
     }
 
-    return new Identifier(buffer);
+    return new Identifier(bytes);
   }
+
+  // Required to satisfy TypeScript's structural typing when this class is
+  // declared as `extends _Identifier` elsewhere; instances are real Uint8Arrays
+  // at runtime via the prototype patch above.
+  declare length: number;
 }
 
-Object.setPrototypeOf(Identifier.prototype, Buffer.prototype);
+Object.setPrototypeOf(Identifier.prototype, Uint8Array.prototype);
 
 export default Identifier;

--- a/packages/wasm-dpp/lib/identifier/Identifier.ts
+++ b/packages/wasm-dpp/lib/identifier/Identifier.ts
@@ -14,16 +14,19 @@ type CborEncoder = {
 type IdentifierEncoding = BufferEncoding | 'base58';
 
 /**
- * @param {Buffer} buffer
+ * @param {Uint8Array} buffer
  * @returns {Identifier}
  * @constructor
  */
 export class Identifier {
   static MEDIA_TYPE = 'application/x.dash.dpp.identifier';
 
-  constructor(buffer: Buffer | Identifier) {
-    if (!Buffer.isBuffer(buffer)) {
-      throw new IdentifierError('Identifier expects Buffer');
+  constructor(buffer: Uint8Array | Identifier) {
+    // Accept both Node Buffer and plain Uint8Array. Buffer extends Uint8Array,
+    // so an instanceof Uint8Array check matches both — existing Buffer callers
+    // continue to work unchanged.
+    if (!(buffer instanceof Uint8Array)) {
+      throw new IdentifierError('Identifier expects Uint8Array');
     }
 
     if (buffer.length !== 32) {
@@ -88,7 +91,7 @@ export class Identifier {
    * Compare to another Identifier
    * @param other
    */
-  equals(other: Identifier | Buffer): boolean {
+  equals(other: Identifier | Uint8Array): boolean {
     // @ts-ignore
     return this.toBuffer().equals(Buffer.from(other));
   }
@@ -96,11 +99,11 @@ export class Identifier {
   /**
    * Create Identifier from buffer or encoded string
    *
-   * @param {string|Buffer|Identifier} value
+   * @param {string|Uint8Array|Identifier} value
    * @param {string} encoding
    * @return {Identifier}
    */
-  static from(value: string | Buffer | Identifier, encoding: string = undefined): Identifier {
+  static from(value: string | Uint8Array | Identifier, encoding: string = undefined): Identifier {
     let buffer;
 
     if (typeof value === 'string') {

--- a/packages/wasm-dpp/lib/index.ts
+++ b/packages/wasm-dpp/lib/index.ts
@@ -26,13 +26,26 @@ export default async function loadDpp(): Promise<DPPModule> {
   return dpp_module;
 };
 
+// Decode base64 to Uint8Array using only platform-standard APIs. atob is
+// available globally in browsers and in Node ≥18.
+const base64ToBytes = (b64: string): Uint8Array => {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) {
+    out[i] = bin.charCodeAt(i);
+  }
+  return out;
+};
+
 const loadDppModule = async () => {
   // @ts-ignore
-  let bytes = Buffer.from(wasmBase, 'base64');
+  const bytes = base64ToBytes(wasmBase);
 
   if (typeof window !== 'undefined') {
-    let blob = new Blob([bytes], { type: "application/wasm" });
-    let wasmUrl = URL.createObjectURL(blob);
+    // Blob's BlobPart typing in lib.dom.d.ts insists on an ArrayBuffer-backed
+    // view; our Uint8Array is structurally compatible at runtime.
+    const blob = new Blob([bytes as BlobPart], { type: "application/wasm" });
+    const wasmUrl = URL.createObjectURL(blob);
     await init(wasmUrl);
   } else {
     dpp_module.initSync({ module: bytes });

--- a/packages/wasm-dpp/test/integration/dataContract/DataContractFacade.spec.js
+++ b/packages/wasm-dpp/test/integration/dataContract/DataContractFacade.spec.js
@@ -48,7 +48,7 @@ describe('DataContractFacade', () => {
 
       expect(result).to.be.an.instanceOf(DataContract);
 
-      expect(result.getOwnerId().toBuffer()).to.deep.equal(dataContract.getOwnerId().toBuffer());
+      expect(result.getOwnerId().toBytes()).to.deep.equal(dataContract.getOwnerId().toBytes());
       expect(result.getDocumentSchemas()).to.deep.equal(dataContract.getDocumentSchemas());
     });
   });

--- a/packages/wasm-dpp/test/integration/document/Document.spec.js
+++ b/packages/wasm-dpp/test/integration/document/Document.spec.js
@@ -64,13 +64,13 @@ describe('ExtendedDocument', () => {
         $transferredAt: null,
         $transferredAtBlockHeight: null,
         $transferredAtCoreBlockHeight: null,
-        $dataContractId: dataContract.getId().toBuffer(),
-        $id: document.getId().toBuffer(),
-        $ownerId: document.getOwnerId().toBuffer(),
+        $dataContractId: dataContract.getId().toBytes(),
+        $id: document.getId().toBytes(),
+        $ownerId: document.getOwnerId().toBytes(),
         $revision: 1,
         $type: 'withByteArrays',
         byteArrayField: document.get('byteArrayField'),
-        identifierField: document.get('identifierField').toBuffer(),
+        identifierField: document.get('identifierField').toBytes(),
       });
     });
 
@@ -82,10 +82,10 @@ describe('ExtendedDocument', () => {
       expect(result.$ownerId).to.be.an.instanceOf(Identifier);
       expect(result.identifierField).to.be.an.instanceOf(Identifier);
 
-      expect(result.$dataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBuffer());
-      expect(result.$id.toBuffer()).to.deep.equal(document.getId().toBuffer());
-      expect(result.$ownerId.toBuffer()).to.deep.equal(document.getOwnerId().toBuffer());
-      expect(result.identifierField.toBuffer()).to.deep.equal(document.get('identifierField').toBuffer());
+      expect(result.$dataContractId.toBytes()).to.deep.equal(dataContract.getId().toBytes());
+      expect(result.$id.toBytes()).to.deep.equal(document.getId().toBytes());
+      expect(result.$ownerId.toBytes()).to.deep.equal(document.getOwnerId().toBytes());
+      expect(result.identifierField.toBytes()).to.deep.equal(document.get('identifierField').toBytes());
       expect(BigInt(result.$revision)).to.deep.equal(document.getRevision());
       expect(result.$type).to.deep.equal(document.getType());
       expect(result.byteArrayField).to.deep.equal(document.get('byteArrayField'));

--- a/packages/wasm-dpp/test/integration/document/DocumentFacade.spec.js
+++ b/packages/wasm-dpp/test/integration/document/DocumentFacade.spec.js
@@ -23,7 +23,7 @@ describe('DocumentFacade', () => {
 
   beforeEach(async function beforeEach() {
     ownerId = await generateRandomIdentifier();
-    const dataContractFixture = await getDataContractFixture(ownerId.toBuffer());
+    const dataContractFixture = await getDataContractFixture(ownerId.toBytes());
     const dataContractObject = dataContractFixture.toObject();
 
     dataContract = new DataContract({

--- a/packages/wasm-dpp/test/integration/document/stateTransition/DocumentsBatchTransition/validation/basic/validateDocumentsBatchTransitionBasicFactory.spec.js
+++ b/packages/wasm-dpp/test/integration/document/stateTransition/DocumentsBatchTransition/validation/basic/validateDocumentsBatchTransitionBasicFactory.spec.js
@@ -450,7 +450,7 @@ describe.skip('validateDocumentsBatchTransitionBasicFactory', () => {
 
           expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
           const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBuffer());
+          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBytes());
         });
       });
 
@@ -474,7 +474,7 @@ describe.skip('validateDocumentsBatchTransitionBasicFactory', () => {
 
           expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
           const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBuffer());
+          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBytes());
         });
 
         it('should be a byte array - Rust', async () => {
@@ -515,11 +515,11 @@ describe.skip('validateDocumentsBatchTransitionBasicFactory', () => {
           const [error] = result.getErrors();
 
           expect(error.getCode()).to.equal(1018);
-          expect(error.getDataContractId()).to.deep.equal(dataContract.getId().toBuffer());
+          expect(error.getDataContractId()).to.deep.equal(dataContract.getId().toBytes());
 
           expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
           const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBuffer());
+          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBytes());
         });
       });
 
@@ -543,7 +543,7 @@ describe.skip('validateDocumentsBatchTransitionBasicFactory', () => {
 
           expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
           const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBuffer());
+          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBytes());
         });
 
         it('should be defined in Data Contract - Rust', async () => {
@@ -565,11 +565,11 @@ describe.skip('validateDocumentsBatchTransitionBasicFactory', () => {
           expect(error.getCode()).to.equal(1024);
           expect(error.getType()).to.equal(firstDocumentTransition.$type);
 
-          expect(error.getDataContractId()).to.deep.equal(dataContract.getId().toBuffer());
+          expect(error.getDataContractId()).to.deep.equal(dataContract.getId().toBytes());
 
           expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
           const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBuffer());
+          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBytes());
         });
       });
 
@@ -594,7 +594,7 @@ describe.skip('validateDocumentsBatchTransitionBasicFactory', () => {
 
           expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
           const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBuffer());
+          expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBytes());
         });
 
         it('should throw InvalidDocumentTransitionActionError if action is not valid - Rust', async () => {
@@ -616,7 +616,7 @@ describe.skip('validateDocumentsBatchTransitionBasicFactory', () => {
 
             expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
             const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-            expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBuffer());
+            expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBytes());
           }
         });
       });
@@ -647,7 +647,7 @@ describe.skip('validateDocumentsBatchTransitionBasicFactory', () => {
 
             expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
             const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-            expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBuffer());
+            expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBytes());
           });
         });
 
@@ -920,7 +920,7 @@ describe.skip('validateDocumentsBatchTransitionBasicFactory', () => {
 
         expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
         const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-        expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBuffer());
+        expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBytes());
       });
     });
   });
@@ -1053,7 +1053,7 @@ describe.skip('validateDocumentsBatchTransitionBasicFactory', () => {
 
     expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
     const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-    expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBuffer());
+    expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBytes());
   });
 
   it('should not validate Document transitions on dry run - Rust', async () => {
@@ -1073,6 +1073,6 @@ describe.skip('validateDocumentsBatchTransitionBasicFactory', () => {
 
     expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
     const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-    expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBuffer());
+    expect(fetchDataContractId.toBuffer()).is.deep.equal(dataContract.getId().toBytes());
   });
 });

--- a/packages/wasm-dpp/test/integration/identity/IdentityFacade.spec.js
+++ b/packages/wasm-dpp/test/integration/identity/IdentityFacade.spec.js
@@ -152,8 +152,8 @@ describe('IdentityFacade', () => {
         );
 
       expect(stateTransition).to.be.instanceOf(IdentityTopUpTransition);
-      expect(stateTransition.getIdentityId().toBuffer())
-        .to.be.deep.equal(identity.getId().toBuffer());
+      expect(stateTransition.getIdentityId().toBytes())
+        .to.be.deep.equal(identity.getId().toBytes());
       expect(stateTransition.getAssetLockProof().toObject()).to.deep.equal(
         instantAssetLockProof.toObject(),
       );
@@ -178,8 +178,8 @@ describe('IdentityFacade', () => {
         );
 
       expect(stateTransition).to.be.instanceOf(IdentityUpdateTransition);
-      expect(stateTransition.getIdentityId().toBuffer())
-        .to.be.deep.equal(identity.getId().toBuffer());
+      expect(stateTransition.getIdentityId().toBytes())
+        .to.be.deep.equal(identity.getId().toBytes());
       expect(stateTransition.getRevision()).to.equal(
         identity.getRevision() + BigInt(1),
       );

--- a/packages/wasm-dpp/test/unit/Identifier.spec.js
+++ b/packages/wasm-dpp/test/unit/Identifier.spec.js
@@ -20,7 +20,15 @@ describe('Identifier', () => {
       expect(identifier).to.be.an.instanceOf(Identifier);
     });
 
-    it('should throw error if first argument is not Buffer', () => {
+    it('should accept Uint8Array', () => {
+      const uint8 = new Uint8Array(buffer);
+      const identifier = new Identifier(uint8);
+
+      expect(identifier.toBuffer()).to.be.deep.equal(buffer);
+      expect(identifier).to.be.an.instanceOf(Identifier);
+    });
+
+    it('should throw error if first argument is not Uint8Array', () => {
       try {
         // eslint-disable-next-line no-unused-vars
         const id = new Identifier(1);
@@ -28,7 +36,7 @@ describe('Identifier', () => {
         expect.fail('Expected to throw an error');
       } catch (e) {
         expect(e).to.be.instanceOf(IdentifierError);
-        expect(e.toString()).to.be.equal('IdentifierError: Identifier expects Buffer');
+        expect(e.toString()).to.be.equal('IdentifierError: Identifier expects Uint8Array');
       }
     });
 

--- a/packages/wasm-dpp/test/unit/Identifier.spec.js
+++ b/packages/wasm-dpp/test/unit/Identifier.spec.js
@@ -84,6 +84,7 @@ describe('Identifier', () => {
     it('should return a new normal Buffer (deprecated)', () => {
       const identifier = new Identifier(buffer);
 
+      // Intentionally exercises the deprecated toBuffer() compatibility shim.
       const buf = identifier.toBuffer();
       expect(Buffer.isBuffer(buf)).to.equal(true);
       expect(buf).to.deep.equal(buffer);

--- a/packages/wasm-dpp/test/unit/Identifier.spec.js
+++ b/packages/wasm-dpp/test/unit/Identifier.spec.js
@@ -16,16 +16,18 @@ describe('Identifier', () => {
     it('should accept Buffer', () => {
       const identifier = new Identifier(buffer);
 
-      expect(identifier.toBuffer()).to.be.deep.equal(buffer);
+      expect(identifier.toBytes()).to.be.deep.equal(new Uint8Array(buffer));
       expect(identifier).to.be.an.instanceOf(Identifier);
+      expect(identifier).to.be.an.instanceOf(Uint8Array);
     });
 
     it('should accept Uint8Array', () => {
       const uint8 = new Uint8Array(buffer);
       const identifier = new Identifier(uint8);
 
-      expect(identifier.toBuffer()).to.be.deep.equal(buffer);
+      expect(identifier.toBytes()).to.be.deep.equal(uint8);
       expect(identifier).to.be.an.instanceOf(Identifier);
+      expect(identifier).to.be.an.instanceOf(Uint8Array);
     });
 
     it('should throw error if first argument is not Uint8Array', () => {
@@ -53,11 +55,38 @@ describe('Identifier', () => {
     });
   });
 
-  describe('#toBuffer', () => {
-    it('should return a new normal Buffer', () => {
+  describe('#toBytes', () => {
+    it('should return a new Uint8Array copy', () => {
       const identifier = new Identifier(buffer);
 
-      expect(identifier.toBuffer()).to.deep.equal(buffer);
+      const bytes = identifier.toBytes();
+      expect(bytes).to.be.an.instanceOf(Uint8Array);
+      expect(bytes).to.deep.equal(new Uint8Array(buffer));
+      // mutating the returned copy must not affect the identifier
+      bytes[0] = (bytes[0] + 1) & 0xff;
+      expect(identifier.toBytes()[0]).to.equal(buffer[0]);
+    });
+
+    it('should be isolated from later mutations to the source bytes', () => {
+      const source = new Uint8Array(buffer);
+      const identifier = new Identifier(source);
+
+      const originalByte = source[0];
+      source[0] = (source[0] + 1) & 0xff;
+
+      // The constructor must have copied the bytes; mutating the source
+      // after construction does not leak into the identifier.
+      expect(identifier.toBytes()[0]).to.equal(originalByte);
+    });
+  });
+
+  describe('#toBuffer', () => {
+    it('should return a new normal Buffer (deprecated)', () => {
+      const identifier = new Identifier(buffer);
+
+      const buf = identifier.toBuffer();
+      expect(Buffer.isBuffer(buf)).to.equal(true);
+      expect(buf).to.deep.equal(buffer);
     });
   });
 
@@ -96,7 +125,16 @@ describe('Identifier', () => {
       const identifier = Identifier.from(buffer);
 
       expect(identifier).to.be.an.instanceOf(Identifier);
-      expect(identifier.toBuffer()).to.deep.equal(buffer);
+      expect(identifier.toBytes()).to.deep.equal(new Uint8Array(buffer));
+    });
+
+    it('should create an instance from Uint8Array', async () => {
+      const uint8 = new Uint8Array(buffer);
+
+      const identifier = Identifier.from(uint8);
+
+      expect(identifier).to.be.an.instanceOf(Identifier);
+      expect(identifier.toBytes()).to.deep.equal(uint8);
     });
 
     it('should throw error if buffer is passed among with encoding', () => {
@@ -116,7 +154,7 @@ describe('Identifier', () => {
       const identifier = Identifier.from(string);
 
       expect(identifier).to.be.an.instanceOf(Identifier);
-      expect(identifier.toBuffer()).to.deep.equal(buffer);
+      expect(identifier.toBytes()).to.deep.equal(new Uint8Array(buffer));
     });
 
     it('should create an instance with a base64 string', () => {
@@ -125,7 +163,7 @@ describe('Identifier', () => {
       const identifier = Identifier.from(string, 'base64');
 
       expect(identifier).to.be.an.instanceOf(Identifier);
-      expect(identifier.toBuffer()).to.deep.equal(buffer);
+      expect(identifier.toBytes()).to.deep.equal(new Uint8Array(buffer));
     });
   });
 });

--- a/packages/wasm-dpp/test/unit/dataContract/DataContract.spec.js
+++ b/packages/wasm-dpp/test/unit/dataContract/DataContract.spec.js
@@ -46,10 +46,10 @@ describe('DataContract', () => {
       [documentType]: documentSchema,
     };
 
-    ownerId = (await generateRandomIdentifier()).toBuffer();
+    ownerId = (await generateRandomIdentifier()).toBytes();
     // eslint-disable-next-line
     identityNonce = BigInt(1);
-    contractId = (await generateRandomIdentifier()).toBuffer();
+    contractId = (await generateRandomIdentifier()).toBytes();
 
     schemaDefs = { something: { type: 'string' } };
 
@@ -73,8 +73,8 @@ describe('DataContract', () => {
         schemaDefs,
       });
 
-      expect(dataContract.getId().toBuffer()).to.deep.equal(contractId);
-      expect(dataContract.getOwnerId().toBuffer()).to.deep.equal(ownerId);
+      expect(dataContract.getId().toBytes()).to.deep.equal(contractId);
+      expect(dataContract.getOwnerId().toBytes()).to.deep.equal(ownerId);
       expect(dataContract.getDocumentSchemas()).to.deep.equal(documentSchemas);
       expect(dataContract.getSchemaDefs()).to.deep.equal(schemaDefs);
     });
@@ -84,7 +84,7 @@ describe('DataContract', () => {
     it('should return DataContract Identifier', () => {
       const result = dataContract.getId();
 
-      expect(result.toBuffer()).to.deep.equal(contractId);
+      expect(result.toBytes()).to.deep.equal(contractId);
       expect(result).to.be.instanceof(Identifier);
     });
   });

--- a/packages/wasm-dpp/test/unit/dataContract/createDataContract.spec.js
+++ b/packages/wasm-dpp/test/unit/dataContract/createDataContract.spec.js
@@ -14,8 +14,8 @@ describe.skip('createDataContract', () => {
 
   beforeEach(async () => {
     rawDataContract = {
-      $id: (await generateRandomIdentifier()).toBuffer(),
-      ownerId: (await generateRandomIdentifier()).toBuffer(),
+      $id: (await generateRandomIdentifier()).toBytes(),
+      ownerId: (await generateRandomIdentifier()).toBytes(),
       protocolVersion: 4,
       version: 20,
       $schema: 'http://test.com/schema',
@@ -32,7 +32,7 @@ describe.skip('createDataContract', () => {
 
     expect(dataContract).to.be.an.instanceOf(DataContract);
 
-    expect(dataContract.getOwnerId().toBuffer()).to.deep.equal(rawDataContract.ownerId);
+    expect(dataContract.getOwnerId().toBytes()).to.deep.equal(rawDataContract.ownerId);
     expect(dataContract.getDocuments()).to.deep.equal(rawDataContract.documents);
   });
 
@@ -45,7 +45,7 @@ describe.skip('createDataContract', () => {
 
     expect(dataContract.getJsonMetaSchema()).to.equal(rawDataContract.$schema);
 
-    expect(dataContract.getOwnerId().toBuffer()).to.deep.equal(rawDataContract.ownerId);
+    expect(dataContract.getOwnerId().toBytes()).to.deep.equal(rawDataContract.ownerId);
     expect(dataContract.getDocuments()).to.deep.equal(rawDataContract.documents);
   });
 
@@ -60,7 +60,7 @@ describe.skip('createDataContract', () => {
 
     expect(dataContract.getDefinitions()).to.deep.equal(rawDataContract.$defs);
 
-    expect(dataContract.getOwnerId().toBuffer()).to.deep.equal(rawDataContract.ownerId);
+    expect(dataContract.getOwnerId().toBytes()).to.deep.equal(rawDataContract.ownerId);
     expect(dataContract.getDocuments()).to.deep.equal(rawDataContract.documents);
   });
 });

--- a/packages/wasm-dpp/test/unit/dataContract/generateDataContractId.spec.js
+++ b/packages/wasm-dpp/test/unit/dataContract/generateDataContractId.spec.js
@@ -31,6 +31,6 @@ describe.skip('generateDataContractId', () => {
     const factory = new DataContractFactory(1337, new DataContractValidator(), entropyGenerator);
     const dataContract = factory.create(ownerId, {});
 
-    expect(Buffer.compare(id, dataContract.getId().toBuffer())).to.equal(0);
+    expect(Buffer.compare(id, dataContract.getId().toBytes())).to.equal(0);
   });
 });

--- a/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractCreateTransition/DataContractCreateTransition.spec.js
+++ b/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractCreateTransition/DataContractCreateTransition.spec.js
@@ -103,7 +103,7 @@ describe('DataContractCreateTransition', () => {
       const contractId = result[0];
 
       expect(contractId).to.be.an.instanceOf(Identifier);
-      expect(contractId.toBuffer()).to.be.deep.equal(dataContract.getId().toBuffer());
+      expect(contractId.toBytes()).to.be.deep.equal(dataContract.getId().toBytes());
     });
   });
 

--- a/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractCreateTransition/validation/state/validateDataContractCreateTransitionStateFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractCreateTransition/validation/state/validateDataContractCreateTransitionStateFactory.spec.js
@@ -71,7 +71,7 @@ describe.skip('validateDataContractCreateTransitionStateFactory', () => {
     const [error] = result.getErrors();
 
     expect(error.getCode()).to.equal(4000);
-    expect(error.getDataContractId()).to.deep.equal(dataContract.getId().toBuffer());
+    expect(error.getDataContractId()).to.deep.equal(dataContract.getId().toBytes());
   });
 
   it('should return valid result', async () => {

--- a/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractUpdateTransition/DataContractUpdateTransition.spec.js
+++ b/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractUpdateTransition/DataContractUpdateTransition.spec.js
@@ -106,7 +106,7 @@ describe('DataContractUpdateTransition', () => {
       const contractId = result[0];
 
       expect(contractId).to.be.an.instanceOf(Identifier);
-      expect(contractId.toBuffer()).to.be.deep.equal(dataContract.getId().toBuffer());
+      expect(contractId.toBytes()).to.be.deep.equal(dataContract.getId().toBytes());
     });
   });
 

--- a/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractUpdateTransition/validation/state/validateDataContractUpdateTransitionStateFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/dataContract/stateTransition/DataContractUpdateTransition/validation/state/validateDataContractUpdateTransitionStateFactory.spec.js
@@ -79,7 +79,7 @@ describe.skip('validateDataContractUpdateTransitionStateFactory', () => {
 
     expect(error).to.be.an.instanceOf(DataContractNotPresentError);
     expect(error.getCode()).to.equal(1018);
-    expect(error.getDataContractId()).to.deep.equal(dataContract.getId().toBuffer());
+    expect(error.getDataContractId()).to.deep.equal(dataContract.getId().toBytes());
   });
 
   it('should return invalid result if Data Contract version is not larger by 1', async () => {

--- a/packages/wasm-dpp/test/unit/document/Document.spec.js
+++ b/packages/wasm-dpp/test/unit/document/Document.spec.js
@@ -335,7 +335,8 @@ describe('Document', () => {
 
   describe('#getDataContractId', () => {
     it('should return $dataContractId', () => {
-      expect(document.getOwnerId().toBytes()).to.deep.equal(rawDocument.$ownerId.toBytes());
+      expect(document.getDataContractId().toBytes())
+        .to.deep.equal(rawDocument.$dataContractId.toBytes());
     });
   });
 

--- a/packages/wasm-dpp/test/unit/document/Document.spec.js
+++ b/packages/wasm-dpp/test/unit/document/Document.spec.js
@@ -95,10 +95,10 @@ describe('Document', () => {
 
     rawDocumentWithBuffers = {
       $protocolVersion: getLatestProtocolVersion(),
-      $id: id.toBuffer(),
+      $id: id.toBytes(),
       $type: 'test',
-      $dataContractId: dataContract.getId().toBuffer(),
-      $ownerId: ownerId.toBuffer(),
+      $dataContractId: dataContract.getId().toBytes(),
+      $ownerId: ownerId.toBytes(),
       $revision: Number(DocumentCreateTransition.INITIAL_REVISION.toString()),
       $createdAt: now,
       $createdAtBlockHeight: 1,
@@ -129,7 +129,7 @@ describe('Document', () => {
       };
 
       document = new ExtendedDocument(rawDocument, dataContract);
-      expect(document.getId().toBuffer()).to.deep.equal(rawDocument.$id.toBuffer());
+      expect(document.getId().toBytes()).to.deep.equal(rawDocument.$id.toBytes());
     });
 
     it.skip('should create DocumentCreateTransition with $type and data if present', () => {
@@ -317,7 +317,7 @@ describe('Document', () => {
 
       const actualId = document.getId();
 
-      expect(id.toBuffer()).to.deep.equal(actualId.toBuffer());
+      expect(id.toBytes()).to.deep.equal(actualId.toBytes());
     });
   });
 
@@ -329,13 +329,13 @@ describe('Document', () => {
 
   describe('#getOwnerId', () => {
     it('should return $ownerId', () => {
-      expect(document.getOwnerId().toBuffer()).to.deep.equal(rawDocument.$ownerId.toBuffer());
+      expect(document.getOwnerId().toBytes()).to.deep.equal(rawDocument.$ownerId.toBytes());
     });
   });
 
   describe('#getDataContractId', () => {
     it('should return $dataContractId', () => {
-      expect(document.getOwnerId().toBuffer()).to.deep.equal(rawDocument.$ownerId.toBuffer());
+      expect(document.getOwnerId().toBytes()).to.deep.equal(rawDocument.$ownerId.toBytes());
     });
   });
 
@@ -374,12 +374,12 @@ describe('Document', () => {
 
     it('should set identifier', () => {
       const path = 'dataObject.binaryObject.identifier';
-      const buffer = Buffer.alloc(32);
-      const identifier = new Identifier(buffer);
+      const bytes = new Uint8Array(32);
+      const identifier = new Identifier(bytes);
 
       document.set(path, identifier);
 
-      expect(document.get(path).toBuffer()).to.deep.equal(buffer);
+      expect(document.get(path).toBytes()).to.deep.equal(bytes);
     });
 
     // It should return Identifier instead of string
@@ -393,7 +393,7 @@ describe('Document', () => {
       document.set(path, value);
       const returnedIdentifier = document.get(identifierPath);
 
-      expect(returnedIdentifier.toBuffer()).to.deep.equal(buffer);
+      expect(returnedIdentifier.toBytes()).to.deep.equal(buffer);
     });
   });
 

--- a/packages/wasm-dpp/test/unit/document/DocumentFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/document/DocumentFactory.spec.js
@@ -84,9 +84,9 @@ describe('DocumentFactory', () => {
 
       expect(newDocument.get('name')).to.equal(name);
 
-      expect(newDocument.getDataContractId().toBuffer()).to.deep.equal(contractId);
+      expect(newDocument.getDataContractId().toBytes()).to.deep.equal(contractId);
 
-      expect(newDocument.getOwnerId().toBuffer()).to.deep.equal(ownerIdJs);
+      expect(newDocument.getOwnerId().toBytes()).to.deep.equal(ownerIdJs);
 
       expect(newDocument.getRevision()).to.equal(DocumentCreateTransition.INITIAL_REVISION);
 
@@ -109,7 +109,7 @@ describe('DocumentFactory', () => {
       } catch (e) {
         expect(e).to.be.an.instanceOf(InvalidDocumentTypeInDataContractError);
         expect(e.getType()).to.equal(type);
-        expect(e.getDataContractId().toBuffer()).to.deep.equal(dataContractId);
+        expect(e.getDataContractId().toBytes()).to.deep.equal(dataContractId);
       }
     });
 
@@ -182,7 +182,7 @@ describe('DocumentFactory', () => {
         expect(stateRepositoryMock.fetchDataContract.callCount).to.be.equal(1);
         const callArguments = stateRepositoryMock.fetchDataContract.getCall(0).args[0];
 
-        expect(callArguments.toBuffer()).to.be.deep.equal(dataContract.getId().toBuffer());
+        expect(callArguments.toBytes()).to.be.deep.equal(dataContract.getId().toBytes());
       }
     });
   });

--- a/packages/wasm-dpp/test/unit/document/stateTransition/DocumetsBatchTransition/DocumentsBatchTransition.spec.js
+++ b/packages/wasm-dpp/test/unit/document/stateTransition/DocumetsBatchTransition/DocumentsBatchTransition.spec.js
@@ -127,14 +127,14 @@ describe.skip('DocumentsBatchTransition', () => {
   //   it('should return owner id', async () => {
   //     const result = stateTransition.getOwnerId();
   //
-  //     expect(result.toBuffer()).to.deep.equal(getDocumentsFixture.ownerId.toBuffer());
+  //     expect(result.toBuffer()).to.deep.equal(getDocumentsFixture.ownerId.toBytes());
   //   });
   // });
   //
   // describe('#getModifiedDataIds', () => {
   //   it('should return ids of affected documents', () => {
-  //     const expectedIds = documentsJs.map((doc) => doc.getId().toBuffer());
-  //     const result = stateTransition.getModifiedDataIds().map((id) => id.toBuffer());
+  //     const expectedIds = documentsJs.map((doc) => doc.getId().toBytes());
+  //     const result = stateTransition.getModifiedDataIds().map((id) => id.toBytes());
   //
   //     expect(result.length).to.be.equal(10);
   //     expect(result).to.be.deep.equal(expectedIds);

--- a/packages/wasm-dpp/test/unit/document/stateTransition/DocumetsBatchTransition/validation/state/validateDocumentsBatchTransitionStateFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/document/stateTransition/DocumetsBatchTransition/validation/state/validateDocumentsBatchTransitionStateFactory.spec.js
@@ -108,11 +108,11 @@ describe.skip('validateDocumentsBatchTransitionStateFactory', () => {
   //   } catch (e) {
   //     expect(e).to.be.instanceOf(DataContractNotPresentNotConsensusError);
   //
-  //     expect(e.getDataContractId()).to.deep.equal(dataContract.getId().toBuffer());
+  //     expect(e.getDataContractId()).to.deep.equal(dataContract.getId().toBytes());
   //
   //     expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
   //     const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-  //     expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBuffer());
+  //     expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBytes());
   //   }
   // });
   //
@@ -128,11 +128,11 @@ describe.skip('validateDocumentsBatchTransitionStateFactory', () => {
   //   const [error] = result.getErrors();
   //
   //   expect(error.getCode()).to.equal(4004);
-  //   expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBuffer());
+  //   expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBytes());
   //
   //   expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
   //   const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBuffer());
+  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBytes());
   // });
   //
   // it('should return invalid result if document transition with action "replace" is not present - Rust', async () => {
@@ -155,11 +155,11 @@ describe.skip('validateDocumentsBatchTransitionStateFactory', () => {
   //   const [error] = result.getErrors();
   //   expect(error).is.instanceOf(DocumentNotFoundError);
   //   expect(error.getCode()).to.equal(4005);
-  //   expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBuffer());
+  //   expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBytes());
   //
   //   expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
   //   const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBuffer());
+  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBytes());
   //
   //   expect(stateRepositoryMock.fetchDocuments)
   //     .to.have.been.callCount(documentTransitionsJs.length);
@@ -186,11 +186,11 @@ describe.skip('validateDocumentsBatchTransitionStateFactory', () => {
   //   const [error] = result.getErrors();
   //   expect(error).is.instanceOf(DocumentNotFoundError);
   //   expect(error.getCode()).to.equal(4005);
-  //   expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBuffer());
+  //   expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBytes());
   //
   //   expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
   //   const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBuffer());
+  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBytes());
   //
   //   expect(stateRepositoryMock.fetchDocuments).to.have.been
   //     .callCount(documentTransitionsJs.length);
@@ -224,12 +224,12 @@ describe.skip('validateDocumentsBatchTransitionStateFactory', () => {
   //   expect(error).is.instanceOf(InvalidDocumentRevisionError);
   //   expect(error.getCode()).to.equal(4010);
   //
-  //   expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBuffer());
+  //   expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBytes());
   //   expect(Number(error.getCurrentRevision())).to.deep.equal(documents[0].getRevision());
   //
   //   expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
   //   const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBuffer());
+  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBytes());
   //
   //   expect(stateRepositoryMock.fetchDocuments).to.have.been
   //     .callCount(documentTransitionsJs.length);
@@ -240,7 +240,7 @@ describe.skip('validateDocumentsBatchTransitionStateFactory', () => {
   //   replaceDocument.setRevision(1);
   //
   //   const fetchedDocument = new ExtendedDocument(documentsJs[0].toObject(), dataContract);
-  //   fetchedDocument.setOwnerId(Identifier.from((await generateRandomIdentifier()).toBuffer()));
+  //   fetchedDocument.setOwnerId(Identifier.from((await generateRandomIdentifier()).toBytes()));
   //
   //   documentTransitionsJs = getDocumentTransitionsFixture({
   //     create: [],
@@ -266,14 +266,14 @@ describe.skip('validateDocumentsBatchTransitionStateFactory', () => {
   //   const [error] = result.getErrors();
   //   expect(error).is.instanceOf(DocumentOwnerIdMismatchError);
   //   expect(error.getCode()).to.equal(4006);
-  //   expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBuffer());
+  //   expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBytes());
   //   expect(error.getExistingDocumentOwnerId()).to.deep.equal(
-  //     fetchedDocument.getOwnerId().toBuffer(),
+  //     fetchedDocument.getOwnerId().toBytes(),
   //   );
   //
   //   expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
   //   const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBuffer());
+  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBytes());
   //
   //   expect(stateRepositoryMock.fetchDocuments).to.have.been
   //     .callCount(documentTransitionsJs.length);
@@ -419,7 +419,7 @@ describe.skip('validateDocumentsBatchTransitionStateFactory', () => {
   //       );
   //       documentTransitionsJs[0].createdAt = undefined;
   //
-  //       expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBuffer());
+  //       expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBytes());
   //       expect(error.getTimestampName()).to.equal('updatedAt');
   //       expect(error.getTimestamp().getMilliseconds()).to.deep.equal(
   //         documentTransitionsJs[0].updatedAt.getMilliseconds(),
@@ -533,7 +533,7 @@ describe.skip('validateDocumentsBatchTransitionStateFactory', () => {
   //         documentTransitionsJs[0].updatedAt.getMinutes() - 6,
   //       );
   //
-  //       expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBuffer());
+  //       expect(error.getDocumentId()).to.deep.equal(documentTransitionsJs[0].getId().toBytes());
   //       expect(error.getTimestampName()).to.equal('updatedAt');
   //       expect(error.getTimestamp()).to.deep.equal(documentTransitionsJs[0].updatedAt);
   //       expect(error.getTimeWindowStart()).to.deep.equal(timeWindowStart);
@@ -608,7 +608,7 @@ describe.skip('validateDocumentsBatchTransitionStateFactory', () => {
   //
   //   expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
   //   const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBuffer());
+  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBytes());
   //
   //   expect(stateRepositoryMock.fetchDocuments).to.have.been.calledOnce();
   // });
@@ -645,7 +645,7 @@ describe.skip('validateDocumentsBatchTransitionStateFactory', () => {
   //
   //   expect(stateRepositoryMock.fetchDataContract).to.have.been.calledOnce();
   //   const [fetchDataContractId] = stateRepositoryMock.fetchDataContract.getCall(0).args;
-  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBuffer());
+  //   expect(fetchDataContractId.toBuffer()).to.deep.equal(dataContract.getId().toBytes());
   //
   //   expect(stateRepositoryMock.fetchDocuments).to.have.been.calledOnce();
   // });

--- a/packages/wasm-dpp/test/unit/document/stateTransition/DocumetsBatchTransition/validation/state/validateDocumentsUniquenessByIndicesFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/document/stateTransition/DocumetsBatchTransition/validation/state/validateDocumentsUniquenessByIndicesFactory.spec.js
@@ -91,7 +91,7 @@ describe.skip('validateDocumentsUniquenessByIndices', () => {
 
     stateRepositoryMock.fetchDocuments
       .withArgs(
-        dataContract.getId().toBuffer(),
+        dataContract.getId().toBytes(),
         william.getType(),
         {
           where: [
@@ -104,7 +104,7 @@ describe.skip('validateDocumentsUniquenessByIndices', () => {
 
     stateRepositoryMock.fetchDocuments
       .withArgs(
-        dataContractJs.getId().toBuffer(),
+        dataContractJs.getId().toBytes(),
         william.getType(),
         {
           where: [
@@ -204,10 +204,10 @@ describe.skip('validateDocumentsUniquenessByIndices', () => {
     expect(error.getCode()).to.equal(40105);
 
     expect(errors.map((e) => e.getDocumentId())).to.have.deep.members([
-      documentTransitionsJs[3].getId().toBuffer(),
-      documentTransitionsJs[3].getId().toBuffer(),
-      documentTransitionsJs[4].getId().toBuffer(),
-      documentTransitionsJs[4].getId().toBuffer(),
+      documentTransitionsJs[3].getId().toBytes(),
+      documentTransitionsJs[3].getId().toBytes(),
+      documentTransitionsJs[4].getId().toBytes(),
+      documentTransitionsJs[4].getId().toBytes(),
     ]);
 
     expect(errors.map((e) => e.getDuplicatingProperties())).to.have.deep.members([

--- a/packages/wasm-dpp/test/unit/identity/IdentityFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/IdentityFactory.spec.js
@@ -218,7 +218,7 @@ describe('IdentityFactory', () => {
         );
 
       expect(stateTransition).to.be.instanceOf(IdentityTopUpTransition);
-      expect(stateTransition.getIdentityId().toBuffer()).to.deep.equal(identity.getId().toBuffer());
+      expect(stateTransition.getIdentityId().toBytes()).to.deep.equal(identity.getId().toBytes());
       expect(stateTransition.getAssetLockProof().toObject())
         .to.deep.equal(instantAssetLockProof.toObject());
     });
@@ -245,7 +245,7 @@ describe('IdentityFactory', () => {
         );
 
       expect(stateTransition).to.be.instanceOf(IdentityUpdateTransition);
-      expect(stateTransition.getIdentityId().toBuffer()).to.deep.equal(identity.getId().toBuffer());
+      expect(stateTransition.getIdentityId().toBytes()).to.deep.equal(identity.getId().toBytes());
       expect(stateTransition.getRevision()).to.deep.equal(revision);
       expect(stateTransition.getPublicKeysToAdd().map((k) => k.toObject()))
         .to.deep.equal(addPublicKeys.map((k) => k.toObject()));

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreateTransition/IdentityCreateTransition.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreateTransition/IdentityCreateTransition.spec.js
@@ -55,8 +55,8 @@ describe('IdentityCreateTransition', () => {
         new InstantAssetLockProof(rawStateTransition.assetLockProof),
       );
 
-      expect(stateTransition.identityId.toBuffer()).to.deep.equal(
-        stateTransition.getAssetLockProof().createIdentifier().toBuffer(),
+      expect(stateTransition.identityId.toBytes()).to.deep.equal(
+        stateTransition.getAssetLockProof().createIdentifier().toBytes(),
       );
     });
   });
@@ -107,16 +107,16 @@ describe('IdentityCreateTransition', () => {
 
   describe('#getIdentityId', () => {
     it('should return identity id', () => {
-      expect(stateTransition.getIdentityId().toBuffer()).to.deep.equal(
-        stateTransition.getAssetLockProof().createIdentifier().toBuffer(),
+      expect(stateTransition.getIdentityId().toBytes()).to.deep.equal(
+        stateTransition.getAssetLockProof().createIdentifier().toBytes(),
       );
     });
   });
 
   describe('#getOwnerId', () => {
     it('should return owner id', () => {
-      expect(stateTransition.getOwnerId().toBuffer()).to.deep.equal(
-        stateTransition.getIdentityId().toBuffer(),
+      expect(stateTransition.getOwnerId().toBytes()).to.deep.equal(
+        stateTransition.getIdentityId().toBytes(),
       );
     });
   });
@@ -168,7 +168,7 @@ describe('IdentityCreateTransition', () => {
       const identityId = result[0];
 
       expect(identityId).to.be.an.instanceOf(Identifier);
-      expect(identityId.toBuffer()).to.be.deep.equal(
+      expect(identityId.toBytes()).to.be.deep.equal(
         stateTransition.getAssetLockProof().createIdentifier(),
       );
     });

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreateTransition/validation/state/validateIdentityCreateTransitionStateFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreateTransition/validation/state/validateIdentityCreateTransitionStateFactory.spec.js
@@ -56,7 +56,7 @@ describe.skip('validateIdentityCreateTransitionStateFactory', () => {
 
     expect(error.getCode()).to.equal(4011);
     expect(error.getIdentityId()).to.exist();
-    expect(error.getIdentityId()).to.deep.equal(stateTransition.getIdentityId().toBuffer());
+    expect(error.getIdentityId()).to.deep.equal(stateTransition.getIdentityId().toBytes());
   });
 
   it('should return valid result if state transition is valid', async () => {

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreditWithdrawalTransition/IdentityCreditWithdrawalTransition.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityCreditWithdrawalTransition/IdentityCreditWithdrawalTransition.spec.js
@@ -24,7 +24,7 @@ describe('IdentityCreditWithdrawalTransition', () => {
 
   describe('#getIdentityId', () => {
     it('should return identity id', () => {
-      expect(stateTransition.getIdentityId().toBuffer()).to.deep.equal(
+      expect(stateTransition.getIdentityId().toBytes()).to.deep.equal(
         rawStateTransition.identityId,
       );
     });
@@ -77,7 +77,7 @@ describe('IdentityCreditWithdrawalTransition', () => {
       expect(rawStateTransition).to.deep.equal({
         $version: '1',
         type: StateTransitionTypes.IdentityCreditWithdrawal,
-        identityId: stateTransition.getIdentityId().toBuffer(),
+        identityId: stateTransition.getIdentityId().toBytes(),
         amount: stateTransition.getAmount(),
         coreFeePerByte: stateTransition.getCoreFeePerByte(),
         pooling: stateTransition.getPooling(),
@@ -94,7 +94,7 @@ describe('IdentityCreditWithdrawalTransition', () => {
       expect(rawStateTransition).to.deep.equal({
         $version: '1',
         type: StateTransitionTypes.IdentityCreditWithdrawal,
-        identityId: stateTransition.getIdentityId().toBuffer(),
+        identityId: stateTransition.getIdentityId().toBytes(),
         amount: stateTransition.getAmount(),
         coreFeePerByte: stateTransition.getCoreFeePerByte(),
         pooling: stateTransition.getPooling(),
@@ -131,7 +131,7 @@ describe('IdentityCreditWithdrawalTransition', () => {
       const [identityId] = result;
 
       expect(identityId).to.be.an.instanceOf(Identifier);
-      expect(identityId.toBuffer()).to.be.deep.equal(rawStateTransition.identityId);
+      expect(identityId.toBytes()).to.be.deep.equal(rawStateTransition.identityId);
     });
   });
 

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityTopUpTransition/IdentityTopUpTransition.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityTopUpTransition/IdentityTopUpTransition.spec.js
@@ -17,7 +17,7 @@ describe('IdentityTopUpTransition', () => {
       expect(stateTransition.getAssetLockProof().toObject()).to.be.deep.equal(
         rawStateTransition.assetLockProof,
       );
-      expect(stateTransition.getIdentityId().toBuffer()).to.be.deep.equal(
+      expect(stateTransition.getIdentityId().toBytes()).to.be.deep.equal(
         rawStateTransition.identityId,
       );
     });
@@ -50,7 +50,7 @@ describe('IdentityTopUpTransition', () => {
 
   describe('#getIdentityId', () => {
     it('should return identity id', () => {
-      expect(stateTransition.getIdentityId().toBuffer()).to.deep.equal(
+      expect(stateTransition.getIdentityId().toBytes()).to.deep.equal(
         rawStateTransition.identityId,
       );
     });
@@ -58,7 +58,7 @@ describe('IdentityTopUpTransition', () => {
 
   describe('#getOwnerId', () => {
     it('should return owner id', () => {
-      expect(stateTransition.getOwnerId().toBuffer()).to.deep.equal(
+      expect(stateTransition.getOwnerId().toBytes()).to.deep.equal(
         rawStateTransition.identityId,
       );
     });
@@ -111,7 +111,7 @@ describe('IdentityTopUpTransition', () => {
       const identityId = result[0];
 
       expect(identityId).to.be.an.instanceOf(Identifier);
-      expect(identityId.toBuffer()).to.be.deep.equal(rawStateTransition.identityId);
+      expect(identityId.toBytes()).to.be.deep.equal(rawStateTransition.identityId);
     });
   });
 

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityUpdateTransition/IdentityUpdateTransition.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/IdentityUpdateTransition/IdentityUpdateTransition.spec.js
@@ -25,14 +25,14 @@ describe('IdentityUpdateTransition', () => {
 
       stateTransition.setIdentityId(id);
 
-      expect(stateTransition.identityId.toBuffer())
-        .to.deep.equal(id.toBuffer());
+      expect(stateTransition.identityId.toBytes())
+        .to.deep.equal(id.toBytes());
     });
   });
 
   describe('#getIdentityId', () => {
     it('should return identityId', () => {
-      expect(stateTransition.getIdentityId().toBuffer())
+      expect(stateTransition.getIdentityId().toBytes())
         .to.deep.equal(rawStateTransition.identityId);
     });
   });
@@ -53,7 +53,7 @@ describe('IdentityUpdateTransition', () => {
 
   describe('#getOwnerId', () => {
     it('should return owner id', () => {
-      expect(stateTransition.getOwnerId().toBuffer()).to.deep.equal(
+      expect(stateTransition.getOwnerId().toBytes()).to.deep.equal(
         rawStateTransition.identityId,
       );
     });
@@ -170,7 +170,7 @@ describe('IdentityUpdateTransition', () => {
       const identityId = result[0];
 
       expect(identityId).to.be.an.instanceOf(Identifier);
-      expect(identityId.toBuffer()).to.be.deep.equal(rawStateTransition.identityId);
+      expect(identityId.toBytes()).to.be.deep.equal(rawStateTransition.identityId);
     });
   });
 

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/assetLockProof/ChainAssetLockProof.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/assetLockProof/ChainAssetLockProof.spec.js
@@ -37,7 +37,7 @@ describe('ChainAssetLockProof', () => {
     it('should return correct identifier', () => {
       const identifier = chainAssetLockProof.createIdentifier();
 
-      expect(identifier.toBuffer())
+      expect(identifier.toBytes())
         .to.have.length(32);
     });
   });

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/assetLockProof/InstantAssetLockProof.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/assetLockProof/InstantAssetLockProof.spec.js
@@ -39,7 +39,7 @@ describe('InstantAssetLockProof', () => {
     it('should return correct identifier', () => {
       const identifier = instantAssetLockProof.createIdentifier();
 
-      expect(identifier.toBuffer())
+      expect(identifier.toBytes())
         .to.have.length(32);
     });
   });

--- a/packages/wasm-dpp/test/unit/identity/stateTransition/identityCreditTransferTransition/identityCreditTransferTransition.spec.js
+++ b/packages/wasm-dpp/test/unit/identity/stateTransition/identityCreditTransferTransition/identityCreditTransferTransition.spec.js
@@ -15,11 +15,11 @@ describe('IdentityCreditTransferTransition', () => {
 
   describe('#constructor', () => {
     it('should create an instance with specified data from specified raw transition', () => {
-      expect(stateTransition.getIdentityId().toBuffer()).to.be.deep.equal(
+      expect(stateTransition.getIdentityId().toBytes()).to.be.deep.equal(
         rawStateTransition.identityId,
       );
 
-      expect(stateTransition.getRecipientId().toBuffer()).to.be.deep.equal(
+      expect(stateTransition.getRecipientId().toBytes()).to.be.deep.equal(
         rawStateTransition.recipientId,
       );
 
@@ -37,7 +37,7 @@ describe('IdentityCreditTransferTransition', () => {
 
   describe('#getIdentityId', () => {
     it('should return identity id', () => {
-      expect(stateTransition.getIdentityId().toBuffer()).to.deep.equal(
+      expect(stateTransition.getIdentityId().toBytes()).to.deep.equal(
         rawStateTransition.identityId,
       );
     });
@@ -45,7 +45,7 @@ describe('IdentityCreditTransferTransition', () => {
 
   describe('#getRecipientId', () => {
     it('should return recipient id', () => {
-      expect(stateTransition.getRecipientId().toBuffer()).to.deep.equal(
+      expect(stateTransition.getRecipientId().toBytes()).to.deep.equal(
         rawStateTransition.recipientId,
       );
     });
@@ -103,10 +103,10 @@ describe('IdentityCreditTransferTransition', () => {
       const [identityId, recipientId] = result;
 
       expect(identityId).to.be.an.instanceOf(Identifier);
-      expect(identityId.toBuffer()).to.be.deep.equal(rawStateTransition.identityId);
+      expect(identityId.toBytes()).to.be.deep.equal(rawStateTransition.identityId);
 
       expect(recipientId).to.be.an.instanceOf(Identifier);
-      expect(recipientId.toBuffer()).to.be.deep.equal(rawStateTransition.recipientId);
+      expect(recipientId.toBytes()).to.be.deep.equal(rawStateTransition.recipientId);
     });
   });
 

--- a/packages/wasm-dpp/test/unit/stateTransition/validation/validateStateTransitionFeeFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/stateTransition/validation/validateStateTransitionFeeFactory.spec.js
@@ -53,7 +53,7 @@ describe.skip('validateStateTransitionFeeFactory', () => {
     let dataContractCreateTransition;
 
     beforeEach(() => {
-      dataContractOwnerId = dataContract.getOwnerId().toBuffer();
+      dataContractOwnerId = dataContract.getOwnerId().toBytes();
       dataContractCreateTransition = dpp.dataContract
         .createDataContractCreateTransition(dataContract);
     });
@@ -102,7 +102,7 @@ describe.skip('validateStateTransitionFeeFactory', () => {
         create: await getDocumentsFixture(),
       });
 
-      ownerId = documentsBatchTransition.getOwnerId().toBuffer();
+      ownerId = documentsBatchTransition.getOwnerId().toBytes();
     });
 
     it('should return invalid result if balance is not enough', async () => {
@@ -218,7 +218,7 @@ describe.skip('validateStateTransitionFeeFactory', () => {
 
     beforeEach(async () => {
       identityTopUpTransition = await getIdentityTopUpTransitionFixture();
-      identityId = identityTopUpTransition.getIdentityId().toBuffer();
+      identityId = identityTopUpTransition.getIdentityId().toBytes();
 
       const { satoshis } = identityTopUpTransition
         .getAssetLockProof()

--- a/packages/wasm-dpp/test/unit/stateTransition/validation/validateStateTransitionIdentitySignatureFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/stateTransition/validation/validateStateTransitionIdentitySignatureFactory.spec.js
@@ -99,7 +99,7 @@ describe.skip('validateStateTransitionIdentitySignatureFactory', () => {
     expect(
       stateRepositoryMock.fetchIdentity.getCall(0).args[0].toBuffer(),
     ).to.be.deep.equal(
-      ownerId.toBuffer(),
+      ownerId.toBytes(),
     );
   });
 
@@ -116,13 +116,13 @@ describe.skip('validateStateTransitionIdentitySignatureFactory', () => {
 
     expect(error).to.be.an.instanceOf(IdentityNotFoundError);
     expect(error.getCode()).to.equal(2000);
-    expect(error.getIdentityId()).to.deep.equal(identity.getId().toBuffer());
+    expect(error.getIdentityId()).to.deep.equal(identity.getId().toBytes());
 
     expect(stateRepositoryMock.fetchIdentity).to.be.calledOnce();
     expect(
       stateRepositoryMock.fetchIdentity.getCall(0).args[0].toBuffer(),
     ).to.be.deep.equal(
-      ownerId.toBuffer(),
+      ownerId.toBytes(),
     );
   });
 
@@ -141,7 +141,7 @@ describe.skip('validateStateTransitionIdentitySignatureFactory', () => {
     expect(
       stateRepositoryMock.fetchIdentity.getCall(0).args[0].toBuffer(),
     ).to.be.deep.equal(
-      ownerId.toBuffer(),
+      ownerId.toBytes(),
     );
 
     expect(result.getErrors()).to.be.an('array');
@@ -172,7 +172,7 @@ describe.skip('validateStateTransitionIdentitySignatureFactory', () => {
     expect(
       stateRepositoryMock.fetchIdentity.getCall(0).args[0].toBuffer(),
     ).to.be.deep.equal(
-      ownerId.toBuffer(),
+      ownerId.toBytes(),
     );
 
     expect(result.getErrors()).to.be.an('array');
@@ -207,7 +207,7 @@ describe.skip('validateStateTransitionIdentitySignatureFactory', () => {
     expect(
       stateRepositoryMock.fetchIdentity.getCall(0).args[0].toBuffer(),
     ).to.be.deep.equal(
-      ownerId.toBuffer(),
+      ownerId.toBytes(),
     );
   });
 

--- a/packages/wasm-dpp/test/unit/stateTransition/validation/validateStateTransitionKeySignatureFactory.spec.js
+++ b/packages/wasm-dpp/test/unit/stateTransition/validation/validateStateTransitionKeySignatureFactory.spec.js
@@ -101,8 +101,8 @@ describe.skip('validateStateTransitionKeySignatureFactory', () => {
 
     const { match } = this.sinon;
     expect(stateRepositoryMock.fetchIdentityBalance).to.be.calledOnceWithExactly(
-      match((identityId) => Buffer.from(identityId.toBuffer())
-        .equals(stateTransition.getIdentityId().toBuffer())),
+      match((identityId) => Buffer.from(identityId.toBytes())
+        .equals(stateTransition.getIdentityId().toBytes())),
       match.instanceOf(StateTransitionExecutionContext),
     );
   });


### PR DESCRIPTION
## Summary
Replaces `Buffer` with `Uint8Array` across `@dashevo/dapi-client`'s public API. Rewrites `@dashevo/wasm-dpp`'s `Identifier` to extend `Uint8Array` directly (instead of `Buffer`) and removes `Buffer.from` from the wasm-dpp module loader. After this PR, both packages' module-load and core construction paths are Buffer-free; only the deprecated `Identifier#toBuffer()` shim still requires a `Buffer` global at call time. The SPV path through dashcore-lib will become Buffer-free once [dashpay/dashcore-lib#315](https://github.com/dashpay/dashcore-lib/pull/315) lands and dapi-client picks up the new release.

This is **PR 2 of 3** in the stacked series. PR 1 (#3679) is merged.

## Why
Removes `Buffer` from the dapi-client and wasm-dpp surfaces so consumers don't need a `Buffer` polyfill in browser bundles. `Buffer` is Node-specific; `Uint8Array` works everywhere.

## What changes

### `@dashevo/dapi-client`
- **New** `lib/utils/bytes.js`: `hexToBytes`, `bytesToHex`, `base64ToBytes`, `bytesToBase64`, `concatBytes`, `bytesEqual` (CJS exports). Input-validated with informative `TypeError`s; uses `String.prototype.slice` not the deprecated `substr`.
- **Exposed** via `DAPIClient.bytes` so the migration path is reachable from the package's public surface (no deep imports).
- All `Buffer.*` call sites in `lib/` converted to `Uint8Array` per the translation table below.
- `createGrpcTransportError`: explicit dual-format handling that the previous `Buffer.from(x, 'base64')` provided implicitly — `typeof x === 'string' ? base64ToBytes(x) : new Uint8Array(x)` for the three metadata-bin fields (grpc-js sends raw bytes; grpc-web sends base64 strings).
- One production exception remains where `Buffer.from` is retained: `BlockHeadersReader` → `new BlockHeader(Buffer.from(header))` because dashcore-lib's `BufferReader` still requires `Buffer`. Tracked upstream: [dashpay/dashcore-lib#315](https://github.com/dashpay/dashcore-lib/pull/315). Once that lands and we bump the dep here, this wrap goes away.

### `@dashevo/wasm-dpp`
- **Identifier extends `Uint8Array`** instead of `Buffer`. `Buffer.isBuffer(id)` now returns `false`; `id instanceof Uint8Array` returns `true`.
- **New `id.toBytes()`** returns a plain `Uint8Array` copy.
- **`id.toBuffer()` retained as `@deprecated`** compatibility shim — calls `Buffer.from(this)`. Requires `Buffer` only at call time, no longer at module load.
- **`id.toString(encoding)`** now handles `'base58'`/`'base64'`/`'hex'` explicitly via inline byte helpers — no `Buffer` method dependency. Throws `IdentifierError: Unsupported encoding: ...` for anything else.
- **`Identifier.from(value, encoding)`** accepts `Uint8Array` directly and `string` with `'base58'` (default) or `'base64'`. The encoding parameter type is narrowed to only the supported values.
- **`id.equals(other)`** byte-by-byte loop, no Buffer methods.
- **wasm-dpp module loader** (`lib/index.ts`) replaces `Buffer.from(wasmBase, 'base64')` with an inline `atob`-based decode. `loadDpp()` no longer requires a `Buffer` global.

### `@dashevo/wallet-lib`
- One production callsite: `IdentitySyncWorker.js:98` migrates `Buffer.isBuffer(identityBuffer)` → `identityBuffer instanceof Uint8Array`. Comment updated.

### Test migrations
All internal test code that called `.toBuffer()` on an Identifier-derived value is migrated to `.toBytes()` (36 test files, ~100 mechanical one-line swaps). The deprecated `.toBuffer()` shim is intentionally exercised in one place — `wasm-dpp/test/unit/Identifier.spec.js` `#toBuffer` describe block — with an explanatory comment.

### README
New "Browser usage" section in dapi-client documenting that response fields are `Uint8Array`, that `DAPIClient.bytes` is the conversion helper, and that one internal path (BlockHeadersProvider via dashcore-lib) still requires a `Buffer` polyfill until upstream changes land.

## Breaking changes

### `@dashevo/dapi-client` public API
| Before | After |
|---|---|
| `response.field.toString('hex')` | `DAPIClient.bytes.bytesToHex(response.field)` |
| `response.field.toString('base64')` | `DAPIClient.bytes.bytesToBase64(response.field)` |
| `Buffer.isBuffer(response.field)` | `response.field instanceof Uint8Array` |
| `response.field.slice(a, b)` | `response.field.subarray(a, b)` |

In Node, `Buffer extends Uint8Array`, so anything that just reads bytes (passes to `crypto`, writes to a stream, length checks, indexed access) continues to work identically.

### `@dashevo/wasm-dpp` Identifier
| Before | After |
|---|---|
| `Buffer.isBuffer(id)` returned `true` | now returns `false` |
| `id instanceof Buffer` returned `true` | now returns `false` |
| `id.readUInt32LE(...)` etc. (Buffer methods) | gone — `id` no longer has Buffer-only methods |
| `id.toBuffer()` | still works (deprecated); prefer `id.toBytes()` |
| `id.toString('hex')` / `id.toString('base64')` | still works (now implemented natively) |
| `id.toString('utf8')`, `'ascii'`, etc. | throws `IdentifierError: Unsupported encoding` (was silently inherited from Buffer) |
| Error message `'Identifier expects Buffer'` | `'Identifier expects Uint8Array'` |

The remaining transitive Buffer dependency in wasm-dpp is `bs58` (via `safe-buffer`) — eliminating it requires replacing `bs58` with a Uint8Array-native base58 library and is out of scope here.

## Test plan
- [ ] CI: `JS packages (@dashevo/dapi-client) / Tests`
- [ ] CI: `JS packages (@dashevo/wasm-dpp) / Tests`
- [ ] CI: `JS packages (@dashevo/wallet-lib) / Tests`
- [ ] CI: `JS packages (dash) / Tests`

## Stack
- [PR 1 — Cleanup](https://github.com/dashpay/platform/pull/3679) (merged)
- ➡️ **PR 2 — Buffer → Uint8Array** (this PR)
- PR 3 — ESM conversion (dapi-client, wallet-lib, js-dash-sdk + platform-test-suite)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bytes utility for hex/base64 conversions, concatenation, and comparisons; exposed via the client.

* **Bug Fixes / Improvements**
  * Improved browser compatibility by using native Uint8Array handling across the client and wasm layer.

* **Breaking Changes**
  * Binary inputs/outputs are now Uint8Array-based instead of Buffer—update integrations accordingly.

* **Documentation**
  * Added browser usage notes and guidance for optional Buffer polyfills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->