### PR TITLE
fix(swift-sdk): drain the persister's autorelease pool per row

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -160,8 +160,26 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
     /// recursive entry. The internal helpers in this file all
     /// assume they are already on the queue and call
     /// `backgroundContext` directly.
+    /// Every caller arrives from a Rust-owned tokio worker thread, and such a
+    /// thread has no autorelease pool: nothing on it ever drains, because the
+    /// drain is normally done by the run loop or by GCD's own worker wrapper,
+    /// and `serialQueue.sync` can execute the block right on the calling
+    /// thread rather than hopping to a GCD worker.
+    ///
+    /// That matters here because SwiftData is Core Data underneath, and
+    /// resolving a managed object hands back autoreleased Foundation objects —
+    /// `-[_NSCoreManagedObjectID URIRepresentation]` alone allocates an
+    /// `NSURL`, an `NSPathStore2` and two `CFString`s per call. Per input, per
+    /// transaction, per block, with nothing draining them, a large wallet's
+    /// initial scan accumulated 7.5 million `NSURL`s and over 2 GB before the
+    /// app was killed.
+    ///
+    /// The pool goes inside the `sync` so it wraps exactly one unit of work
+    /// and is drained before the Rust caller is resumed.
     private func onQueue<T>(_ body: () throws -> T) rethrows -> T {
-        try serialQueue.sync(execute: body)
+        try serialQueue.sync {
+            try autoreleasepool { try body() }
+        }
     }
 
     // MARK: - Platform Address Balances
@@ -954,30 +972,40 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
         }
 
         // Transactions.
+        //
+        // One pool per row, not one around the loop. SwiftData is Core Data
+        // underneath, and every object-ID it resolves in here autoreleases an
+        // `NSURL`, an `NSPathStore2` and two `CFString`s — see the pool in
+        // `onQueue`. That outer pool drains only when the whole changeset is
+        // done, and a large wallet's initial scan sends changesets big enough
+        // for the interim to reach millions of live objects and gigabytes.
+        // Draining per row keeps the peak flat regardless of batch size.
         if acc.transactions_count > 0, let txsPtr = acc.transactions {
             for i in 0..<Int(acc.transactions_count) {
-                upsertTransaction(account: account, tx: txsPtr[i])
+                autoreleasepool {
+                    upsertTransaction(account: account, tx: txsPtr[i])
+                }
             }
         }
 
         // UTXOs added.
         if acc.utxos_added_count > 0, let utxosPtr = acc.utxos_added {
             for i in 0..<Int(acc.utxos_added_count) {
-                upsertUtxo(account: account, utxo: utxosPtr[i])
+                autoreleasepool { upsertUtxo(account: account, utxo: utxosPtr[i]) }
             }
         }
 
         // UTXOs spent — mark them spent (keep for history).
         if acc.utxos_spent_count > 0, let spentPtr = acc.utxos_spent {
             for i in 0..<Int(acc.utxos_spent_count) {
-                markUtxoSpent(spentPtr[i])
+                autoreleasepool { markUtxoSpent(spentPtr[i]) }
             }
         }
 
         // UTXOs became InstantSend-locked — update flag.
         if acc.utxos_instant_locked_count > 0, let ilPtr = acc.utxos_instant_locked {
             for i in 0..<Int(acc.utxos_instant_locked_count) {
-                markUtxoInstantLocked(ilPtr[i])
+                autoreleasepool { markUtxoInstantLocked(ilPtr[i]) }
             }
         }
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented

The app reaches a ~16 GB physical footprint during a large wallet's initial scan and is killed before the scan finishes. The logs stay quiet the whole time, which is what made this hard to attribute.

The persister callbacks arrive on Rust-owned tokio worker threads, and such a thread has no autorelease pool — the drain is normally done by a run loop or by GCD's own worker wrapper, and `serialQueue.sync` can run the block straight on the calling thread. Nothing in this file — 8200 lines and 38 C callbacks — opened one.

That matters because SwiftData is Core Data underneath. Resolving a managed object hands back autoreleased Foundation objects, and `-[_NSCoreManagedObjectID URIRepresentation]` alone allocates an `NSURL`, an `NSPathStore2` and two `CFString`s. `resolveInputOutpoint` reaches that per input, per transaction, per block.

Heap dump at 3 GB, taken from the running app:

| count | class |
|---|---|
| 7 512 707 | `NSURL` |
| 7 512 604 | `NSPathStore2` |
| 15 052 753 | `CFString` |
| 44 735 | `@autoreleasepool content` pages (183 MB) |

33 M live allocations, `MALLOC_SMALL` at 3.1 GB. `malloc_history` put every one of them under `persistWalletChangesetCallback` → `applyAccountChangeset` → `upsertTransaction` → `resolveInputOutpoint` → `URIRepresentation`.

## What was done?

Two pools, and the inner one is the fix.

A pool in `onQueue` alone still drains only when the whole changeset is done, and a large wallet's changesets are big enough that the interim peak was still millions of objects. That was measured, not assumed: it moved the live `NSURL` count from 7.5 M to 6.5 M — i.e. almost nothing. The per-row pools in `applyAccountChangeset` (transactions, added UTXOs, spent UTXOs, InstantSend locks) keep the peak flat regardless of batch size.

## How Has This Been Tested?

Measured on the reproducing wallet, same device and same restore-from-seed scenario, before and after:

| | before | after |
|---|---|---|
| live `NSURL` | 7 512 707, climbing | 1 000 – 18 000, flat |
| footprint | 3+ GB, killed | 496 MB, `growth=+0.0 MB/s` |
| scan | never finished | completes: 8582 filters matched, 3269 relevant blocks, 5095 transactions |

`xcodebuild test -scheme SwiftDashSDK` — 352 tests, 0 failures, on the branch this was developed on. CI covers it here.

## Breaking Changes

None. `autoreleasepool` wrappers around existing call sites; no behaviour, ordering or atomicity change — no `save()` was added or moved.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved memory management during large wallet data synchronization and persistence operations.
  * Reduced temporary memory usage while processing transactions and unspent outputs.
* **Bug Fixes**
  * Preserved existing wallet persistence behavior while improving stability during bulk updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->