### PR TITLE
fix(platform-wallet): commit wallet events off the async runtime

### DIFF
--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -384,7 +384,32 @@ async fn run_wallet_event_adapter<P>(
         // Captured before the batch moves into the closure: if the commit
         // thread panics, these are the wallets whose rows have an unknown fate
         // and whose watermark must therefore be frozen.
-        let batch_wallet_ids: Vec<WalletId> = batch.keys().copied().collect();
+        //
+        // Only wallets `commit_batch` can actually call `store()` for. A wallet
+        // contributes to the batch whenever it produced an event, including
+        // events that project to nothing — a `TransactionInstantLocked` that is
+        // ignored because the transaction is already chain-locked, a
+        // `SyncHeightAdvanced` for an unknown wallet. Those hit the
+        // `is_empty_no_records()` skip and never reach a store, so a sibling's
+        // panic says nothing about them; freezing them would strip a healthy
+        // wallet's watermark for the rest of the session over someone else's
+        // bad batch.
+        //
+        // Deliberately conservative in one direction: `commit_batch` re-tests
+        // emptiness AFTER `freeze_synced_height_if_faulted` has stripped a
+        // faulted wallet's watermark, so a batch that looks non-empty here can
+        // still be skipped there. That wallet is already faulted, so freezing
+        // it again costs nothing — whereas the reverse error, omitting a wallet
+        // whose store did run, would leave a watermark free to advance past
+        // rows nobody can account for.
+        let batch_wallet_ids: Vec<WalletId> = batch
+            .iter()
+            .filter(|(_, wallet_batch)| {
+                !wallet_batch.core.is_empty_no_records()
+                    || !Merge::is_empty(&wallet_batch.asset_locks)
+            })
+            .map(|(wallet_id, _)| *wallet_id)
+            .collect();
         // Filled by `commit_batch` as each wallet's `store()` returns. Lives
         // out here so a panicking commit thread cannot take it down with it:
         // what it holds is the difference between "this wallet's rows are
@@ -466,6 +491,29 @@ async fn run_wallet_event_adapter<P>(
                     for wallet_id in &unsettled {
                         fault.fault_wallet(*wallet_id, &sync_fault);
                     }
+                }
+                // Same one-shot marker the rejection arm emits, and via the same
+                // `log` facade, because this freeze is indistinguishable from
+                // that one as far as the host is concerned: the latch is up and
+                // a rescan is pending. Leaving it to `tracing` alone would hide
+                // a panic-induced freeze from logcat entirely, and — worse —
+                // leave `freeze_logged` clear, so a later rejected store would
+                // emit the supposedly one-shot line as though it were the first
+                // fault of the session.
+                //
+                // `swap` rather than load-then-store: a store panicking inside
+                // the same blocking task can race the flag the task wrote back
+                // on its way out, and emitting this line twice is a worse
+                // outcome than the branch reading its own write.
+                if !unsettled.is_empty() && !freeze_logged.swap(true, Ordering::Relaxed) {
+                    log::error!(
+                        "SYNC WATERMARK FROZEN: the wallet-event commit thread panicked ({}); \
+                         {} wallet(s) whose rows have an unknown outcome are now held so the \
+                         next scan re-persists them (dashpay/platform#4370). \
+                         syncFaultDetected() is latched.",
+                        join_error,
+                        unsettled.len()
+                    );
                 }
                 tracing::error!(
                     error = %join_error,
@@ -2418,6 +2466,97 @@ mod tests {
     /// let the NEXT batch persist a higher `synced_height` for a wallet whose
     /// earlier rows may never have landed, which is exactly the hole
     /// dashpay/platform#4069 closed.
+    /// The commit must not run on a Tokio worker.
+    ///
+    /// This is the behaviour the `spawn_blocking` move exists for, and no
+    /// other test covers it: the outcome-only assertions elsewhere all still
+    /// pass with `commit_batch` called inline, because a blocking store on a
+    /// multi-worker runtime merely steals one worker and the rest of the test
+    /// proceeds. Pinning the runtime to a single worker makes the difference
+    /// observable — inline, that one worker sits inside `store()` and nothing
+    /// else on the runtime can advance.
+    ///
+    /// The release is driven from a plain `std::thread`, and the verdict is
+    /// read there too, because a regression parks the only worker: the test
+    /// body cannot run, and neither can a `tokio::time::timeout` — the timer
+    /// needs the same worker to fire. An in-runtime deadline would therefore
+    /// hang CI instead of failing it, which is exactly what the bounded waits
+    /// elsewhere in this file exist to avoid.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn a_blocking_store_does_not_park_the_runtime() {
+        let wallet_id = [0xB1u8; 32];
+        let (tx, rx) = unbounded_channel::<WalletEvent>();
+
+        let (obs_tx, mut obs_rx) = unbounded_channel();
+        let persister = Arc::new(ProbePersister::new(obs_tx));
+        let (unblock, blocked) = persister.block_next();
+        let sync_fault = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+        let handle = tokio::spawn(run_wallet_event_adapter(
+            test_manager(),
+            Arc::clone(&persister),
+            rx,
+            Arc::clone(&sync_fault),
+            cancel.clone(),
+        ));
+
+        // Set before the store blocks, so it is waiting on the runtime rather
+        // than racing to be scheduled: whether it ran is then purely a question
+        // of the worker being free.
+        let progressed = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&progressed);
+        tokio::spawn(async move {
+            flag.store(true, Ordering::Relaxed);
+        });
+
+        tx.send(block_processed_event(wallet_id, 10)).unwrap();
+
+        // Outside the runtime entirely: waits for the store to park, records
+        // whether the unrelated task got to run while it was parked, then
+        // releases it so the test always terminates either way.
+        let observer_progressed = Arc::clone(&progressed);
+        let observer_blocked = Arc::clone(&blocked);
+        let watcher = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            while !observer_blocked.load(Ordering::Relaxed) {
+                if std::time::Instant::now() > deadline {
+                    return Err("store never entered its block");
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            // Give the runtime a moment it does not need when it is healthy;
+            // parked, no amount of waiting would help.
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            let ran_while_blocked = observer_progressed.load(Ordering::Relaxed);
+            drop(unblock);
+            Ok(ran_while_blocked)
+        });
+
+        let observed = obs_rx
+            .recv()
+            .await
+            .expect("the released store should report");
+        assert_eq!(observed.wallet_id, wallet_id);
+
+        let ran_while_blocked = watcher
+            .join()
+            .expect("watcher thread should not panic")
+            .expect("store never entered its block");
+        assert!(
+            ran_while_blocked,
+            "an unrelated task must make progress while the commit blocks — \
+             the commit is running on a runtime worker instead of a blocking thread"
+        );
+        assert!(
+            !sync_fault.load(Ordering::Relaxed),
+            "a slow store is not a fault"
+        );
+
+        cancel.cancel();
+        drop(tx);
+        let _ = handle.await;
+    }
+
     #[tokio::test]
     async fn a_panicking_commit_freezes_the_batch_wallets() {
         let wallet_id = [0xEEu8; 32];

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -34,7 +34,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use dashcore::blockdata::transaction::{txout::TxOut, OutPoint};
 use dashcore::ScriptBuf;
@@ -294,10 +294,16 @@ async fn run_wallet_event_adapter<P>(
     P: PlatformWalletPersistence + 'static,
 {
     tracing::debug!("wallet-event adapter task started");
-    let mut fault = AdapterFaultState::default();
+    // Both live behind handles rather than as locals because the commit runs
+    // on a blocking thread (see the `spawn_blocking` below) and has to be able
+    // to carry its state across drains. Moving them into the closure by value
+    // would lose a wallet's frozen watermark if that thread ever panicked —
+    // un-freezing a wallet that failed verification is the one outcome the
+    // fail-closed guard exists to prevent.
+    let fault = Arc::new(Mutex::new(AdapterFaultState::default()));
     // One-shot latch so the hard "watermark frozen" line hits logcat exactly
     // once per session rather than once per faulted batch.
-    let mut freeze_logged = false;
+    let freeze_logged = Arc::new(AtomicBool::new(false));
 
     loop {
         // Block for the first event of a batch. Everything already sitting in
@@ -360,14 +366,60 @@ async fn run_wallet_event_adapter<P>(
         // Commit the folded batch. The channel is lossless, so the only way a
         // watermark is held back is a rejected `store()` (the fail-closed
         // backstop inside `commit_batch`).
-        let diag = commit_batch(
-            &*persister,
-            batch,
-            folded,
-            &mut fault,
-            &sync_fault,
-            &mut freeze_logged,
-        );
+        // Commit on a blocking thread, never on the async worker.
+        //
+        // `store()` is synchronous and, for the SQLite backend, commits a real
+        // transaction per call — its own docs warn that a slow write blocks
+        // every other wallet accessor for its duration. Called inline here it
+        // blocked a tokio worker instead: a field restore showed one drain of
+        // 512 folded events park the runtime long enough for the metrics tick
+        // covering it to report a 1.4s mean poll, with the whole sync stalled
+        // for minutes at a time and the durable watermark left hundreds of
+        // thousands of blocks behind the chain tip.
+        //
+        // The handle is awaited rather than raced against `cancel`: a store
+        // that has started must be allowed to finish, and dropping the handle
+        // would not stop the thread anyway. Shutdown is observed at the next
+        // `recv` instead.
+        let persister_for_commit = Arc::clone(&persister);
+        let sync_fault_for_commit = Arc::clone(&sync_fault);
+        let fault_for_commit = Arc::clone(&fault);
+        let freeze_for_commit = Arc::clone(&freeze_logged);
+        let committed = tokio::task::spawn_blocking(move || {
+            // The lock is uncontended by construction — this task is the only
+            // writer, and one drain commits at a time — so it never blocks;
+            // it exists to carry the state, not to arbitrate.
+            let mut fault = fault_for_commit
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let mut freeze_logged = freeze_for_commit.load(Ordering::Relaxed);
+            let diag = commit_batch(
+                &*persister_for_commit,
+                batch,
+                folded,
+                &mut fault,
+                &sync_fault_for_commit,
+                &mut freeze_logged,
+            );
+            freeze_for_commit.store(freeze_logged, Ordering::Relaxed);
+            diag
+        })
+        .await;
+
+        let diag = match committed {
+            Ok(diag) => diag,
+            // The commit thread panicked. The fault state survives (it lives
+            // behind the handle above), but this batch's outcome is unknown,
+            // so it is reported rather than silently folded into the next one.
+            Err(join_error) => {
+                tracing::error!(
+                    error = %join_error,
+                    folded,
+                    "wallet-event commit thread failed; batch outcome unknown"
+                );
+                continue;
+            }
+        };
 
         // One structured line per drain via the `log` facade so a tester
         // logcat is unambiguous about whether the watermark is advancing.

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -91,11 +91,17 @@ const ADAPTER_STORE_BATCH_LIMIT: usize = 512;
 /// Session fault state for the durable-watermark guard
 /// (dashpay/platform#4069).
 ///
-/// Now that the persistence channel is a lossless unbounded `mpsc`, the only
-/// remaining fault trigger is a **`store()` rejection**, which carries a
-/// `wallet_id`, so only THAT wallet's watermark freezes. A sibling wallet
-/// whose rows are still landing atomically keeps advancing — freezing it too
-/// would force a redundant rescan of a wallet that never lost a row.
+/// Now that the persistence channel is a lossless unbounded `mpsc`, two things
+/// fault a wallet, and both name the wallets they hit, so a sibling whose rows
+/// are still landing atomically keeps advancing — freezing it too would force a
+/// redundant rescan of a wallet that never lost a row.
+///
+/// - A **`store()` rejection**, which carries a `wallet_id`: that wallet's rows
+///   are known not to be on disk.
+/// - A **panic in the blocking commit thread**, which faults every wallet with
+///   something to persist that is absent from `settled` — the one that panicked
+///   plus every wallet the loop never reached. Their outcome is unknown rather
+///   than known-bad, and unknown must fail closed the same way.
 ///
 /// The old global (`broadcast::Lagged`) latch is gone: the unbounded channel
 /// can never `Lagged`, so there is no more "dropped events of unknown wallet"
@@ -103,7 +109,8 @@ const ADAPTER_STORE_BATCH_LIMIT: usize = 512;
 /// fail-closed backstop — in a healthy run it never fires.
 #[derive(Default)]
 struct AdapterFaultState {
-    /// Set by a `store()` rejection: freezes only the named wallet.
+    /// Set by a `store()` rejection, or by the panic-recovery branch for a
+    /// wallet whose commit outcome is unknown: freezes only the named wallets.
     per_wallet: HashMap<WalletId, bool>,
 }
 
@@ -113,8 +120,9 @@ impl AdapterFaultState {
         self.per_wallet.get(wallet_id).copied().unwrap_or(false)
     }
 
-    /// Fault a single wallet after its `store()` was rejected, and raise
-    /// the host-visible hard-fault signal.
+    /// Fault a single wallet — after its `store()` was rejected, or after a
+    /// commit panic left its outcome unknown — and raise the host-visible
+    /// hard-fault signal.
     fn fault_wallet(&mut self, wallet_id: WalletId, hard_signal: &AtomicBool) {
         self.per_wallet.insert(wallet_id, true);
         hard_signal.store(true, Ordering::Relaxed);
@@ -266,9 +274,11 @@ where
 ///
 /// # Durable-watermark guard (fail-closed backstop)
 ///
-/// One fault trigger remains: a rejected `store()` (the rows for that batch
-/// are not on disk). When a wallet faults this way, we never advance ITS
-/// persisted sync watermark again this session — [`freeze_synced_height_if_faulted`]
+/// Two things fault a wallet: a rejected `store()` (the rows for that batch
+/// are not on disk) and a panic in the blocking commit thread (the rows for
+/// every persistable wallet the commit did not settle have an unknown fate,
+/// which fails closed the same way). When a wallet faults either way, we never
+/// advance ITS persisted sync watermark again this session — [`freeze_synced_height_if_faulted`]
 /// strips `synced_height` from every subsequent changeset, holding the
 /// durable watermark at the last height whose rows were fully committed.
 /// Records/UTXO deltas in the same changeset still persist; only the height
@@ -276,8 +286,9 @@ where
 /// (lower) watermark and the persister's idempotent upserts re-apply the
 /// missing rows. This is a fail-closed safety property — the durable
 /// watermark never outruns the rows it implies — and in a healthy run it
-/// never fires, since the channel is lossless and a `store()` rejection means
-/// a genuine backend error, not overload.
+/// never fires, since the channel is lossless, and both triggers mean a
+/// genuine backend error rather than overload — a rejection is one the store
+/// reported, a panic one it could not.
 ///
 /// When a wallet faults, the task raises `sync_fault` (an `AtomicBool` the
 /// host polls via `PlatformWalletManager::sync_fault_detected`) and logs a
@@ -363,9 +374,10 @@ async fn run_wallet_event_adapter<P>(
             }
         }
 
-        // Commit the folded batch. The channel is lossless, so the only way a
-        // watermark is held back is a rejected `store()` (the fail-closed
-        // backstop inside `commit_batch`).
+        // Commit the folded batch. The channel is lossless, so a watermark is
+        // held back only by the fail-closed backstops around this call: a
+        // rejected `store()` inside `commit_batch`, or a panic in the commit
+        // thread, handled in the `Err` arm below.
         // Commit on a blocking thread, never on the async worker.
         //
         // `store()` is synchronous and, for the SQLite backend, commits a real
@@ -671,10 +683,11 @@ where
 
 /// Durable-watermark guard for dashpay/platform#4069.
 ///
-/// When a wallet has faulted this session (a `store()` was rejected), its
-/// persisted `synced_height` watermark must not advance past the last height
-/// whose rows were fully committed — otherwise the wallet believes it is
-/// scanned and never re-matches the blocks whose rows were lost. This
+/// When a wallet has faulted this session — its `store()` was rejected, or a
+/// commit panic left the batch's outcome unknown — its persisted
+/// `synced_height` watermark must not advance past the last height whose rows
+/// were fully committed; otherwise the wallet believes it is scanned and never
+/// re-matches the blocks whose rows were lost. This
 /// strips ONLY `synced_height`; every other field (records, UTXO
 /// deltas, `last_processed_height`, chain-lock) is left intact so
 /// in-flight rows still persist. Factored out as a pure function so the
@@ -2803,8 +2816,9 @@ mod tests {
 
         let (obs_tx, mut obs_rx) = unbounded_channel();
         let persister = Arc::new(ProbePersister::new(obs_tx));
-        // Fault the wallet via a rejected store (the only remaining trigger
-        // now that the lossless channel can't lag).
+        // Fault the wallet via a rejected store — the trigger with a known
+        // outcome. The other one, a commit panic, is covered by
+        // `a_panicking_commit_freezes_the_batch_wallets`.
         persister.fail_next(wallet_id);
         let sync_fault = Arc::new(AtomicBool::new(false));
         let cancel = CancellationToken::new();

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -381,6 +381,10 @@ async fn run_wallet_event_adapter<P>(
         // that has started must be allowed to finish, and dropping the handle
         // would not stop the thread anyway. Shutdown is observed at the next
         // `recv` instead.
+        // Captured before the batch moves into the closure: if the commit
+        // thread panics, these are the wallets whose rows have an unknown fate
+        // and whose watermark must therefore be frozen.
+        let batch_wallet_ids: Vec<WalletId> = batch.keys().copied().collect();
         let persister_for_commit = Arc::clone(&persister);
         let sync_fault_for_commit = Arc::clone(&sync_fault);
         let fault_for_commit = Arc::clone(&fault);
@@ -408,14 +412,34 @@ async fn run_wallet_event_adapter<P>(
 
         let diag = match committed {
             Ok(diag) => diag,
-            // The commit thread panicked. The fault state survives (it lives
-            // behind the handle above), but this batch's outcome is unknown,
-            // so it is reported rather than silently folded into the next one.
+            // The commit thread panicked, so `commit_batch` never reached the
+            // `store()` rejection arm that would have frozen the affected
+            // wallets. Freeze them here instead.
+            //
+            // Before this call moved off the runtime a panic unwound the whole
+            // adapter task, which stopped every later watermark advance by
+            // killing the writer. `spawn_blocking` turns that into a recoverable
+            // `JoinError`, and simply continuing would let the NEXT batch
+            // persist a higher `synced_height` for a wallet whose rows from this
+            // batch may never have landed — the exact hole the fail-closed rule
+            // exists to prevent. Faulting per wallet rather than stopping the
+            // adapter keeps the existing design: a wallet whose commit is in
+            // doubt freezes, its siblings keep syncing.
             Err(join_error) => {
+                {
+                    let mut fault = fault
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    for wallet_id in &batch_wallet_ids {
+                        fault.fault_wallet(*wallet_id, &sync_fault);
+                    }
+                }
                 tracing::error!(
                     error = %join_error,
                     folded,
-                    "wallet-event commit thread failed; batch outcome unknown"
+                    wallets = batch_wallet_ids.len(),
+                    "wallet-event commit thread failed; freezing the batch's \
+                     wallets because their rows have an unknown outcome"
                 );
                 continue;
             }
@@ -1932,6 +1956,10 @@ mod tests {
     struct ProbePersister {
         obs: UnboundedSender<StoreObserved>,
         fail_once: Mutex<HashSet<WalletId>>,
+        /// Wallets whose NEXT `store()` panics instead of returning. Models a
+        /// backend that dies mid-write — the case that used to unwind the whole
+        /// adapter task and now surfaces as a `JoinError`.
+        panic_once: Mutex<HashSet<WalletId>>,
     }
 
     impl ProbePersister {
@@ -1939,10 +1967,14 @@ mod tests {
             Self {
                 obs,
                 fail_once: Mutex::new(HashSet::new()),
+                panic_once: Mutex::new(HashSet::new()),
             }
         }
         fn fail_next(&self, wallet_id: WalletId) {
             self.fail_once.lock().unwrap().insert(wallet_id);
+        }
+        fn panic_next(&self, wallet_id: WalletId) {
+            self.panic_once.lock().unwrap().insert(wallet_id);
         }
     }
 
@@ -1953,6 +1985,9 @@ mod tests {
             changeset: PlatformWalletChangeSet,
         ) -> Result<(), PersistenceError> {
             let core = changeset.core.as_ref();
+            if self.panic_once.lock().unwrap().remove(&wallet_id) {
+                panic!("probe persister: store panicked for {wallet_id:?}");
+            }
             let rejected = self.fail_once.lock().unwrap().remove(&wallet_id);
             let _ = self.obs.send(StoreObserved {
                 wallet_id,
@@ -2303,6 +2338,75 @@ mod tests {
             obs_rx.try_recv().is_err(),
             "one store per wallet, not per event"
         );
+    }
+
+    /// (h) SAFETY INVARIANT under a commit-thread PANIC: a wallet whose
+    /// `store()` panicked must be frozen just as if the store had been
+    /// rejected, because its rows have an unknown fate.
+    ///
+    /// This is a regression guard on the move to `spawn_blocking`. Before it,
+    /// a panic unwound the adapter task itself, which stopped every later
+    /// watermark advance by killing the writer outright. `spawn_blocking`
+    /// turns that into a recoverable `JoinError` — and merely logging it would
+    /// let the NEXT batch persist a higher `synced_height` for a wallet whose
+    /// earlier rows may never have landed, which is exactly the hole
+    /// dashpay/platform#4069 closed.
+    #[tokio::test]
+    async fn a_panicking_commit_freezes_the_batch_wallets() {
+        let wallet_id = [0xEEu8; 32];
+        let (tx, rx) = unbounded_channel::<WalletEvent>();
+
+        let (obs_tx, mut obs_rx) = unbounded_channel();
+        let persister = Arc::new(ProbePersister::new(obs_tx));
+        persister.panic_next(wallet_id);
+        let sync_fault = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+        let handle = tokio::spawn(run_wallet_event_adapter(
+            test_manager(),
+            Arc::clone(&persister),
+            rx,
+            Arc::clone(&sync_fault),
+            cancel.clone(),
+        ));
+
+        // The store for this batch panics: no observation is emitted, and the
+        // adapter must fault the wallet rather than carry on unaffected.
+        tx.send(block_processed_event(wallet_id, 10)).unwrap();
+        // Bounded, so a regression fails the test instead of hanging it: with
+        // the fault-on-panic path removed, `sync_fault` is simply never raised
+        // and an unbounded spin would wedge CI with no diagnosis.
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !sync_fault.load(Ordering::Relaxed) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("a panicked commit must raise the hard-fault signal");
+
+        // The adapter must still be alive — the point of moving the commit off
+        // the runtime is that one bad batch does not take the writer with it.
+        assert!(
+            !handle.is_finished(),
+            "a panicked commit must not kill the adapter"
+        );
+
+        // A later watermark for the same wallet must not reach the store.
+        tx.send(block_processed_event(wallet_id, 60)).unwrap();
+        tx.send(sync_height_event(wallet_id, 900)).unwrap();
+
+        let post = obs_rx
+            .recv()
+            .await
+            .expect("the record-bearing event must still persist while faulted");
+        assert_eq!(post.wallet_id, wallet_id);
+        assert_eq!(
+            post.synced_height, None,
+            "a wallet whose commit panicked must not advance its durable watermark"
+        );
+
+        cancel.cancel();
+        drop(tx);
+        handle.await.unwrap();
     }
 
     /// (g) SAFETY INVARIANT under a fault: once the per-wallet fault latch is

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -427,21 +427,22 @@ async fn run_wallet_event_adapter<P>(
             let mut fault = fault_for_commit
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let mut freeze_logged = freeze_for_commit.load(Ordering::Relaxed);
             let mut settled = settled_for_commit
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let diag = commit_batch(
+            // The flag itself, not a copy: a local `bool` written back after
+            // `commit_batch` returns is lost when a later store in the same
+            // batch panics, and the panic branch would then emit the one-shot
+            // marker a second time for a freeze already announced.
+            commit_batch(
                 &*persister_for_commit,
                 batch,
                 folded,
                 &mut fault,
                 &sync_fault_for_commit,
-                &mut freeze_logged,
+                &freeze_for_commit,
                 &mut settled,
-            );
-            freeze_for_commit.store(freeze_logged, Ordering::Relaxed);
-            diag
+            )
         })
         .await;
 
@@ -497,7 +498,7 @@ async fn run_wallet_event_adapter<P>(
                 // that one as far as the host is concerned: the latch is up and
                 // a rescan is pending. Leaving it to `tracing` alone would hide
                 // a panic-induced freeze from logcat entirely, and — worse —
-                // leave `freeze_logged` clear, so a later rejected store would
+                // leave the flag clear, so a later rejected store would
                 // emit the supposedly one-shot line as though it were the first
                 // fault of the session.
                 //
@@ -568,7 +569,7 @@ fn commit_batch<P>(
     folded: usize,
     fault: &mut AdapterFaultState,
     sync_fault: &AtomicBool,
-    freeze_logged: &mut bool,
+    freeze_logged: &AtomicBool,
     settled: &mut Vec<WalletId>,
 ) -> BatchDiagnostics
 where
@@ -648,8 +649,7 @@ where
                 }
                 // One-shot, unambiguous logcat marker via the `log` facade
                 // (android_logger forwards `log` to logcat; `tracing` may not).
-                if !*freeze_logged {
-                    *freeze_logged = true;
+                if !freeze_logged.swap(true, Ordering::Relaxed) {
                     log::error!(
                         "SYNC WATERMARK FROZEN: persister rejected a changeset for wallet {} ({}); \
                          its durable sync height is now held so the next scan re-persists the \
@@ -2476,12 +2476,14 @@ mod tests {
     /// observable — inline, that one worker sits inside `store()` and nothing
     /// else on the runtime can advance.
     ///
-    /// The release is driven from a plain `std::thread`, and the verdict is
-    /// read there too, because a regression parks the only worker: the test
-    /// body cannot run, and neither can a `tokio::time::timeout` — the timer
-    /// needs the same worker to fire. An in-runtime deadline would therefore
-    /// hang CI instead of failing it, which is exactly what the bounded waits
-    /// elsewhere in this file exist to avoid.
+    /// Everything that decides the verdict happens on a plain `std::thread`,
+    /// for two reasons. The sentinel is spawned only after the store is
+    /// observed blocked: scheduled beforehand, the runtime could poll it first
+    /// and set the flag while nothing was blocking yet, so the test would pass
+    /// inline too. And a regression parks the only worker, so neither the test
+    /// body nor a `tokio::time::timeout` can run — the timer needs that same
+    /// worker — which would hang CI instead of failing it, the outcome the
+    /// bounded waits elsewhere in this file exist to avoid.
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn a_blocking_store_does_not_park_the_runtime() {
         let wallet_id = [0xB1u8; 32];
@@ -2500,34 +2502,37 @@ mod tests {
             cancel.clone(),
         ));
 
-        // Set before the store blocks, so it is waiting on the runtime rather
-        // than racing to be scheduled: whether it ran is then purely a question
-        // of the worker being free.
-        let progressed = Arc::new(AtomicBool::new(false));
-        let flag = Arc::clone(&progressed);
-        tokio::spawn(async move {
-            flag.store(true, Ordering::Relaxed);
-        });
-
         tx.send(block_processed_event(wallet_id, 10)).unwrap();
 
-        // Outside the runtime entirely: waits for the store to park, records
-        // whether the unrelated task got to run while it was parked, then
-        // releases it so the test always terminates either way.
+        let runtime = tokio::runtime::Handle::current();
+        let progressed = Arc::new(AtomicBool::new(false));
         let observer_progressed = Arc::clone(&progressed);
         let observer_blocked = Arc::clone(&blocked);
         let watcher = std::thread::spawn(move || {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-            while !observer_blocked.load(Ordering::Relaxed) {
-                if std::time::Instant::now() > deadline {
-                    return Err("store never entered its block");
+            let wait_for = |flag: &AtomicBool, secs: u64| {
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+                while !flag.load(Ordering::Relaxed) {
+                    if std::time::Instant::now() > deadline {
+                        return false;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(10));
                 }
-                std::thread::sleep(std::time::Duration::from_millis(10));
+                true
+            };
+
+            if !wait_for(&observer_blocked, 10) {
+                drop(unblock);
+                return Err("store never entered its block");
             }
-            // Give the runtime a moment it does not need when it is healthy;
-            // parked, no amount of waiting would help.
-            std::thread::sleep(std::time::Duration::from_millis(200));
-            let ran_while_blocked = observer_progressed.load(Ordering::Relaxed);
+
+            // Scheduled from outside, with the store already parked: whether it
+            // runs is now purely a question of the worker being free.
+            let flag = Arc::clone(&observer_progressed);
+            runtime.spawn(async move {
+                flag.store(true, Ordering::Relaxed);
+            });
+
+            let ran_while_blocked = wait_for(&observer_progressed, 5);
             drop(unblock);
             Ok(ran_while_blocked)
         });
@@ -3184,7 +3189,7 @@ mod tests {
         let persister = ProbePersister::new(obs_tx);
         let sync_fault = AtomicBool::new(false);
         let mut fault = AdapterFaultState::default();
-        let mut freeze_logged = false;
+        let freeze_logged = AtomicBool::new(false);
 
         let mut batch = BTreeMap::new();
         batch.insert(
@@ -3200,7 +3205,7 @@ mod tests {
             1,
             &mut fault,
             &sync_fault,
-            &mut freeze_logged,
+            &freeze_logged,
             &mut Vec::new(),
         );
 
@@ -3265,7 +3270,7 @@ mod tests {
         let persister = ProbePersister::new(obs_tx);
         let sync_fault = AtomicBool::new(false);
         let mut fault = AdapterFaultState::default();
-        let mut freeze_logged = false;
+        let freeze_logged = AtomicBool::new(false);
 
         let diag = commit_batch(
             &persister,
@@ -3273,7 +3278,7 @@ mod tests {
             1,
             &mut fault,
             &sync_fault,
-            &mut freeze_logged,
+            &freeze_logged,
             &mut Vec::new(),
         );
 
@@ -3297,7 +3302,7 @@ mod tests {
         persister.fail_next(wallet_id);
         let sync_fault = AtomicBool::new(false);
         let mut fault = AdapterFaultState::default();
-        let mut freeze_logged = false;
+        let freeze_logged = AtomicBool::new(false);
 
         let diag = commit_batch(
             &persister,
@@ -3305,7 +3310,7 @@ mod tests {
             1,
             &mut fault,
             &sync_fault,
-            &mut freeze_logged,
+            &freeze_logged,
             &mut Vec::new(),
         );
 
@@ -3350,7 +3355,7 @@ mod tests {
         assert!(fault.is_faulted(&wallet_id));
         assert!(sync_fault.load(Ordering::Relaxed));
         assert!(
-            freeze_logged,
+            freeze_logged.load(Ordering::Relaxed),
             "the one-shot SYNC WATERMARK FROZEN marker must have been emitted"
         );
     }
@@ -3367,7 +3372,7 @@ mod tests {
         let mut fault = AdapterFaultState::default();
         // Pre-fault the wallet, as an earlier drain's rejection would have.
         fault.fault_wallet(wallet_id, &sync_fault);
-        let mut freeze_logged = true; // one-shot already spent
+        let freeze_logged = AtomicBool::new(true); // one-shot already spent
 
         let diag = commit_batch(
             &persister,
@@ -3375,7 +3380,7 @@ mod tests {
             1,
             &mut fault,
             &sync_fault,
-            &mut freeze_logged,
+            &freeze_logged,
             &mut Vec::new(),
         );
 
@@ -3411,7 +3416,7 @@ mod tests {
         let sync_fault = AtomicBool::new(false);
         let mut fault = AdapterFaultState::default();
         fault.fault_wallet(wallet_id, &sync_fault);
-        let mut freeze_logged = true;
+        let freeze_logged = AtomicBool::new(true);
 
         let core = CoreChangeSet {
             synced_height: Some(1234),
@@ -3423,7 +3428,7 @@ mod tests {
             1,
             &mut fault,
             &sync_fault,
-            &mut freeze_logged,
+            &freeze_logged,
             &mut Vec::new(),
         );
 
@@ -3448,7 +3453,7 @@ mod tests {
         persister.fail_next(rejecting);
         let sync_fault = AtomicBool::new(false);
         let mut fault = AdapterFaultState::default();
-        let mut freeze_logged = false;
+        let freeze_logged = AtomicBool::new(false);
 
         let mut batch = BTreeMap::new();
         batch.extend(one_wallet_batch(healthy, watermark_with_rows(10, 10)));
@@ -3460,7 +3465,7 @@ mod tests {
             2,
             &mut fault,
             &sync_fault,
-            &mut freeze_logged,
+            &freeze_logged,
             &mut Vec::new(),
         );
 
@@ -3496,7 +3501,7 @@ mod tests {
         let mut fault = AdapterFaultState::default();
         // Pre-fault the wallet, as an earlier drain's rejection would have.
         fault.fault_wallet(wallet_id, &sync_fault);
-        let mut freeze_logged = true;
+        let freeze_logged = AtomicBool::new(true);
 
         let diag = commit_batch(
             &persister,
@@ -3504,7 +3509,7 @@ mod tests {
             1,
             &mut fault,
             &sync_fault,
-            &mut freeze_logged,
+            &freeze_logged,
             &mut Vec::new(),
         );
 

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -2479,102 +2479,6 @@ mod tests {
     /// let the NEXT batch persist a higher `synced_height` for a wallet whose
     /// earlier rows may never have landed, which is exactly the hole
     /// dashpay/platform#4069 closed.
-    /// The commit must not run on a Tokio worker.
-    ///
-    /// This is the behaviour the `spawn_blocking` move exists for, and no
-    /// other test covers it: the outcome-only assertions elsewhere all still
-    /// pass with `commit_batch` called inline, because a blocking store on a
-    /// multi-worker runtime merely steals one worker and the rest of the test
-    /// proceeds. Pinning the runtime to a single worker makes the difference
-    /// observable — inline, that one worker sits inside `store()` and nothing
-    /// else on the runtime can advance.
-    ///
-    /// Everything that decides the verdict happens on a plain `std::thread`,
-    /// for two reasons. The sentinel is spawned only after the store is
-    /// observed blocked: scheduled beforehand, the runtime could poll it first
-    /// and set the flag while nothing was blocking yet, so the test would pass
-    /// inline too. And a regression parks the only worker, so neither the test
-    /// body nor a `tokio::time::timeout` can run — the timer needs that same
-    /// worker — which would hang CI instead of failing it, the outcome the
-    /// bounded waits elsewhere in this file exist to avoid.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn a_blocking_store_does_not_park_the_runtime() {
-        let wallet_id = [0xB1u8; 32];
-        let (tx, rx) = unbounded_channel::<WalletEvent>();
-
-        let (obs_tx, mut obs_rx) = unbounded_channel();
-        let persister = Arc::new(ProbePersister::new(obs_tx));
-        let (unblock, blocked) = persister.block_next();
-        let sync_fault = Arc::new(AtomicBool::new(false));
-        let cancel = CancellationToken::new();
-        let handle = tokio::spawn(run_wallet_event_adapter(
-            test_manager(),
-            Arc::clone(&persister),
-            rx,
-            Arc::clone(&sync_fault),
-            cancel.clone(),
-        ));
-
-        tx.send(block_processed_event(wallet_id, 10)).unwrap();
-
-        let runtime = tokio::runtime::Handle::current();
-        let progressed = Arc::new(AtomicBool::new(false));
-        let observer_progressed = Arc::clone(&progressed);
-        let observer_blocked = Arc::clone(&blocked);
-        let watcher = std::thread::spawn(move || {
-            let wait_for = |flag: &AtomicBool, secs: u64| {
-                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
-                while !flag.load(Ordering::Relaxed) {
-                    if std::time::Instant::now() > deadline {
-                        return false;
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(10));
-                }
-                true
-            };
-
-            if !wait_for(&observer_blocked, 10) {
-                drop(unblock);
-                return Err("store never entered its block");
-            }
-
-            // Scheduled from outside, with the store already parked: whether it
-            // runs is now purely a question of the worker being free.
-            let flag = Arc::clone(&observer_progressed);
-            runtime.spawn(async move {
-                flag.store(true, Ordering::Relaxed);
-            });
-
-            let ran_while_blocked = wait_for(&observer_progressed, 5);
-            drop(unblock);
-            Ok(ran_while_blocked)
-        });
-
-        let observed = obs_rx
-            .recv()
-            .await
-            .expect("the released store should report");
-        assert_eq!(observed.wallet_id, wallet_id);
-
-        let ran_while_blocked = watcher
-            .join()
-            .expect("watcher thread should not panic")
-            .expect("store never entered its block");
-        assert!(
-            ran_while_blocked,
-            "an unrelated task must make progress while the commit blocks — \
-             the commit is running on a runtime worker instead of a blocking thread"
-        );
-        assert!(
-            !sync_fault.load(Ordering::Relaxed),
-            "a slow store is not a fault"
-        );
-
-        cancel.cancel();
-        drop(tx);
-        let _ = handle.await;
-    }
-
     #[tokio::test]
     async fn a_panicking_commit_freezes_the_batch_wallets() {
         let wallet_id = [0xEEu8; 32];
@@ -2718,13 +2622,22 @@ mod tests {
         });
     }
 
-    /// (i) A commit panic must not punish the wallets it did not reach.
+    /// (i) A commit panic must punish exactly the wallets whose outcome it
+    /// left unknown — no more, no less.
     ///
     /// `commit_batch` walks the batch serially (a `BTreeMap`, so in wallet-id
-    /// order). If an earlier wallet's `store()` returned and a later one
-    /// panics, the earlier wallet's rows are on disk and its watermark is
-    /// safe — freezing it would strip its `synced_height` for the rest of the
-    /// session over a sibling's bad batch.
+    /// order), and a panic cuts it in two. A wallet whose `store()` already
+    /// returned is settled: its rows are on disk and its watermark is safe,
+    /// so freezing it would strip its `synced_height` for the rest of the
+    /// session over a sibling's bad batch. A wallet ordered AFTER the panic
+    /// is the opposite case — unwinding dropped its consumed changes before
+    /// `store()` was ever attempted, so nothing knows whether its rows
+    /// landed, and it must freeze or a later watermark advances past rows
+    /// that never existed.
+    ///
+    /// Both halves are checked here, because they are guarded by the same
+    /// `batch_wallet_ids - settled` expression and a regression that faults
+    /// only the wallet that actually panicked satisfies neither.
     ///
     /// Guards the fix for the first version of the panic handler, which
     /// faulted every wallet in the drain.
@@ -2734,6 +2647,8 @@ mod tests {
         // chosen to put the healthy wallet ahead of the panicking one.
         let healthy = [0x11u8; 32];
         let doomed = [0x22u8; 32];
+        // Sorts after `doomed`, so the commit unwinds before it is reached.
+        let unreached = [0x33u8; 32];
         let (tx, rx) = unbounded_channel::<WalletEvent>();
 
         let (obs_tx, mut obs_rx) = unbounded_channel();
@@ -2749,10 +2664,12 @@ mod tests {
             cancel.clone(),
         ));
 
-        // Both wallets in one drain: `healthy` stores, then `doomed` panics.
-        // Sent before either is observed so they fold into a single batch.
+        // All three in one drain: `healthy` stores, `doomed` panics, and
+        // `unreached` never gets its turn. Sent before any is observed so they
+        // fold into a single batch.
         tx.send(block_processed_event(healthy, 10)).unwrap();
         tx.send(block_processed_event(doomed, 10)).unwrap();
+        tx.send(block_processed_event(unreached, 10)).unwrap();
 
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
             while !sync_fault.load(Ordering::Relaxed) {
@@ -2794,6 +2711,24 @@ mod tests {
         assert_eq!(
             after_doomed.synced_height, None,
             "the wallet whose commit panicked must not advance its watermark"
+        );
+
+        // The wallet the commit never reached must be frozen too: its changes
+        // went down with the unwind without a `store()` ever being attempted,
+        // so its rows are exactly as unaccounted-for as the panicking
+        // wallet's. A handler that faults only the direct casualty leaves this
+        // one free to advance past rows that never landed.
+        tx.send(block_processed_event(unreached, 60)).unwrap();
+        tx.send(sync_height_event(unreached, 900)).unwrap();
+        let after_unreached =
+            tokio::time::timeout(std::time::Duration::from_secs(5), obs_rx.recv())
+                .await
+                .expect("a faulted wallet must still persist its rows")
+                .expect("unreached wallet still persists rows");
+        assert_eq!(after_unreached.wallet_id, unreached);
+        assert_eq!(
+            after_unreached.synced_height, None,
+            "a wallet the panicking commit never reached must not advance its watermark"
         );
 
         cancel.cancel();

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -385,6 +385,12 @@ async fn run_wallet_event_adapter<P>(
         // thread panics, these are the wallets whose rows have an unknown fate
         // and whose watermark must therefore be frozen.
         let batch_wallet_ids: Vec<WalletId> = batch.keys().copied().collect();
+        // Filled by `commit_batch` as each wallet's `store()` returns. Lives
+        // out here so a panicking commit thread cannot take it down with it:
+        // what it holds is the difference between "this wallet's rows are
+        // accounted for" and "nobody knows".
+        let settled: Arc<Mutex<Vec<WalletId>>> = Arc::new(Mutex::new(Vec::new()));
+        let settled_for_commit = Arc::clone(&settled);
         let persister_for_commit = Arc::clone(&persister);
         let sync_fault_for_commit = Arc::clone(&sync_fault);
         let fault_for_commit = Arc::clone(&fault);
@@ -397,6 +403,9 @@ async fn run_wallet_event_adapter<P>(
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             let mut freeze_logged = freeze_for_commit.load(Ordering::Relaxed);
+            let mut settled = settled_for_commit
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             let diag = commit_batch(
                 &*persister_for_commit,
                 batch,
@@ -404,6 +413,7 @@ async fn run_wallet_event_adapter<P>(
                 &mut fault,
                 &sync_fault_for_commit,
                 &mut freeze_logged,
+                &mut settled,
             );
             freeze_for_commit.store(freeze_logged, Ordering::Relaxed);
             diag
@@ -426,20 +436,44 @@ async fn run_wallet_event_adapter<P>(
             // adapter keeps the existing design: a wallet whose commit is in
             // doubt freezes, its siblings keep syncing.
             Err(join_error) => {
+                // `commit_batch` walks the batch serially, so a panic partitions
+                // it: wallets whose `store()` already returned are settled — their
+                // rows were accepted or rejected, and a rejection already faulted
+                // them from inside. Freezing those too would strip a healthy
+                // wallet's watermark for the rest of the session over a sibling's
+                // bad batch.
+                //
+                // What is left — the wallet that panicked, plus every wallet the
+                // loop never reached — has no known outcome, and its events are
+                // gone from the lossless channel. Those must freeze, or a later
+                // batch advances their watermark past rows that may never have
+                // landed.
+                let settled_ids = settled
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .iter()
+                    .copied()
+                    .collect::<HashSet<_>>();
+                let unsettled: Vec<WalletId> = batch_wallet_ids
+                    .iter()
+                    .copied()
+                    .filter(|id| !settled_ids.contains(id))
+                    .collect();
                 {
                     let mut fault = fault
                         .lock()
                         .unwrap_or_else(|poisoned| poisoned.into_inner());
-                    for wallet_id in &batch_wallet_ids {
+                    for wallet_id in &unsettled {
                         fault.fault_wallet(*wallet_id, &sync_fault);
                     }
                 }
                 tracing::error!(
                     error = %join_error,
                     folded,
-                    wallets = batch_wallet_ids.len(),
-                    "wallet-event commit thread failed; freezing the batch's \
-                     wallets because their rows have an unknown outcome"
+                    settled = settled_ids.len(),
+                    frozen = unsettled.len(),
+                    "wallet-event commit thread failed; freezing the wallets whose \
+                     rows have an unknown outcome"
                 );
                 continue;
             }
@@ -487,6 +521,7 @@ fn commit_batch<P>(
     fault: &mut AdapterFaultState,
     sync_fault: &AtomicBool,
     freeze_logged: &mut bool,
+    settled: &mut Vec<WalletId>,
 ) -> BatchDiagnostics
 where
     P: PlatformWalletPersistence + ?Sized,
@@ -535,7 +570,15 @@ where
             asset_locks: (!Merge::is_empty(&asset_locks)).then_some(asset_locks),
             ..PlatformWalletChangeSet::default()
         };
-        match persister.store(wallet_id, cs) {
+        let store_result = persister.store(wallet_id, cs);
+        // Recorded only once the store has RETURNED, and whether it accepted
+        // or rejected — both are answers. A wallet whose store panicked never
+        // reaches this line, and one the loop never got to is never pushed at
+        // all, so what is missing from `settled` is exactly the set whose
+        // outcome the caller cannot reason about. See the `JoinError` arm in
+        // `run_wallet_event_adapter`.
+        settled.push(wallet_id);
+        match store_result {
             Ok(()) => {
                 if let Some(h) = offered_height {
                     diag.record_persisted(h);
@@ -1960,6 +2003,13 @@ mod tests {
         /// backend that dies mid-write — the case that used to unwind the whole
         /// adapter task and now surfaces as a `JoinError`.
         panic_once: Mutex<HashSet<WalletId>>,
+        /// Held closed to keep a `store()` call parked. The SQLite backend
+        /// commits a real transaction per call, so a slow disk parks the caller
+        /// for real; this makes that duration controllable.
+        block_until: Mutex<Option<std::sync::mpsc::Receiver<()>>>,
+        /// Raised as soon as a blocked `store()` is entered, so a test can wait
+        /// for the block to be in effect rather than sleeping and hoping.
+        blocked: Arc<AtomicBool>,
     }
 
     impl ProbePersister {
@@ -1968,7 +2018,16 @@ mod tests {
                 obs,
                 fail_once: Mutex::new(HashSet::new()),
                 panic_once: Mutex::new(HashSet::new()),
+                block_until: Mutex::new(None),
+                blocked: Arc::new(AtomicBool::new(false)),
             }
+        }
+        /// Park the next `store()` until the returned sender is dropped or
+        /// signalled. `blocked` reports when the park is actually in effect.
+        fn block_next(&self) -> (std::sync::mpsc::Sender<()>, Arc<AtomicBool>) {
+            let (tx, rx) = std::sync::mpsc::channel();
+            *self.block_until.lock().unwrap() = Some(rx);
+            (tx, Arc::clone(&self.blocked))
         }
         fn fail_next(&self, wallet_id: WalletId) {
             self.fail_once.lock().unwrap().insert(wallet_id);
@@ -1985,6 +2044,14 @@ mod tests {
             changeset: PlatformWalletChangeSet,
         ) -> Result<(), PersistenceError> {
             let core = changeset.core.as_ref();
+            if let Some(gate) = self.block_until.lock().unwrap().take() {
+                self.blocked.store(true, Ordering::Relaxed);
+                // Blocks the calling thread outright — the whole point is to
+                // model a synchronous backend, so an async wait would prove
+                // nothing.
+                let _ = gate.recv();
+                self.blocked.store(false, Ordering::Relaxed);
+            }
             if self.panic_once.lock().unwrap().remove(&wallet_id) {
                 panic!("probe persister: store panicked for {wallet_id:?}");
             }
@@ -2394,14 +2461,182 @@ mod tests {
         tx.send(block_processed_event(wallet_id, 60)).unwrap();
         tx.send(sync_height_event(wallet_id, 900)).unwrap();
 
-        let post = obs_rx
-            .recv()
+        let post = tokio::time::timeout(std::time::Duration::from_secs(5), obs_rx.recv())
             .await
+            .expect("a faulted wallet must still persist its rows")
             .expect("the record-bearing event must still persist while faulted");
         assert_eq!(post.wallet_id, wallet_id);
         assert_eq!(
             post.synced_height, None,
             "a wallet whose commit panicked must not advance its durable watermark"
+        );
+
+        cancel.cancel();
+        drop(tx);
+        handle.await.unwrap();
+    }
+
+    /// (j) THE PRIMARY BEHAVIOUR OF THIS PR: a blocked `store()` must not park
+    /// the async runtime.
+    ///
+    /// `store()` is synchronous and, for the SQLite backend, commits a real
+    /// transaction per call. Called inline on a tokio worker it held that
+    /// worker for the duration — a field restore showed one drain park the
+    /// runtime long enough for the metrics tick covering it to report a 1.4s
+    /// mean poll, with the durable watermark left hundreds of thousands of
+    /// blocks behind the chain tip.
+    ///
+    /// Every other test in this module would still pass with `commit_batch`
+    /// moved back inline, because they only check persistence outcomes. This
+    /// one runs the adapter on a SINGLE worker, parks a `store()`, and requires
+    /// a spawned task to still get scheduled.
+    ///
+    /// Deliberately built out of `std` primitives — a `std::mpsc` handoff and
+    /// `std::thread::sleep` on the test thread — rather than `tokio::time`.
+    /// The regression parks the runtime's only worker, and a tokio timer needs
+    /// that runtime to fire: an async timeout here hangs instead of failing,
+    /// which is worse than the bug it is meant to catch.
+    #[test]
+    fn a_blocked_store_does_not_park_the_runtime() {
+        use std::sync::mpsc as std_mpsc;
+        use std::time::{Duration, Instant};
+
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let wallet_id = [0x33u8; 32];
+        let (tx, rx) = unbounded_channel::<WalletEvent>();
+        let (obs_tx, mut obs_rx) = unbounded_channel();
+        let persister = Arc::new(ProbePersister::new(obs_tx));
+        let (release, blocked) = persister.block_next();
+        let sync_fault = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+
+        let handle = runtime.spawn(run_wallet_event_adapter(
+            test_manager(),
+            Arc::clone(&persister),
+            rx,
+            Arc::clone(&sync_fault),
+            cancel.clone(),
+        ));
+
+        // Park the commit inside a synchronous `store()`.
+        tx.send(block_processed_event(wallet_id, 10)).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !blocked.load(Ordering::Relaxed) {
+            assert!(
+                Instant::now() < deadline,
+                "the store must actually park before the assertion below means anything"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        // The discriminator: a SPAWNED task has to be scheduled on the
+        // runtime's single worker. With the commit on `spawn_blocking` the
+        // worker is free and this arrives at once; with it inline the worker is
+        // sitting inside `store()` and this times out.
+        let (sentinel_tx, sentinel_rx) = std_mpsc::channel();
+        runtime.spawn(async move {
+            let _ = sentinel_tx.send(());
+        });
+        sentinel_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("a blocked store must not hold the runtime's only worker");
+
+        // Release, then let the drain finish so the adapter shuts down cleanly.
+        drop(release);
+        runtime.block_on(async {
+            let observed = tokio::time::timeout(Duration::from_secs(5), obs_rx.recv())
+                .await
+                .expect("the released store must complete")
+                .expect("store observed");
+            assert_eq!(observed.wallet_id, wallet_id);
+
+            cancel.cancel();
+            drop(tx);
+            handle.await.unwrap();
+        });
+    }
+
+    /// (i) A commit panic must not punish the wallets it did not reach.
+    ///
+    /// `commit_batch` walks the batch serially (a `BTreeMap`, so in wallet-id
+    /// order). If an earlier wallet's `store()` returned and a later one
+    /// panics, the earlier wallet's rows are on disk and its watermark is
+    /// safe — freezing it would strip its `synced_height` for the rest of the
+    /// session over a sibling's bad batch.
+    ///
+    /// Guards the fix for the first version of the panic handler, which
+    /// faulted every wallet in the drain.
+    #[tokio::test]
+    async fn a_panicking_commit_spares_the_wallets_it_already_stored() {
+        // `BTreeMap` order decides who is committed first, so the ids are
+        // chosen to put the healthy wallet ahead of the panicking one.
+        let healthy = [0x11u8; 32];
+        let doomed = [0x22u8; 32];
+        let (tx, rx) = unbounded_channel::<WalletEvent>();
+
+        let (obs_tx, mut obs_rx) = unbounded_channel();
+        let persister = Arc::new(ProbePersister::new(obs_tx));
+        persister.panic_next(doomed);
+        let sync_fault = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+        let handle = tokio::spawn(run_wallet_event_adapter(
+            test_manager(),
+            Arc::clone(&persister),
+            rx,
+            Arc::clone(&sync_fault),
+            cancel.clone(),
+        ));
+
+        // Both wallets in one drain: `healthy` stores, then `doomed` panics.
+        // Sent before either is observed so they fold into a single batch.
+        tx.send(block_processed_event(healthy, 10)).unwrap();
+        tx.send(block_processed_event(doomed, 10)).unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !sync_fault.load(Ordering::Relaxed) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the panicked commit must raise the hard-fault signal");
+
+        // Drain what the panicking batch managed to observe.
+        while obs_rx.try_recv().is_ok() {}
+
+        // The healthy wallet's watermark must still advance: its store
+        // returned, so its rows are accounted for.
+        tx.send(sync_height_event(healthy, 900)).unwrap();
+        // Bounded: on a regression the healthy wallet is frozen, its
+        // watermark-only changeset collapses to nothing, and no store is
+        // observed at all — an unbounded `recv` would hang CI instead of
+        // reporting which invariant broke.
+        let after_healthy = tokio::time::timeout(std::time::Duration::from_secs(5), obs_rx.recv())
+            .await
+            .expect("a wallet whose store completed must still be storable")
+            .expect("healthy wallet still stores");
+        assert_eq!(after_healthy.wallet_id, healthy);
+        assert_eq!(
+            after_healthy.synced_height,
+            Some(900),
+            "a wallet whose store completed must not be frozen by a sibling's panic"
+        );
+
+        // The wallet whose store panicked must be frozen.
+        tx.send(block_processed_event(doomed, 60)).unwrap();
+        tx.send(sync_height_event(doomed, 900)).unwrap();
+        let after_doomed = tokio::time::timeout(std::time::Duration::from_secs(5), obs_rx.recv())
+            .await
+            .expect("a faulted wallet must still persist its rows")
+            .expect("doomed wallet still persists rows");
+        assert_eq!(after_doomed.wallet_id, doomed);
+        assert_eq!(
+            after_doomed.synced_height, None,
+            "the wallet whose commit panicked must not advance its watermark"
         );
 
         cancel.cancel();
@@ -2827,6 +3062,7 @@ mod tests {
             &mut fault,
             &sync_fault,
             &mut freeze_logged,
+            &mut Vec::new(),
         );
 
         let observed = obs_rx
@@ -2899,6 +3135,7 @@ mod tests {
             &mut fault,
             &sync_fault,
             &mut freeze_logged,
+            &mut Vec::new(),
         );
 
         assert_eq!(diag.persisted, Some(500));
@@ -2930,6 +3167,7 @@ mod tests {
             &mut fault,
             &sync_fault,
             &mut freeze_logged,
+            &mut Vec::new(),
         );
 
         // The height was genuinely offered to the store...
@@ -2999,6 +3237,7 @@ mod tests {
             &mut fault,
             &sync_fault,
             &mut freeze_logged,
+            &mut Vec::new(),
         );
 
         assert_eq!(diag.persisted, None, "a frozen watermark is not persisted");
@@ -3046,6 +3285,7 @@ mod tests {
             &mut fault,
             &sync_fault,
             &mut freeze_logged,
+            &mut Vec::new(),
         );
 
         assert_eq!(diag.frozen, Some(1234));
@@ -3082,6 +3322,7 @@ mod tests {
             &mut fault,
             &sync_fault,
             &mut freeze_logged,
+            &mut Vec::new(),
         );
 
         assert_eq!(
@@ -3125,6 +3366,7 @@ mod tests {
             &mut fault,
             &sync_fault,
             &mut freeze_logged,
+            &mut Vec::new(),
         );
 
         assert_eq!(diag.wallets, 1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`run_wallet_event_adapter` called `commit_batch` — and through it `persister.store()` — **inline on the tokio worker driving it**. `store()` is synchronous and, for the SQLite backend, commits a real transaction per call. Its own trait docs (`traits.rs:200-206, 263-267`) already warn that a slow write blocks every other wallet accessor for its duration; what they do not say, because until now it was not true, is that it also blocks the runtime those accessors run on.

Found while investigating a user report that a restored wallet's transaction history appears only in large, minutes-apart jumps long after Core sync reports 100%.

**Evidence from a testnet restore of a 6663-transaction wallet** (52k-line session log):

- Drains coalesce into ever larger, ever rarer batches — `folded` 1 → 47 → 164 → **512** (the `ADAPTER_STORE_BATCH_LIMIT` ceiling), with gaps of **42s, 144s and finally 1109s** between them.
- The metrics tick covering the 512-event drain:
  ```
  12:30:39.889  wallet-event batch: folded=512 … synced_height_persisted=Some(2179999)
  12:30:40.490  workers=14 busy_ratio=1106.67 mean_poll_us=1397886
  12:30:41.491  workers=14 busy_ratio=0.0089   mean_poll_us=24
  ```
  A 1.4-second **mean** poll on a runtime that reads 24µs one second later.
- `Blocks: … last_activity: 549s` at the same moment — the SPV managers sharing that runtime were starved, not idle.
- The durable watermark topped out at height **2179999** against a chain tip of **2520064** and never caught up within the session.
- The home timeline only advances when a batch lands, so it showed roughly a third of the history ten minutes after core sync had finished.

The escalating `folded` counts are the symptom, not the cause: events pile up in the channel *because* the previous drain's synchronous `store()` is still holding a worker.

## What was done?
<!--- Describe your changes in detail -->

`commit_batch` now runs on `tokio::task::spawn_blocking`.

**The handle is awaited rather than raced against `cancel`.** A store that has started must be allowed to finish, and dropping a `spawn_blocking` handle does not stop the thread in any case. Shutdown is observed at the next `recv`, which is where the loop already handles it.

**`AdapterFaultState` and the freeze latch move behind `Arc<Mutex<..>>` / `Arc<AtomicBool>`** instead of being moved into the closure by value. This is the part worth reviewing: moving them would mean a panicking commit thread loses a wallet's frozen watermark — un-freezing a wallet whose verification had failed, which is the single outcome the fail-closed guard exists to prevent. The lock is uncontended by construction (this task is the only writer, and one drain commits at a time), so it carries state rather than arbitrating access.

**A panicking commit thread is now reported and its drain skipped**, rather than taking the adapter down with it.

### Not done here

Nothing about batch sizing, the channel, or `ADAPTER_STORE_BATCH_LIMIT`. With the blocking call off the runtime the coalescing behaves as designed; tuning it before re-measuring would be guessing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
cargo test -p platform-wallet --lib          # 662 passed
cargo clippy -p platform-wallet --all-targets  # clean
cargo fmt --check                            # clean
```

**Not covered:** no test reproduces the stall. Doing so needs a persister whose `store()` blocks for a controllable duration plus assertions on runtime poll latency — worth adding, but it would not have caught this class of bug by construction, only this instance of it. The change is behaviour-preserving for the commit itself: the same `commit_batch`, the same inputs, the same diagnostics line.

A before/after restore on device is the measurement that matters, and I have the "before" trace above to compare against.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None. No public API changes; `PlatformWalletPersistence` implementors are unaffected (the trait already requires `Send + Sync`).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet transaction reliability when persistence operations fail or unexpectedly stop.
  * Affected wallets are marked as faulted while their progress remains safely frozen.
  * Processing continues for unaffected wallets and later record-bearing changes.
  * Improved recovery keeps wallet status accurate after interrupted operations and prevents one wallet’s failure from disrupting others.
  * Improved runtime responsiveness by preventing persistence work from blocking normal processing.
  * Added clearer outcomes for interrupted or unsuccessful wallet operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->