### PR TITLE
fix(dashmate): re-sync stale 3.x Drive and rs-dapi images

### DIFF
--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1522,7 +1522,9 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
       },
       '4.0.0-rc.3': (configFile) => {
         Object.entries(configFile.configs)
-          .forEach(([, options]) => {
+          .forEach(([name, options]) => {
+            const defaultConfig = getDefaultConfigByNameOrGroup(name, options.group);
+
             // Bump the default Tenderdash image to the 1.6.0 line. Pulled DRY from
             // the base config so it tracks whatever the base config pins.
             // Keyed at the next release (4.0.0-rc.3), not the already-released
@@ -1541,6 +1543,31 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
             if (options.platform?.gateway?.rateLimiter
               && typeof options.platform.gateway.rateLimiter.responseHeaders === 'undefined') {
               options.platform.gateway.rateLimiter.responseHeaders = base.get('platform.gateway.rateLimiter.responseHeaders');
+            }
+
+            // Re-sync Drive ABCI and rs-dapi docker images to the current
+            // dashmate default. Pre-3.0.0 → 3.0.0 already did this in the
+            // 3.0.0 migration, but nodes that were already on 3.0.x skip
+            // that step (semver.gt filter), and the 3.0.1 / 3.0.2 / 3.1.0
+            // migrations only touched Core / Gateway / Tenderdash images.
+            // Without this, a 3.0.x → 4.0.0-rc.x update keeps the old
+            // protocol-11 images (dashpay/drive:3, dashpay/rs-dapi:3) and
+            // the node crash-loops after protocol 12 activation (#3889).
+            // Only replace stale dashpay/drive:3* / dashpay/rs-dapi:3* tags;
+            // any custom image (private fork, vendor build, pinned digest) is
+            // left untouched.
+            if (options.platform?.drive?.abci?.docker
+              && /^dashpay\/drive:3/.test(options.platform.drive.abci.docker.image)
+              && defaultConfig.has('platform.drive.abci.docker.image')) {
+              options.platform.drive.abci.docker.image = defaultConfig
+                .get('platform.drive.abci.docker.image');
+            }
+
+            if (options.platform?.dapi?.rsDapi?.docker
+              && /^dashpay\/rs-dapi:3/.test(options.platform.dapi.rsDapi.docker.image)
+              && defaultConfig.has('platform.dapi.rsDapi.docker.image')) {
+              options.platform.dapi.rsDapi.docker.image = defaultConfig
+                .get('platform.dapi.rsDapi.docker.image');
             }
           });
 

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1559,15 +1559,13 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
             if (options.platform?.drive?.abci?.docker
               && /^dashpay\/drive:3/.test(options.platform.drive.abci.docker.image)
               && defaultConfig.has('platform.drive.abci.docker.image')) {
-              options.platform.drive.abci.docker.image = defaultConfig
-                .get('platform.drive.abci.docker.image');
+              options.platform.drive.abci.docker.image = defaultConfig.get('platform.drive.abci.docker.image');
             }
 
             if (options.platform?.dapi?.rsDapi?.docker
               && /^dashpay\/rs-dapi:3/.test(options.platform.dapi.rsDapi.docker.image)
               && defaultConfig.has('platform.dapi.rsDapi.docker.image')) {
-              options.platform.dapi.rsDapi.docker.image = defaultConfig
-                .get('platform.dapi.rsDapi.docker.image');
+              options.platform.dapi.rsDapi.docker.image = defaultConfig.get('platform.dapi.rsDapi.docker.image');
             }
           });
 

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1547,13 +1547,22 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
         // as the 3.0.2 Envoy CVE migration. A custom / private /
         // manually-corrected image (private fork, vendor-patched
         // build, `:latest`, etc.) is left untouched.
+        // The 3.x line shipped four prerelease label series:
+        //   `3.0.0-dev.X` / `3.1.0-dev.X` → `:3-dev`
+        //   `3.0.0-rc.X`                  → `:3-rc`
+        //   `3.0.1-hotfix.{1..4}` /
+        //   `3.1.0-hotfix.1`              → `:3-hotfix`
+        //   stable 3.0.0 / 3.0.1 / 3.0.2 / 3.1.0 → `:3`
+        // All of them resolve to a protocol-11 image and crash-loop
+        // after protocol 12 activation. Keep the alternation tight so
+        // custom tags (`:3-mycorp`, `:3.0.0`, `:latest`, etc.) survive.
         const isStaleDriveImage = (image) => (
           typeof image === 'string'
-          && /^dashpay\/drive:3(?:-(?:dev|rc))?$/.test(image)
+          && /^dashpay\/drive:3(?:-(?:dev|rc|hotfix))?$/.test(image)
         );
         const isStaleRsDapiImage = (image) => (
           typeof image === 'string'
-          && /^dashpay\/rs-dapi:3(?:-(?:dev|rc))?$/.test(image)
+          && /^dashpay\/rs-dapi:3(?:-(?:dev|rc|hotfix))?$/.test(image)
         );
 
         Object.entries(configFile.configs)

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1521,6 +1521,41 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
         return configFile;
       },
       '4.0.0-rc.3': (configFile) => {
+        // Re-sync Drive ABCI and rs-dapi docker images that dashmate
+        // 3.0.x → 4.0.0-rc.2 left at the protocol-11 default tag
+        // (`dashpay/drive:3`, `dashpay/rs-dapi:3`), causing nodes to
+        // crash-loop after protocol 12 activation (#3889).
+        //
+        // Pre-3.0.0 → 3.0.0 already re-synced these images, but nodes
+        // already on 3.0.x skipped the 3.0.0 step (semver.gt filter),
+        // and the 3.0.1 / 3.0.2 / 3.1.0 migrations only touched
+        // Core / Gateway / Tenderdash images.
+        //
+        // The original attempt (#3889) keyed this migration at the
+        // same version it shipped with (4.0.0-rc.2), so
+        // already-stamped 4.0.0-rc.2 configs short-circuit in
+        // migrateConfigFile (fromVersion === toVersion). Re-keying at
+        // the next release ensures the fix fires for both:
+        //   • 3.0.x → 4.0.0-rc.x upgrades (the loop runs every
+        //     migration with key > fromVersion, regardless of
+        //     toVersion), and
+        //   • 4.0.0-rc.2 → 4.0.0-rc.3 once a chore(release) bumps
+        //     packages/dashmate/package.json (the convention; cf.
+        //     #3794 + #3796 for the 3.0.2 Envoy CVE).
+        //
+        // Only rewrite the stale dashmate-shipped tags — same style
+        // as the 3.0.2 Envoy CVE migration. A custom / private /
+        // manually-corrected image (private fork, vendor-patched
+        // build, `:latest`, etc.) is left untouched.
+        const isStaleDriveImage = (image) => (
+          typeof image === 'string'
+          && /^dashpay\/drive:3(?:-(?:dev|rc))?$/.test(image)
+        );
+        const isStaleRsDapiImage = (image) => (
+          typeof image === 'string'
+          && /^dashpay\/rs-dapi:3(?:-(?:dev|rc))?$/.test(image)
+        );
+
         Object.entries(configFile.configs)
           .forEach(([name, options]) => {
             const defaultConfig = getDefaultConfigByNameOrGroup(name, options.group);
@@ -1545,27 +1580,18 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
               options.platform.gateway.rateLimiter.responseHeaders = base.get('platform.gateway.rateLimiter.responseHeaders');
             }
 
-            // Re-sync Drive ABCI and rs-dapi docker images to the current
-            // dashmate default. Pre-3.0.0 → 3.0.0 already did this in the
-            // 3.0.0 migration, but nodes that were already on 3.0.x skip
-            // that step (semver.gt filter), and the 3.0.1 / 3.0.2 / 3.1.0
-            // migrations only touched Core / Gateway / Tenderdash images.
-            // Without this, a 3.0.x → 4.0.0-rc.x update keeps the old
-            // protocol-11 images (dashpay/drive:3, dashpay/rs-dapi:3) and
-            // the node crash-loops after protocol 12 activation (#3889).
-            // Only replace stale dashpay/drive:3* / dashpay/rs-dapi:3* tags;
-            // any custom image (private fork, vendor build, pinned digest) is
-            // left untouched.
-            if (options.platform?.drive?.abci?.docker
-              && /^dashpay\/drive:3/.test(options.platform.drive.abci.docker.image)
+            const driveDocker = options.platform?.drive?.abci?.docker;
+            if (driveDocker
+              && isStaleDriveImage(driveDocker.image)
               && defaultConfig.has('platform.drive.abci.docker.image')) {
-              options.platform.drive.abci.docker.image = defaultConfig.get('platform.drive.abci.docker.image');
+              driveDocker.image = defaultConfig.get('platform.drive.abci.docker.image');
             }
 
-            if (options.platform?.dapi?.rsDapi?.docker
-              && /^dashpay\/rs-dapi:3/.test(options.platform.dapi.rsDapi.docker.image)
+            const rsDapiDocker = options.platform?.dapi?.rsDapi?.docker;
+            if (rsDapiDocker
+              && isStaleRsDapiImage(rsDapiDocker.image)
               && defaultConfig.has('platform.dapi.rsDapi.docker.image')) {
-              options.platform.dapi.rsDapi.docker.image = defaultConfig.get('platform.dapi.rsDapi.docker.image');
+              rsDapiDocker.image = defaultConfig.get('platform.dapi.rsDapi.docker.image');
             }
           });
 

--- a/packages/dashmate/test/unit/config/configFile/migrate3xTo4xRcImages.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrate3xTo4xRcImages.spec.js
@@ -7,24 +7,30 @@ import getMainnetConfigFactory from '../../../../configs/defaults/getMainnetConf
 import getConfigFileMigrationsFactory from '../../../../configs/getConfigFileMigrationsFactory.js';
 import migrateConfigFileFactory from '../../../../src/config/configFile/migrateConfigFileFactory.js';
 
-// Regression coverage for dashpay/platform#3889.
+// Regression coverage for dashpay/platform#3889 and its rework.
 //
 // A node already on 3.0.1 skips the 3.0.0 migration (semver.gt filter)
 // that used to re-sync Drive ABCI and rs-dapi images. The intervening
 // 3.0.1 / 3.0.2 / 3.1.0 migrations only touched Core / Gateway / Tenderdash
-// `.docker.image` fields (3.1.0 does add `buildArgs` on the drive/rsDapi
-// `docker.build` blocks, but never their image tags). The result: a
-// `dashmate update 3.0.x → 4.0.0-rc.x` kept the protocol-11 images and
-// the node crash-looped after protocol 12 activation.
+// `.docker.image` fields. The result: a `dashmate update 3.0.x → 4.0.0-rc.x`
+// kept the protocol-11 images (`dashpay/drive:3`, `dashpay/rs-dapi:3`)
+// and the node crash-looped after protocol 12 activation.
 //
-// The new `4.0.0-rc.2` migration must re-sync those two image fields
-// from the current default config.
-describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', () => {
+// The original fix keyed the migration at 4.0.0-rc.2 — the same version
+// dashmate already shipped — so any node already stamped
+// configFormatVersion: "4.0.0-rc.2" short-circuited in migrateConfigFile
+// (fromVersion === toVersion) and never ran the migration. The rework
+// re-keys it at 4.0.0-rc.3 (the next release) and adds a stale-shipped-
+// image predicate to preserve customised images.
+describe('migration 4.0.0-rc.3: re-sync Drive ABCI & rs-dapi images (#3889)', () => {
   const STALE_DRIVE = 'dashpay/drive:3';
+  const STALE_DRIVE_DEV = 'dashpay/drive:3-dev';
   const STALE_RS_DAPI = 'dashpay/rs-dapi:3';
+  const STALE_RS_DAPI_DEV = 'dashpay/rs-dapi:3-dev';
+  const CUSTOM_DRIVE = 'private-registry.internal/drive:patched-v3';
+  const CUSTOM_RS_DAPI = 'my-org/rs-dapi:fork-3';
 
   let migrate;
-  let defaults;
   let expectedDriveImage;
   let expectedRsDapiImage;
 
@@ -37,7 +43,7 @@ describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', ()
       joinPath: (...segments) => path.join('/tmp/dashmate-spec', ...segments),
     };
     const getBaseConfig = getBaseConfigFactory();
-    defaults = new DefaultConfigs([
+    const defaults = new DefaultConfigs([
       getBaseConfig,
       getLocalConfigFactory(getBaseConfig),
       getTestnetConfigFactory(homeDirStub, getBaseConfig),
@@ -50,11 +56,9 @@ describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', ()
     expectedRsDapiImage = defaults.get('base').get('platform.dapi.rsDapi.docker.image');
   });
 
-  // Minimal post-3.0.x config shape carrying the stale protocol-11
-  // image tags that dashmate 3.0.x shipped. Earlier migrations expect
-  // a much richer object, so we set fromVersion >= 3.0.1 to make the
-  // semver.gt filter run only the new step.
-  function buildStaleConfig({ network, group }) {
+  function buildConfig({
+    network, group, driveImage, rsDapiImage,
+  }) {
     return {
       group,
       network,
@@ -62,7 +66,7 @@ describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', ()
         enable: true,
         drive: {
           abci: {
-            docker: { image: STALE_DRIVE },
+            docker: { image: driveImage },
           },
           tenderdash: {
             docker: { image: 'dashpay/tenderdash:1.5' },
@@ -70,30 +74,48 @@ describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', ()
         },
         dapi: {
           rsDapi: {
-            docker: { image: STALE_RS_DAPI },
+            docker: { image: rsDapiImage },
           },
         },
       },
     };
   }
 
-  // Both fromVersion variants are real-world entry points: a node could
-  // be on 3.0.1 (the version that originally skipped the 3.0.0 image
-  // re-sync — the direct #3889 repro) or on 3.1.0 (skipping it for the
-  // same reason). Either way the new migration must converge them.
-  ['3.0.1', '3.1.0'].forEach((fromVersion) => {
-    it(`re-syncs drive.abci and dapi.rsDapi images on ${fromVersion} → 4.0.0-rc.2`, () => {
+  // 3.0.x and 3.1.0 are real-world entry points: a node could be on 3.0.1
+  // (the version that originally skipped the 3.0.0 image re-sync — the
+  // direct #3889 repro) or on 3.1.0 (skipping it for the same reason).
+  // Either way the new migration must converge them — and crucially, the
+  // loop runs every migration with key > fromVersion, so this fires even
+  // when toVersion is still 4.0.0-rc.2 (the version currently in
+  // packages/dashmate/package.json).
+  [
+    { fromVersion: '3.0.1', toVersion: '4.0.0-rc.2' },
+    { fromVersion: '3.1.0', toVersion: '4.0.0-rc.2' },
+    { fromVersion: '3.0.1', toVersion: '4.0.0-rc.3' },
+    { fromVersion: '3.1.0', toVersion: '4.0.0-rc.3' },
+  ].forEach(({ fromVersion, toVersion }) => {
+    it(`re-syncs stale drive.abci and dapi.rsDapi images on ${fromVersion} → ${toVersion}`, () => {
       const rawConfigFile = {
         configFormatVersion: fromVersion,
         defaultConfigName: null,
         defaultGroupName: null,
         configs: {
-          testnet: buildStaleConfig({ network: 'testnet', group: 'testnet' }),
-          mainnet: buildStaleConfig({ network: 'mainnet', group: 'mainnet' }),
+          testnet: buildConfig({
+            network: 'testnet',
+            group: 'testnet',
+            driveImage: STALE_DRIVE,
+            rsDapiImage: STALE_RS_DAPI,
+          }),
+          mainnet: buildConfig({
+            network: 'mainnet',
+            group: 'mainnet',
+            driveImage: STALE_DRIVE,
+            rsDapiImage: STALE_RS_DAPI,
+          }),
         },
       };
 
-      const migrated = migrate(rawConfigFile, fromVersion, '4.0.0-rc.2');
+      const migrated = migrate(rawConfigFile, fromVersion, toVersion);
 
       ['testnet', 'mainnet'].forEach((name) => {
         const { docker: driveDocker } = migrated.configs[name].platform.drive.abci;
@@ -109,8 +131,156 @@ describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', ()
         expect(rsDapiDocker.image).to.not.equal(STALE_RS_DAPI);
       });
 
-      expect(migrated.configFormatVersion).to.equal('4.0.0-rc.2');
+      expect(migrated.configFormatVersion).to.equal(toVersion);
     });
+  });
+
+  it('re-syncs the dev-series stale tags too (dashpay/drive:3-dev, dashpay/rs-dapi:3-dev)', () => {
+    const rawConfigFile = {
+      configFormatVersion: '3.1.0',
+      defaultConfigName: null,
+      defaultGroupName: null,
+      configs: {
+        testnet: buildConfig({
+          network: 'testnet',
+          group: 'testnet',
+          driveImage: STALE_DRIVE_DEV,
+          rsDapiImage: STALE_RS_DAPI_DEV,
+        }),
+      },
+    };
+
+    const migrated = migrate(rawConfigFile, '3.1.0', '4.0.0-rc.3');
+
+    expect(migrated.configs.testnet.platform.drive.abci.docker.image)
+      .to.equal(expectedDriveImage);
+    expect(migrated.configs.testnet.platform.dapi.rsDapi.docker.image)
+      .to.equal(expectedRsDapiImage);
+  });
+
+  // The exact case the rework targets: a node that already upgraded to
+  // 4.0.0-rc.2 binary kept the stale dashpay/drive:3 / dashpay/rs-dapi:3
+  // tags and got configFormatVersion: "4.0.0-rc.2" stamped on disk.
+  // After a chore(release) bumps packages/dashmate/package.json to
+  // 4.0.0-rc.3, the next dashmate load enters migrateConfigFile with
+  // fromVersion=4.0.0-rc.2 / toVersion=4.0.0-rc.3, and the new
+  // migration finally runs (the original 4.0.0-rc.2 key would have
+  // been short-circuited by semver.gt('4.0.0-rc.2', '4.0.0-rc.2')).
+  it('re-syncs already-stamped 4.0.0-rc.2 configs on the rc.3 release bump', () => {
+    const rawConfigFile = {
+      configFormatVersion: '4.0.0-rc.2',
+      defaultConfigName: null,
+      defaultGroupName: null,
+      configs: {
+        mainnet: buildConfig({
+          network: 'mainnet',
+          group: 'mainnet',
+          driveImage: STALE_DRIVE,
+          rsDapiImage: STALE_RS_DAPI,
+        }),
+      },
+    };
+
+    const migrated = migrate(rawConfigFile, '4.0.0-rc.2', '4.0.0-rc.3');
+
+    expect(migrated.configs.mainnet.platform.drive.abci.docker.image)
+      .to.equal(expectedDriveImage);
+    expect(migrated.configs.mainnet.platform.dapi.rsDapi.docker.image)
+      .to.equal(expectedRsDapiImage);
+    expect(migrated.configFormatVersion).to.equal('4.0.0-rc.3');
+  });
+
+  // Documents the bound of what migration alone can fix: as long as
+  // packages/dashmate/package.json sits at 4.0.0-rc.2, a config already
+  // stamped 4.0.0-rc.2 short-circuits in migrateConfigFile before any
+  // entry can run. This is the structural limitation that motivated
+  // re-keying the migration at the *next* release rather than reusing
+  // 4.0.0-rc.2 — and why the full rollout depends on a follow-up
+  // chore(release) PR bumping the package version (same flow as the
+  // 3.0.2 Envoy CVE: #3794 added the migration, #3796 cut the release).
+  it('cannot reach a 4.0.0-rc.2 stale config while toVersion is still 4.0.0-rc.2 (release-bump prerequisite)', () => {
+    const rawConfigFile = {
+      configFormatVersion: '4.0.0-rc.2',
+      defaultConfigName: null,
+      defaultGroupName: null,
+      configs: {
+        mainnet: buildConfig({
+          network: 'mainnet',
+          group: 'mainnet',
+          driveImage: STALE_DRIVE,
+          rsDapiImage: STALE_RS_DAPI,
+        }),
+      },
+    };
+
+    const migrated = migrate(rawConfigFile, '4.0.0-rc.2', '4.0.0-rc.2');
+
+    // No migration runs — config returned untouched.
+    expect(migrated.configs.mainnet.platform.drive.abci.docker.image).to.equal(STALE_DRIVE);
+    expect(migrated.configs.mainnet.platform.dapi.rsDapi.docker.image).to.equal(STALE_RS_DAPI);
+    expect(migrated.configFormatVersion).to.equal('4.0.0-rc.2');
+  });
+
+  // Custom-image preservation. The original 4.0.0-rc.2 migration
+  // unconditionally overwrote every drive/rsDapi image with the
+  // current default, clobbering private forks, vendor-patched builds,
+  // and `:latest` pins. The rework matches only the stale shipped
+  // defaults — same style as the 3.0.2 Envoy CVE migration that
+  // rewrote only `dashpay/envoy:1.30.*`.
+  it('preserves custom Drive / rs-dapi images', () => {
+    const rawConfigFile = {
+      configFormatVersion: '3.1.0',
+      defaultConfigName: null,
+      defaultGroupName: null,
+      configs: {
+        mainnet: buildConfig({
+          network: 'mainnet',
+          group: 'mainnet',
+          driveImage: CUSTOM_DRIVE,
+          rsDapiImage: CUSTOM_RS_DAPI,
+        }),
+      },
+    };
+
+    const migrated = migrate(rawConfigFile, '3.1.0', '4.0.0-rc.3');
+
+    expect(migrated.configs.mainnet.platform.drive.abci.docker.image).to.equal(CUSTOM_DRIVE);
+    expect(migrated.configs.mainnet.platform.dapi.rsDapi.docker.image).to.equal(CUSTOM_RS_DAPI);
+  });
+
+  // Mixed config: one config has stale dashmate defaults (gets rewritten),
+  // a sibling has a custom image (preserved). Exercises the same predicate
+  // pattern as the 3.0.2 Envoy CVE migration end-to-end.
+  it('only rewrites the stale config when siblings have custom images', () => {
+    const rawConfigFile = {
+      configFormatVersion: '3.1.0',
+      defaultConfigName: null,
+      defaultGroupName: null,
+      configs: {
+        testnet: buildConfig({
+          network: 'testnet',
+          group: 'testnet',
+          driveImage: STALE_DRIVE,
+          rsDapiImage: STALE_RS_DAPI,
+        }),
+        mainnet: buildConfig({
+          network: 'mainnet',
+          group: 'mainnet',
+          driveImage: CUSTOM_DRIVE,
+          rsDapiImage: CUSTOM_RS_DAPI,
+        }),
+      },
+    };
+
+    const migrated = migrate(rawConfigFile, '3.1.0', '4.0.0-rc.3');
+
+    expect(migrated.configs.testnet.platform.drive.abci.docker.image)
+      .to.equal(expectedDriveImage);
+    expect(migrated.configs.testnet.platform.dapi.rsDapi.docker.image)
+      .to.equal(expectedRsDapiImage);
+
+    expect(migrated.configs.mainnet.platform.drive.abci.docker.image).to.equal(CUSTOM_DRIVE);
+    expect(migrated.configs.mainnet.platform.dapi.rsDapi.docker.image).to.equal(CUSTOM_RS_DAPI);
   });
 
   it('no-ops on configs without platform.dapi.rsDapi', () => {
@@ -138,7 +308,7 @@ describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', ()
       },
     };
 
-    const migrated = migrate(rawConfigFile, '3.1.0', '4.0.0-rc.2');
+    const migrated = migrate(rawConfigFile, '3.1.0', '4.0.0-rc.3');
 
     expect(migrated.configs.mainnet.platform.drive.abci.docker.image)
       .to.equal(expectedDriveImage);

--- a/packages/dashmate/test/unit/config/configFile/migrate3xTo4xRcImages.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrate3xTo4xRcImages.spec.js
@@ -1,0 +1,152 @@
+import path from 'path';
+import DefaultConfigs from '../../../../src/config/DefaultConfigs.js';
+import getBaseConfigFactory from '../../../../configs/defaults/getBaseConfigFactory.js';
+import getLocalConfigFactory from '../../../../configs/defaults/getLocalConfigFactory.js';
+import getTestnetConfigFactory from '../../../../configs/defaults/getTestnetConfigFactory.js';
+import getMainnetConfigFactory from '../../../../configs/defaults/getMainnetConfigFactory.js';
+import getConfigFileMigrationsFactory from '../../../../configs/getConfigFileMigrationsFactory.js';
+import migrateConfigFileFactory from '../../../../src/config/configFile/migrateConfigFileFactory.js';
+
+// Regression coverage for dashpay/platform#3889.
+//
+// A node already on 3.0.1 skips the 3.0.0 migration (semver.gt filter)
+// that used to re-sync Drive ABCI and rs-dapi images. The intervening
+// 3.0.2 / 3.1.0 migrations only touched Gateway / Tenderdash, so a
+// `dashmate update 3.0.x → 4.0.0-rc.x` kept the old protocol-11
+// images and the node crash-looped after protocol 12 activation.
+//
+// The new `4.0.0-rc.2` migration must re-sync those two image fields
+// from the current default config.
+describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', () => {
+  let migrate;
+  let defaults;
+
+  beforeEach(() => {
+    // Construct the migration directly (no DI). The full DI container
+    // transitively imports `@dashevo/dapi-client`, which can fail to
+    // load when `@dashevo/wasm-dpp` hasn't been built; the migration
+    // itself only needs the default-config factories.
+    const homeDirStub = {
+      joinPath: (...segments) => path.join('/tmp/dashmate-spec', ...segments),
+    };
+    const getBaseConfig = getBaseConfigFactory();
+    defaults = new DefaultConfigs([
+      getBaseConfig,
+      getLocalConfigFactory(getBaseConfig),
+      getTestnetConfigFactory(homeDirStub, getBaseConfig),
+      getMainnetConfigFactory(homeDirStub, getBaseConfig),
+    ]);
+    const getMigrations = getConfigFileMigrationsFactory(homeDirStub, defaults);
+    migrate = migrateConfigFileFactory(getMigrations);
+  });
+
+  // Minimal post-3.0.x config shape carrying the stale protocol-11
+  // image tags that dashmate 3.0.x shipped. Earlier migrations expect
+  // a much richer object, so we set fromVersion >= 3.1.0 to make the
+  // semver.gt filter run only the new step.
+  function buildStaleConfig({ network, group, customImages = {} }) {
+    return {
+      group,
+      network,
+      platform: {
+        enable: true,
+        drive: {
+          abci: {
+            docker: {
+              image: customImages.drive ?? 'dashpay/drive:3',
+            },
+          },
+        },
+        dapi: {
+          rsDapi: {
+            docker: {
+              image: customImages.rsDapi ?? 'dashpay/rs-dapi:3',
+            },
+          },
+        },
+      },
+    };
+  }
+
+  it('re-syncs drive.abci and dapi.rsDapi images to current defaults', () => {
+    const rawConfigFile = {
+      configFormatVersion: '3.1.0',
+      defaultConfigName: null,
+      defaultGroupName: null,
+      configs: {
+        testnet: buildStaleConfig({ network: 'testnet', group: 'testnet' }),
+        mainnet: buildStaleConfig({ network: 'mainnet', group: 'mainnet' }),
+      },
+    };
+
+    const expectedDriveImage = defaults.get('base').get('platform.drive.abci.docker.image');
+    const expectedRsDapiImage = defaults.get('base').get('platform.dapi.rsDapi.docker.image');
+
+    const migrated = migrate(rawConfigFile, '3.1.0', '4.0.0-rc.2');
+
+    expect(migrated.configs.testnet.platform.drive.abci.docker.image)
+      .to.equal(expectedDriveImage);
+    expect(migrated.configs.testnet.platform.dapi.rsDapi.docker.image)
+      .to.equal(expectedRsDapiImage);
+    expect(migrated.configs.mainnet.platform.drive.abci.docker.image)
+      .to.equal(expectedDriveImage);
+    expect(migrated.configs.mainnet.platform.dapi.rsDapi.docker.image)
+      .to.equal(expectedRsDapiImage);
+    expect(migrated.configFormatVersion).to.equal('4.0.0-rc.2');
+  });
+
+  it('runs for 3.0.1 fromVersion (the version skipped by the 3.0.0 migration)', () => {
+    // Direct repro of #3889: nodes that were already on 3.0.1 must
+    // still get the image re-sync, even though 3.0.0 itself is gated
+    // out by `semver.gt('3.0.0', '3.0.1') === false`.
+    const rawConfigFile = {
+      configFormatVersion: '3.0.1',
+      defaultConfigName: null,
+      defaultGroupName: null,
+      configs: {
+        testnet: buildStaleConfig({ network: 'testnet', group: 'testnet' }),
+      },
+    };
+
+    const expectedDriveImage = defaults.get('base').get('platform.drive.abci.docker.image');
+    const expectedRsDapiImage = defaults.get('base').get('platform.dapi.rsDapi.docker.image');
+
+    const migrated = migrate(rawConfigFile, '3.0.1', '4.0.0-rc.2');
+
+    expect(migrated.configs.testnet.platform.drive.abci.docker.image)
+      .to.equal(expectedDriveImage);
+    expect(migrated.configs.testnet.platform.dapi.rsDapi.docker.image)
+      .to.equal(expectedRsDapiImage);
+  });
+
+  it('no-ops on configs without platform.dapi.rsDapi', () => {
+    const rawConfigFile = {
+      configFormatVersion: '3.1.0',
+      defaultConfigName: null,
+      defaultGroupName: null,
+      configs: {
+        mainnet: {
+          group: 'mainnet',
+          network: 'mainnet',
+          platform: {
+            enable: true,
+            drive: {
+              abci: {
+                docker: { image: 'dashpay/drive:3' },
+              },
+            },
+            dapi: {},
+          },
+        },
+      },
+    };
+
+    const expectedDriveImage = defaults.get('base').get('platform.drive.abci.docker.image');
+
+    const migrated = migrate(rawConfigFile, '3.1.0', '4.0.0-rc.2');
+
+    expect(migrated.configs.mainnet.platform.drive.abci.docker.image)
+      .to.equal(expectedDriveImage);
+    expect(migrated.configs.mainnet.platform.dapi.rsDapi).to.equal(undefined);
+  });
+});

--- a/packages/dashmate/test/unit/config/configFile/migrate3xTo4xRcImages.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrate3xTo4xRcImages.spec.js
@@ -25,8 +25,12 @@ import migrateConfigFileFactory from '../../../../src/config/configFile/migrateC
 describe('migration 4.0.0-rc.3: re-sync Drive ABCI & rs-dapi images (#3889)', () => {
   const STALE_DRIVE = 'dashpay/drive:3';
   const STALE_DRIVE_DEV = 'dashpay/drive:3-dev';
+  const STALE_DRIVE_RC = 'dashpay/drive:3-rc';
+  const STALE_DRIVE_HOTFIX = 'dashpay/drive:3-hotfix';
   const STALE_RS_DAPI = 'dashpay/rs-dapi:3';
   const STALE_RS_DAPI_DEV = 'dashpay/rs-dapi:3-dev';
+  const STALE_RS_DAPI_RC = 'dashpay/rs-dapi:3-rc';
+  const STALE_RS_DAPI_HOTFIX = 'dashpay/rs-dapi:3-hotfix';
   const CUSTOM_DRIVE = 'private-registry.internal/drive:patched-v3';
   const CUSTOM_RS_DAPI = 'my-org/rs-dapi:fork-3';
 
@@ -135,27 +139,38 @@ describe('migration 4.0.0-rc.3: re-sync Drive ABCI & rs-dapi images (#3889)', ()
     });
   });
 
-  it('re-syncs the dev-series stale tags too (dashpay/drive:3-dev, dashpay/rs-dapi:3-dev)', () => {
-    const rawConfigFile = {
-      configFormatVersion: '3.1.0',
-      defaultConfigName: null,
-      defaultGroupName: null,
-      configs: {
-        testnet: buildConfig({
-          network: 'testnet',
-          group: 'testnet',
-          driveImage: STALE_DRIVE_DEV,
-          rsDapiImage: STALE_RS_DAPI_DEV,
-        }),
-      },
-    };
+  // All the prerelease label series the 3.x line shipped derive from
+  // semver.prerelease(version)[0] in getBaseConfigFactory.js, producing
+  // these stale tags. The hotfix variant in particular came from
+  // 3.0.1-hotfix.{1..4} (#3020/#3044/#3055/#3060) and 3.1.0-hotfix.1 —
+  // an early oversight in the predicate missed it.
+  [
+    { label: 'dev-series', drive: STALE_DRIVE_DEV, rsDapi: STALE_RS_DAPI_DEV },
+    { label: 'rc-series', drive: STALE_DRIVE_RC, rsDapi: STALE_RS_DAPI_RC },
+    { label: 'hotfix-series', drive: STALE_DRIVE_HOTFIX, rsDapi: STALE_RS_DAPI_HOTFIX },
+  ].forEach(({ label, drive, rsDapi }) => {
+    it(`re-syncs the ${label} stale tags (${drive}, ${rsDapi})`, () => {
+      const rawConfigFile = {
+        configFormatVersion: '3.1.0',
+        defaultConfigName: null,
+        defaultGroupName: null,
+        configs: {
+          testnet: buildConfig({
+            network: 'testnet',
+            group: 'testnet',
+            driveImage: drive,
+            rsDapiImage: rsDapi,
+          }),
+        },
+      };
 
-    const migrated = migrate(rawConfigFile, '3.1.0', '4.0.0-rc.3');
+      const migrated = migrate(rawConfigFile, '3.1.0', '4.0.0-rc.3');
 
-    expect(migrated.configs.testnet.platform.drive.abci.docker.image)
-      .to.equal(expectedDriveImage);
-    expect(migrated.configs.testnet.platform.dapi.rsDapi.docker.image)
-      .to.equal(expectedRsDapiImage);
+      expect(migrated.configs.testnet.platform.drive.abci.docker.image)
+        .to.equal(expectedDriveImage);
+      expect(migrated.configs.testnet.platform.dapi.rsDapi.docker.image)
+        .to.equal(expectedRsDapiImage);
+    });
   });
 
   // The exact case the rework targets: a node that already upgraded to

--- a/packages/dashmate/test/unit/config/configFile/migrate3xTo4xRcImages.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrate3xTo4xRcImages.spec.js
@@ -11,15 +11,22 @@ import migrateConfigFileFactory from '../../../../src/config/configFile/migrateC
 //
 // A node already on 3.0.1 skips the 3.0.0 migration (semver.gt filter)
 // that used to re-sync Drive ABCI and rs-dapi images. The intervening
-// 3.0.2 / 3.1.0 migrations only touched Gateway / Tenderdash, so a
-// `dashmate update 3.0.x → 4.0.0-rc.x` kept the old protocol-11
-// images and the node crash-looped after protocol 12 activation.
+// 3.0.1 / 3.0.2 / 3.1.0 migrations only touched Core / Gateway / Tenderdash
+// `.docker.image` fields (3.1.0 does add `buildArgs` on the drive/rsDapi
+// `docker.build` blocks, but never their image tags). The result: a
+// `dashmate update 3.0.x → 4.0.0-rc.x` kept the protocol-11 images and
+// the node crash-looped after protocol 12 activation.
 //
 // The new `4.0.0-rc.2` migration must re-sync those two image fields
 // from the current default config.
 describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', () => {
+  const STALE_DRIVE = 'dashpay/drive:3';
+  const STALE_RS_DAPI = 'dashpay/rs-dapi:3';
+
   let migrate;
   let defaults;
+  let expectedDriveImage;
+  let expectedRsDapiImage;
 
   beforeEach(() => {
     // Construct the migration directly (no DI). The full DI container
@@ -38,13 +45,16 @@ describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', ()
     ]);
     const getMigrations = getConfigFileMigrationsFactory(homeDirStub, defaults);
     migrate = migrateConfigFileFactory(getMigrations);
+
+    expectedDriveImage = defaults.get('base').get('platform.drive.abci.docker.image');
+    expectedRsDapiImage = defaults.get('base').get('platform.dapi.rsDapi.docker.image');
   });
 
   // Minimal post-3.0.x config shape carrying the stale protocol-11
   // image tags that dashmate 3.0.x shipped. Earlier migrations expect
-  // a much richer object, so we set fromVersion >= 3.1.0 to make the
+  // a much richer object, so we set fromVersion >= 3.0.1 to make the
   // semver.gt filter run only the new step.
-  function buildStaleConfig({ network, group, customImages = {} }) {
+  function buildStaleConfig({ network, group }) {
     return {
       group,
       network,
@@ -52,71 +62,55 @@ describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', ()
         enable: true,
         drive: {
           abci: {
-            docker: {
-              image: customImages.drive ?? 'dashpay/drive:3',
-            },
+            docker: { image: STALE_DRIVE },
+          },
+          tenderdash: {
+            docker: { image: 'dashpay/tenderdash:1.5' },
           },
         },
         dapi: {
           rsDapi: {
-            docker: {
-              image: customImages.rsDapi ?? 'dashpay/rs-dapi:3',
-            },
+            docker: { image: STALE_RS_DAPI },
           },
         },
       },
     };
   }
 
-  it('re-syncs drive.abci and dapi.rsDapi images to current defaults', () => {
-    const rawConfigFile = {
-      configFormatVersion: '3.1.0',
-      defaultConfigName: null,
-      defaultGroupName: null,
-      configs: {
-        testnet: buildStaleConfig({ network: 'testnet', group: 'testnet' }),
-        mainnet: buildStaleConfig({ network: 'mainnet', group: 'mainnet' }),
-      },
-    };
+  // Both fromVersion variants are real-world entry points: a node could
+  // be on 3.0.1 (the version that originally skipped the 3.0.0 image
+  // re-sync — the direct #3889 repro) or on 3.1.0 (skipping it for the
+  // same reason). Either way the new migration must converge them.
+  ['3.0.1', '3.1.0'].forEach((fromVersion) => {
+    it(`re-syncs drive.abci and dapi.rsDapi images on ${fromVersion} → 4.0.0-rc.2`, () => {
+      const rawConfigFile = {
+        configFormatVersion: fromVersion,
+        defaultConfigName: null,
+        defaultGroupName: null,
+        configs: {
+          testnet: buildStaleConfig({ network: 'testnet', group: 'testnet' }),
+          mainnet: buildStaleConfig({ network: 'mainnet', group: 'mainnet' }),
+        },
+      };
 
-    const expectedDriveImage = defaults.get('base').get('platform.drive.abci.docker.image');
-    const expectedRsDapiImage = defaults.get('base').get('platform.dapi.rsDapi.docker.image');
+      const migrated = migrate(rawConfigFile, fromVersion, '4.0.0-rc.2');
 
-    const migrated = migrate(rawConfigFile, '3.1.0', '4.0.0-rc.2');
+      ['testnet', 'mainnet'].forEach((name) => {
+        const { docker: driveDocker } = migrated.configs[name].platform.drive.abci;
+        const { docker: rsDapiDocker } = migrated.configs[name].platform.dapi.rsDapi;
 
-    expect(migrated.configs.testnet.platform.drive.abci.docker.image)
-      .to.equal(expectedDriveImage);
-    expect(migrated.configs.testnet.platform.dapi.rsDapi.docker.image)
-      .to.equal(expectedRsDapiImage);
-    expect(migrated.configs.mainnet.platform.drive.abci.docker.image)
-      .to.equal(expectedDriveImage);
-    expect(migrated.configs.mainnet.platform.dapi.rsDapi.docker.image)
-      .to.equal(expectedRsDapiImage);
-    expect(migrated.configFormatVersion).to.equal('4.0.0-rc.2');
-  });
+        expect(driveDocker.image).to.equal(expectedDriveImage);
+        expect(rsDapiDocker.image).to.equal(expectedRsDapiImage);
 
-  it('runs for 3.0.1 fromVersion (the version skipped by the 3.0.0 migration)', () => {
-    // Direct repro of #3889: nodes that were already on 3.0.1 must
-    // still get the image re-sync, even though 3.0.0 itself is gated
-    // out by `semver.gt('3.0.0', '3.0.1') === false`.
-    const rawConfigFile = {
-      configFormatVersion: '3.0.1',
-      defaultConfigName: null,
-      defaultGroupName: null,
-      configs: {
-        testnet: buildStaleConfig({ network: 'testnet', group: 'testnet' }),
-      },
-    };
+        // Pin against the specific regression so the test stays
+        // meaningful even if a future default happens to match
+        // the stale value again.
+        expect(driveDocker.image).to.not.equal(STALE_DRIVE);
+        expect(rsDapiDocker.image).to.not.equal(STALE_RS_DAPI);
+      });
 
-    const expectedDriveImage = defaults.get('base').get('platform.drive.abci.docker.image');
-    const expectedRsDapiImage = defaults.get('base').get('platform.dapi.rsDapi.docker.image');
-
-    const migrated = migrate(rawConfigFile, '3.0.1', '4.0.0-rc.2');
-
-    expect(migrated.configs.testnet.platform.drive.abci.docker.image)
-      .to.equal(expectedDriveImage);
-    expect(migrated.configs.testnet.platform.dapi.rsDapi.docker.image)
-      .to.equal(expectedRsDapiImage);
+      expect(migrated.configFormatVersion).to.equal('4.0.0-rc.2');
+    });
   });
 
   it('no-ops on configs without platform.dapi.rsDapi', () => {
@@ -132,7 +126,10 @@ describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', ()
             enable: true,
             drive: {
               abci: {
-                docker: { image: 'dashpay/drive:3' },
+                docker: { image: STALE_DRIVE },
+              },
+              tenderdash: {
+                docker: { image: 'dashpay/tenderdash:1.5' },
               },
             },
             dapi: {},
@@ -140,8 +137,6 @@ describe('migration 4.0.0-rc.2: re-sync Drive ABCI & rs-dapi images (#3889)', ()
         },
       },
     };
-
-    const expectedDriveImage = defaults.get('base').get('platform.drive.abci.docker.image');
 
     const migrated = migrate(rawConfigFile, '3.1.0', '4.0.0-rc.2');
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes dashpay/platform#3889.

Dashmate configs upgraded from the 3.x line to 4.0.0-rc.2 could keep stale protocol-11 Drive ABCI and rs-dapi Docker image tags (`dashpay/drive:3*`, `dashpay/rs-dapi:3*`). Those images crash-loop after protocol 12 activation.

## What was done?

- Added a dashmate config migration that re-syncs stale shipped Drive ABCI and rs-dapi image tags from the current defaults.
- Keyed the migration at `4.0.0-rc.3` so configs already stamped `4.0.0-rc.2` can be repaired on the next release bump instead of being skipped by the same-version short-circuit.
- Preserved custom/private/manually-corrected images by only matching dashmate-shipped stale tags: `:3`, `:3-dev`, `:3-rc`, and `:3-hotfix`.
- Added focused regression coverage for 3.0.1/3.1.0 upgrades, already-stamped rc.2 configs, custom image preservation, mixed sibling configs, and missing rs-dapi config sections.

## How Has This Been Tested?

Environment:

- macOS Darwin 24.6.0 arm64
- Repository worktree: `/Users/claw/Projects/platform/worktrees/fix-dashmate-rc-image-migration`
- Node 22 via `npx -p node@22` because local system Node 25 hits an EBADF loader issue before the spec runs.

Validation:

```bash
npx -y -p node@22 node .yarn/releases/yarn-4.12.0.cjs workspace dashmate exec mocha test/unit/config/configFile/migrate3xTo4xRcImages.spec.js
```

Result: `11 passing (87ms)`.

Pre-PR review gate:

```text
code-review dashpay/platform upstream/v3.1-dev fix-dashmate-rc-image-migration "Fix dashmate config migration so 3.0.x/3.1.0 configs upgraded to 4.0.0-rc line re-sync only stale shipped Drive ABCI and rs-dapi Docker image tags from defaults; re-key for rc.3 so already-stamped rc.2 configs are repairable on next release; regression tests for platform#3889."
```

Result: `Recommendation: ship`.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**

- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the **4.0.0-rc.3** configuration migration to update stale **Dashpay protocol-11** Docker image tags for **Drive (ABCI)** and **rsDapi** to the current defaults during upgrades. Only matching outdated tag patterns are updated, custom/private image selections are preserved, and upgrading to the same version remains a strict no-op.
* **Tests**
  * Added regression unit tests for the **4.0.0-rc.3** migration, including mainnet/testnet coverage, prerelease tag variants, sibling config rewrites, rsDapi-missing scenarios, and re-migration from **4.0.0-rc.2** to **4.0.0-rc.3**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->