### PR TITLE
feat(dpp): client-side expected-fee estimator for address funding + wallet reserve calibration pins

### DIFF
--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/estimate_expected_fee/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/estimate_expected_fee/mod.rs
@@ -1,0 +1,47 @@
+mod v0;
+
+use crate::fee::Credits;
+use crate::state_transition::address_funding_from_asset_lock_transition::AddressFundingFromAssetLockTransition;
+use crate::ProtocolError;
+use platform_version::version::PlatformVersion;
+
+impl AddressFundingFromAssetLockTransition {
+    /// Estimate the fee the network is EXPECTED to actually charge for an
+    /// address funding, given input and output counts, without needing a
+    /// constructed transition.
+    ///
+    /// This is a client-side display/planning estimate of the
+    /// GroveDB-metered execution fee — deliberately DISTINCT from
+    /// [`calculate_min_required_fee`], which is the consensus floor the
+    /// locked value must cover before processing starts (the floor is
+    /// several times larger than the metered charge). No consensus path
+    /// reads this estimate; a miss shows a slightly-off display number,
+    /// never a failed transition.
+    ///
+    /// The constants live in the versioned fee tables
+    /// (`state_transition_min_fees`) and are pinned against real
+    /// `apply = true` execution by the drive-abci
+    /// `expected_fee_calibration` tests, with headroom for state-tree
+    /// growth (the metered fee drifts logarithmically with tree size).
+    ///
+    /// [`calculate_min_required_fee`]:
+    ///     crate::state_transition::StateTransitionEstimatedFeeValidation::calculate_min_required_fee
+    pub fn estimate_expected_fee(
+        input_count: usize,
+        output_count: usize,
+        platform_version: &PlatformVersion,
+    ) -> Result<Credits, ProtocolError> {
+        match platform_version
+            .dpp
+            .methods
+            .estimate_address_funding_expected_fee
+        {
+            0 => Self::estimate_expected_fee_v0(input_count, output_count, platform_version),
+            version => Err(ProtocolError::UnknownVersionMismatch {
+                method: "AddressFundingFromAssetLockTransition::estimate_expected_fee".to_string(),
+                known_versions: vec![0],
+                received: version,
+            }),
+        }
+    }
+}

--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/estimate_expected_fee/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/estimate_expected_fee/mod.rs
@@ -10,13 +10,20 @@ impl AddressFundingFromAssetLockTransition {
     /// address funding, given input and output counts, without needing a
     /// constructed transition.
     ///
-    /// This is a client-side display/planning estimate of the
+    /// This is a client-side DISPLAY/PLANNING estimate of the
     /// GroveDB-metered execution fee — deliberately DISTINCT from
     /// [`calculate_min_required_fee`], which is the consensus floor the
     /// locked value must cover before processing starts (the floor is
     /// several times larger than the metered charge). No consensus path
-    /// reads this estimate; a miss shows a slightly-off display number,
-    /// never a failed transition.
+    /// reads this estimate.
+    ///
+    /// NOT an upper bound — callers MUST NOT size funding locks (or any
+    /// execution budget) from it. The charged fee is metered on live
+    /// state, grows with `user_fee_increase` (the SDK's stuck-ST retry
+    /// bumps it), and `validate_fees_of_event` additionally requires the
+    /// fee strategy to cover an average-case estimate that can exceed
+    /// this number. Locks must carry a conservative reserve instead; a
+    /// miss here shows a slightly-off display number, nothing more.
     ///
     /// The constants live in the versioned fee tables
     /// (`state_transition_min_fees`) and are pinned against real

--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/estimate_expected_fee/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/estimate_expected_fee/v0/mod.rs
@@ -1,0 +1,51 @@
+use crate::fee::Credits;
+use crate::state_transition::address_funding_from_asset_lock_transition::AddressFundingFromAssetLockTransition;
+use crate::ProtocolError;
+use platform_version::version::PlatformVersion;
+
+impl AddressFundingFromAssetLockTransition {
+    /// v0 expected-fee formula:
+    ///
+    /// `base + per_input × input_count + per_output × max(output_count, 1)`
+    ///
+    /// - `base` covers the fixed execution work of a minimal funding: the
+    ///   asset-lock outpoint write, proof validation, the one-time-key
+    ///   ECDSA verification, and signable-bytes hashing. A typical-size
+    ///   hashing allowance is folded in (the signable bytes embed the full
+    ///   asset-lock proof, unknown before the L1 build, but the term is
+    ///   ~0.3% of the total — a length parameter would buy nothing).
+    /// - `per_output` covers the metered balance/nonce write of a (new)
+    ///   platform address entry.
+    /// - `per_input` covers the nonce/balance retrieval, witness signature
+    ///   verification and hashing, and the update of an existing entry.
+    ///
+    /// `output_count` is clamped to at least 1, mirroring the consensus
+    /// floor's shape (a funding always credits at least the remainder
+    /// output). Checked arithmetic — overflow fails closed.
+    pub(super) fn estimate_expected_fee_v0(
+        input_count: usize,
+        output_count: usize,
+        platform_version: &PlatformVersion,
+    ) -> Result<Credits, ProtocolError> {
+        let min_fees = &platform_version.fee_version.state_transition_min_fees;
+        let inputs_fee = min_fees
+            .address_funding_expected_fee_per_input
+            .checked_mul(input_count as u64)
+            .ok_or(ProtocolError::Overflow(
+                "address funding expected fee: per-input overflow",
+            ))?;
+        let outputs_fee = min_fees
+            .address_funding_expected_fee_per_output
+            .checked_mul(output_count.max(1) as u64)
+            .ok_or(ProtocolError::Overflow(
+                "address funding expected fee: per-output overflow",
+            ))?;
+        min_fees
+            .address_funding_expected_base_fee
+            .checked_add(inputs_fee)
+            .and_then(|sum| sum.checked_add(outputs_fee))
+            .ok_or(ProtocolError::Overflow(
+                "address funding expected fee: total overflow",
+            ))
+    }
+}

--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/mod.rs
@@ -1,4 +1,5 @@
 pub mod accessors;
+mod estimate_expected_fee;
 mod fields;
 pub mod methods;
 mod proved;

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
@@ -3202,11 +3202,15 @@ mod tests {
 
         /// Wallet-side Core→Platform funding reserve (credits) — mirrors
         /// `CoreToPlatformAmountPolicy.fundingReserveDuffs × 1000` in the
-        /// iOS wallet. A wallet-CHOSEN conservative reserve (equal to the
-        /// admission floor), NOT a proven fee maximum — these tests pin its
-        /// adequacy against real execution so a protocol change that grows
-        /// the fee past it fails loudly here instead of shrinking user
-        /// topups silently.
+        /// iOS wallet. A TEMPORARY, wallet-CHOSEN conservative reserve
+        /// (equal to the admission floor), NOT a proven fee maximum. The
+        /// wallet credits `lock − actual fee`; the tests referencing this
+        /// constant are regression SAMPLES confirming the reserve covers
+        /// the fee for the current protocol versions and these specific
+        /// scenarios — they do NOT prove an upper bound of the fee on
+        /// arbitrary live GroveDB state. Their value is tripwiring: a
+        /// protocol change that grows the fee past the reserve fails
+        /// loudly here instead of shrinking user topups silently.
         const WALLET_FUNDING_RESERVE_CREDITS: u64 = 56_000_000;
 
         /// Highest `user_fee_increase` the SDK's stuck-ST retry loop can
@@ -3379,14 +3383,16 @@ mod tests {
         }
 
         /// The wallet's minimal lock (admission floor + 1 duff) must be
-        /// ACCEPTED end-to-end. This exercises both admission gates the
-        /// wallet's lock sizing has to clear: the `calculate_min_required_fee`
-        /// floor in `transform_into_action` AND the average-case estimated
-        /// fee that `validate_fees_of_event` requires the fee strategy to
-        /// cover before execution. If this ever fails with
-        /// `AddressesNotEnoughFundsError`, the estimated gate has outgrown
-        /// the floor and the wallet-side funding reserve must be raised —
-        /// the error carries the required balance to size it by.
+        /// ACCEPTED end-to-end ON THIS GENESIS FIXTURE. This exercises both
+        /// admission gates the wallet's lock sizing has to clear: the
+        /// `calculate_min_required_fee` floor in `transform_into_action`
+        /// AND the average-case estimated fee that `validate_fees_of_event`
+        /// requires the fee strategy to cover before execution. A
+        /// regression sample, not a proof for arbitrary live state. If this
+        /// ever fails with `AddressesNotEnoughFundsError`, the estimated
+        /// gate has outgrown the floor and the wallet-side funding reserve
+        /// must be raised — the error carries the required balance to size
+        /// it by.
         #[tokio::test]
         async fn test_minimal_admissible_lock_is_accepted() {
             let platform_config = PlatformConfig {
@@ -3451,10 +3457,12 @@ mod tests {
             );
         }
 
-        /// The wallet funding reserve must cover the actual charged fee
-        /// even at the HIGHEST `user_fee_increase` the SDK's stuck-ST
-        /// retry loop can reach — otherwise a retried topup could eat into
-        /// the user's confirmed amount via `ReduceOutput(0)`.
+        /// Regression sample on GENESIS state: the wallet funding reserve
+        /// covers the actual charged fee at the HIGHEST `user_fee_increase`
+        /// the SDK's stuck-ST retry loop can reach — otherwise a retried
+        /// topup could eat into the user's confirmed amount via
+        /// `ReduceOutput(0)`. Confirms this scenario for the current
+        /// protocol version; not a proof for arbitrary live state.
         #[tokio::test]
         async fn test_max_retry_fee_increase_stays_within_the_wallet_reserve() {
             let platform_config = PlatformConfig {
@@ -3520,6 +3528,129 @@ mod tests {
                 "actual fee {actual} at max retry fee increase exceeds the wallet \
                  funding reserve {WALLET_FUNDING_RESERVE_CREDITS}: raise the reserve \
                  (CoreToPlatformAmountPolicy.fundingReserveDuffs)"
+            );
+        }
+
+        /// Regression sample on state POPULATED by prior committed
+        /// fundings (deeper address/balance trees than genesis), at the
+        /// max retry `user_fee_increase`. Still a sample for one concrete
+        /// state shape and the current protocol version — not a proof
+        /// that the reserve bounds the fee on arbitrary live state.
+        #[tokio::test]
+        async fn test_max_retry_fee_increase_within_reserve_on_state_populated_by_prior_fundings() {
+            let platform_config = PlatformConfig {
+                testing_configs: PlatformTestConfig {
+                    disable_instant_lock_signature_verification: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let platform = TestPlatformBuilder::new()
+                .with_config(platform_config)
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let signer = TestAddressSigner::new();
+            let platform_state = platform.state.load();
+
+            // Populate: eight committed fundings to distinct remainder
+            // addresses, deepening the trees the probe's ops are metered
+            // against.
+            for i in 0..8u64 {
+                let mut rng = StdRng::seed_from_u64(710 + i);
+                let (asset_lock_proof, asset_lock_pk) = create_asset_lock_proof_with_key(&mut rng);
+
+                let mut outputs = BTreeMap::new();
+                outputs.insert(create_platform_address(10 + u8::try_from(i).unwrap()), None);
+
+                let state_transition = create_signed_address_funding_from_asset_lock_transition(
+                    asset_lock_proof,
+                    &asset_lock_pk,
+                    &signer,
+                    BTreeMap::new(),
+                    outputs,
+                    vec![AddressFundsFeeStrategyStep::ReduceOutput(0)],
+                )
+                .await;
+
+                let result = state_transition
+                    .serialize_to_bytes()
+                    .expect("should serialize");
+
+                let transaction = platform.drive.grove.start_transaction();
+                let processing_result = platform
+                    .platform
+                    .process_raw_state_transitions(
+                        &[result],
+                        &platform_state,
+                        &BlockInfo::default(),
+                        &transaction,
+                        PlatformVersion::latest(),
+                        false,
+                        None,
+                    )
+                    .expect("expected to process state transition");
+                assert_matches!(
+                    processing_result.execution_results().as_slice(),
+                    [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+                );
+                platform
+                    .drive
+                    .grove
+                    .commit_transaction(transaction)
+                    .unwrap()
+                    .expect("expected to commit");
+            }
+
+            // Probe on the populated state at the max retry fee increase.
+            let mut rng = StdRng::seed_from_u64(720);
+            let (asset_lock_proof, asset_lock_pk) = create_asset_lock_proof_with_key(&mut rng);
+
+            let mut outputs = BTreeMap::new();
+            outputs.insert(create_platform_address(1), None); // Remainder recipient
+
+            let state_transition =
+                create_signed_address_funding_from_asset_lock_transition_with_fee_increase(
+                    asset_lock_proof,
+                    &asset_lock_pk,
+                    &signer,
+                    BTreeMap::new(),
+                    outputs,
+                    vec![AddressFundsFeeStrategyStep::ReduceOutput(0)],
+                    MAX_RETRY_USER_FEE_INCREASE,
+                )
+                .await;
+
+            let result = state_transition
+                .serialize_to_bytes()
+                .expect("should serialize");
+
+            let transaction = platform.drive.grove.start_transaction();
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[result],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    PlatformVersion::latest(),
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            let fee_result = assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { fee_result, .. }] =>
+                    fee_result.clone()
+            );
+            let actual = fee_result.total_base_fee();
+            assert!(
+                actual <= WALLET_FUNDING_RESERVE_CREDITS,
+                "actual fee {actual} on populated state at max retry fee increase \
+                 exceeds the wallet funding reserve {WALLET_FUNDING_RESERVE_CREDITS}: \
+                 raise the reserve (CoreToPlatformAmountPolicy.fundingReserveDuffs)"
             );
         }
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
@@ -3200,6 +3200,41 @@ mod tests {
     mod expected_fee_calibration {
         use super::*;
 
+        /// Wallet-side Core→Platform funding reserve (credits) — mirrors
+        /// `CoreToPlatformAmountPolicy.fundingReserveDuffs × 1000` in the
+        /// iOS wallet. A wallet-CHOSEN conservative reserve (equal to the
+        /// admission floor), NOT a proven fee maximum — these tests pin its
+        /// adequacy against real execution so a protocol change that grows
+        /// the fee past it fails loudly here instead of shrinking user
+        /// topups silently.
+        const WALLET_FUNDING_RESERVE_CREDITS: u64 = 56_000_000;
+
+        /// Highest `user_fee_increase` the SDK's stuck-ST retry loop can
+        /// reach: `submit_with_cl_height_retry` bumps it by 1 per attempt,
+        /// and `CL_HEIGHT_RETRY_BUDGET / CL_HEIGHT_RETRY_DELAY` (210s/15s)
+        /// bounds the attempts at 14.
+        const MAX_RETRY_USER_FEE_INCREASE: u16 = 14;
+
+        /// Asset-lock proof with an explicit lock value, for admission
+        /// boundary probes (`create_asset_lock_proof_with_key` hardcodes
+        /// the fixture default).
+        fn create_asset_lock_proof_with_key_and_amount(
+            rng: &mut StdRng,
+            amount_duffs: u64,
+        ) -> (AssetLockProof, Vec<u8>) {
+            let platform_version = PlatformVersion::latest();
+            let (_, pk) = ECDSA_SECP256K1
+                .random_public_and_private_key_data(rng, platform_version)
+                .unwrap();
+
+            let asset_lock_proof = instant_asset_lock_proof_fixture(
+                Some(PrivateKey::from_byte_array(&pk, Network::Testnet).unwrap()),
+                Some(amount_duffs),
+            );
+
+            (asset_lock_proof, pk.to_vec())
+        }
+
         /// Execute one funding transition on genesis state and return the
         /// actual charged fee (`total_base_fee`).
         async fn execute_and_get_actual_fee(
@@ -3298,6 +3333,12 @@ mod tests {
             .expect("should estimate expected fee");
 
             assert_within_band(actual, expected);
+            assert!(
+                actual <= WALLET_FUNDING_RESERVE_CREDITS,
+                "actual fee {actual} exceeds the wallet funding reserve \
+                 {WALLET_FUNDING_RESERVE_CREDITS}: raise the reserve \
+                 (CoreToPlatformAmountPolicy.fundingReserveDuffs)"
+            );
         }
 
         #[tokio::test]
@@ -3335,6 +3376,178 @@ mod tests {
             .expect("should estimate expected fee");
 
             assert_within_band(actual, expected);
+        }
+
+        /// The wallet's minimal lock (admission floor + 1 duff) must be
+        /// ACCEPTED end-to-end. This exercises both admission gates the
+        /// wallet's lock sizing has to clear: the `calculate_min_required_fee`
+        /// floor in `transform_into_action` AND the average-case estimated
+        /// fee that `validate_fees_of_event` requires the fee strategy to
+        /// cover before execution. If this ever fails with
+        /// `AddressesNotEnoughFundsError`, the estimated gate has outgrown
+        /// the floor and the wallet-side funding reserve must be raised —
+        /// the error carries the required balance to size it by.
+        #[tokio::test]
+        async fn test_minimal_admissible_lock_is_accepted() {
+            let platform_config = PlatformConfig {
+                testing_configs: PlatformTestConfig {
+                    disable_instant_lock_signature_verification: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let platform = TestPlatformBuilder::new()
+                .with_config(platform_config)
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let signer = TestAddressSigner::new();
+            let mut rng = StdRng::seed_from_u64(702);
+            // Floor is 56,000 duffs; 56,001 is the smallest strictly-above
+            // lock the wallet can produce (amount 1 duff + 56k reserve).
+            let (asset_lock_proof, asset_lock_pk) =
+                create_asset_lock_proof_with_key_and_amount(&mut rng, 56_001);
+
+            let mut outputs = BTreeMap::new();
+            outputs.insert(create_platform_address(1), None); // Remainder recipient
+
+            let state_transition = create_signed_address_funding_from_asset_lock_transition(
+                asset_lock_proof,
+                &asset_lock_pk,
+                &signer,
+                BTreeMap::new(),
+                outputs,
+                vec![AddressFundsFeeStrategyStep::ReduceOutput(0)],
+            )
+            .await;
+
+            let result = state_transition
+                .serialize_to_bytes()
+                .expect("should serialize");
+
+            let platform_state = platform.state.load();
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[result],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    PlatformVersion::latest(),
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }],
+                "a minimal wallet lock (floor + 1 duff) must clear BOTH \
+                 admission gates; if this fails the wallet funding reserve \
+                 must be raised above the estimated-fee gate"
+            );
+        }
+
+        /// The wallet funding reserve must cover the actual charged fee
+        /// even at the HIGHEST `user_fee_increase` the SDK's stuck-ST
+        /// retry loop can reach — otherwise a retried topup could eat into
+        /// the user's confirmed amount via `ReduceOutput(0)`.
+        #[tokio::test]
+        async fn test_max_retry_fee_increase_stays_within_the_wallet_reserve() {
+            let platform_config = PlatformConfig {
+                testing_configs: PlatformTestConfig {
+                    disable_instant_lock_signature_verification: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let platform = TestPlatformBuilder::new()
+                .with_config(platform_config)
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let signer = TestAddressSigner::new();
+            let mut rng = StdRng::seed_from_u64(703);
+            let (asset_lock_proof, asset_lock_pk) = create_asset_lock_proof_with_key(&mut rng);
+
+            let mut outputs = BTreeMap::new();
+            outputs.insert(create_platform_address(1), None); // Remainder recipient
+
+            let state_transition =
+                create_signed_address_funding_from_asset_lock_transition_with_fee_increase(
+                    asset_lock_proof,
+                    &asset_lock_pk,
+                    &signer,
+                    BTreeMap::new(),
+                    outputs,
+                    vec![AddressFundsFeeStrategyStep::ReduceOutput(0)],
+                    MAX_RETRY_USER_FEE_INCREASE,
+                )
+                .await;
+
+            let result = state_transition
+                .serialize_to_bytes()
+                .expect("should serialize");
+
+            let platform_state = platform.state.load();
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[result],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    PlatformVersion::latest(),
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            let fee_result = assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { fee_result, .. }] =>
+                    fee_result.clone()
+            );
+            let actual = fee_result.total_base_fee();
+            assert!(
+                actual <= WALLET_FUNDING_RESERVE_CREDITS,
+                "actual fee {actual} at max retry fee increase exceeds the wallet \
+                 funding reserve {WALLET_FUNDING_RESERVE_CREDITS}: raise the reserve \
+                 (CoreToPlatformAmountPolicy.fundingReserveDuffs)"
+            );
+        }
+
+        /// The estimate must not depend on which platform version the
+        /// caller resolves (the FFI estimator pins `latest()` while the
+        /// builder resolves the network-floored `sdk.version()`): every
+        /// shipped fee version shares the same fee table today, and this
+        /// pins that assumption.
+        #[tokio::test]
+        async fn test_expected_fee_is_stable_across_shipped_platform_versions() {
+            let latest = AddressFundingFromAssetLockTransition::estimate_expected_fee(
+                0,
+                1,
+                PlatformVersion::latest(),
+            )
+            .expect("should estimate under latest");
+            let first = AddressFundingFromAssetLockTransition::estimate_expected_fee(
+                0,
+                1,
+                PlatformVersion::first(),
+            )
+            .expect("should estimate under first");
+            assert_eq!(
+                latest, first,
+                "expected-fee constants diverged across platform versions — the \
+                 FFI estimator's latest() pin no longer matches builders resolving \
+                 sdk.version(); thread the version through instead"
+            );
         }
     }
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
@@ -3188,6 +3188,156 @@ mod tests {
         }
     }
 
+    // ==========================================
+    // EXPECTED-FEE CALIBRATION TESTS
+    // Pin `AddressFundingFromAssetLockTransition::estimate_expected_fee`
+    // (the client-side display estimate) against the REAL GroveDB-metered
+    // fee of an executed funding. A protocol change that moves the metered
+    // fee outside the band trips these tests and forces a constant bump in
+    // `state_transition_min_fees` (address_funding_expected_*).
+    // ==========================================
+
+    mod expected_fee_calibration {
+        use super::*;
+
+        /// Execute one funding transition on genesis state and return the
+        /// actual charged fee (`total_base_fee`).
+        async fn execute_and_get_actual_fee(
+            inputs: BTreeMap<PlatformAddress, (AddressNonce, u64)>,
+            outputs: BTreeMap<PlatformAddress, Option<u64>>,
+            signer: &TestAddressSigner,
+            platform: &crate::test::helpers::setup::TempPlatform<MockCoreRPCLike>,
+            seed: u64,
+        ) -> u64 {
+            let platform_version = PlatformVersion::latest();
+            let mut rng = StdRng::seed_from_u64(seed);
+            let (asset_lock_proof, asset_lock_pk) = create_asset_lock_proof_with_key(&mut rng);
+
+            let state_transition = create_signed_address_funding_from_asset_lock_transition(
+                asset_lock_proof,
+                &asset_lock_pk,
+                signer,
+                inputs,
+                outputs,
+                vec![AddressFundsFeeStrategyStep::ReduceOutput(0)],
+            )
+            .await;
+
+            let result = state_transition
+                .serialize_to_bytes()
+                .expect("should serialize");
+
+            let platform_state = platform.state.load();
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[result],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            let fee_result = assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { fee_result, .. }] =>
+                    fee_result.clone()
+            );
+            fee_result.total_base_fee()
+        }
+
+        /// Genesis-state metering is slightly shallower than a live
+        /// network's, so the estimate must sit ABOVE the calibrated actual
+        /// with growth headroom, but not absurdly above it. Band chosen
+        /// against observed testnet actuals (14_964_200 / 14_702_160 for
+        /// 0-in/1-out) vs the 17_500_000 estimate (+17–19%).
+        fn assert_within_band(actual: u64, expected: u64) {
+            assert!(
+                actual <= expected,
+                "actual metered fee {actual} exceeds the expected-fee constant {expected}: \
+                 bump address_funding_expected_* in state_transition_min_fees"
+            );
+            assert!(
+                actual >= expected * 50 / 100,
+                "actual metered fee {actual} fell below 50% of the expected-fee constant \
+                 {expected}: the constants overstate the fee — lower them"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_expected_fee_brackets_actual_for_minimal_funding() {
+            let platform_config = PlatformConfig {
+                testing_configs: PlatformTestConfig {
+                    disable_instant_lock_signature_verification: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let platform = TestPlatformBuilder::new()
+                .with_config(platform_config)
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let signer = TestAddressSigner::new();
+            let mut outputs = BTreeMap::new();
+            outputs.insert(create_platform_address(1), None); // Remainder recipient
+
+            let actual =
+                execute_and_get_actual_fee(BTreeMap::new(), outputs, &signer, &platform, 700).await;
+            let expected = AddressFundingFromAssetLockTransition::estimate_expected_fee(
+                0,
+                1,
+                PlatformVersion::latest(),
+            )
+            .expect("should estimate expected fee");
+
+            assert_within_band(actual, expected);
+        }
+
+        #[tokio::test]
+        async fn test_expected_fee_brackets_actual_with_input_and_two_outputs() {
+            let platform_config = PlatformConfig {
+                testing_configs: PlatformTestConfig {
+                    disable_instant_lock_signature_verification: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let mut platform = TestPlatformBuilder::new()
+                .with_config(platform_config)
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut signer = TestAddressSigner::new();
+            let input_address = signer.add_p2pkh([7u8; 32]);
+            setup_address_with_balance(&mut platform, input_address, 0, dash_to_credits!(0.5));
+
+            let mut inputs = BTreeMap::new();
+            inputs.insert(input_address, (1 as AddressNonce, dash_to_credits!(0.3)));
+
+            let mut outputs = BTreeMap::new();
+            outputs.insert(create_platform_address(2), Some(dash_to_credits!(0.5)));
+            outputs.insert(create_platform_address(3), None); // Remainder recipient
+
+            let actual = execute_and_get_actual_fee(inputs, outputs, &signer, &platform, 701).await;
+            let expected = AddressFundingFromAssetLockTransition::estimate_expected_fee(
+                1,
+                2,
+                PlatformVersion::latest(),
+            )
+            .expect("should estimate expected fee");
+
+            assert_within_band(actual, expected);
+        }
+    }
+
     mod fee_edge_cases {
         use super::*;
 

--- a/packages/rs-platform-version/src/version/dpp_versions/dpp_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions/dpp_method_versions/mod.rs
@@ -10,4 +10,5 @@ pub struct DPPMethodVersions {
     pub deduct_fee_from_outputs_or_remaining_balance_of_inputs: FeatureVersion,
     pub compute_minimum_shielded_fee: FeatureVersion,
     pub shielded_extra_sighash_data: FeatureVersion,
+    pub estimate_address_funding_expected_fee: FeatureVersion,
 }

--- a/packages/rs-platform-version/src/version/dpp_versions/dpp_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions/dpp_method_versions/v1.rs
@@ -5,4 +5,5 @@ pub const DPP_METHOD_VERSIONS_V1: DPPMethodVersions = DPPMethodVersions {
     deduct_fee_from_outputs_or_remaining_balance_of_inputs: 0,
     compute_minimum_shielded_fee: 0,
     shielded_extra_sighash_data: 0,
+    estimate_address_funding_expected_fee: 0,
 };

--- a/packages/rs-platform-version/src/version/dpp_versions/dpp_method_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions/dpp_method_versions/v2.rs
@@ -5,4 +5,5 @@ pub const DPP_METHOD_VERSIONS_V2: DPPMethodVersions = DPPMethodVersions {
     deduct_fee_from_outputs_or_remaining_balance_of_inputs: 0,
     compute_minimum_shielded_fee: 0,
     shielded_extra_sighash_data: 0,
+    estimate_address_funding_expected_fee: 0,
 };

--- a/packages/rs-platform-version/src/version/fee/state_transition_min_fees/mod.rs
+++ b/packages/rs-platform-version/src/version/fee/state_transition_min_fees/mod.rs
@@ -19,6 +19,16 @@ pub struct StateTransitionMinFees {
     pub identity_create_base_cost: u64,
     pub identity_topup_base_cost: u64,
     pub identity_key_in_creation_cost: u64,
+    /// Expected (display) fee components for
+    /// `AddressFundingFromAssetLockTransition` — a client-side estimate of
+    /// the GroveDB-metered fee actually charged at execution, NOT a
+    /// consensus value (no consensus path reads these; the consensus floor
+    /// is `calculate_min_required_fee`). Calibrated against `apply = true`
+    /// execution in the drive-abci calibration test with headroom for
+    /// state-tree growth.
+    pub address_funding_expected_base_fee: u64,
+    pub address_funding_expected_fee_per_input: u64,
+    pub address_funding_expected_fee_per_output: u64,
 }
 
 #[derive(Clone, Debug, Encode, Decode, Default, PartialEq, Eq)]
@@ -54,6 +64,12 @@ impl From<StateTransitionMinFeesBeforeProtocolVersion11> for StateTransitionMinF
             identity_topup_base_cost: STATE_TRANSITION_MIN_FEES_VERSION1.identity_topup_base_cost,
             identity_key_in_creation_cost: STATE_TRANSITION_MIN_FEES_VERSION1
                 .identity_key_in_creation_cost,
+            address_funding_expected_base_fee: STATE_TRANSITION_MIN_FEES_VERSION1
+                .address_funding_expected_base_fee,
+            address_funding_expected_fee_per_input: STATE_TRANSITION_MIN_FEES_VERSION1
+                .address_funding_expected_fee_per_input,
+            address_funding_expected_fee_per_output: STATE_TRANSITION_MIN_FEES_VERSION1
+                .address_funding_expected_fee_per_output,
         }
     }
 }

--- a/packages/rs-platform-version/src/version/fee/state_transition_min_fees/v1.rs
+++ b/packages/rs-platform-version/src/version/fee/state_transition_min_fees/v1.rs
@@ -16,4 +16,13 @@ pub const STATE_TRANSITION_MIN_FEES_VERSION1: StateTransitionMinFees = StateTran
     identity_create_base_cost: 2_000_000,
     identity_key_in_creation_cost: 6_500_000,
     identity_topup_base_cost: 500_000,
+    // Expected (display) fee for AddressFundingFromAssetLockTransition —
+    // estimate of the GroveDB-metered charge, not a consensus value.
+    // Calibrated from apply=true execution (see the drive-abci
+    // `expected_fee_calibration` tests) with headroom for tree growth;
+    // observed testnet actuals for a 0-input/1-output funding:
+    // 14_964_200 and 14_702_160 credits.
+    address_funding_expected_base_fee: 10_000_000,
+    address_funding_expected_fee_per_input: 2_000_000,
+    address_funding_expected_fee_per_output: 7_500_000,
 };

--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
@@ -274,20 +274,25 @@ pub(super) unsafe fn decode_funding_addresses(
 /// charge for an `AddressFundingFromAssetLockTransition` with the given
 /// input and output counts.
 ///
-/// This is a display/planning estimate of the GroveDB-metered execution
-/// fee — deliberately DISTINCT from the consensus minimum the locked value
-/// must cover (`calculate_min_required_fee`, ~56k duffs for a one-output
-/// funding), which is several times larger than the metered charge. The
-/// constants are pinned against real execution by the drive-abci
-/// `expected_fee_calibration` tests.
+/// DISPLAY-ONLY: this is an informational estimate of the GroveDB-metered
+/// execution fee — deliberately DISTINCT from the consensus minimum the
+/// locked value must cover (`calculate_min_required_fee`, ~56k duffs for a
+/// one-output funding). It is NOT an upper bound: the charged fee is
+/// metered on live state, grows with `user_fee_increase` (the stuck-ST
+/// retry bumps it), and the pre-execution `validate_fees_of_event` gate
+/// requires the fee strategy to cover an average-case estimate that can
+/// exceed this number. Callers MUST NOT size funding locks from it — locks
+/// carry a conservative wallet reserve instead. The constants are pinned
+/// against real execution by the drive-abci `expected_fee_calibration`
+/// tests.
 ///
-/// The version is pinned to [`PlatformVersion::latest()`]. The funding
-/// builder resolves `sdk.version()` (network-floored), which can lag
-/// `latest()` — but every shipped fee version shares the same
-/// `state_transition_min_fees` table today, so the estimate cannot drift
-/// in practice. If a future fee version diverges, add an optional
-/// `protocol_version` parameter (0 = latest) rather than changing this
-/// default.
+/// The version is pinned to [`PlatformVersion::latest()`], while the
+/// funding builder resolves the network-floored `sdk.version()` — an
+/// acceptable mismatch ONLY because the value is display-only and every
+/// shipped fee version shares the same `state_transition_min_fees` table
+/// (pinned by `test_expected_fee_is_stable_across_shipped_platform_versions`).
+/// If a future fee version diverges, thread the protocol version through
+/// rather than changing this default.
 ///
 /// Pure computation: no wallet handle, no network. Writes the fee to
 /// `out_fee` and returns `ok()`; a formula overflow returns

--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
@@ -269,3 +269,97 @@ pub(super) unsafe fn decode_funding_addresses(
     }
     Ok(address_map)
 }
+
+/// Estimate the fee (in credits) the network is EXPECTED to actually
+/// charge for an `AddressFundingFromAssetLockTransition` with the given
+/// input and output counts.
+///
+/// This is a display/planning estimate of the GroveDB-metered execution
+/// fee — deliberately DISTINCT from the consensus minimum the locked value
+/// must cover (`calculate_min_required_fee`, ~56k duffs for a one-output
+/// funding), which is several times larger than the metered charge. The
+/// constants are pinned against real execution by the drive-abci
+/// `expected_fee_calibration` tests.
+///
+/// The version is pinned to [`PlatformVersion::latest()`]. The funding
+/// builder resolves `sdk.version()` (network-floored), which can lag
+/// `latest()` — but every shipped fee version shares the same
+/// `state_transition_min_fees` table today, so the estimate cannot drift
+/// in practice. If a future fee version diverges, add an optional
+/// `protocol_version` parameter (0 = latest) rather than changing this
+/// default.
+///
+/// Pure computation: no wallet handle, no network. Writes the fee to
+/// `out_fee` and returns `ok()`; a formula overflow returns
+/// `ErrorArithmeticOverflow`.
+///
+/// # Safety
+/// `out_fee` must point to 8 writable bytes (a `u64`).
+#[no_mangle]
+pub unsafe extern "C" fn platform_wallet_address_funding_estimate_fee(
+    input_count: usize,
+    output_count: usize,
+    out_fee: *mut u64,
+) -> PlatformWalletFFIResult {
+    check_ptr!(out_fee);
+
+    let platform_version = dpp::version::PlatformVersion::latest();
+    match dpp::state_transition::address_funding_from_asset_lock_transition::AddressFundingFromAssetLockTransition::estimate_expected_fee(
+        input_count,
+        output_count,
+        platform_version,
+    ) {
+        Ok(credits) => {
+            *out_fee = credits;
+            PlatformWalletFFIResult::ok()
+        }
+        Err(e) => PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorArithmeticOverflow,
+            format!("address funding fee estimation failed: {e}"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod estimate_fee_tests {
+    use super::*;
+
+    /// Pin the estimator's output for the canonical wallet topup shape
+    /// (0 inputs, 1 remainder output) and the per-input/per-output slopes,
+    /// so a constant change is always a conscious, reviewed bump.
+    #[test]
+    fn estimates_pinned_values() {
+        unsafe {
+            let estimate = |input_count: usize, output_count: usize| {
+                let mut fee: u64 = 0;
+                let result = platform_wallet_address_funding_estimate_fee(
+                    input_count,
+                    output_count,
+                    &mut fee,
+                );
+                assert_eq!(
+                    result.code,
+                    PlatformWalletFFIResultCode::Success,
+                    "estimate ({input_count}, {output_count}) must succeed"
+                );
+                fee
+            };
+            assert_eq!(estimate(0, 1), 17_500_000, "canonical wallet topup");
+            // output_count is clamped to at least 1.
+            assert_eq!(estimate(0, 0), 17_500_000, "zero outputs clamps to one");
+            assert_eq!(
+                estimate(1, 2),
+                10_000_000 + 2_000_000 + 2 * 7_500_000,
+                "per-input and per-output slopes"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_null_out_pointer() {
+        unsafe {
+            let result = platform_wallet_address_funding_estimate_fee(0, 1, std::ptr::null_mut());
+            assert_ne!(result.code, PlatformWalletFFIResultCode::Success);
+        }
+    }
+}

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
@@ -648,6 +648,29 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
         }
     }
 
+    /// Expected fee (in credits) the network will actually charge for an
+    /// `AddressFundingFromAssetLockTransition` with the given input and
+    /// output counts — a display/planning estimate of the metered
+    /// execution fee, NOT the (several-times-larger) consensus minimum
+    /// the locked value must cover. Pure computation on the Rust side
+    /// (no handle, no network); the constants are pinned against real
+    /// execution by the drive-abci calibration tests. The canonical
+    /// wallet topup is `(inputCount: 0, outputCount: 1)` — the single
+    /// remainder recipient.
+    public static func estimateAddressFundingFee(
+        inputCount: Int = 0,
+        outputCount: Int = 1
+    ) throws -> UInt64 {
+        var fee: UInt64 = 0
+        // Counts are `usize` on the Rust side → imported as `UInt`.
+        try platform_wallet_address_funding_estimate_fee(
+            UInt(inputCount),
+            UInt(outputCount),
+            &fee
+        ).check()
+        return fee
+    }
+
     /// Fund this wallet's platform addresses from a Core L1 asset lock,
     /// orchestrated entirely on the Rust side (build asset-lock tx →
     /// wait for IS-lock or fall back to ChainLock → submit

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
@@ -648,15 +648,17 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
         }
     }
 
-    /// Expected fee (in credits) the network will actually charge for an
-    /// `AddressFundingFromAssetLockTransition` with the given input and
-    /// output counts — a display/planning estimate of the metered
-    /// execution fee, NOT the (several-times-larger) consensus minimum
-    /// the locked value must cover. Pure computation on the Rust side
-    /// (no handle, no network); the constants are pinned against real
-    /// execution by the drive-abci calibration tests. The canonical
-    /// wallet topup is `(inputCount: 0, outputCount: 1)` — the single
-    /// remainder recipient.
+    /// DISPLAY-ONLY estimate (in credits) of the fee the network charges
+    /// for an `AddressFundingFromAssetLockTransition` with the given input
+    /// and output counts. NOT an upper bound and NOT the consensus
+    /// minimum the locked value must cover — the charged fee is metered on
+    /// live state and grows with the retry loop's `user_fee_increase`, so
+    /// callers MUST NOT size funding locks (or any execution budget) from
+    /// this number; locks carry a conservative wallet funding reserve
+    /// instead. Pure computation on the Rust side (no handle, no network);
+    /// the constants are pinned against real execution by the drive-abci
+    /// calibration tests. The canonical wallet topup is
+    /// `(inputCount: 0, outputCount: 1)` — the single remainder recipient.
     public static func estimateAddressFundingFee(
         inputCount: Int = 0,
         outputCount: Int = 1


### PR DESCRIPTION
## Issue being fixed or feature implemented
Wallets funding Platform addresses from an asset lock (Core → Platform topup) had no client-side way to show the user the fee the network is expected to actually charge — only the several-times-larger consensus minimum (`calculate_min_required_fee`). Sizing or labeling the lock from that minimum overstates the fee; sizing from nothing understates the risk.

## What was done?
- **`AddressFundingFromAssetLockTransition::estimate_expected_fee(input_count, output_count)`** in rs-dpp: a pure, display-only estimate of the GroveDB-metered execution fee, built from new `address_funding_expected_*` constants in `state_transition_min_fees`. Explicitly documented as informational — NOT an upper bound, and never to be used to size funding locks.
- **FFI + Swift**: `platform_wallet_address_funding_estimate_fee` and `ManagedPlatformAddressWallet.estimateAddressFundingFee` expose it to wallets, with the same display-only contract in the docs.
- **`expected_fee_calibration` tests** in drive-abci pin the estimate and the iOS wallet's 56k-duff funding reserve against real execution:
  - the actual metered fee stays within the \[50%, 100%\] band of the estimate (0-input/1-output and 1-input/2-output shapes);
  - the actual fee fits the wallet funding reserve, on genesis and on state populated by eight committed fundings, both at the highest `user_fee_increase` the SDK's stuck-ST retry loop can reach (14);
  - a minimal wallet lock (admission floor + 1 duff) is accepted end-to-end through both admission gates (`calculate_min_required_fee` floor and the `validate_fees_of_event` average-case gate);
  - the estimate is identical under `PlatformVersion::first()` and `latest()`, so the FFI's `latest()` pin cannot diverge from builders resolving the network-floored `sdk.version()`.

These are regression samples for the current protocol versions and scenarios — deliberately documented as NOT a proof of a fee upper bound on arbitrary live state. Their value is tripwiring: a protocol change that moves the metered fee outside the band or past the wallet reserve fails loudly in CI instead of silently shrinking user topups via `ReduceOutput`.

## How Has This Been Tested?
- `cargo test -p drive-abci expected_fee_calibration --lib` — 6/6 passing.
- `cargo test -p platform-wallet-ffi --lib estimate_fee_tests` — passing.
- `cargo fmt --all -- --check` — clean.
- Consumed by the iOS wallet (dashpay/dashwallet-ios#1030): confirm-sheet estimate verified against real testnet Core → Platform transfers.

## Breaking Changes
None. Additive API; fee constants and execution paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added address-funding fee estimation based on the number of inputs and outputs.
  * Exposed fee estimation through the platform wallet interface and Swift SDK.
  * Added configurable base, per-input, and per-output fee values.
  * Zero outputs are handled using a minimum chargeable output count of one.

* **Bug Fixes**
  * Added safeguards for arithmetic overflow and invalid output pointers.

* **Tests**
  * Added coverage validating fee calculations, limits, retries, and platform-version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->