### PR TITLE
fix(dashmate): use live Tenderdash app version for protocol status

### DIFF
--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -144,11 +144,7 @@ export default function getPlatformScopeFactory(
             .catch(() => null),
         ]);
 
-        const [
-          tenderdashStatus,
-          tenderdashNetInfo,
-          tenderdashAbciInfo,
-        ] = await Promise.all([
+        const [tenderdashStatus, tenderdashNetInfo, tenderdashAbciInfo] = await Promise.all([
           tenderdashStatusResponse.json(),
           tenderdashNetInfoResponse.json(),
           tenderdashAbciInfoResponse.json(),

--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -7,6 +7,31 @@ import determineStatus from '../determineStatus.js';
 import ContainerIsNotPresentError from '../../docker/errors/ContainerIsNotPresentError.js';
 import ServiceIsNotRunningError from '../../docker/errors/ServiceIsNotRunningError.js';
 
+function parseProtocolVersion(protocolVersion) {
+  if (protocolVersion === null || typeof protocolVersion === 'undefined') {
+    return null;
+  }
+
+  const protocolVersionString = protocolVersion.toString().trim();
+
+  if (!/^\d+$/.test(protocolVersionString)) {
+    return null;
+  }
+
+  const parsedProtocolVersion = Number(protocolVersionString);
+
+  if (!Number.isSafeInteger(parsedProtocolVersion) || parsedProtocolVersion < 0) {
+    return null;
+  }
+
+  return parsedProtocolVersion;
+}
+
+function getConsensusParamsAppVersion(tenderdashConsensusParams) {
+  return tenderdashConsensusParams?.result?.consensus_params?.version?.app_version
+    ?? tenderdashConsensusParams?.consensus_params?.version?.app_version;
+}
+
 /**
  * @returns {getPlatformScopeFactory}
  * @param {DockerCompose} dockerCompose
@@ -116,13 +141,21 @@ export default function getPlatformScopeFactory(
           tenderdashStatusResponse,
           tenderdashNetInfoResponse,
           tenderdashAbciInfoResponse,
+          tenderdashConsensusParams,
         ] = await Promise.all([
           fetch(`http://${tenderdashHost}:${port}/status`),
           fetch(`http://${tenderdashHost}:${port}/net_info`),
           fetch(`http://${tenderdashHost}:${port}/abci_info`),
+          fetch(`http://${tenderdashHost}:${port}/consensus_params`)
+            .then((response) => response.json())
+            .catch(() => null),
         ]);
 
-        const [tenderdashStatus, tenderdashNetInfo, tenderdashAbciInfo] = await Promise.all([
+        const [
+          tenderdashStatus,
+          tenderdashNetInfo,
+          tenderdashAbciInfo,
+        ] = await Promise.all([
           tenderdashStatusResponse.json(),
           tenderdashNetInfoResponse.json(),
           tenderdashAbciInfoResponse.json(),
@@ -144,14 +177,14 @@ export default function getPlatformScopeFactory(
         }
 
         info.version = version;
-        // Prefer live application_info.version (current after in-process upgrades).
-        // Tenderdash may omit application_info entirely (json omitempty when ABCIInfo
-        // fails, or older builds without the field). Fall back to
-        // node_info.protocol_version.app only then — that snapshot can be stale, so it
-        // must not win when the live field is present.
-        const appProtocolVersion = tenderdashStatus.application_info?.version
-          ?? tenderdashStatus.node_info.protocol_version.app;
-        info.protocolVersion = parseInt(appProtocolVersion, 10);
+        const activeProtocolVersion = parseProtocolVersion(
+          getConsensusParamsAppVersion(tenderdashConsensusParams),
+        );
+        const nodeInfoProtocolVersion = parseProtocolVersion(
+          tenderdashStatus.node_info.protocol_version.app,
+        );
+
+        info.protocolVersion = activeProtocolVersion ?? nodeInfoProtocolVersion;
         // abci_info app_version reflects the installed software's desired/supported version.
         info.desiredProtocolVersion = tenderdashAbciInfo.response.app_version;
         info.listening = listening;

--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -144,10 +144,14 @@ export default function getPlatformScopeFactory(
         }
 
         info.version = version;
-        // node_info.protocol_version.app is snapshotted at Tenderdash process start and
-        // stays stale across in-process protocol upgrades. application_info.version is
-        // the live active/current app protocol version.
-        info.protocolVersion = parseInt(tenderdashStatus.application_info.version, 10);
+        // Prefer live application_info.version (current after in-process upgrades).
+        // Tenderdash may omit application_info entirely (json omitempty when ABCIInfo
+        // fails, or older builds without the field). Fall back to
+        // node_info.protocol_version.app only then — that snapshot can be stale, so it
+        // must not win when the live field is present.
+        const appProtocolVersion = tenderdashStatus.application_info?.version
+          ?? tenderdashStatus.node_info.protocol_version.app;
+        info.protocolVersion = parseInt(appProtocolVersion, 10);
         // abci_info app_version reflects the installed software's desired/supported version.
         info.desiredProtocolVersion = tenderdashAbciInfo.response.app_version;
         info.listening = listening;

--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -8,28 +8,9 @@ import ContainerIsNotPresentError from '../../docker/errors/ContainerIsNotPresen
 import ServiceIsNotRunningError from '../../docker/errors/ServiceIsNotRunningError.js';
 
 function parseProtocolVersion(protocolVersion) {
-  if (protocolVersion === null || typeof protocolVersion === 'undefined') {
-    return null;
-  }
+  const parsedProtocolVersion = parseInt(protocolVersion, 10);
 
-  const protocolVersionString = protocolVersion.toString().trim();
-
-  if (!/^\d+$/.test(protocolVersionString)) {
-    return null;
-  }
-
-  const parsedProtocolVersion = Number(protocolVersionString);
-
-  if (!Number.isSafeInteger(parsedProtocolVersion) || parsedProtocolVersion < 0) {
-    return null;
-  }
-
-  return parsedProtocolVersion;
-}
-
-function getConsensusParamsAppVersion(tenderdashConsensusParams) {
-  return tenderdashConsensusParams?.result?.consensus_params?.version?.app_version
-    ?? tenderdashConsensusParams?.consensus_params?.version?.app_version;
+  return Number.isNaN(parsedProtocolVersion) ? null : parsedProtocolVersion;
 }
 
 /**
@@ -177,8 +158,11 @@ export default function getPlatformScopeFactory(
         }
 
         info.version = version;
+        // Tenderdash GET RPC responses are unwrapped (writeHTTPResponse sends
+        // the bare result). node_info.protocol_version.app is snapshotted at
+        // process start, so it is only a fallback for the live consensus value.
         const activeProtocolVersion = parseProtocolVersion(
-          getConsensusParamsAppVersion(tenderdashConsensusParams),
+          tenderdashConsensusParams?.consensus_params?.version?.app_version,
         );
         const nodeInfoProtocolVersion = parseProtocolVersion(
           tenderdashStatus.node_info.protocol_version.app,

--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -144,7 +144,11 @@ export default function getPlatformScopeFactory(
         }
 
         info.version = version;
-        info.protocolVersion = parseInt(tenderdashStatus.node_info.protocol_version.app, 10);
+        // node_info.protocol_version.app is snapshotted at Tenderdash process start and
+        // stays stale across in-process protocol upgrades. application_info.version is
+        // the live active/current app protocol version.
+        info.protocolVersion = parseInt(tenderdashStatus.application_info.version, 10);
+        // abci_info app_version reflects the installed software's desired/supported version.
         info.desiredProtocolVersion = tenderdashAbciInfo.response.app_version;
         info.listening = listening;
         info.latestBlockHeight = latestBlockHeight;

--- a/packages/dashmate/src/status/scopes/platform.js
+++ b/packages/dashmate/src/status/scopes/platform.js
@@ -8,9 +8,21 @@ import ContainerIsNotPresentError from '../../docker/errors/ContainerIsNotPresen
 import ServiceIsNotRunningError from '../../docker/errors/ServiceIsNotRunningError.js';
 
 function parseProtocolVersion(protocolVersion) {
-  const parsedProtocolVersion = parseInt(protocolVersion, 10);
+  // The value is Tenderdash serializing a uint64. Accept only a primitive
+  // that is entirely a plain decimal integer: prefix parsing ('3.5' -> 3) or
+  // array coercion (['3'] -> '3') would mask the node_info fallback with a
+  // bogus active version.
+  if (typeof protocolVersion !== 'string' && typeof protocolVersion !== 'number') {
+    return null;
+  }
 
-  return Number.isNaN(parsedProtocolVersion) ? null : parsedProtocolVersion;
+  if (!/^\d+$/.test(String(protocolVersion).trim())) {
+    return null;
+  }
+
+  const parsedProtocolVersion = Number(protocolVersion);
+
+  return Number.isSafeInteger(parsedProtocolVersion) ? parsedProtocolVersion : null;
 }
 
 /**

--- a/packages/dashmate/test/unit/status/scopes/platform.spec.js
+++ b/packages/dashmate/test/unit/status/scopes/platform.spec.js
@@ -77,8 +77,7 @@ describe('getPlatformScopeFactory', () => {
       mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
-      // node_info.protocol_version.app can be stale after in-process upgrades;
-      // protocolVersion must come from live consensus params.
+      // node_info app differs from consensus params so the expectation pins the live source
       const mockStatus = {
         node_info: {
           protocol_version: {

--- a/packages/dashmate/test/unit/status/scopes/platform.spec.js
+++ b/packages/dashmate/test/unit/status/scopes/platform.spec.js
@@ -78,12 +78,14 @@ describe('getPlatformScopeFactory', () => {
       mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
+      // node_info.protocol_version.app can be stale after in-process upgrades;
+      // protocolVersion must come from application_info.version (live).
       const mockStatus = {
         node_info: {
           protocol_version: {
             p2p: '10',
             block: '14',
-            app: '3',
+            app: '11',
           },
           version: '0',
           network: 'test',
@@ -158,73 +160,6 @@ describe('getPlatformScopeFactory', () => {
       const scope = await getPlatformScope(config);
 
       expect(scope).to.deep.equal(expectedScope);
-    });
-
-    it('should use live application_info version when node_info protocol version is stale', async () => {
-      mockDetermineDockerStatus.returns(DockerStatusEnum.running);
-      mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
-      mockRpcClient.getBlockchainInfo.returns({
-        result: {
-          softforks: {
-            mn_rr: { active: true, height: 1337 },
-          },
-        },
-      });
-      mockDockerCompose.isServiceRunning.returns(true);
-      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci status').resolves({ exitCode: 0, out: '' });
-      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '4.0.0' });
-      mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
-
-      // After an in-process protocol upgrade, Tenderdash keeps the process-start
-      // snapshot in node_info.protocol_version.app while application_info.version
-      // and abci_info.app_version report the live/desired values.
-      const mockStatus = {
-        node_info: {
-          protocol_version: {
-            p2p: '10',
-            block: '14',
-            app: '11',
-          },
-          version: '1.6.0',
-          network: 'dash-mainnet-1',
-          moniker: 'evonode',
-        },
-        application_info: {
-          version: '12',
-        },
-        sync_info: {
-          catching_up: false,
-          latest_app_hash: 'DEADBEEF',
-          latest_block_height: 398435,
-          latest_block_hash: 'DEADBEEF',
-          latest_block_time: 1337,
-        },
-      };
-      const mockNetInfo = { n_peers: 6, listening: true };
-
-      const mockAbciInfo = {
-        response: {
-          version: '4.0.0',
-          app_version: 12,
-          last_block_height: 398435,
-          last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
-        },
-      };
-
-      mockFetch
-        .onFirstCall()
-        .returns(Promise.resolve({ json: () => Promise.resolve(mockStatus) }))
-        .onSecondCall()
-        .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
-        .onThirdCall()
-        .resolves({ json: () => Promise.resolve(mockAbciInfo) });
-
-      const scope = await getPlatformScope(config);
-
-      expect(scope.tenderdash.protocolVersion).to.equal(12);
-      expect(scope.tenderdash.desiredProtocolVersion).to.equal(12);
-      expect(scope.tenderdash.version).to.equal('1.6.0');
-      expect(scope.tenderdash.latestBlockHeight).to.equal(398435);
     });
 
     it('should return platform syncing when it is catching up', async () => {

--- a/packages/dashmate/test/unit/status/scopes/platform.spec.js
+++ b/packages/dashmate/test/unit/status/scopes/platform.spec.js
@@ -44,7 +44,6 @@ describe('getPlatformScopeFactory', () => {
       mockCreateRpcClient = () => mockRpcClient;
       mockDetermineDockerStatus = this.sinon.stub(determineStatus, 'docker');
       mockMNOWatchProvider = this.sinon.stub(providers.mnowatch, 'checkPortStatus');
-      // eslint-disable-next-line
       mockFetch = this.sinon.stub(globalThis, 'fetch');
       mockGetConnectionHost = this.sinon.stub();
 
@@ -79,7 +78,7 @@ describe('getPlatformScopeFactory', () => {
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
       // node_info.protocol_version.app can be stale after in-process upgrades;
-      // protocolVersion must come from application_info.version (live).
+      // protocolVersion must come from live consensus params.
       const mockStatus = {
         node_info: {
           protocol_version: {
@@ -92,7 +91,7 @@ describe('getPlatformScopeFactory', () => {
           moniker: 'test',
         },
         application_info: {
-          version: '3',
+          version: '999',
         },
         sync_info: {
           catching_up: false,
@@ -110,6 +109,13 @@ describe('getPlatformScopeFactory', () => {
           app_version: 4,
           last_block_height: 90,
           last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
+        },
+      };
+      const mockConsensusParams = {
+        consensus_params: {
+          version: {
+            app_version: '3',
+          },
         },
       };
 
@@ -154,7 +160,9 @@ describe('getPlatformScopeFactory', () => {
         .onSecondCall()
         .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
         .onThirdCall()
-        .resolves({ json: () => Promise.resolve(mockAbciInfo) });
+        .resolves({ json: () => Promise.resolve(mockAbciInfo) })
+        .onCall(3)
+        .resolves({ json: () => Promise.resolve(mockConsensusParams) });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
       const scope = await getPlatformScope(config);
@@ -162,7 +170,7 @@ describe('getPlatformScopeFactory', () => {
       expect(scope).to.deep.equal(expectedScope);
     });
 
-    it('should fall back to node_info app protocol when application_info is absent', async () => {
+    it('should fall back to node_info app protocol when consensus params app version is absent', async () => {
       mockDetermineDockerStatus.returns(DockerStatusEnum.running);
       mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
       mockRpcClient.getBlockchainInfo.returns({
@@ -177,8 +185,8 @@ describe('getPlatformScopeFactory', () => {
       mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
-      // When application_info is omitted (omitempty / unavailable), status must still
-      // report a numeric protocolVersion from node_info.protocol_version.app.
+      // Older Tenderdash builds may omit consensus_params.version.app_version.
+      // Status must still report a numeric protocolVersion from node_info.protocol_version.app.
       const mockStatus = {
         node_info: {
           protocol_version: {
@@ -207,6 +215,14 @@ describe('getPlatformScopeFactory', () => {
           last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
         },
       };
+      const mockConsensusParams = {
+        consensus_params: {
+          block: {
+            max_bytes: '2097152',
+            max_gas: '57631392000',
+          },
+        },
+      };
 
       mockFetch
         .onFirstCall()
@@ -214,13 +230,227 @@ describe('getPlatformScopeFactory', () => {
         .onSecondCall()
         .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
         .onThirdCall()
-        .resolves({ json: () => Promise.resolve(mockAbciInfo) });
+        .resolves({ json: () => Promise.resolve(mockAbciInfo) })
+        .onCall(3)
+        .resolves({ json: () => Promise.resolve(mockConsensusParams) });
 
       const scope = await getPlatformScope(config);
 
       expect(scope.tenderdash.serviceStatus).to.equal(ServiceStatusEnum.up);
       expect(scope.tenderdash.protocolVersion).to.equal(3);
       expect(scope.tenderdash.desiredProtocolVersion).to.equal(4);
+    });
+
+    it('should fall back to node_info app protocol when consensus params app version is empty', async () => {
+      mockDetermineDockerStatus.returns(DockerStatusEnum.running);
+      mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          softforks: {
+            mn_rr: { active: true, height: 1337 },
+          },
+        },
+      });
+      mockDockerCompose.isServiceRunning.returns(true);
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci status').resolves({ exitCode: 0, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
+      mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
+
+      const mockStatus = {
+        node_info: {
+          protocol_version: {
+            p2p: '10',
+            block: '14',
+            app: '3',
+          },
+          version: '0',
+          network: 'test',
+          moniker: 'test',
+        },
+        application_info: {
+          version: '',
+        },
+        sync_info: {
+          catching_up: false,
+          latest_app_hash: 'DEADBEEF',
+          latest_block_height: 1,
+          latest_block_hash: 'DEADBEEF',
+          latest_block_time: 1337,
+        },
+      };
+      const mockNetInfo = { n_peers: 6, listening: true };
+      const mockAbciInfo = {
+        response: {
+          version: '1.4.1',
+          app_version: 4,
+          last_block_height: 90,
+          last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
+        },
+      };
+      const mockConsensusParams = {
+        consensus_params: {
+          version: {
+            app_version: '',
+          },
+        },
+      };
+
+      mockFetch
+        .onFirstCall()
+        .returns(Promise.resolve({ json: () => Promise.resolve(mockStatus) }))
+        .onSecondCall()
+        .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
+        .onThirdCall()
+        .resolves({ json: () => Promise.resolve(mockAbciInfo) })
+        .onCall(3)
+        .resolves({ json: () => Promise.resolve(mockConsensusParams) });
+
+      const scope = await getPlatformScope(config);
+
+      expect(scope.tenderdash.protocolVersion).to.equal(3);
+      expect(Number.isNaN(scope.tenderdash.protocolVersion)).to.equal(false);
+      expect(scope.tenderdash.desiredProtocolVersion).to.equal(4);
+    });
+
+    it('should fall back to node_info app protocol when consensus params app version is malformed', async () => {
+      mockDetermineDockerStatus.returns(DockerStatusEnum.running);
+      mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          softforks: {
+            mn_rr: { active: true, height: 1337 },
+          },
+        },
+      });
+      mockDockerCompose.isServiceRunning.returns(true);
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci status').resolves({ exitCode: 0, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
+      mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
+
+      const mockStatus = {
+        node_info: {
+          protocol_version: {
+            p2p: '10',
+            block: '14',
+            app: '3',
+          },
+          version: '0',
+          network: 'test',
+          moniker: 'test',
+        },
+        application_info: {
+          version: '999',
+        },
+        sync_info: {
+          catching_up: false,
+          latest_app_hash: 'DEADBEEF',
+          latest_block_height: 1,
+          latest_block_hash: 'DEADBEEF',
+          latest_block_time: 1337,
+        },
+      };
+      const mockNetInfo = { n_peers: 6, listening: true };
+      const mockAbciInfo = {
+        response: {
+          version: '1.4.1',
+          app_version: 4,
+          last_block_height: 90,
+          last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
+        },
+      };
+      const mockConsensusParams = {
+        consensus_params: {
+          version: {
+            app_version: 'not-a-number',
+          },
+        },
+      };
+
+      mockFetch
+        .onFirstCall()
+        .returns(Promise.resolve({ json: () => Promise.resolve(mockStatus) }))
+        .onSecondCall()
+        .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
+        .onThirdCall()
+        .resolves({ json: () => Promise.resolve(mockAbciInfo) })
+        .onCall(3)
+        .resolves({ json: () => Promise.resolve(mockConsensusParams) });
+
+      const scope = await getPlatformScope(config);
+
+      expect(scope.tenderdash.protocolVersion).to.equal(3);
+      expect(Number.isNaN(scope.tenderdash.protocolVersion)).to.equal(false);
+      expect(scope.tenderdash.desiredProtocolVersion).to.equal(4);
+    });
+
+    it('should keep active consensus protocol distinct from newer desired version during rollout', async () => {
+      mockDetermineDockerStatus.returns(DockerStatusEnum.running);
+      mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          softforks: {
+            mn_rr: { active: true, height: 1337 },
+          },
+        },
+      });
+      mockDockerCompose.isServiceRunning.returns(true);
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci status').resolves({ exitCode: 0, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.5.0' });
+      mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
+
+      const mockStatus = {
+        node_info: {
+          protocol_version: {
+            p2p: '10',
+            block: '14',
+            app: '10',
+          },
+          version: '1.6.0',
+          network: 'test',
+          moniker: 'test',
+        },
+        application_info: {
+          version: '12',
+        },
+        sync_info: {
+          catching_up: false,
+          latest_app_hash: 'DEADBEEF',
+          latest_block_height: 1,
+          latest_block_hash: 'DEADBEEF',
+          latest_block_time: 1337,
+        },
+      };
+      const mockNetInfo = { n_peers: 6, listening: true };
+      const mockAbciInfo = {
+        response: {
+          version: '1.5.0',
+          app_version: 12,
+          last_block_height: 90,
+          last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
+        },
+      };
+      const mockConsensusParams = {
+        consensus_params: {
+          version: {
+            app_version: '11',
+          },
+        },
+      };
+
+      mockFetch
+        .onFirstCall()
+        .returns(Promise.resolve({ json: () => Promise.resolve(mockStatus) }))
+        .onSecondCall()
+        .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
+        .onThirdCall()
+        .resolves({ json: () => Promise.resolve(mockAbciInfo) })
+        .onCall(3)
+        .resolves({ json: () => Promise.resolve(mockConsensusParams) });
+
+      const scope = await getPlatformScope(config);
+
+      expect(scope.tenderdash.protocolVersion).to.equal(11);
+      expect(scope.tenderdash.desiredProtocolVersion).to.equal(12);
     });
 
     it('should return platform syncing when it is catching up', async () => {
@@ -269,6 +499,13 @@ describe('getPlatformScopeFactory', () => {
           last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
         },
       };
+      const mockConsensusParams = {
+        consensus_params: {
+          version: {
+            app_version: '3',
+          },
+        },
+      };
 
       const expectedScope = {
         platformActivation: 'Activated (at height 1337)',
@@ -311,7 +548,9 @@ describe('getPlatformScopeFactory', () => {
         .onSecondCall()
         .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
         .onThirdCall()
-        .resolves({ json: () => Promise.resolve(mockAbciInfo) });
+        .resolves({ json: () => Promise.resolve(mockAbciInfo) })
+        .onCall(3)
+        .resolves({ json: () => Promise.resolve(mockConsensusParams) });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
       const scope = await getPlatformScope(config);
@@ -535,6 +774,13 @@ describe('getPlatformScopeFactory', () => {
           last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
         },
       };
+      const mockConsensusParams = {
+        consensus_params: {
+          version: {
+            app_version: '3',
+          },
+        },
+      };
 
       mockFetch
         .onFirstCall()
@@ -542,7 +788,9 @@ describe('getPlatformScopeFactory', () => {
         .onSecondCall()
         .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
         .onThirdCall()
-        .resolves({ json: () => Promise.resolve(mockAbciInfo) });
+        .resolves({ json: () => Promise.resolve(mockAbciInfo) })
+        .onCall(3)
+        .resolves({ json: () => Promise.resolve(mockConsensusParams) });
 
       const expectedScope = {
         platformActivation: 'Activated (at height 1337)',

--- a/packages/dashmate/test/unit/status/scopes/platform.spec.js
+++ b/packages/dashmate/test/unit/status/scopes/platform.spec.js
@@ -89,6 +89,9 @@ describe('getPlatformScopeFactory', () => {
           network: 'test',
           moniker: 'test',
         },
+        application_info: {
+          version: '3',
+        },
         sync_info: {
           catching_up: false,
           latest_app_hash: 'DEADBEEF',
@@ -157,6 +160,73 @@ describe('getPlatformScopeFactory', () => {
       expect(scope).to.deep.equal(expectedScope);
     });
 
+    it('should use live application_info version when node_info protocol version is stale', async () => {
+      mockDetermineDockerStatus.returns(DockerStatusEnum.running);
+      mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          softforks: {
+            mn_rr: { active: true, height: 1337 },
+          },
+        },
+      });
+      mockDockerCompose.isServiceRunning.returns(true);
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci status').resolves({ exitCode: 0, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '4.0.0' });
+      mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
+
+      // After an in-process protocol upgrade, Tenderdash keeps the process-start
+      // snapshot in node_info.protocol_version.app while application_info.version
+      // and abci_info.app_version report the live/desired values.
+      const mockStatus = {
+        node_info: {
+          protocol_version: {
+            p2p: '10',
+            block: '14',
+            app: '11',
+          },
+          version: '1.6.0',
+          network: 'dash-mainnet-1',
+          moniker: 'evonode',
+        },
+        application_info: {
+          version: '12',
+        },
+        sync_info: {
+          catching_up: false,
+          latest_app_hash: 'DEADBEEF',
+          latest_block_height: 398435,
+          latest_block_hash: 'DEADBEEF',
+          latest_block_time: 1337,
+        },
+      };
+      const mockNetInfo = { n_peers: 6, listening: true };
+
+      const mockAbciInfo = {
+        response: {
+          version: '4.0.0',
+          app_version: 12,
+          last_block_height: 398435,
+          last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
+        },
+      };
+
+      mockFetch
+        .onFirstCall()
+        .returns(Promise.resolve({ json: () => Promise.resolve(mockStatus) }))
+        .onSecondCall()
+        .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
+        .onThirdCall()
+        .resolves({ json: () => Promise.resolve(mockAbciInfo) });
+
+      const scope = await getPlatformScope(config);
+
+      expect(scope.tenderdash.protocolVersion).to.equal(12);
+      expect(scope.tenderdash.desiredProtocolVersion).to.equal(12);
+      expect(scope.tenderdash.version).to.equal('1.6.0');
+      expect(scope.tenderdash.latestBlockHeight).to.equal(398435);
+    });
+
     it('should return platform syncing when it is catching up', async () => {
       mockDetermineDockerStatus.returns(DockerStatusEnum.running);
       mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
@@ -181,6 +251,9 @@ describe('getPlatformScopeFactory', () => {
           version: '0',
           network: 'test',
           moniker: 'test',
+        },
+        application_info: {
+          version: '3',
         },
         sync_info: {
           catching_up: true,
@@ -444,6 +517,9 @@ describe('getPlatformScopeFactory', () => {
           version: '0',
           network: 'test',
           moniker: 'test',
+        },
+        application_info: {
+          version: '3',
         },
         sync_info: {
           catching_up: false,

--- a/packages/dashmate/test/unit/status/scopes/platform.spec.js
+++ b/packages/dashmate/test/unit/status/scopes/platform.spec.js
@@ -254,16 +254,32 @@ describe('getPlatformScopeFactory', () => {
       expect(scope.tenderdash.desiredProtocolVersion).to.equal(4);
     });
 
-    it('should fall back to node_info app version when consensus params app_version is not numeric', async () => {
+    it('should fall back to node_info app version when consensus params app_version is not a plain integer', async () => {
+      // '3.5' would parseInt to 3 and mask the fallback; it must be rejected
+      // whole. node_info is 2 here so a leaked prefix-parse (3) fails the test.
       mockHealthyPlatform({
-        nodeInfoApp: '3',
+        nodeInfoApp: '2',
         abciAppVersion: 4,
-        consensusParams: { consensus_params: { version: { app_version: 'not-a-number' } } },
+        consensusParams: { consensus_params: { version: { app_version: '3.5' } } },
       });
 
       const scope = await getPlatformScope(config);
 
-      expect(scope.tenderdash.protocolVersion).to.equal(3);
+      expect(scope.tenderdash.protocolVersion).to.equal(2);
+      expect(scope.tenderdash.desiredProtocolVersion).to.equal(4);
+    });
+
+    it('should fall back to node_info app version when consensus params app_version is not a primitive', async () => {
+      // [3] would coerce to '3' via String(); non-primitives must be rejected.
+      mockHealthyPlatform({
+        nodeInfoApp: '2',
+        abciAppVersion: 4,
+        consensusParams: { consensus_params: { version: { app_version: [3] } } },
+      });
+
+      const scope = await getPlatformScope(config);
+
+      expect(scope.tenderdash.protocolVersion).to.equal(2);
       expect(scope.tenderdash.desiredProtocolVersion).to.equal(4);
     });
 

--- a/packages/dashmate/test/unit/status/scopes/platform.spec.js
+++ b/packages/dashmate/test/unit/status/scopes/platform.spec.js
@@ -162,6 +162,67 @@ describe('getPlatformScopeFactory', () => {
       expect(scope).to.deep.equal(expectedScope);
     });
 
+    it('should fall back to node_info app protocol when application_info is absent', async () => {
+      mockDetermineDockerStatus.returns(DockerStatusEnum.running);
+      mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          softforks: {
+            mn_rr: { active: true, height: 1337 },
+          },
+        },
+      });
+      mockDockerCompose.isServiceRunning.returns(true);
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci status').resolves({ exitCode: 0, out: '' });
+      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
+      mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
+
+      // When application_info is omitted (omitempty / unavailable), status must still
+      // report a numeric protocolVersion from node_info.protocol_version.app.
+      const mockStatus = {
+        node_info: {
+          protocol_version: {
+            p2p: '10',
+            block: '14',
+            app: '3',
+          },
+          version: '0',
+          network: 'test',
+          moniker: 'test',
+        },
+        sync_info: {
+          catching_up: false,
+          latest_app_hash: 'DEADBEEF',
+          latest_block_height: 1,
+          latest_block_hash: 'DEADBEEF',
+          latest_block_time: 1337,
+        },
+      };
+      const mockNetInfo = { n_peers: 6, listening: true };
+      const mockAbciInfo = {
+        response: {
+          version: '1.4.1',
+          app_version: 4,
+          last_block_height: 90,
+          last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
+        },
+      };
+
+      mockFetch
+        .onFirstCall()
+        .returns(Promise.resolve({ json: () => Promise.resolve(mockStatus) }))
+        .onSecondCall()
+        .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
+        .onThirdCall()
+        .resolves({ json: () => Promise.resolve(mockAbciInfo) });
+
+      const scope = await getPlatformScope(config);
+
+      expect(scope.tenderdash.serviceStatus).to.equal(ServiceStatusEnum.up);
+      expect(scope.tenderdash.protocolVersion).to.equal(3);
+      expect(scope.tenderdash.desiredProtocolVersion).to.equal(4);
+    });
+
     it('should return platform syncing when it is catching up', async () => {
       mockDetermineDockerStatus.returns(DockerStatusEnum.running);
       mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });

--- a/packages/dashmate/test/unit/status/scopes/platform.spec.js
+++ b/packages/dashmate/test/unit/status/scopes/platform.spec.js
@@ -170,7 +170,19 @@ describe('getPlatformScopeFactory', () => {
       expect(scope).to.deep.equal(expectedScope);
     });
 
-    it('should fall back to node_info app protocol when consensus params app version is absent', async () => {
+    /**
+     * Stub a healthy synced node so the protocol-version tests only vary
+     * the version sources.
+     *
+     * @param {Object} options
+     * @param {string} options.nodeInfoApp - node_info.protocol_version.app (process-start snapshot)
+     * @param {number} options.abciAppVersion - abci_info app_version (installed/desired)
+     * @param {Object} [options.consensusParams] - /consensus_params response body
+     * @param {Error} [options.consensusParamsError] - reject the /consensus_params request instead
+     */
+    function mockHealthyPlatform({
+      nodeInfoApp, abciAppVersion, consensusParams, consensusParamsError,
+    }) {
       mockDetermineDockerStatus.returns(DockerStatusEnum.running);
       mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
       mockRpcClient.getBlockchainInfo.returns({
@@ -185,14 +197,12 @@ describe('getPlatformScopeFactory', () => {
       mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
       mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
 
-      // Older Tenderdash builds may omit consensus_params.version.app_version.
-      // Status must still report a numeric protocolVersion from node_info.protocol_version.app.
       const mockStatus = {
         node_info: {
           protocol_version: {
             p2p: '10',
             block: '14',
-            app: '3',
+            app: nodeInfoApp,
           },
           version: '0',
           network: 'test',
@@ -210,242 +220,74 @@ describe('getPlatformScopeFactory', () => {
       const mockAbciInfo = {
         response: {
           version: '1.4.1',
-          app_version: 4,
+          app_version: abciAppVersion,
           last_block_height: 90,
           last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
-        },
-      };
-      const mockConsensusParams = {
-        consensus_params: {
-          block: {
-            max_bytes: '2097152',
-            max_gas: '57631392000',
-          },
         },
       };
 
       mockFetch
         .onFirstCall()
-        .returns(Promise.resolve({ json: () => Promise.resolve(mockStatus) }))
+        .resolves({ json: () => Promise.resolve(mockStatus) })
         .onSecondCall()
-        .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
+        .resolves({ json: () => Promise.resolve(mockNetInfo) })
         .onThirdCall()
-        .resolves({ json: () => Promise.resolve(mockAbciInfo) })
-        .onCall(3)
-        .resolves({ json: () => Promise.resolve(mockConsensusParams) });
+        .resolves({ json: () => Promise.resolve(mockAbciInfo) });
+
+      if (consensusParamsError) {
+        mockFetch.onCall(3).rejects(consensusParamsError);
+      } else {
+        mockFetch.onCall(3).resolves({ json: () => Promise.resolve(consensusParams) });
+      }
+    }
+
+    it('should fall back to node_info app version when consensus params omit app_version', async () => {
+      mockHealthyPlatform({
+        nodeInfoApp: '3',
+        abciAppVersion: 4,
+        consensusParams: { consensus_params: { block: { max_bytes: '2097152' } } },
+      });
 
       const scope = await getPlatformScope(config);
 
-      expect(scope.tenderdash.serviceStatus).to.equal(ServiceStatusEnum.up);
       expect(scope.tenderdash.protocolVersion).to.equal(3);
       expect(scope.tenderdash.desiredProtocolVersion).to.equal(4);
     });
 
-    it('should fall back to node_info app protocol when consensus params app version is empty', async () => {
-      mockDetermineDockerStatus.returns(DockerStatusEnum.running);
-      mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
-      mockRpcClient.getBlockchainInfo.returns({
-        result: {
-          softforks: {
-            mn_rr: { active: true, height: 1337 },
-          },
-        },
+    it('should fall back to node_info app version when consensus params app_version is not numeric', async () => {
+      mockHealthyPlatform({
+        nodeInfoApp: '3',
+        abciAppVersion: 4,
+        consensusParams: { consensus_params: { version: { app_version: 'not-a-number' } } },
       });
-      mockDockerCompose.isServiceRunning.returns(true);
-      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci status').resolves({ exitCode: 0, out: '' });
-      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
-      mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
-
-      const mockStatus = {
-        node_info: {
-          protocol_version: {
-            p2p: '10',
-            block: '14',
-            app: '3',
-          },
-          version: '0',
-          network: 'test',
-          moniker: 'test',
-        },
-        application_info: {
-          version: '',
-        },
-        sync_info: {
-          catching_up: false,
-          latest_app_hash: 'DEADBEEF',
-          latest_block_height: 1,
-          latest_block_hash: 'DEADBEEF',
-          latest_block_time: 1337,
-        },
-      };
-      const mockNetInfo = { n_peers: 6, listening: true };
-      const mockAbciInfo = {
-        response: {
-          version: '1.4.1',
-          app_version: 4,
-          last_block_height: 90,
-          last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
-        },
-      };
-      const mockConsensusParams = {
-        consensus_params: {
-          version: {
-            app_version: '',
-          },
-        },
-      };
-
-      mockFetch
-        .onFirstCall()
-        .returns(Promise.resolve({ json: () => Promise.resolve(mockStatus) }))
-        .onSecondCall()
-        .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
-        .onThirdCall()
-        .resolves({ json: () => Promise.resolve(mockAbciInfo) })
-        .onCall(3)
-        .resolves({ json: () => Promise.resolve(mockConsensusParams) });
 
       const scope = await getPlatformScope(config);
 
       expect(scope.tenderdash.protocolVersion).to.equal(3);
-      expect(Number.isNaN(scope.tenderdash.protocolVersion)).to.equal(false);
       expect(scope.tenderdash.desiredProtocolVersion).to.equal(4);
     });
 
-    it('should fall back to node_info app protocol when consensus params app version is malformed', async () => {
-      mockDetermineDockerStatus.returns(DockerStatusEnum.running);
-      mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
-      mockRpcClient.getBlockchainInfo.returns({
-        result: {
-          softforks: {
-            mn_rr: { active: true, height: 1337 },
-          },
-        },
+    it('should fall back to node_info app version when the consensus params request fails', async () => {
+      mockHealthyPlatform({
+        nodeInfoApp: '3',
+        abciAppVersion: 4,
+        consensusParamsError: new Error('consensus_params endpoint unavailable'),
       });
-      mockDockerCompose.isServiceRunning.returns(true);
-      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci status').resolves({ exitCode: 0, out: '' });
-      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.4.1' });
-      mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
-
-      const mockStatus = {
-        node_info: {
-          protocol_version: {
-            p2p: '10',
-            block: '14',
-            app: '3',
-          },
-          version: '0',
-          network: 'test',
-          moniker: 'test',
-        },
-        application_info: {
-          version: '999',
-        },
-        sync_info: {
-          catching_up: false,
-          latest_app_hash: 'DEADBEEF',
-          latest_block_height: 1,
-          latest_block_hash: 'DEADBEEF',
-          latest_block_time: 1337,
-        },
-      };
-      const mockNetInfo = { n_peers: 6, listening: true };
-      const mockAbciInfo = {
-        response: {
-          version: '1.4.1',
-          app_version: 4,
-          last_block_height: 90,
-          last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
-        },
-      };
-      const mockConsensusParams = {
-        consensus_params: {
-          version: {
-            app_version: 'not-a-number',
-          },
-        },
-      };
-
-      mockFetch
-        .onFirstCall()
-        .returns(Promise.resolve({ json: () => Promise.resolve(mockStatus) }))
-        .onSecondCall()
-        .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
-        .onThirdCall()
-        .resolves({ json: () => Promise.resolve(mockAbciInfo) })
-        .onCall(3)
-        .resolves({ json: () => Promise.resolve(mockConsensusParams) });
 
       const scope = await getPlatformScope(config);
 
       expect(scope.tenderdash.protocolVersion).to.equal(3);
-      expect(Number.isNaN(scope.tenderdash.protocolVersion)).to.equal(false);
       expect(scope.tenderdash.desiredProtocolVersion).to.equal(4);
     });
 
     it('should keep active consensus protocol distinct from newer desired version during rollout', async () => {
-      mockDetermineDockerStatus.returns(DockerStatusEnum.running);
-      mockRpcClient.mnsync.withArgs('status').returns({ result: { IsSynced: true } });
-      mockRpcClient.getBlockchainInfo.returns({
-        result: {
-          softforks: {
-            mn_rr: { active: true, height: 1337 },
-          },
-        },
+      // Mid-rollout (#4135): consensus already activated 11, the installed
+      // software supports 12, and node_info still snapshots pre-upgrade 10.
+      mockHealthyPlatform({
+        nodeInfoApp: '10',
+        abciAppVersion: 12,
+        consensusParams: { consensus_params: { version: { app_version: '11' } } },
       });
-      mockDockerCompose.isServiceRunning.returns(true);
-      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci status').resolves({ exitCode: 0, out: '' });
-      mockDockerCompose.execCommand.withArgs(config, 'drive_abci', 'drive-abci version').resolves({ exitCode: 0, out: '1.5.0' });
-      mockMNOWatchProvider.returns(Promise.resolve('OPEN'));
-
-      const mockStatus = {
-        node_info: {
-          protocol_version: {
-            p2p: '10',
-            block: '14',
-            app: '10',
-          },
-          version: '1.6.0',
-          network: 'test',
-          moniker: 'test',
-        },
-        application_info: {
-          version: '12',
-        },
-        sync_info: {
-          catching_up: false,
-          latest_app_hash: 'DEADBEEF',
-          latest_block_height: 1,
-          latest_block_hash: 'DEADBEEF',
-          latest_block_time: 1337,
-        },
-      };
-      const mockNetInfo = { n_peers: 6, listening: true };
-      const mockAbciInfo = {
-        response: {
-          version: '1.5.0',
-          app_version: 12,
-          last_block_height: 90,
-          last_block_app_hash: 's0CySQxgRg96DrnJ7HCsql+k/Sk4JiT3y0psCaUI3TI=',
-        },
-      };
-      const mockConsensusParams = {
-        consensus_params: {
-          version: {
-            app_version: '11',
-          },
-        },
-      };
-
-      mockFetch
-        .onFirstCall()
-        .returns(Promise.resolve({ json: () => Promise.resolve(mockStatus) }))
-        .onSecondCall()
-        .returns(Promise.resolve({ json: () => Promise.resolve(mockNetInfo) }))
-        .onThirdCall()
-        .resolves({ json: () => Promise.resolve(mockAbciInfo) })
-        .onCall(3)
-        .resolves({ json: () => Promise.resolve(mockConsensusParams) });
 
       const scope = await getPlatformScope(config);
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
After an in-process Platform protocol upgrade, `dashmate status platform` kept reporting a stale **Protocol Version** from Tenderdash `node_info.protocol_version.app` (snapshotted at process start), while live consensus state already reflected the activated version. That made healthy upgraded nodes look stuck on the previous protocol during rollout windows.

Fixes #4135

## What was done?
- Source **Protocol Version** (active/current) from Tenderdash `/consensus_params` `consensus_params.version.app_version`, which reflects live consensus state.
- Keep **Desired Protocol Version** (installed/supported) from `/abci_info` `response.app_version`.
- Use `node_info.protocol_version.app` only as a compatibility fallback when the live consensus value is omitted, empty, malformed, or the optional consensus-params request is unavailable.
- Stop using `/status` `application_info.version` as the active version because Tenderdash populates it from ABCI Info and Platform reports the desired protocol version there.
- Parse candidate versions strictly so empty or invalid values never produce `NaN`.
- Add rollout, empty-string, malformed-value, omitted-field, and fallback regression coverage.

## How Has This Been Tested?
- Focused Dashmate unit tests: `yarn workspace dashmate mocha --require ./test/bootstrap.js test/unit/status/scopes/platform.spec.js` → **11 passing**
- Targeted lint: `yarn workspace dashmate eslint src/status/scopes/platform.js test/unit/status/scopes/platform.spec.js` → **0 errors, 0 warnings**
- Syntax checks: `node --check packages/dashmate/src/status/scopes/platform.js && node --check packages/dashmate/test/unit/status/scopes/platform.spec.js`
- Whitespace validation: `git diff --check`

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform status reporting by prioritizing the active consensus protocol version.
  * Added reliable fallback behavior when consensus-parameter data is unavailable, invalid, or incomplete.
  * Improved validation of protocol versions by rejecting malformed, non-integer, and unsafe values.
  * Accurately distinguishes active and desired protocol versions during rollouts.
  * Platform status remains available when consensus-parameter requests fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->