### PR TITLE
chore: bump rust-dashcore pin for multilingual BIP-39 mnemonic parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 dependencies = [
  "dash-network",
 ]
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1797,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1823,12 +1823,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1841,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2923,7 +2923,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 
 [[package]]
 name = "glob"
@@ -4114,7 +4114,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 dependencies = [
  "aes",
  "async-trait",
@@ -4143,7 +4143,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4159,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a062ccb9887c222bae72ab9f207b16baa3cce358#a062ccb9887c222bae72ab9f207b16baa3cce358"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,14 +53,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "173ffac0fdc0c73dda0626cf385bbcfcf2437aeb" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "173ffac0fdc0c73dda0626cf385bbcfcf2437aeb" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "173ffac0fdc0c73dda0626cf385bbcfcf2437aeb" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "173ffac0fdc0c73dda0626cf385bbcfcf2437aeb" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "173ffac0fdc0c73dda0626cf385bbcfcf2437aeb" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "173ffac0fdc0c73dda0626cf385bbcfcf2437aeb" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "173ffac0fdc0c73dda0626cf385bbcfcf2437aeb" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "173ffac0fdc0c73dda0626cf385bbcfcf2437aeb" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "a062ccb9887c222bae72ab9f207b16baa3cce358" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "a062ccb9887c222bae72ab9f207b16baa3cce358" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "a062ccb9887c222bae72ab9f207b16baa3cce358" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "a062ccb9887c222bae72ab9f207b16baa3cce358" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "a062ccb9887c222bae72ab9f207b16baa3cce358" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "a062ccb9887c222bae72ab9f207b16baa3cce358" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "a062ccb9887c222bae72ab9f207b16baa3cce358" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "a062ccb9887c222bae72ab9f207b16baa3cce358" }
 
 tokio-metrics = "0.5"
 


### PR DESCRIPTION
Pins `fix/mnemonic-any-language-173ffac` (`a062ccb9`) — the cherry-pick of dashpay/rust-dashcore#980 onto `173ffac0`, the exact rev `v4.2-dev` already pins.
