### PR TITLE
ci: enforce macOS runner disk reserve

### DIFF
--- a/.github/workflows/swift-sdk-build.yml
+++ b/.github/workflows/swift-sdk-build.yml
@@ -22,6 +22,32 @@ jobs:
             -e target/ \
             -e target/**
 
+      - name: Enforce macOS disk reserve
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cleanup_at_kib=$((120 * 1024 * 1024))
+          minimum_free_kib=$((100 * 1024 * 1024))
+          free_before_kib=$(df -Pk "$GITHUB_WORKSPACE" | awk 'NR == 2 { print $4 }')
+          free_before_gib=$((free_before_kib / 1024 / 1024))
+
+          if (( free_before_kib < cleanup_at_kib )); then
+            echo "::warning::Only ${free_before_gib}GiB is free; removing generated Swift and Rust build output"
+            rm -rf target
+            rm -rf packages/swift-sdk/DashSDKFFI.xcframework
+            find "$RUNNER_TEMP" -mindepth 1 -delete 2>/dev/null || true
+          fi
+
+          free_after_kib=$(df -Pk "$GITHUB_WORKSPACE" | awk 'NR == 2 { print $4 }')
+          free_after_gib=$((free_after_kib / 1024 / 1024))
+          df -h "$GITHUB_WORKSPACE"
+
+          if (( free_after_kib < minimum_free_kib )); then
+            echo "::error::Only ${free_after_gib}GiB is free after cleanup; the runner requires at least 100GiB"
+            exit 1
+          fi
+
       # Rust + Cargo cache to speed up FFI build
       - name: Set up Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- check free disk before the Swift SDK build
- discard generated Rust/Swift output only when free space drops below 120 GiB
- fail early with an explicit infrastructure error if cleanup cannot restore 100 GiB

## Context
Job 88561517581 failed in rustc/LLVM with ENOSPC while the workflow preserved a large Rust target directory. Host-level idle-only disk guards are now also installed on both self-hosted Macs.

## Verification
- `git diff --check`
- workflow YAML parsed successfully
- embedded Bash preflight passed `bash -n`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by proactively managing available disk space during macOS SDK builds.
  * Builds now clean up temporary and generated files when storage is low and stop with a clear error if sufficient space cannot be restored.

* **Chores**
  * Existing build, caching, cleanup, and test processes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->