### PR TITLE
feat(sdk-ffi): expose the current epoch; fix getCurrentEpoch and the proposed-blocks range proof

### DIFF
--- a/packages/rs-sdk-ffi/src/system/queries/current_epoch.rs
+++ b/packages/rs-sdk-ffi/src/system/queries/current_epoch.rs
@@ -1,0 +1,107 @@
+//! `dash_sdk_system_get_current_epoch` — the newest started epoch, via
+//! [`ExtendedEpochInfo::fetch_current`].
+//!
+//! `dash_sdk_system_get_epochs_info` cannot answer "which epoch is it now":
+//! an unbounded descending proved query is rejected by the proof verifier,
+//! and `start = None, ascending = true` is epoch 0. `fetch_current` runs the
+//! two-query probe that resolves the current epoch against proofs, so hosts
+//! get a verified answer from one call.
+
+use crate::types::SDKHandle;
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, DashSDKResultDataType};
+use dash_sdk::dpp::block::extended_epoch_info::v0::ExtendedEpochInfoV0Getters;
+use dash_sdk::dpp::block::extended_epoch_info::ExtendedEpochInfo;
+use dash_sdk::platform::fetch_current_no_parameters::FetchCurrent;
+use std::ffi::{c_void, CString};
+
+/// Fetch the current (newest started) epoch as a JSON object with the same
+/// keys `dash_sdk_system_get_epochs_info` emits per epoch:
+/// `{"index","first_block_time","first_block_height","first_core_block_height",
+/// "fee_multiplier_permille","protocol_version"}`.
+///
+/// Returns `NoData` (no error) when Platform has no epoch yet.
+///
+/// # Safety
+/// `sdk_handle` must be a valid SDK handle or null (null ⇒ error result).
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_system_get_current_epoch(
+    sdk_handle: *const SDKHandle,
+) -> DashSDKResult {
+    match get_current_epoch(sdk_handle) {
+        Ok(Some(json)) => {
+            let c_str = match CString::new(json) {
+                Ok(s) => s,
+                Err(e) => {
+                    return DashSDKResult {
+                        data_type: DashSDKResultDataType::NoData,
+                        data: std::ptr::null_mut(),
+                        error: Box::into_raw(Box::new(DashSDKError::new(
+                            DashSDKErrorCode::InternalError,
+                            format!("Failed to create CString: {}", e),
+                        ))),
+                    }
+                }
+            };
+            DashSDKResult {
+                data_type: DashSDKResultDataType::String,
+                data: c_str.into_raw() as *mut c_void,
+                error: std::ptr::null_mut(),
+            }
+        }
+        Ok(None) => DashSDKResult {
+            data_type: DashSDKResultDataType::NoData,
+            data: std::ptr::null_mut(),
+            error: std::ptr::null_mut(),
+        },
+        Err(e) => DashSDKResult {
+            data_type: DashSDKResultDataType::NoData,
+            data: std::ptr::null_mut(),
+            error: Box::into_raw(Box::new(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                e,
+            ))),
+        },
+    }
+}
+
+fn get_current_epoch(sdk_handle: *const SDKHandle) -> Result<Option<String>, String> {
+    if sdk_handle.is_null() {
+        return Err("SDK handle is null".to_string());
+    }
+
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
+        .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
+
+    let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };
+    let sdk = wrapper.sdk.clone();
+
+    rt.block_on(async move {
+        match ExtendedEpochInfo::fetch_current(&sdk).await {
+            Ok(epoch) => Ok(Some(format!(
+                r#"{{"index":{},"first_block_time":{},"first_block_height":{},"first_core_block_height":{},"fee_multiplier_permille":{},"protocol_version":{}}}"#,
+                epoch.index(),
+                epoch.first_block_time(),
+                epoch.first_block_height(),
+                epoch.first_core_block_height(),
+                epoch.fee_multiplier_permille(),
+                epoch.protocol_version()
+            ))),
+            Err(dash_sdk::Error::EpochNotFound) => Ok(None),
+            Err(e) => Err(format!("Failed to fetch current epoch: {}", e)),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn null_handle_is_an_error() {
+        unsafe {
+            let result = dash_sdk_system_get_current_epoch(std::ptr::null());
+            assert!(!result.error.is_null());
+            crate::dash_sdk_error_free(result.error);
+        }
+    }
+}

--- a/packages/rs-sdk-ffi/src/system/queries/mod.rs
+++ b/packages/rs-sdk-ffi/src/system/queries/mod.rs
@@ -1,4 +1,5 @@
 // System-level queries
+pub mod current_epoch;
 pub mod current_quorums_info;
 pub mod epochs_info;
 pub mod path_elements;
@@ -7,6 +8,7 @@ pub mod prefunded_specialized_balance;
 pub mod total_credits_in_platform;
 
 // Re-export all public functions for convenient access
+pub use current_epoch::dash_sdk_system_get_current_epoch;
 pub use current_quorums_info::dash_sdk_system_get_current_quorums_info;
 pub use epochs_info::dash_sdk_system_get_epochs_info;
 pub use path_elements::dash_sdk_system_get_path_elements;

--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
@@ -1607,21 +1607,19 @@ extension SDK {
         return try processJSONArrayResult(result)
     }
 
-    /// Get current epoch
+    /// Get the current (newest started) epoch — same keys as one
+    /// `getEpochsInfo` entry (`index`, `first_block_time`, …).
+    ///
+    /// Goes through `dash_sdk_system_get_current_epoch`
+    /// (`ExtendedEpochInfo::fetch_current`): the epochs-info query cannot
+    /// express "the latest epoch" — `start = nil, ascending` is epoch 0, and an
+    /// unbounded descending proved query is rejected by the proof verifier.
     public func getCurrentEpoch() async throws -> [String: Any] {
         guard let handle = handle else {
             throw SDKError.invalidState("SDK not initialized")
         }
-
-        // Get current epoch info by passing nil as start_epoch to get the latest
-        let result = dash_sdk_system_get_epochs_info(handle, nil, 1, true)
-        let epochs = try processJSONArrayResult(result)
-
-        guard let currentEpoch = epochs.first else {
-            throw SDKError.notFound("Current epoch not found")
-        }
-
-        return currentEpoch
+        let result = dash_sdk_system_get_current_epoch(handle)
+        return try processJSONResult(result)
     }
 
     /// Get finalized epoch infos


### PR DESCRIPTION
## Summary

- New `dash_sdk_system_get_current_epoch(sdk)` in rs-sdk-ffi: the newest started epoch via `ExtendedEpochInfo::fetch_current` (the proved two-query probe), returned as one JSON object with the same keys `dash_sdk_system_get_epochs_info` emits per epoch (`index`, `first_block_time`, `first_block_height`, `first_core_block_height`, `fee_multiplier_permille`, `protocol_version`). `NoData` when Platform has no epoch yet.
- Swift `SDK.getCurrentEpoch()` now calls it. The previous implementation used `getEpochsInfo(start: nil, count: 1, ascending: true)`, which per `EpochQuery` semantics is **epoch 0**, not the current epoch — and an unbounded descending proved query is rejected by the proof verifier, so no existing bridge could answer "which epoch is it now".

- `dash_sdk_evonode_get_proposed_epoch_blocks_by_range` now carries its `limit` in the request. It used to send `limit: None`, so Drive built the proof for its default page while the verifier re-derived a no-limit query from the request — every proved call failed with `Proof is missing data for query range … KVHash` (seen on mainnet from the iOS wallet). `0` ⇒ Drive's default page.

Consumer: dashwallet-ios home-screen "blocks proposed this epoch" card (dashpay/dashwallet-ios#1036).

## Test plan
- [x] `cargo test -p rs-sdk-ffi --lib -- current_epoch proposed_epoch_blocks`, `cargo clippy -p rs-sdk-ffi --all-targets -- -D warnings`, `cargo fmt`
- [x] `./build_ios.sh --target sim` (xcframework + SwiftExampleApp, warnings-as-errors)
- [ ] Mainnet/testnet: the iOS card shows the real current epoch index and the range pages verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)
