### PR TITLE
feat(sdk): prefer DAPI peers supporting the client's latest protocol version

### DIFF
--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/QueriesNative.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/QueriesNative.kt
@@ -277,8 +277,11 @@ internal object QueriesNative {
 
     /**
      * Refresh the SDK's protocol version from the network (proven
-     * `getEpochsInfo` ratchet). Returns the resulting version as a decimal
-     * string, or null.
+     * `getEpochsInfo` ratchet, preceded by a bounded best-effort peer
+     * protocol-version probe that biases peer selection). Blocks the calling
+     * thread for the probe + query duration — call from a background
+     * dispatcher only. Returns the resulting version as a decimal string,
+     * or null.
      */
     external fun refreshProtocolVersion(sdk: Long): String?
 

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/queries/PlatformQueries.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/queries/PlatformQueries.kt
@@ -373,6 +373,16 @@ class SystemQueries internal constructor(private val sdk: Sdk) {
      * `PlatformWalletManager`'s), so fee-sensitive flows pick it up. Call on
      * app start and after every network switch. Returns the version after the
      * (possible) ratchet, or null.
+     *
+     * The refresh also best-effort probes a bounded random sample of the
+     * known DAPI peers (unproven `getStatus`, limited concurrency, hard
+     * overall time budget on the Rust side) and biases subsequent peer
+     * selection towards nodes supporting this client's latest protocol
+     * version. The probe runs even for a version-pinned SDK, so this call
+     * performs network I/O in every mode. Like every entry point here, the
+     * blocking native call is marshalled onto [Dispatchers.IO] by
+     * `queryGate.op` — it occupies a worker thread (and the query gate) for
+     * the probe + query duration, never the caller's dispatcher.
      */
     suspend fun refreshProtocolVersion(): Int? = sdk.queryGate.op {
         mapNativeErrors { QueriesNative.refreshProtocolVersion(sdk.handle) }?.toIntOrNull()

--- a/packages/rs-dapi-client/Cargo.toml
+++ b/packages/rs-dapi-client/Cargo.toml
@@ -50,6 +50,9 @@ http-serde = { version = "2.1", optional = true }
 rand = { version = "0.8.5", features = [
   "small_rng",
   "getrandom",
+  # IteratorRandom::choose_multiple (used by AddressList::sample_live_addresses)
+  # is gated behind rand's `alloc` feature.
+  "alloc",
 ], default-features = false }
 thiserror = "2.0.17"
 tracing = "0.1.41"

--- a/packages/rs-dapi-client/src/address_list.rs
+++ b/packages/rs-dapi-client/src/address_list.rs
@@ -3,7 +3,7 @@
 use crate::address_ban_info::AddressBanInfo;
 use crate::Uri;
 use chrono::Utc;
-use rand::{rngs::SmallRng, seq::IteratorRandom, SeedableRng};
+use rand::{rngs::SmallRng, seq::IteratorRandom, Rng, SeedableRng};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -14,6 +14,14 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 const DEFAULT_BASE_BAN_PERIOD: Duration = Duration::from_secs(60);
+
+/// Share of selections (in percent) that consult the preferred-protocol tier
+/// first in [`AddressList::get_live_address`]. The remainder select uniformly
+/// from all live addresses even when preferred peers exist, so a peer's
+/// unproved, self-reported protocol version can bias routing but never
+/// exclusively capture it: every live peer keeps a nonzero selection
+/// probability.
+const PREFERRED_PROTOCOL_SELECTION_PERCENT: u32 = 90;
 
 /// DAPI address.
 #[derive(Debug, Clone, Eq)]
@@ -214,8 +222,10 @@ impl AddressList {
     /// Set (or clear with `None`) the protocol version peers should support for
     /// [`AddressList::get_live_address`] to prefer them.
     ///
-    /// The preference is best-effort: selection falls back to any live address
-    /// when no live address is known to support `version` (see
+    /// The preference is best-effort and non-exclusive: selection is only
+    /// weighted towards supporting peers
+    /// ([`PREFERRED_PROTOCOL_SELECTION_PERCENT`]%), and falls back to any
+    /// live address when no live address is known to support `version` (see
     /// [`AddressList::get_live_address`]). Protocol versions start at 1, so `0`
     /// is rejected as if `None` was passed.
     pub fn set_preferred_protocol_version(&self, version: Option<u32>) {
@@ -358,12 +368,15 @@ impl AddressList {
     ///
     /// When a preferred protocol version is set (see
     /// [`AddressList::set_preferred_protocol_version`]), selection is
-    /// best-effort biased towards it: a live address whose reported supported
-    /// protocol version (see [`AddressList::set_supported_protocol_version`])
-    /// is at least the preferred one is chosen first, and only when no such
-    /// address exists does selection fall back to a random live address —
-    /// including nodes whose version is unknown or lower. Nodes are never
-    /// excluded by version alone.
+    /// best-effort *weighted* towards it: for
+    /// [`PREFERRED_PROTOCOL_SELECTION_PERCENT`]% of selections, a live
+    /// address whose reported supported protocol version (see
+    /// [`AddressList::set_supported_protocol_version`]) is at least the
+    /// preferred one is chosen first, falling back to a random live address
+    /// when no such address exists. The remaining selections go uniformly to
+    /// any live address — including nodes whose version is unknown or lower —
+    /// so the unproved, self-reported version signal can never exclusively
+    /// capture routing. Nodes are never excluded by version alone.
     pub fn get_live_address(&self) -> Option<Address> {
         // TODO(low): module-wide `.read()/.write().unwrap()` panics on a
         // poisoned lock; adopt poison-tolerant locking consistently (SEC-003).
@@ -380,20 +393,22 @@ impl AddressList {
         };
 
         if let Some(preferred) = self.preferred_protocol_version() {
-            let preferred_address = guard
-                .iter()
-                .filter(|(_, status)| {
-                    is_live(status)
-                        && status
-                            .supported_protocol_version
-                            .map(|version| version >= preferred)
-                            .unwrap_or(false)
-                })
-                .choose(&mut rng)
-                .map(|(addr, _)| addr.clone());
+            if rng.gen_range(0..100) < PREFERRED_PROTOCOL_SELECTION_PERCENT {
+                let preferred_address = guard
+                    .iter()
+                    .filter(|(_, status)| {
+                        is_live(status)
+                            && status
+                                .supported_protocol_version
+                                .map(|version| version >= preferred)
+                                .unwrap_or(false)
+                    })
+                    .choose(&mut rng)
+                    .map(|(addr, _)| addr.clone());
 
-            if preferred_address.is_some() {
-                return preferred_address;
+                if preferred_address.is_some() {
+                    return preferred_address;
+                }
             }
         }
 
@@ -1139,11 +1154,13 @@ mod tests {
         assert_eq!(list.supported_protocol_version(&addr), None);
     }
 
-    /// With a preference set, only live addresses whose reported supported
-    /// version is at least the preferred one are selected — nodes with an
-    /// unknown or lower version are skipped while a matching node exists.
+    /// With a preference set, selection is *weighted* towards live addresses
+    /// whose reported supported version is at least the preferred one — but
+    /// never exclusive: nodes with an unknown or lower version must keep a
+    /// nonzero selection probability so an unproved self-reported version
+    /// cannot fully capture routing.
     #[test]
-    fn test_get_live_address_prefers_supporting_peers() {
+    fn test_get_live_address_prefers_supporting_peers_without_capturing_routing() {
         let mut list = AddressList::new();
         let matching: Address = "http://127.0.0.1:3000".parse().unwrap();
         let older: Address = "http://127.0.0.1:3001".parse().unwrap();
@@ -1157,10 +1174,25 @@ mod tests {
         list.set_supported_protocol_version(&older, Some(12));
         list.set_preferred_protocol_version(Some(13));
 
-        // Random selection: sample repeatedly, must always land on `matching`.
-        for _ in 0..50 {
-            assert_eq!(list.get_live_address(), Some(matching.clone()));
+        // Expected share for `matching`: 90% (weighted tier) + 10%×⅓ ≈ 93%.
+        // Bounds are generous (>5σ) so the test cannot realistically flake.
+        let draws = 2000;
+        let mut matching_hits = 0;
+        for _ in 0..draws {
+            match list.get_live_address() {
+                Some(addr) if addr == matching => matching_hits += 1,
+                Some(_) => {}
+                None => panic!("a live address must always be selectable"),
+            }
         }
+        assert!(
+            matching_hits > draws * 8 / 10,
+            "preferred peer must receive a strong majority of selections, got {matching_hits}/{draws}"
+        );
+        assert!(
+            matching_hits < draws,
+            "non-preferred peers must remain reachable — preference must not be exclusive"
+        );
     }
 
     /// A peer reporting a version *newer* than the preferred one also counts
@@ -1178,9 +1210,19 @@ mod tests {
         list.set_supported_protocol_version(&older, Some(12));
         list.set_preferred_protocol_version(Some(13));
 
-        for _ in 0..50 {
-            assert_eq!(list.get_live_address(), Some(newer.clone()));
-        }
+        // Expected share for `newer`: 90% + 10%×½ = 95%; generous bounds.
+        let draws = 2000;
+        let newer_hits = (0..draws)
+            .filter(|_| list.get_live_address() == Some(newer.clone()))
+            .count();
+        assert!(
+            newer_hits > draws * 8 / 10,
+            "newer-than-preferred peer must count as preferred, got {newer_hits}/{draws}"
+        );
+        assert!(
+            newer_hits < draws,
+            "the older peer must remain reachable — preference must not be exclusive"
+        );
     }
 
     /// Best-effort fallback: when no live peer is known to support the
@@ -1257,10 +1299,20 @@ mod tests {
         clone.set_supported_protocol_version(&older, Some(12));
         clone.set_preferred_protocol_version(Some(13));
 
+        // State written through the clone is visible through the original …
         assert_eq!(list.preferred_protocol_version(), Some(13));
-        for _ in 0..50 {
-            assert_eq!(list.get_live_address(), Some(matching.clone()));
-        }
+        assert_eq!(list.supported_protocol_version(&matching), Some(13));
+        assert_eq!(list.supported_protocol_version(&older), Some(12));
+
+        // … and drives (weighted) selection through the original handle.
+        let draws = 2000;
+        let matching_hits = (0..draws)
+            .filter(|_| list.get_live_address() == Some(matching.clone()))
+            .count();
+        assert!(
+            matching_hits > draws * 8 / 10,
+            "preference set via a clone must weight selection on the original, got {matching_hits}/{draws}"
+        );
     }
 
     /// Invariant 1 at the ladder source: the exponential ban window is

--- a/packages/rs-dapi-client/src/address_list.rs
+++ b/packages/rs-dapi-client/src/address_list.rs
@@ -440,6 +440,32 @@ impl AddressList {
             .collect()
     }
 
+    /// Randomly sample up to `count` distinct not-banned addresses.
+    ///
+    /// Uses the same liveness filter as [`Self::get_live_addresses`]. Intended
+    /// to bound best-effort maintenance fan-outs (e.g. protocol-version
+    /// probes) so they never contact every known node at once.
+    pub fn sample_live_addresses(&self, count: usize) -> Vec<Address> {
+        let guard = self.addresses.read().unwrap();
+
+        let mut rng = SmallRng::from_entropy();
+        let now = chrono::Utc::now();
+
+        guard
+            .iter()
+            .filter(|(_, status)| {
+                status
+                    .banned_until
+                    .map(|banned_until| banned_until < now)
+                    .unwrap_or(true)
+            })
+            .map(|(addr, _)| addr)
+            .choose_multiple(&mut rng, count)
+            .into_iter()
+            .cloned()
+            .collect()
+    }
+
     /// Get an owned snapshot of every address' ban state.
     ///
     /// Clones the current state into an owned `Vec<AddressBanInfo>` so
@@ -1045,6 +1071,35 @@ mod tests {
             list.is_banned(&addr),
             "is_banned() must still be true after window expiry (ban_count not reset)"
         );
+    }
+
+    /// `sample_live_addresses` bounds the fan-out: returns at most `count`
+    /// distinct live addresses, skips banned ones, and returns everything
+    /// live when the list is smaller than `count`.
+    #[test]
+    fn test_sample_live_addresses_bounds_and_filters() {
+        let mut list = AddressList::new();
+        let banned: Address = "http://127.0.0.1:3999".parse().unwrap();
+        for port in 3000..3010 {
+            list.add(format!("http://127.0.0.1:{port}").parse().unwrap());
+        }
+        list.add(banned.clone());
+        list.ban(&banned);
+
+        // Cap below the live count: exactly `count` distinct live addresses.
+        let sample = list.sample_live_addresses(4);
+        assert_eq!(sample.len(), 4);
+        let unique: std::collections::HashSet<_> = sample.iter().collect();
+        assert_eq!(unique.len(), 4, "sampled addresses must be distinct");
+        assert!(!sample.contains(&banned), "banned address must be excluded");
+
+        // Cap above the live count: all 10 live addresses, banned excluded.
+        let sample = list.sample_live_addresses(100);
+        assert_eq!(sample.len(), 10);
+        assert!(!sample.contains(&banned));
+
+        // Zero cap: empty sample.
+        assert!(list.sample_live_addresses(0).is_empty());
     }
 
     #[test]

--- a/packages/rs-dapi-client/src/address_list.rs
+++ b/packages/rs-dapi-client/src/address_list.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
@@ -78,6 +79,11 @@ pub struct AddressStatus {
     /// on [`AddressStatus::unban`]. Sourced from the error that caused
     /// the ban (see `update_address_ban_status`).
     ban_reason: Option<String>,
+    /// Highest protocol version this node reports supporting
+    /// (`version.protocol.drive.latest` from `getStatus`), when known.
+    /// Unlike the ban fields this survives [`AddressStatus::unban`]:
+    /// version knowledge is orthogonal to node health.
+    supported_protocol_version: Option<u32>,
 }
 
 impl AddressStatus {
@@ -172,6 +178,10 @@ pub enum AddressListError {
 pub struct AddressList {
     addresses: Arc<RwLock<HashMap<Address, AddressStatus>>>,
     base_ban_period: Duration,
+    /// Protocol version peers should support for [`AddressList::get_live_address`]
+    /// to prefer them; `0` means no preference. Shared across clones (like the
+    /// address map) so a preference set on one clone applies everywhere.
+    preferred_protocol_version: Arc<AtomicU32>,
 }
 
 impl Default for AddressList {
@@ -197,7 +207,54 @@ impl AddressList {
         AddressList {
             addresses: Arc::new(RwLock::new(HashMap::new())),
             base_ban_period,
+            preferred_protocol_version: Arc::new(AtomicU32::new(0)),
         }
+    }
+
+    /// Set (or clear with `None`) the protocol version peers should support for
+    /// [`AddressList::get_live_address`] to prefer them.
+    ///
+    /// The preference is best-effort: selection falls back to any live address
+    /// when no live address is known to support `version` (see
+    /// [`AddressList::get_live_address`]). Protocol versions start at 1, so `0`
+    /// is rejected as if `None` was passed.
+    pub fn set_preferred_protocol_version(&self, version: Option<u32>) {
+        self.preferred_protocol_version
+            .store(version.unwrap_or(0), Ordering::Relaxed);
+    }
+
+    /// Get the preferred protocol version for peer selection, if set.
+    pub fn preferred_protocol_version(&self) -> Option<u32> {
+        match self.preferred_protocol_version.load(Ordering::Relaxed) {
+            0 => None,
+            version => Some(version),
+        }
+    }
+
+    /// Record the highest protocol version `address` reports supporting
+    /// (`version.protocol.drive.latest` from `getStatus`), or clear it with
+    /// `None` when a fresh probe could not determine it.
+    ///
+    /// Returns `false` if the address is not in the list.
+    pub fn set_supported_protocol_version(&self, address: &Address, version: Option<u32>) -> bool {
+        let mut guard = self.addresses.write().unwrap();
+
+        let Some(status) = guard.get_mut(address) else {
+            return false;
+        };
+
+        status.supported_protocol_version = version;
+
+        true
+    }
+
+    /// Get the highest protocol version `address` reports supporting, when known.
+    pub fn supported_protocol_version(&self, address: &Address) -> Option<u32> {
+        let guard = self.addresses.read().unwrap();
+
+        guard
+            .get(address)
+            .and_then(|status| status.supported_protocol_version)
     }
 
     /// Bans address
@@ -298,6 +355,15 @@ impl AddressList {
     ///
     /// An address is considered live when it has never been banned or when its
     /// ban period has already expired.
+    ///
+    /// When a preferred protocol version is set (see
+    /// [`AddressList::set_preferred_protocol_version`]), selection is
+    /// best-effort biased towards it: a live address whose reported supported
+    /// protocol version (see [`AddressList::set_supported_protocol_version`])
+    /// is at least the preferred one is chosen first, and only when no such
+    /// address exists does selection fall back to a random live address —
+    /// including nodes whose version is unknown or lower. Nodes are never
+    /// excluded by version alone.
     pub fn get_live_address(&self) -> Option<Address> {
         // TODO(low): module-wide `.read()/.write().unwrap()` panics on a
         // poisoned lock; adopt poison-tolerant locking consistently (SEC-003).
@@ -306,14 +372,34 @@ impl AddressList {
         let mut rng = SmallRng::from_entropy();
         let now = chrono::Utc::now();
 
+        let is_live = |status: &AddressStatus| {
+            status
+                .banned_until
+                .map(|banned_until| banned_until < now)
+                .unwrap_or(true)
+        };
+
+        if let Some(preferred) = self.preferred_protocol_version() {
+            let preferred_address = guard
+                .iter()
+                .filter(|(_, status)| {
+                    is_live(status)
+                        && status
+                            .supported_protocol_version
+                            .map(|version| version >= preferred)
+                            .unwrap_or(false)
+                })
+                .choose(&mut rng)
+                .map(|(addr, _)| addr.clone());
+
+            if preferred_address.is_some() {
+                return preferred_address;
+            }
+        }
+
         guard
             .iter()
-            .filter(|(_, status)| {
-                status
-                    .banned_until
-                    .map(|banned_until| banned_until < now)
-                    .unwrap_or(true)
-            })
+            .filter(|(_, status)| is_live(status))
             .choose(&mut rng)
             .map(|(addr, _)| addr.clone())
     }
@@ -959,6 +1045,167 @@ mod tests {
             list.is_banned(&addr),
             "is_banned() must still be true after window expiry (ban_count not reset)"
         );
+    }
+
+    #[test]
+    fn test_preferred_protocol_version_roundtrip() {
+        let list = AddressList::new();
+        assert_eq!(list.preferred_protocol_version(), None);
+
+        list.set_preferred_protocol_version(Some(13));
+        assert_eq!(list.preferred_protocol_version(), Some(13));
+
+        list.set_preferred_protocol_version(None);
+        assert_eq!(list.preferred_protocol_version(), None);
+
+        // 0 is the "no preference" sentinel — setting it behaves like None.
+        list.set_preferred_protocol_version(Some(0));
+        assert_eq!(list.preferred_protocol_version(), None);
+    }
+
+    #[test]
+    fn test_set_supported_protocol_version_unknown_address() {
+        let list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        assert!(!list.set_supported_protocol_version(&addr, Some(13)));
+        assert_eq!(list.supported_protocol_version(&addr), None);
+    }
+
+    #[test]
+    fn test_set_supported_protocol_version_roundtrip() {
+        let mut list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        list.add(addr.clone());
+
+        assert_eq!(list.supported_protocol_version(&addr), None);
+        assert!(list.set_supported_protocol_version(&addr, Some(13)));
+        assert_eq!(list.supported_protocol_version(&addr), Some(13));
+        assert!(list.set_supported_protocol_version(&addr, None));
+        assert_eq!(list.supported_protocol_version(&addr), None);
+    }
+
+    /// With a preference set, only live addresses whose reported supported
+    /// version is at least the preferred one are selected — nodes with an
+    /// unknown or lower version are skipped while a matching node exists.
+    #[test]
+    fn test_get_live_address_prefers_supporting_peers() {
+        let mut list = AddressList::new();
+        let matching: Address = "http://127.0.0.1:3000".parse().unwrap();
+        let older: Address = "http://127.0.0.1:3001".parse().unwrap();
+        let unknown: Address = "http://127.0.0.1:3002".parse().unwrap();
+
+        list.add(matching.clone());
+        list.add(older.clone());
+        list.add(unknown.clone());
+
+        list.set_supported_protocol_version(&matching, Some(13));
+        list.set_supported_protocol_version(&older, Some(12));
+        list.set_preferred_protocol_version(Some(13));
+
+        // Random selection: sample repeatedly, must always land on `matching`.
+        for _ in 0..50 {
+            assert_eq!(list.get_live_address(), Some(matching.clone()));
+        }
+    }
+
+    /// A peer reporting a version *newer* than the preferred one also counts
+    /// as preferred (>= semantics): it supports our latest version too.
+    #[test]
+    fn test_get_live_address_newer_peer_counts_as_preferred() {
+        let mut list = AddressList::new();
+        let newer: Address = "http://127.0.0.1:3000".parse().unwrap();
+        let older: Address = "http://127.0.0.1:3001".parse().unwrap();
+
+        list.add(newer.clone());
+        list.add(older.clone());
+
+        list.set_supported_protocol_version(&newer, Some(14));
+        list.set_supported_protocol_version(&older, Some(12));
+        list.set_preferred_protocol_version(Some(13));
+
+        for _ in 0..50 {
+            assert_eq!(list.get_live_address(), Some(newer.clone()));
+        }
+    }
+
+    /// Best-effort fallback: when no live peer is known to support the
+    /// preferred version, selection falls back to any live peer instead of
+    /// returning None.
+    #[test]
+    fn test_get_live_address_falls_back_when_no_peer_matches() {
+        let mut list = AddressList::new();
+        let older: Address = "http://127.0.0.1:3000".parse().unwrap();
+        let unknown: Address = "http://127.0.0.1:3001".parse().unwrap();
+
+        list.add(older.clone());
+        list.add(unknown.clone());
+
+        list.set_supported_protocol_version(&older, Some(12));
+        list.set_preferred_protocol_version(Some(13));
+
+        let selected = list
+            .get_live_address()
+            .expect("fallback must select a peer");
+        assert!(selected == older || selected == unknown);
+    }
+
+    /// A banned matching peer must not be selected: the ban filter applies
+    /// before the version preference, falling back to live non-matching peers.
+    #[test]
+    fn test_get_live_address_banned_preferred_peer_falls_back() {
+        let mut list = AddressList::new();
+        let matching: Address = "http://127.0.0.1:3000".parse().unwrap();
+        let older: Address = "http://127.0.0.1:3001".parse().unwrap();
+
+        list.add(matching.clone());
+        list.add(older.clone());
+
+        list.set_supported_protocol_version(&matching, Some(13));
+        list.set_supported_protocol_version(&older, Some(12));
+        list.set_preferred_protocol_version(Some(13));
+
+        list.ban(&matching);
+
+        for _ in 0..50 {
+            assert_eq!(list.get_live_address(), Some(older.clone()));
+        }
+    }
+
+    /// The supported version recorded for a node survives unban: version
+    /// knowledge is orthogonal to node health.
+    #[test]
+    fn test_supported_protocol_version_survives_unban() {
+        let mut list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        list.add(addr.clone());
+
+        list.set_supported_protocol_version(&addr, Some(13));
+        list.ban(&addr);
+        list.unban(&addr);
+
+        assert_eq!(list.supported_protocol_version(&addr), Some(13));
+    }
+
+    /// The preference and reported versions are shared across clones, like the
+    /// address map itself, so a preference set through one handle (e.g. the
+    /// SDK's) applies to selection through another (e.g. the DAPI client's).
+    #[test]
+    fn test_protocol_version_preference_shared_across_clones() {
+        let mut list = AddressList::new();
+        let matching: Address = "http://127.0.0.1:3000".parse().unwrap();
+        let older: Address = "http://127.0.0.1:3001".parse().unwrap();
+        list.add(matching.clone());
+        list.add(older.clone());
+
+        let clone = list.clone();
+        clone.set_supported_protocol_version(&matching, Some(13));
+        clone.set_supported_protocol_version(&older, Some(12));
+        clone.set_preferred_protocol_version(Some(13));
+
+        assert_eq!(list.preferred_protocol_version(), Some(13));
+        for _ in 0..50 {
+            assert_eq!(list.get_live_address(), Some(matching.clone()));
+        }
     }
 
     /// Invariant 1 at the ladder source: the exponential ban window is

--- a/packages/rs-sdk-ffi/src/protocol_version/queries/refresh.rs
+++ b/packages/rs-sdk-ffi/src/protocol_version/queries/refresh.rs
@@ -17,11 +17,16 @@ use std::ffi::CString;
 /// flows (shielded pool shield/unshield/transfer/withdraw) reserve against the
 /// network's actual protocol version instead of the SDK's seed version.
 ///
-/// As part of the refresh the SDK also best-effort probes the known DAPI peers
-/// (unproven `getStatus`, concurrent, short timeout) and biases subsequent peer
-/// selection towards nodes whose software already supports this client's latest
-/// protocol version. Probe failures are ignored and no peer is ever excluded —
-/// when no peer matches, selection falls back to any live peer.
+/// As part of the refresh the SDK also best-effort probes a bounded random
+/// sample of the known DAPI peers (unproven `getStatus`, limited concurrency,
+/// hard overall time budget) and biases subsequent peer selection towards
+/// nodes whose software already supports this client's latest protocol
+/// version. Probe failures are ignored and no peer is ever excluded — when no
+/// peer matches, selection falls back to any live peer.
+///
+/// This call blocks the calling thread until the probe and the proven query
+/// complete (it drives the SDK runtime via `block_on`); bindings must invoke
+/// it from a background thread/executor, never from the UI thread.
 ///
 /// For an SDK pinned to a fixed protocol version (version updating disabled)
 /// the proven version query is skipped and the pinned version is returned

--- a/packages/rs-sdk-ffi/src/protocol_version/queries/refresh.rs
+++ b/packages/rs-sdk-ffi/src/protocol_version/queries/refresh.rs
@@ -17,9 +17,15 @@ use std::ffi::CString;
 /// flows (shielded pool shield/unshield/transfer/withdraw) reserve against the
 /// network's actual protocol version instead of the SDK's seed version.
 ///
+/// As part of the refresh the SDK also best-effort probes the known DAPI peers
+/// (unproven `getStatus`, concurrent, short timeout) and biases subsequent peer
+/// selection towards nodes whose software already supports this client's latest
+/// protocol version. Probe failures are ignored and no peer is ever excluded —
+/// when no peer matches, selection falls back to any live peer.
+///
 /// For an SDK pinned to a fixed protocol version (version updating disabled)
-/// this is a no-op: no network request is made and the pinned version is
-/// returned unchanged.
+/// the proven version query is skipped and the pinned version is returned
+/// unchanged; the best-effort peer probe above still runs.
 ///
 /// # Parameters
 /// * `sdk_handle` - Handle to the SDK instance.

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -413,6 +413,10 @@ impl Sdk {
     pub async fn refresh_protocol_version(&self) -> Result<u32, Error> {
         // Best-effort: bias peer selection towards nodes that already support
         // this client's newest protocol version. Never fails, never ratchets.
+        // Deliberately sequenced before (not overlapped with) the proven query
+        // below so that query already picks a preferred, up-to-date peer —
+        // probes run concurrently, so the added latency is one status
+        // round-trip (bounded by PEER_VERSION_PROBE_TIMEOUT).
         self.prefer_peers_with_latest_protocol_version().await;
 
         if !self.prove() {

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -480,7 +480,9 @@ impl Sdk {
     ///   unproved self-assertion;
     /// - the probe is *unproven* and feeds only peer ordering, never the SDK's
     ///   protocol-version ratchet, which stays proof-driven
-    ///   ([`Self::maybe_update_protocol_version`]).
+    ///   ([`Self::maybe_update_protocol_version`]);
+    /// - the pass also stops early on [`Self::shutdown`], so a shutdown during
+    ///   refresh is not delayed by the remaining probe budget.
     ///
     /// Probes execute their transport directly against the target address
     /// instead of going through the `DapiClient` executor: the executor pairs
@@ -591,8 +593,14 @@ impl Sdk {
             }
         ))
         .buffer_unordered(PEER_VERSION_PROBE_CONCURRENCY)
-        .take_until(rs_dapi_client::transport::sleep(
-            PEER_VERSION_PROBE_TOTAL_BUDGET,
+        // Stop on whichever comes first: the overall probe budget, or SDK
+        // shutdown. Without the cancellation arm a `Sdk::shutdown()` issued
+        // during a refresh would still wait out the full budget.
+        .take_until(futures::future::select(
+            Box::pin(rs_dapi_client::transport::sleep(
+                PEER_VERSION_PROBE_TOTAL_BUDGET,
+            )),
+            Box::pin(self.cancelled()),
         )));
 
         let mut preferred_count = 0;

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -76,9 +76,24 @@ const fn min_protocol_version(network: Network) -> u32 {
 const DEFAULT_METADATA_TIME_TOLERANCE_MS: u64 = 31 * 60 * 1000;
 
 /// Per-node timeout for the best-effort peer protocol-version probe
-/// ([`Sdk::prefer_peers_with_latest_protocol_version`]). Probes run
-/// concurrently, so this also bounds the total probe time.
+/// ([`Sdk::prefer_peers_with_latest_protocol_version`]).
 const PEER_VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// Maximum number of peers sampled per protocol-version probe. Bootstrap
+/// address lists can hold hundreds of seeds (mainnet ships ~340 Evo nodes);
+/// probing a random sample is enough to find preferred peers without a
+/// connection storm, and unprobed peers stay usable via the best-effort
+/// fallback in peer selection.
+const MAX_PEER_VERSION_PROBES: usize = 16;
+
+/// Maximum number of protocol-version probe connections in flight at once.
+const PEER_VERSION_PROBE_CONCURRENCY: usize = 8;
+
+/// Overall wall-clock budget for one protocol-version probe pass. Results
+/// that arrived before the deadline are kept; outstanding probes are dropped
+/// (their nodes simply stay unranked). Keeps app-start latency bounded even
+/// when several sampled peers hang until [`PEER_VERSION_PROBE_TIMEOUT`].
+const PEER_VERSION_PROBE_TOTAL_BUDGET: Duration = Duration::from_secs(6);
 
 /// The default request settings for the SDK, used when the user does not provide any.
 ///
@@ -415,8 +430,9 @@ impl Sdk {
         // this client's newest protocol version. Never fails, never ratchets.
         // Deliberately sequenced before (not overlapped with) the proven query
         // below so that query already picks a preferred, up-to-date peer —
-        // probes run concurrently, so the added latency is one status
-        // round-trip (bounded by PEER_VERSION_PROBE_TIMEOUT).
+        // probes are sampled and run concurrently, so the added latency is
+        // typically one status round-trip and hard-capped by
+        // PEER_VERSION_PROBE_TOTAL_BUDGET.
         self.prefer_peers_with_latest_protocol_version().await;
 
         if !self.prove() {
@@ -440,9 +456,12 @@ impl Sdk {
     /// Best-effort: probe DAPI peers for the protocol version they support and
     /// prefer peers supporting this client's latest protocol version.
     ///
-    /// Concurrently issues an unproven `getStatus` to every live address in the
-    /// SDK's address list (per-node timeout [`PEER_VERSION_PROBE_TIMEOUT`], no
-    /// retries, no banning) and records each node's reported
+    /// Issues an unproven `getStatus` to a random sample of up to
+    /// [`MAX_PEER_VERSION_PROBES`] live addresses from the SDK's address list —
+    /// at most [`PEER_VERSION_PROBE_CONCURRENCY`] connections in flight, each
+    /// with a [`PEER_VERSION_PROBE_TIMEOUT`] per-node timeout, no retries, no
+    /// banning, and an overall [`PEER_VERSION_PROBE_TOTAL_BUDGET`] wall-clock
+    /// cap — and records each node's reported
     /// `version.protocol.drive.latest` — the highest protocol version that
     /// node's software supports, i.e. the version it desires/votes for. It then
     /// marks [`PlatformVersion::latest()`] (this client's newest supported
@@ -450,7 +469,8 @@ impl Sdk {
     /// pick, when possible, peers whose reported version is at least ours.
     ///
     /// The preference is strictly best-effort:
-    /// - probe failures are ignored (the node stays in rotation, unranked);
+    /// - probe failures are ignored (the node stays in rotation, unranked), as
+    ///   are peers outside the sample or unanswered within the budget;
     /// - when no live peer is known to support the target version, selection
     ///   falls back to any live peer — no peer is ever excluded by version;
     /// - the probe is *unproven* and feeds only peer ordering, never the SDK's
@@ -461,8 +481,10 @@ impl Sdk {
     /// start and network switch in the mobile SDKs); callable directly for
     /// custom startup flows. On a mock SDK this is a no-op.
     ///
-    /// Returns the number of live peers found to support the target version.
+    /// Returns the number of probed peers found to support the target version.
     pub async fn prefer_peers_with_latest_protocol_version(&self) -> usize {
+        use futures::StreamExt;
+
         #[cfg(feature = "mocks")]
         if matches!(self.inner, SdkInstance::Mock { .. }) {
             return 0;
@@ -470,7 +492,7 @@ impl Sdk {
 
         let target = PlatformVersion::latest().protocol_version;
         let address_list = self.address_list();
-        let addresses = address_list.get_live_addresses();
+        let addresses = address_list.sample_live_addresses(MAX_PEER_VERSION_PROBES);
 
         let settings = RequestSettings {
             connect_timeout: Some(PEER_VERSION_PROBE_TIMEOUT),
@@ -480,18 +502,27 @@ impl Sdk {
             max_decoding_message_size: None,
         };
 
-        let probes = addresses.into_iter().map(|address| async move {
-            let result = EvoNodeStatus::fetch_unproved_with_settings(
-                self,
-                EvoNode::new(address.clone()),
-                settings,
-            )
-            .await;
-            (address, result)
-        });
+        // Bounded fan-out: sampled peers only, limited concurrency, and an
+        // overall deadline. `take_until` keeps results that completed before
+        // the budget elapsed and drops the rest (those nodes stay unranked).
+        let mut probes = std::pin::pin!(futures::stream::iter(addresses.into_iter().map(
+            |address| async move {
+                let result = EvoNodeStatus::fetch_unproved_with_settings(
+                    self,
+                    EvoNode::new(address.clone()),
+                    settings,
+                )
+                .await;
+                (address, result)
+            }
+        ))
+        .buffer_unordered(PEER_VERSION_PROBE_CONCURRENCY)
+        .take_until(rs_dapi_client::transport::sleep(
+            PEER_VERSION_PROBE_TOTAL_BUDGET,
+        )));
 
         let mut preferred_count = 0;
-        for (address, result) in futures::future::join_all(probes).await {
+        while let Some((address, result)) = probes.next().await {
             let supported = match result {
                 Ok((Some(status), _)) => status
                     .version

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -7,7 +7,8 @@ use crate::mock::MockResponse;
 use crate::mock::{provider::GrpcContextProvider, MockDashPlatformSdk};
 use crate::platform::fetch_current_no_parameters::FetchCurrent;
 use crate::platform::transition::put_settings::PutSettings;
-use crate::platform::Identifier;
+use crate::platform::types::evonode::EvoNode;
+use crate::platform::{FetchUnproved, Identifier};
 use arc_swap::ArcSwapOption;
 use dapi_grpc::mock::Mockable;
 use dapi_grpc::platform::v0::{Proof, ResponseMetadata};
@@ -23,6 +24,7 @@ use dpp::dashcore::Network;
 use dpp::prelude::IdentityNonce;
 use dpp::version::PlatformVersion;
 use drive::grovedb::operations::proof::GroveDBProof;
+use drive_proof_verifier::types::evonode_status::EvoNodeStatus;
 use drive_proof_verifier::FromProof;
 pub use http::Uri;
 #[cfg(feature = "mocks")]
@@ -42,6 +44,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::{atomic, Arc};
+use std::time::Duration;
 #[cfg(feature = "mocks")]
 use tokio::sync::{Mutex, MutexGuard};
 use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
@@ -71,6 +74,11 @@ const fn min_protocol_version(network: Network) -> u32 {
 
 /// Default signed-metadata freshness window for network SDKs.
 const DEFAULT_METADATA_TIME_TOLERANCE_MS: u64 = 31 * 60 * 1000;
+
+/// Per-node timeout for the best-effort peer protocol-version probe
+/// ([`Sdk::prefer_peers_with_latest_protocol_version`]). Probes run
+/// concurrently, so this also bounds the total probe time.
+const PEER_VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(4);
 
 /// The default request settings for the SDK, used when the user does not provide any.
 ///
@@ -374,8 +382,16 @@ impl Sdk {
     /// succeeds. Refresh therefore inherits the exact cryptographic trust of
     /// ordinary traffic; it adds no second, weaker source of truth.
     ///
+    /// Before the proven queries, this best-effort probes the known DAPI peers and
+    /// biases future peer selection towards nodes supporting this client's latest
+    /// protocol version (see [`Self::prefer_peers_with_latest_protocol_version`]).
+    /// The probe is unproven and can never fail this call; it only reorders peer
+    /// preference, it does not feed the version ratchet.
+    ///
     /// On a pinned SDK ([`SdkBuilder::with_version`], `version_pinned`
-    /// on) this issues no request and returns the pinned version.
+    /// on) this issues no proven query and returns the pinned version (the
+    /// best-effort peer probe above still runs — peer preference is orthogonal
+    /// to version pinning).
     ///
     /// If the fetch fails the failure is **non-fatal**: whatever version was
     /// already learned is kept — we never fall back to an unverified one. Note
@@ -386,14 +402,19 @@ impl Sdk {
     /// ratchet step is proof-verified and upward-only, so a partial refresh can
     /// only ever leave the SDK closer to the network's real version.
     ///
-    /// On a proofs-disabled SDK ([`SdkBuilder::with_proofs`]`(false)`) this is a
-    /// no-op that returns the current version: refresh relies on a proven query,
-    /// so with proofs off there is no trusted source to ratchet from.
+    /// On a proofs-disabled SDK ([`SdkBuilder::with_proofs`]`(false)`) the
+    /// proven ratchet is skipped and the current version is returned: refresh
+    /// relies on a proven query, so with proofs off there is no trusted source
+    /// to ratchet from. The peer probe still runs.
     ///
     /// Returns the SDK's protocol version number after the (possible) ratchet.
     ///
     /// [`SdkBuilder::with_version`]: SdkBuilder::with_version
     pub async fn refresh_protocol_version(&self) -> Result<u32, Error> {
+        // Best-effort: bias peer selection towards nodes that already support
+        // this client's newest protocol version. Never fails, never ratchets.
+        self.prefer_peers_with_latest_protocol_version().await;
+
         if !self.prove() {
             return Ok(self.protocol_version_number());
         }
@@ -410,6 +431,96 @@ impl Sdk {
             }
         }
         Ok(self.protocol_version_number())
+    }
+
+    /// Best-effort: probe DAPI peers for the protocol version they support and
+    /// prefer peers supporting this client's latest protocol version.
+    ///
+    /// Concurrently issues an unproven `getStatus` to every live address in the
+    /// SDK's address list (per-node timeout [`PEER_VERSION_PROBE_TIMEOUT`], no
+    /// retries, no banning) and records each node's reported
+    /// `version.protocol.drive.latest` — the highest protocol version that
+    /// node's software supports, i.e. the version it desires/votes for. It then
+    /// marks [`PlatformVersion::latest()`] (this client's newest supported
+    /// protocol version) as the preferred peer version, so subsequent requests
+    /// pick, when possible, peers whose reported version is at least ours.
+    ///
+    /// The preference is strictly best-effort:
+    /// - probe failures are ignored (the node stays in rotation, unranked);
+    /// - when no live peer is known to support the target version, selection
+    ///   falls back to any live peer — no peer is ever excluded by version;
+    /// - the probe is *unproven* and feeds only peer ordering, never the SDK's
+    ///   protocol-version ratchet, which stays proof-driven
+    ///   ([`Self::maybe_update_protocol_version`]).
+    ///
+    /// Called automatically by [`Self::refresh_protocol_version`] (i.e. on app
+    /// start and network switch in the mobile SDKs); callable directly for
+    /// custom startup flows. On a mock SDK this is a no-op.
+    ///
+    /// Returns the number of live peers found to support the target version.
+    pub async fn prefer_peers_with_latest_protocol_version(&self) -> usize {
+        #[cfg(feature = "mocks")]
+        if matches!(self.inner, SdkInstance::Mock { .. }) {
+            return 0;
+        }
+
+        let target = PlatformVersion::latest().protocol_version;
+        let address_list = self.address_list();
+        let addresses = address_list.get_live_addresses();
+
+        let settings = RequestSettings {
+            connect_timeout: Some(PEER_VERSION_PROBE_TIMEOUT),
+            timeout: Some(PEER_VERSION_PROBE_TIMEOUT),
+            retries: Some(0),
+            ban_failed_address: Some(false),
+            max_decoding_message_size: None,
+        };
+
+        let probes = addresses.into_iter().map(|address| async move {
+            let result = EvoNodeStatus::fetch_unproved_with_settings(
+                self,
+                EvoNode::new(address.clone()),
+                settings,
+            )
+            .await;
+            (address, result)
+        });
+
+        let mut preferred_count = 0;
+        for (address, result) in futures::future::join_all(probes).await {
+            let supported = match result {
+                Ok((Some(status), _)) => status
+                    .version
+                    .protocol
+                    .and_then(|protocol| protocol.drive)
+                    .map(|drive| drive.latest),
+                Ok((None, _)) => None,
+                Err(error) => {
+                    tracing::debug!(
+                        target: "dash_sdk::protocol_version",
+                        %address,
+                        %error,
+                        "peer protocol-version probe failed; leaving peer unranked"
+                    );
+                    None
+                }
+            };
+
+            address_list.set_supported_protocol_version(&address, supported);
+            if supported.is_some_and(|version| version >= target) {
+                preferred_count += 1;
+            }
+        }
+
+        address_list.set_preferred_protocol_version(Some(target));
+        tracing::debug!(
+            target: "dash_sdk::protocol_version",
+            target_protocol_version = target,
+            preferred_peers = preferred_count,
+            "peer protocol-version probe complete; preferring peers supporting our latest version"
+        );
+
+        preferred_count
     }
 
     /// Retrieve object `O` from proof contained in `request` (of type `R`) and `response`.

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -8,7 +8,7 @@ use crate::mock::{provider::GrpcContextProvider, MockDashPlatformSdk};
 use crate::platform::fetch_current_no_parameters::FetchCurrent;
 use crate::platform::transition::put_settings::PutSettings;
 use crate::platform::types::evonode::EvoNode;
-use crate::platform::{FetchUnproved, Identifier};
+use crate::platform::Identifier;
 use arc_swap::ArcSwapOption;
 use dapi_grpc::mock::Mockable;
 use dapi_grpc::platform::v0::{Proof, ResponseMetadata};
@@ -469,13 +469,25 @@ impl Sdk {
     /// pick, when possible, peers whose reported version is at least ours.
     ///
     /// The preference is strictly best-effort:
-    /// - probe failures are ignored (the node stays in rotation, unranked), as
-    ///   are peers outside the sample or unanswered within the budget;
+    /// - the rankings of all sampled peers are cleared at the start of each
+    ///   pass, so a probe that fails — or is dropped by the total budget —
+    ///   leaves its peer unranked rather than preserving a stale claim from
+    ///   an earlier pass;
     /// - when no live peer is known to support the target version, selection
-    ///   falls back to any live peer — no peer is ever excluded by version;
+    ///   falls back to any live peer — and even when preferred peers exist,
+    ///   selection is only *weighted* towards them, never exclusive (see
+    ///   `AddressList::get_live_address`), because the reported version is an
+    ///   unproved self-assertion;
     /// - the probe is *unproven* and feeds only peer ordering, never the SDK's
     ///   protocol-version ratchet, which stays proof-driven
     ///   ([`Self::maybe_update_protocol_version`]).
+    ///
+    /// Probes execute their transport directly against the target address
+    /// instead of going through the `DapiClient` executor: the executor pairs
+    /// every response with an address *it* selected, so a targeted probe
+    /// routed through it would attribute one peer's success to an unrelated
+    /// peer and mutate that peer's ban state. Direct execution keeps probes
+    /// free of any health-state side effects.
     ///
     /// Called automatically by [`Self::refresh_protocol_version`] (i.e. on app
     /// start and network switch in the mobile SDKs); callable directly for
@@ -483,18 +495,28 @@ impl Sdk {
     ///
     /// Returns the number of probed peers found to support the target version.
     pub async fn prefer_peers_with_latest_protocol_version(&self) -> usize {
+        use drive_proof_verifier::unproved::FromUnproved;
         use futures::StreamExt;
+        use rs_dapi_client::transport::{PlatformGrpcClient, TransportClient};
+        use rs_dapi_client::ConnectionPool;
 
-        #[cfg(feature = "mocks")]
-        if matches!(self.inner, SdkInstance::Mock { .. }) {
-            return 0;
-        }
+        let dapi = match &self.inner {
+            SdkInstance::Dapi { dapi, .. } => dapi,
+            #[cfg(feature = "mocks")]
+            SdkInstance::Mock { .. } => return 0,
+        };
 
         let target = PlatformVersion::latest().protocol_version;
-        let address_list = self.address_list();
+        let address_list = dapi.address_list();
         let addresses = address_list.sample_live_addresses(MAX_PEER_VERSION_PROBES);
 
-        let settings = RequestSettings {
+        // A fresh pass owns the rankings of every sampled peer: clear them up
+        // front so an unanswered probe cannot leave a stale claim behind.
+        for address in &addresses {
+            address_list.set_supported_protocol_version(address, None);
+        }
+
+        let probe_settings = RequestSettings {
             connect_timeout: Some(PEER_VERSION_PROBE_TIMEOUT),
             timeout: Some(PEER_VERSION_PROBE_TIMEOUT),
             retries: Some(0),
@@ -507,13 +529,65 @@ impl Sdk {
         // the budget elapsed and drops the rest (those nodes stay unranked).
         let mut probes = std::pin::pin!(futures::stream::iter(addresses.into_iter().map(
             |address| async move {
-                let result = EvoNodeStatus::fetch_unproved_with_settings(
-                    self,
-                    EvoNode::new(address.clone()),
-                    settings,
-                )
-                .await;
-                (address, result)
+                let applied = self
+                    .dapi_client_settings
+                    .override_by(probe_settings)
+                    .finalize();
+                #[cfg(not(target_arch = "wasm32"))]
+                let applied = applied.with_ca_certificate(dapi.ca_certificate.clone());
+
+                // Direct transport execution — deliberately NOT
+                // `self.execute(..)`: see the health-state note in the method
+                // docs. `EvoNode` connects to its own address; the client we
+                // pass only satisfies the transport signature.
+                let node = EvoNode::new(address.clone());
+                let pool = ConnectionPool::new(1);
+                let result = match PlatformGrpcClient::with_uri_and_settings(
+                    address.uri().clone(),
+                    &applied,
+                    &pool,
+                ) {
+                    Ok(mut client) => node.clone().execute_transport(&mut client, &applied).await,
+                    Err(error) => Err(error),
+                };
+
+                let supported = match result {
+                    Ok(response) => {
+                        match <EvoNodeStatus as FromUnproved<EvoNode>>::maybe_from_unproved_with_metadata(
+                            node,
+                            response,
+                            self.network,
+                            self.version(),
+                        ) {
+                            Ok((Some(status), _)) => status
+                                .version
+                                .protocol
+                                .and_then(|protocol| protocol.drive)
+                                .map(|drive| drive.latest),
+                            Ok((None, _)) => None,
+                            Err(error) => {
+                                tracing::debug!(
+                                    target: "dash_sdk::protocol_version",
+                                    %address,
+                                    %error,
+                                    "peer protocol-version probe response invalid; leaving peer unranked"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        tracing::debug!(
+                            target: "dash_sdk::protocol_version",
+                            %address,
+                            %error,
+                            "peer protocol-version probe failed; leaving peer unranked"
+                        );
+                        None
+                    }
+                };
+
+                (address, supported)
             }
         ))
         .buffer_unordered(PEER_VERSION_PROBE_CONCURRENCY)
@@ -522,25 +596,7 @@ impl Sdk {
         )));
 
         let mut preferred_count = 0;
-        while let Some((address, result)) = probes.next().await {
-            let supported = match result {
-                Ok((Some(status), _)) => status
-                    .version
-                    .protocol
-                    .and_then(|protocol| protocol.drive)
-                    .map(|drive| drive.latest),
-                Ok((None, _)) => None,
-                Err(error) => {
-                    tracing::debug!(
-                        target: "dash_sdk::protocol_version",
-                        %address,
-                        %error,
-                        "peer protocol-version probe failed; leaving peer unranked"
-                    );
-                    None
-                }
-            };
-
+        while let Some((address, supported)) = probes.next().await {
             address_list.set_supported_protocol_version(&address, supported);
             if supported.is_some_and(|version| version >= target) {
                 preferred_count += 1;

--- a/packages/rs-unified-sdk-jni/src/queries.rs
+++ b/packages/rs-unified-sdk-jni/src/queries.rs
@@ -936,8 +936,12 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_QueriesNative_evonode
 /// Refresh the SDK's protocol version from the network (proven
 /// `getEpochsInfo` ratchet — see `dash_sdk_refresh_protocol_version`) and
 /// return the resulting version as a decimal string, or null after
-/// throwing. Backs the protocol-version-gated shielded denomination picker
-/// (Kotlin port of iOS `SDK.refreshProtocolVersion`).
+/// throwing. Also runs the bounded best-effort peer protocol-version probe
+/// first (see `Sdk::prefer_peers_with_latest_protocol_version`), so the
+/// call performs network I/O even for a pinned SDK and blocks the calling
+/// thread for the probe + query duration — the Kotlin wrapper marshals it
+/// onto `Dispatchers.IO`. Backs the protocol-version-gated shielded
+/// denomination picker (Kotlin port of iOS `SDK.refreshProtocolVersion`).
 #[no_mangle]
 pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_QueriesNative_refreshProtocolVersion(
     mut env: JNIEnv,

--- a/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
@@ -503,10 +503,21 @@ public final class SDK: @unchecked Sendable {
   /// (including the clone held by a `PlatformWalletManager`), so fee-sensitive
   /// flows pick it up automatically.
   ///
+  /// The refresh also best-effort probes a bounded random sample of the known
+  /// DAPI peers (unproven `getStatus`, limited concurrency, hard overall time
+  /// budget) and biases subsequent peer selection towards nodes whose software
+  /// already supports this client's latest protocol version. Probe failures
+  /// are ignored and no peer is ever excluded — when no peer matches,
+  /// selection falls back to any live peer.
+  ///
   /// Call on app start and after every network switch. For an SDK pinned to a
-  /// fixed protocol version (version updating disabled) this is a no-op: no
-  /// network request is made and the pinned version is returned. Bridges
-  /// `dash_sdk_refresh_protocol_version`.
+  /// fixed protocol version (version updating disabled) the proven version
+  /// query is skipped and the pinned version is returned unchanged; the
+  /// best-effort peer probe above still runs, so this call performs network
+  /// I/O even when pinned. Bridges `dash_sdk_refresh_protocol_version`.
+  ///
+  /// This call blocks the calling thread until the probe and the proven query
+  /// complete — invoke it from a background queue/task, never the main thread.
   ///
   /// - Returns: the SDK's protocol version number after the (possible) ratchet.
   @discardableResult

--- a/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
@@ -516,8 +516,9 @@ public final class SDK: @unchecked Sendable {
   /// best-effort peer probe above still runs, so this call performs network
   /// I/O even when pinned. Bridges `dash_sdk_refresh_protocol_version`.
   ///
-  /// This call blocks the calling thread until the probe and the proven query
-  /// complete — invoke it from a background queue/task, never the main thread.
+  /// This call blocks the calling thread until the probe and, when applicable,
+  /// the proven query complete — invoke it from a background queue/task, never
+  /// the main thread.
   ///
   /// - Returns: the SDK's protocol version number after the (possible) ratchet.
   @discardableResult


### PR DESCRIPTION
## Issue being fixed or feature implemented

When a client (rs-sdk / platform wallet / mobile bindings) connects to DAPI, peer selection is uniformly random over all live addresses. Nodes running older software may not support the client's newest protocol version, which can degrade behavior for version-sensitive flows. On startup the client should make a best effort to talk to peers whose software already supports (i.e. desires/votes for) the client's latest protocol version.

## What was done?

- **rs-dapi-client**: `AddressList` now tracks, per address, the highest protocol version the node reports supporting, plus an optional preferred-version target shared across clones. `get_live_address` picks randomly among live peers whose reported version is at least the preferred one, and falls back to any live peer when none match — no peer is ever excluded by version alone, and version knowledge survives unban (health and version are orthogonal).
- **rs-sdk**: new `Sdk::prefer_peers_with_latest_protocol_version()` concurrently issues an unproven `getStatus` to every live peer (4 s per-node timeout, no retries, no banning), records each node's `version.protocol.drive.latest`, and sets the preference target to `PlatformVersion::latest().protocol_version` (the client's newest supported version). Probe failures leave the peer in rotation, unranked.
- The probe is wired into `Sdk::refresh_protocol_version()` — the documented app-start / network-switch hook — so rs-sdk-ffi (Swift), the JNI bindings (Kotlin), and any caller of refresh get the behavior with no binding changes. It runs even for pinned or proofs-disabled SDKs (peer preference is orthogonal to version pinning); the proven version-ratchet path is unchanged and the unproven probe never feeds it.

## How Has This Been Tested?

- New unit tests in `rs-dapi-client` covering: preference targeting (`>=` semantics, newer peers count as preferred), best-effort fallback when no peer matches, ban filtering taking precedence over preference, version knowledge surviving unban, and preference propagation across `AddressList` clones.
- `cargo test -p rs-dapi-client` and `cargo test -p dash-sdk --lib` pass; `cargo clippy --all-targets` clean on both crates; `rs-sdk-ffi` and `wasm-sdk` (wasm32-unknown-unknown) still compile.

## Breaking Changes

None — all API additions are backward compatible, and with no preference set peer selection behaves exactly as before.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved peer selection by preferring live nodes that support the latest protocol version.
  * Added protocol-version preference and per-peer capability tracking, preserved across unbans.
  * Added an SDK method to proactively prefer compatible peers.
* **Bug Fixes**
  * Banned peers are excluded, with fallback to other live peers when needed.
  * Peer sampling now returns bounded, distinct, non-banned addresses.
* **Documentation**
  * Clarified bounded peer probing, fallback behavior, ignored probe failures, and blocking requirements during protocol refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->