### PR TITLE
feat(drive)!: make the daily withdrawal limit 15% of the total credits held a day ago

### DIFF
--- a/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/mod.rs
+++ b/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/mod.rs
@@ -5,14 +5,23 @@ use platform_version::version::PlatformVersion;
 
 mod v0;
 mod v1;
+mod v2;
 
+/// Returns the maximum amount of credits Platform may pool into asset unlock
+/// transactions per 24 hours.
+///
+/// `reference_total_credits` is the base the limit is derived from: the current
+/// total credits in Platform for version 0 (10% of it, bounded), ignored by
+/// version 1 (a flat 2000 Dash), and the total credits Platform held a day ago
+/// for version 2 (`daily_withdrawal_limit_percent` of it).
 pub fn daily_withdrawal_limit(
-    total_credits_in_platform: Credits,
+    reference_total_credits: Credits,
     platform_version: &PlatformVersion,
 ) -> Result<Credits, ProtocolError> {
     match platform_version.dpp.methods.daily_withdrawal_limit {
-        0 => Ok(daily_withdrawal_limit_v0(total_credits_in_platform)),
-        1 => Ok(v1::daily_withdrawal_limit_v1(platform_version)),
+        0 => Ok(daily_withdrawal_limit_v0(reference_total_credits)),
+        1 => Ok(v1::daily_withdrawal_limit_v1()),
+        2 => v2::daily_withdrawal_limit_v2(reference_total_credits, platform_version),
         v => Err(ProtocolError::UnknownVersionError(format!(
             "Unknown daily_withdrawal_limit version {v}"
         ))),
@@ -25,23 +34,24 @@ mod tests {
     use crate::dash_to_credits;
 
     #[test]
-    fn should_double_flat_daily_withdrawal_limit_at_protocol_version_14() {
+    fn should_switch_from_flat_to_relative_daily_withdrawal_limit_at_protocol_version_14() {
         let v13 = PlatformVersion::get(13).expect("expected protocol version 13");
         let v14 = PlatformVersion::get(14).expect("expected protocol version 14");
 
-        // Both flat limits are independent of the credits held in Platform.
-        for total_credits in [
-            dash_to_credits!(50),
-            dash_to_credits!(5000),
-            dash_to_credits!(1000000),
+        for (total_credits_a_day_ago, expected_v14) in [
+            (dash_to_credits!(50), dash_to_credits!(7.5)),
+            (dash_to_credits!(30000), dash_to_credits!(4500)),
+            (dash_to_credits!(1000000), dash_to_credits!(150000)),
         ] {
+            // v13 keeps the flat 2000 Dash whatever the total is.
             assert_eq!(
-                daily_withdrawal_limit(total_credits, v13).expect("expected v13 limit"),
+                daily_withdrawal_limit(total_credits_a_day_ago, v13).expect("expected v13 limit"),
                 dash_to_credits!(2000)
             );
+            // v14 allows 15% of the total credits a day ago.
             assert_eq!(
-                daily_withdrawal_limit(total_credits, v14).expect("expected v14 limit"),
-                dash_to_credits!(4000)
+                daily_withdrawal_limit(total_credits_a_day_ago, v14).expect("expected v14 limit"),
+                expected_v14
             );
         }
     }

--- a/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/mod.rs
+++ b/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/mod.rs
@@ -14,8 +14,8 @@ mod v2;
 /// total credits in Platform for version 0 (10% of it, bounded; required), ignored
 /// by version 1 (a flat 2000 Dash), and the total credits Platform held a day ago
 /// for version 2 (`daily_withdrawal_limit_percent` of it, never below one maximal
-/// withdrawal; the flat limit of version 1 while that day-old total is not known
-/// yet).
+/// withdrawal nor above `max_daily_withdrawal_amount`; the flat limit of version 1
+/// while that day-old total is not known yet).
 pub fn daily_withdrawal_limit(
     reference_total_credits: Option<Credits>,
     platform_version: &PlatformVersion,
@@ -51,8 +51,10 @@ mod tests {
             // Below one maximal withdrawal (500 Dash) the limit is floored there.
             (dash_to_credits!(50), dash_to_credits!(500)),
             (dash_to_credits!(2000), dash_to_credits!(500)),
-            (dash_to_credits!(30000), dash_to_credits!(4500)),
-            (dash_to_credits!(1000000), dash_to_credits!(150000)),
+            (dash_to_credits!(20000), dash_to_credits!(3000)),
+            // Above Core's unlock capacity per day (4000 Dash) the limit is capped there.
+            (dash_to_credits!(30000), dash_to_credits!(4000)),
+            (dash_to_credits!(1000000), dash_to_credits!(4000)),
         ] {
             // v13 keeps the flat 2000 Dash whatever the total is.
             assert_eq!(

--- a/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/mod.rs
+++ b/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/mod.rs
@@ -11,15 +11,24 @@ mod v2;
 /// transactions per 24 hours.
 ///
 /// `reference_total_credits` is the base the limit is derived from: the current
-/// total credits in Platform for version 0 (10% of it, bounded), ignored by
-/// version 1 (a flat 2000 Dash), and the total credits Platform held a day ago
-/// for version 2 (`daily_withdrawal_limit_percent` of it).
+/// total credits in Platform for version 0 (10% of it, bounded; required), ignored
+/// by version 1 (a flat 2000 Dash), and the total credits Platform held a day ago
+/// for version 2 (`daily_withdrawal_limit_percent` of it, never below one maximal
+/// withdrawal; the flat limit of version 1 while that day-old total is not known
+/// yet).
 pub fn daily_withdrawal_limit(
-    reference_total_credits: Credits,
+    reference_total_credits: Option<Credits>,
     platform_version: &PlatformVersion,
 ) -> Result<Credits, ProtocolError> {
     match platform_version.dpp.methods.daily_withdrawal_limit {
-        0 => Ok(daily_withdrawal_limit_v0(reference_total_credits)),
+        0 => reference_total_credits
+            .map(daily_withdrawal_limit_v0)
+            .ok_or_else(|| {
+                ProtocolError::CorruptedCodeExecution(
+                    "daily_withdrawal_limit v0 requires the current total credits in Platform"
+                        .to_string(),
+                )
+            }),
         1 => Ok(v1::daily_withdrawal_limit_v1()),
         2 => v2::daily_withdrawal_limit_v2(reference_total_credits, platform_version),
         v => Err(ProtocolError::UnknownVersionError(format!(
@@ -39,20 +48,30 @@ mod tests {
         let v14 = PlatformVersion::get(14).expect("expected protocol version 14");
 
         for (total_credits_a_day_ago, expected_v14) in [
-            (dash_to_credits!(50), dash_to_credits!(7.5)),
+            // Below one maximal withdrawal (500 Dash) the limit is floored there.
+            (dash_to_credits!(50), dash_to_credits!(500)),
+            (dash_to_credits!(2000), dash_to_credits!(500)),
             (dash_to_credits!(30000), dash_to_credits!(4500)),
             (dash_to_credits!(1000000), dash_to_credits!(150000)),
         ] {
             // v13 keeps the flat 2000 Dash whatever the total is.
             assert_eq!(
-                daily_withdrawal_limit(total_credits_a_day_ago, v13).expect("expected v13 limit"),
+                daily_withdrawal_limit(Some(total_credits_a_day_ago), v13)
+                    .expect("expected v13 limit"),
                 dash_to_credits!(2000)
             );
             // v14 allows 15% of the total credits a day ago.
             assert_eq!(
-                daily_withdrawal_limit(total_credits_a_day_ago, v14).expect("expected v14 limit"),
+                daily_withdrawal_limit(Some(total_credits_a_day_ago), v14)
+                    .expect("expected v14 limit"),
                 expected_v14
             );
         }
+
+        // Until the total credits a day ago are known, v14 keeps v13's flat limit.
+        assert_eq!(
+            daily_withdrawal_limit(None, v14).expect("expected v14 bootstrap limit"),
+            dash_to_credits!(2000)
+        );
     }
 }

--- a/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v1/mod.rs
+++ b/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v1/mod.rs
@@ -1,9 +1,9 @@
 use crate::fee::Credits;
-use platform_version::version::PlatformVersion;
 
-/// Flat daily withdrawal limit, read from the protocol version's system limits
-/// (`SystemLimits::daily_withdrawal_limit`): 2000 Dash up to protocol version 13
-/// (the limit in Core v22), 4000 Dash from protocol version 14 (Core v24).
-pub fn daily_withdrawal_limit_v1(platform_version: &PlatformVersion) -> Credits {
-    platform_version.system_limits.daily_withdrawal_limit
+/// Flat daily withdrawal limit of 2000 Dash, matching the limit in Core v22
+/// (`LimitAmountV22`). In force from protocol version 8 to protocol version 13;
+/// superseded by the relative limit of version 2.
+pub const fn daily_withdrawal_limit_v1() -> Credits {
+    // 2000 Dash
+    200_000_000_000_000
 }

--- a/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v2/mod.rs
+++ b/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v2/mod.rs
@@ -47,13 +47,22 @@ pub fn daily_withdrawal_limit_v2(
             )
         })?;
 
+    let max_withdrawal_amount = platform_version.system_limits.max_withdrawal_amount;
+    if max_daily_withdrawal_amount < max_withdrawal_amount {
+        // A cap below one maximal withdrawal would let an accepted withdrawal never fit the
+        // daily maximum; that is a contradictory configuration, not a limit to apply.
+        return Err(ProtocolError::CorruptedCodeExecution(format!(
+            "daily_withdrawal_limit v2 requires system_limits.max_daily_withdrawal_amount ({max_daily_withdrawal_amount}) to be at least max_withdrawal_amount ({max_withdrawal_amount})"
+        )));
+    }
+
     // u128 keeps `total * percent` from overflowing for any u64 total.
     let relative_limit = (total_credits_a_day_ago as u128) * (percent as u128) / 100;
     let relative_limit = Credits::try_from(relative_limit)
         .map_err(|_| ProtocolError::Overflow("daily withdrawal limit overflow"))?;
 
     Ok(relative_limit
-        .max(platform_version.system_limits.max_withdrawal_amount)
+        .max(max_withdrawal_amount)
         .min(max_daily_withdrawal_amount))
 }
 
@@ -158,5 +167,28 @@ mod tests {
             daily_withdrawal_limit_v2(Some(dash_to_credits!(100)), &platform_version),
             Err(ProtocolError::CorruptedCodeExecution(_))
         ));
+    }
+
+    #[test]
+    fn should_fail_when_the_cap_is_below_one_maximal_withdrawal() {
+        let mut platform_version = platform_version_with(Some(15));
+        platform_version.system_limits.max_daily_withdrawal_amount =
+            Some(dash_to_credits!(500) - 1);
+
+        // Whatever the total, a cap below the floor is a contradictory configuration.
+        for total in [0, dash_to_credits!(100), dash_to_credits!(30000)] {
+            assert!(matches!(
+                daily_withdrawal_limit_v2(Some(total), &platform_version),
+                Err(ProtocolError::CorruptedCodeExecution(_))
+            ));
+        }
+
+        // Exactly the floor is allowed and the limit is that floor.
+        platform_version.system_limits.max_daily_withdrawal_amount = Some(dash_to_credits!(500));
+        assert_eq!(
+            daily_withdrawal_limit_v2(Some(dash_to_credits!(30000)), &platform_version)
+                .expect("expected limit"),
+            dash_to_credits!(500)
+        );
     }
 }

--- a/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v2/mod.rs
+++ b/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v2/mod.rs
@@ -8,10 +8,13 @@ use platform_version::version::PlatformVersion;
 /// Using a day-old base means a sudden jump in the total credits does not raise
 /// the limit for a day.
 ///
-/// Two guards keep it usable:
+/// Three guards keep it usable:
 /// * it is never below `max_withdrawal_amount`, so every withdrawal Platform
 ///   accepts eventually fits the daily maximum and cannot block the pooling
 ///   queue behind it;
+/// * it is never above `max_daily_withdrawal_amount`, Core's credit-pool unlock
+///   capacity per day: pooling more than Core will mine only cycles those
+///   unlocks through expiry and re-signing;
 /// * while the total credits a day ago are not known (`None`: the history is
 ///   younger than a day, i.e. right after this rule activates), the flat limit
 ///   of version 1 applies, so the lag cannot be skipped by inflating the total
@@ -34,12 +37,24 @@ pub fn daily_withdrawal_limit_v2(
             )
         })?;
 
+    let max_daily_withdrawal_amount = platform_version
+        .system_limits
+        .max_daily_withdrawal_amount
+        .ok_or_else(|| {
+            ProtocolError::CorruptedCodeExecution(
+                "daily_withdrawal_limit v2 requires system_limits.max_daily_withdrawal_amount"
+                    .to_string(),
+            )
+        })?;
+
     // u128 keeps `total * percent` from overflowing for any u64 total.
     let relative_limit = (total_credits_a_day_ago as u128) * (percent as u128) / 100;
     let relative_limit = Credits::try_from(relative_limit)
         .map_err(|_| ProtocolError::Overflow("daily withdrawal limit overflow"))?;
 
-    Ok(relative_limit.max(platform_version.system_limits.max_withdrawal_amount))
+    Ok(relative_limit
+        .max(platform_version.system_limits.max_withdrawal_amount)
+        .min(max_daily_withdrawal_amount))
 }
 
 #[cfg(test)]
@@ -53,6 +68,7 @@ mod tests {
             .system_limits
             .daily_withdrawal_limit_percent = percent;
         platform_version.system_limits.max_withdrawal_amount = dash_to_credits!(500);
+        platform_version.system_limits.max_daily_withdrawal_amount = Some(dash_to_credits!(4000));
         platform_version
     }
 
@@ -61,14 +77,15 @@ mod tests {
         let platform_version = platform_version_with(Some(15));
 
         assert_eq!(
-            daily_withdrawal_limit_v2(Some(dash_to_credits!(30000)), &platform_version)
+            daily_withdrawal_limit_v2(Some(dash_to_credits!(20000)), &platform_version)
                 .expect("expected limit"),
-            dash_to_credits!(4500)
+            dash_to_credits!(3000)
         );
+        // Rounds down to whole credits.
         assert_eq!(
-            daily_withdrawal_limit_v2(Some(Credits::MAX), &platform_version)
+            daily_withdrawal_limit_v2(Some(dash_to_credits!(500) + 7), &platform_version)
                 .expect("expected limit"),
-            ((Credits::MAX as u128) * 15 / 100) as Credits
+            dash_to_credits!(500)
         );
     }
 
@@ -95,6 +112,29 @@ mod tests {
     }
 
     #[test]
+    fn should_never_exceed_cores_unlock_capacity_per_day() {
+        let platform_version = platform_version_with(Some(15));
+
+        // 15% of 30000 Dash is 4500 Dash, above what Core mines per day.
+        assert_eq!(
+            daily_withdrawal_limit_v2(Some(dash_to_credits!(30000)), &platform_version)
+                .expect("expected limit"),
+            dash_to_credits!(4000)
+        );
+        assert_eq!(
+            daily_withdrawal_limit_v2(Some(Credits::MAX), &platform_version)
+                .expect("expected limit"),
+            dash_to_credits!(4000)
+        );
+        // Just under the boundary the percent still applies.
+        assert_eq!(
+            daily_withdrawal_limit_v2(Some(dash_to_credits!(26666)), &platform_version)
+                .expect("expected limit"),
+            dash_to_credits!(3999.9)
+        );
+    }
+
+    #[test]
     fn should_keep_the_flat_limit_until_the_lagged_total_is_known() {
         let platform_version = platform_version_with(Some(15));
 
@@ -105,9 +145,15 @@ mod tests {
     }
 
     #[test]
-    fn should_fail_when_the_percent_is_not_configured() {
+    fn should_fail_when_the_percent_or_the_cap_is_not_configured() {
         let platform_version = platform_version_with(None);
+        assert!(matches!(
+            daily_withdrawal_limit_v2(Some(dash_to_credits!(100)), &platform_version),
+            Err(ProtocolError::CorruptedCodeExecution(_))
+        ));
 
+        let mut platform_version = platform_version_with(Some(15));
+        platform_version.system_limits.max_daily_withdrawal_amount = None;
         assert!(matches!(
             daily_withdrawal_limit_v2(Some(dash_to_credits!(100)), &platform_version),
             Err(ProtocolError::CorruptedCodeExecution(_))

--- a/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v2/mod.rs
+++ b/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v2/mod.rs
@@ -1,16 +1,29 @@
 use crate::fee::Credits;
+use crate::withdrawal::daily_withdrawal_limit::v1::daily_withdrawal_limit_v1;
 use crate::ProtocolError;
 use platform_version::version::PlatformVersion;
 
 /// Relative daily withdrawal limit: `daily_withdrawal_limit_percent` (from the
-/// protocol version's system limits) of the total credits Platform held a day
-/// ago. The caller passes that lagged total as `total_credits_in_platform_a_day_ago`;
-/// using a day-old base means a sudden jump in the total credits does not raise
+/// protocol version's system limits) of the total credits Platform held a day ago.
+/// Using a day-old base means a sudden jump in the total credits does not raise
 /// the limit for a day.
+///
+/// Two guards keep it usable:
+/// * it is never below `max_withdrawal_amount`, so every withdrawal Platform
+///   accepts eventually fits the daily maximum and cannot block the pooling
+///   queue behind it;
+/// * while the total credits a day ago are not known (`None`: the history is
+///   younger than a day, i.e. right after this rule activates), the flat limit
+///   of version 1 applies, so the lag cannot be skipped by inflating the total
+///   before or at activation.
 pub fn daily_withdrawal_limit_v2(
-    total_credits_in_platform_a_day_ago: Credits,
+    total_credits_in_platform_a_day_ago: Option<Credits>,
     platform_version: &PlatformVersion,
 ) -> Result<Credits, ProtocolError> {
+    let Some(total_credits_a_day_ago) = total_credits_in_platform_a_day_ago else {
+        return Ok(daily_withdrawal_limit_v1());
+    };
+
     let percent = platform_version
         .system_limits
         .daily_withdrawal_limit_percent
@@ -22,9 +35,11 @@ pub fn daily_withdrawal_limit_v2(
         })?;
 
     // u128 keeps `total * percent` from overflowing for any u64 total.
-    let limit = (total_credits_in_platform_a_day_ago as u128) * (percent as u128) / 100;
+    let relative_limit = (total_credits_a_day_ago as u128) * (percent as u128) / 100;
+    let relative_limit = Credits::try_from(relative_limit)
+        .map_err(|_| ProtocolError::Overflow("daily withdrawal limit overflow"))?;
 
-    Credits::try_from(limit).map_err(|_| ProtocolError::Overflow("daily withdrawal limit overflow"))
+    Ok(relative_limit.max(platform_version.system_limits.max_withdrawal_amount))
 }
 
 #[cfg(test)]
@@ -32,38 +47,69 @@ mod tests {
     use super::*;
     use crate::dash_to_credits;
 
-    #[test]
-    fn should_return_the_configured_percent_of_the_lagged_total() {
+    fn platform_version_with(percent: Option<u8>) -> PlatformVersion {
         let mut platform_version = PlatformVersion::latest().clone();
         platform_version
             .system_limits
-            .daily_withdrawal_limit_percent = Some(15);
+            .daily_withdrawal_limit_percent = percent;
+        platform_version.system_limits.max_withdrawal_amount = dash_to_credits!(500);
+        platform_version
+    }
+
+    #[test]
+    fn should_return_the_configured_percent_of_the_lagged_total() {
+        let platform_version = platform_version_with(Some(15));
 
         assert_eq!(
-            daily_withdrawal_limit_v2(dash_to_credits!(30000), &platform_version)
+            daily_withdrawal_limit_v2(Some(dash_to_credits!(30000)), &platform_version)
                 .expect("expected limit"),
             dash_to_credits!(4500)
         );
-        // Rounds down to whole credits.
         assert_eq!(
-            daily_withdrawal_limit_v2(7, &platform_version).expect("expected limit"),
-            1
-        );
-        assert_eq!(
-            daily_withdrawal_limit_v2(Credits::MAX, &platform_version).expect("expected limit"),
+            daily_withdrawal_limit_v2(Some(Credits::MAX), &platform_version)
+                .expect("expected limit"),
             ((Credits::MAX as u128) * 15 / 100) as Credits
         );
     }
 
     #[test]
+    fn should_never_go_below_one_maximal_withdrawal() {
+        let platform_version = platform_version_with(Some(15));
+
+        // 15% of 2000 Dash is 300 Dash, below the 500 Dash a single withdrawal may carry.
+        assert_eq!(
+            daily_withdrawal_limit_v2(Some(dash_to_credits!(2000)), &platform_version)
+                .expect("expected limit"),
+            dash_to_credits!(500)
+        );
+        assert_eq!(
+            daily_withdrawal_limit_v2(Some(0), &platform_version).expect("expected limit"),
+            dash_to_credits!(500)
+        );
+        // Exactly at the boundary the percent takes over.
+        assert_eq!(
+            daily_withdrawal_limit_v2(Some(dash_to_credits!(4000)), &platform_version)
+                .expect("expected limit"),
+            dash_to_credits!(600)
+        );
+    }
+
+    #[test]
+    fn should_keep_the_flat_limit_until_the_lagged_total_is_known() {
+        let platform_version = platform_version_with(Some(15));
+
+        assert_eq!(
+            daily_withdrawal_limit_v2(None, &platform_version).expect("expected limit"),
+            dash_to_credits!(2000)
+        );
+    }
+
+    #[test]
     fn should_fail_when_the_percent_is_not_configured() {
-        let mut platform_version = PlatformVersion::latest().clone();
-        platform_version
-            .system_limits
-            .daily_withdrawal_limit_percent = None;
+        let platform_version = platform_version_with(None);
 
         assert!(matches!(
-            daily_withdrawal_limit_v2(dash_to_credits!(100), &platform_version),
+            daily_withdrawal_limit_v2(Some(dash_to_credits!(100)), &platform_version),
             Err(ProtocolError::CorruptedCodeExecution(_))
         ));
     }

--- a/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v2/mod.rs
+++ b/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v2/mod.rs
@@ -1,0 +1,70 @@
+use crate::fee::Credits;
+use crate::ProtocolError;
+use platform_version::version::PlatformVersion;
+
+/// Relative daily withdrawal limit: `daily_withdrawal_limit_percent` (from the
+/// protocol version's system limits) of the total credits Platform held a day
+/// ago. The caller passes that lagged total as `total_credits_in_platform_a_day_ago`;
+/// using a day-old base means a sudden jump in the total credits does not raise
+/// the limit for a day.
+pub fn daily_withdrawal_limit_v2(
+    total_credits_in_platform_a_day_ago: Credits,
+    platform_version: &PlatformVersion,
+) -> Result<Credits, ProtocolError> {
+    let percent = platform_version
+        .system_limits
+        .daily_withdrawal_limit_percent
+        .ok_or_else(|| {
+            ProtocolError::CorruptedCodeExecution(
+                "daily_withdrawal_limit v2 requires system_limits.daily_withdrawal_limit_percent"
+                    .to_string(),
+            )
+        })?;
+
+    // u128 keeps `total * percent` from overflowing for any u64 total.
+    let limit = (total_credits_in_platform_a_day_ago as u128) * (percent as u128) / 100;
+
+    Credits::try_from(limit).map_err(|_| ProtocolError::Overflow("daily withdrawal limit overflow"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dash_to_credits;
+
+    #[test]
+    fn should_return_the_configured_percent_of_the_lagged_total() {
+        let mut platform_version = PlatformVersion::latest().clone();
+        platform_version
+            .system_limits
+            .daily_withdrawal_limit_percent = Some(15);
+
+        assert_eq!(
+            daily_withdrawal_limit_v2(dash_to_credits!(30000), &platform_version)
+                .expect("expected limit"),
+            dash_to_credits!(4500)
+        );
+        // Rounds down to whole credits.
+        assert_eq!(
+            daily_withdrawal_limit_v2(7, &platform_version).expect("expected limit"),
+            1
+        );
+        assert_eq!(
+            daily_withdrawal_limit_v2(Credits::MAX, &platform_version).expect("expected limit"),
+            ((Credits::MAX as u128) * 15 / 100) as Credits
+        );
+    }
+
+    #[test]
+    fn should_fail_when_the_percent_is_not_configured() {
+        let mut platform_version = PlatformVersion::latest().clone();
+        platform_version
+            .system_limits
+            .daily_withdrawal_limit_percent = None;
+
+        assert!(matches!(
+            daily_withdrawal_limit_v2(dash_to_credits!(100), &platform_version),
+            Err(ProtocolError::CorruptedCodeExecution(_))
+        ));
+    }
+}

--- a/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v2/mod.rs
+++ b/packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/v2/mod.rs
@@ -81,11 +81,11 @@ mod tests {
                 .expect("expected limit"),
             dash_to_credits!(3000)
         );
-        // Rounds down to whole credits.
+        // Rounds down to whole credits: 15% of 4000 Dash + 7 credits is 600 Dash + 1.05 credits.
         assert_eq!(
-            daily_withdrawal_limit_v2(Some(dash_to_credits!(500) + 7), &platform_version)
+            daily_withdrawal_limit_v2(Some(dash_to_credits!(4000) + 7), &platform_version)
                 .expect("expected limit"),
-            dash_to_credits!(500)
+            dash_to_credits!(600) + 1
         );
     }
 

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
@@ -353,8 +353,8 @@ where
         // Prune anchors older than the configured retention depth
         self.prune_shielded_pool_anchors(block_proposal.height, transaction, platform_version)?;
 
-        // Record the total credits in Platform for this block: the daily withdrawal limit is a
-        // share of the total credits Platform held a day ago, read from this history
+        // Record the total credits in Platform if this block changed it: the daily withdrawal
+        // limit is a share of the total credits Platform held a day ago, read from this history
         self.record_total_credits_history_for_withdrawals(
             &block_info,
             transaction,

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
@@ -353,14 +353,6 @@ where
         // Prune anchors older than the configured retention depth
         self.prune_shielded_pool_anchors(block_proposal.height, transaction, platform_version)?;
 
-        // Record the total credits in Platform if this block changed it: the daily withdrawal
-        // limit is a share of the total credits Platform held a day ago, read from this history
-        self.record_total_credits_history_for_withdrawals(
-            &block_info,
-            transaction,
-            platform_version,
-        )?;
-
         // Pool withdrawals into transactions queue
 
         // Takes queued withdrawals, creates untiled withdrawal transaction payload, saves them to queue
@@ -409,6 +401,16 @@ where
         )?;
 
         tracing::debug!(block_fees = ?processed_block_fees, "block fees are processed");
+
+        // Record the total credits in Platform if this block changed it: the daily withdrawal
+        // limit is a share of the total credits Platform held a day ago, read from this history.
+        // This runs after fees and epoch rewards, the last things in a block that can move the
+        // total, and before the app hash so the entry is part of this block's state.
+        self.record_total_credits_history_for_withdrawals(
+            &block_info,
+            transaction,
+            platform_version,
+        )?;
 
         let root_hash = self
             .drive

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
@@ -353,6 +353,14 @@ where
         // Prune anchors older than the configured retention depth
         self.prune_shielded_pool_anchors(block_proposal.height, transaction, platform_version)?;
 
+        // Record the total credits in Platform for this block: the daily withdrawal limit is a
+        // share of the total credits Platform held a day ago, read from this history
+        self.record_total_credits_history_for_withdrawals(
+            &block_info,
+            transaction,
+            platform_version,
+        )?;
+
         // Pool withdrawals into transactions queue
 
         // Takes queued withdrawals, creates untiled withdrawal transaction payload, saves them to queue

--- a/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
@@ -19,8 +19,8 @@ use drive::drive::identity::key::fetch::{
     IdentityKeysRequest, KeyIDIdentityPublicKeyPairBTreeMap, KeyRequestType,
 };
 use drive::drive::identity::withdrawals::paths::{
-    get_withdrawal_root_path, WITHDRAWAL_TRANSACTIONS_BROADCASTED_KEY,
-    WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY,
+    get_withdrawal_root_path, WITHDRAWAL_TOTAL_CREDITS_HISTORY_KEY,
+    WITHDRAWAL_TRANSACTIONS_BROADCASTED_KEY, WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY,
 };
 use drive::drive::prefunded_specialized_balances::prefunded_specialized_balances_for_voting_path_vec;
 use drive::drive::saved_block_transactions::{
@@ -712,6 +712,17 @@ impl<C> Platform<C> {
             platform_version,
         )?;
 
+        // Total credits history under the withdrawals tree: the daily withdrawal limit becomes
+        // a share of the total credits Platform held a day ago, recorded here every block.
+        self.drive.grove_insert_if_not_exists(
+            get_withdrawal_root_path().as_slice().into(),
+            &WITHDRAWAL_TOTAL_CREDITS_HISTORY_KEY,
+            Element::empty_tree(),
+            Some(transaction),
+            None,
+            &platform_version.drive,
+        )?;
+
         Ok(())
     }
 }
@@ -1375,6 +1386,71 @@ mod tests {
         assert!(
             element.value.is_ok(),
             "AddressBalances root tree should exist"
+        );
+    }
+
+    #[test]
+    fn test_transition_to_version_14_creates_total_credits_history_tree() {
+        let platform_version = PlatformVersion::latest();
+        let platform = TestPlatformBuilder::new()
+            .with_initial_protocol_version(13)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        use drive::grovedb_path::SubtreePath;
+
+        // Not there on a v13 genesis state
+        assert!(platform
+            .drive
+            .grove
+            .get(
+                SubtreePath::from(&get_withdrawal_root_path()),
+                &WITHDRAWAL_TOTAL_CREDITS_HISTORY_KEY,
+                Some(&transaction),
+                &platform_version.drive.grove_version,
+            )
+            .value
+            .is_err());
+
+        let block_info = BlockInfo {
+            time_ms: 1_000_000,
+            height: 100,
+            core_height: 10,
+            epoch: Epoch::default(),
+        };
+        platform
+            .transition_to_version_14(&block_info, &transaction, platform_version)
+            .expect("expected the transition to succeed");
+
+        let element = platform
+            .drive
+            .grove
+            .get(
+                SubtreePath::from(&get_withdrawal_root_path()),
+                &WITHDRAWAL_TOTAL_CREDITS_HISTORY_KEY,
+                Some(&transaction),
+                &platform_version.drive.grove_version,
+            )
+            .value
+            .expect("total credits history tree should exist after the v14 transition");
+        assert!(element.is_any_tree());
+
+        // Running it again is harmless and the tree stays usable
+        platform
+            .transition_to_version_14(&block_info, &transaction, platform_version)
+            .expect("expected the transition to be idempotent");
+        assert_eq!(
+            platform
+                .drive
+                .fetch_total_credits_in_platform_a_day_ago(
+                    block_info.time_ms,
+                    Some(&transaction),
+                    platform_version,
+                )
+                .expect("expected to read an empty history"),
+            None
         );
     }
 

--- a/packages/rs-drive-abci/src/execution/platform_events/withdrawals/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/withdrawals/mod.rs
@@ -5,4 +5,5 @@ pub(in crate::execution) mod dequeue_and_build_unsigned_withdrawal_transactions;
 pub(in crate::execution) mod fetch_transactions_block_inclusion_status;
 pub(in crate::execution) mod pool_withdrawals_into_transactions_queue;
 pub(in crate::execution) mod rebroadcast_expired_withdrawal_documents;
+pub(in crate::execution) mod record_total_credits_history_for_withdrawals;
 pub(in crate::execution) mod update_broadcasted_withdrawal_statuses;

--- a/packages/rs-drive-abci/src/execution/platform_events/withdrawals/pool_withdrawals_into_transactions_queue/v1/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/withdrawals/pool_withdrawals_into_transactions_queue/v1/mod.rs
@@ -100,9 +100,11 @@ where
         }
 
         // Only take documents up to the withdrawal amount
-        let withdrawals_info = self
-            .drive
-            .calculate_current_withdrawal_limit(transaction, platform_version)?;
+        let withdrawals_info = self.drive.calculate_current_withdrawal_limit(
+            block_info,
+            transaction,
+            platform_version,
+        )?;
 
         tracing::trace!(
             ?withdrawals_info,

--- a/packages/rs-drive-abci/src/execution/platform_events/withdrawals/record_total_credits_history_for_withdrawals/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/withdrawals/record_total_credits_history_for_withdrawals/mod.rs
@@ -1,0 +1,45 @@
+mod v0;
+
+use crate::error::execution::ExecutionError;
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::rpc::core::CoreRPCLike;
+use dpp::block::block_info::BlockInfo;
+use dpp::version::PlatformVersion;
+use drive::grovedb::Transaction;
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// Records the total credits in Platform for this block in the history the day-lagged
+    /// daily withdrawal limit reads, pruning entries the limit can no longer use.
+    ///
+    /// Runs every block before withdrawals are pooled, so the first block the history exists
+    /// in already has an entry to derive the limit from.
+    pub(in crate::execution) fn record_total_credits_history_for_withdrawals(
+        &self,
+        block_info: &BlockInfo,
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        match platform_version
+            .drive_abci
+            .methods
+            .withdrawals
+            .record_total_credits_history_for_withdrawals
+        {
+            None => Ok(()),
+            Some(0) => self.record_total_credits_history_for_withdrawals_v0(
+                block_info,
+                transaction,
+                platform_version,
+            ),
+            Some(version) => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
+                method: "record_total_credits_history_for_withdrawals".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/withdrawals/record_total_credits_history_for_withdrawals/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/withdrawals/record_total_credits_history_for_withdrawals/mod.rs
@@ -13,10 +13,13 @@ where
     C: CoreRPCLike,
 {
     /// Records the total credits in Platform for this block in the history the day-lagged
-    /// daily withdrawal limit reads, pruning entries the limit can no longer use.
+    /// daily withdrawal limit reads — only when it differs from the latest recorded total,
+    /// since the limit reads the entry in force a day ago and an entry describes the total
+    /// until the next one — pruning entries the limit can no longer use.
     ///
     /// Runs every block before withdrawals are pooled, so the first block the history exists
-    /// in already has an entry to derive the limit from.
+    /// in already has an entry to derive the limit from; blocks that leave the total untouched
+    /// cost one read and no write.
     pub(in crate::execution) fn record_total_credits_history_for_withdrawals(
         &self,
         block_info: &BlockInfo,

--- a/packages/rs-drive-abci/src/execution/platform_events/withdrawals/record_total_credits_history_for_withdrawals/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/withdrawals/record_total_credits_history_for_withdrawals/mod.rs
@@ -17,9 +17,10 @@ where
     /// since the limit reads the entry in force a day ago and an entry describes the total
     /// until the next one — pruning entries the limit can no longer use.
     ///
-    /// Runs every block before withdrawals are pooled, so the first block the history exists
-    /// in already has an entry to derive the limit from; blocks that leave the total untouched
-    /// cost one read and no write.
+    /// Runs every block once fees and epoch rewards are processed (the last things that can
+    /// move the total in a block) and before the app hash is taken; blocks that leave the total
+    /// untouched cost one read and no write. Until an entry is a day old the limit applies its
+    /// bootstrap rule, so pooling never depends on this block's entry.
     pub(in crate::execution) fn record_total_credits_history_for_withdrawals(
         &self,
         block_info: &BlockInfo,

--- a/packages/rs-drive-abci/src/execution/platform_events/withdrawals/record_total_credits_history_for_withdrawals/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/withdrawals/record_total_credits_history_for_withdrawals/v0/mod.rs
@@ -1,0 +1,131 @@
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::rpc::core::CoreRPCLike;
+use dpp::block::block_info::BlockInfo;
+use dpp::version::PlatformVersion;
+use drive::grovedb::Transaction;
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// Delegates to `Drive::record_total_credits_history`, bounding the per-block prune by
+    /// `withdrawal_constants.total_credits_history_prune_limit`.
+    pub(super) fn record_total_credits_history_for_withdrawals_v0(
+        &self,
+        block_info: &BlockInfo,
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        self.drive
+            .record_total_credits_history(
+                block_info,
+                platform_version
+                    .drive_abci
+                    .withdrawal_constants
+                    .total_credits_history_prune_limit,
+                Some(transaction),
+                platform_version,
+            )
+            .map_err(Error::Drive)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::dash_to_credits;
+    use dpp::version::PlatformVersion;
+    use drive::drive::identity::withdrawals::fetch_total_credits_in_platform_a_day_ago::RecordedTotalCredits;
+
+    /// Every block leaves an entry holding the total credits in Platform at that block.
+    #[test]
+    fn v0_records_the_total_credits_for_the_block() {
+        let platform_version = PlatformVersion::latest();
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_initial_state_structure();
+        let transaction = platform.drive.grove.start_transaction();
+
+        platform
+            .drive
+            .add_to_system_credits(
+                dash_to_credits!(30000),
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to add credits");
+
+        let block_info = BlockInfo {
+            time_ms: 1_000_000_000,
+            height: 100,
+            ..Default::default()
+        };
+
+        platform
+            .record_total_credits_history_for_withdrawals_v0(
+                &block_info,
+                &transaction,
+                platform_version,
+            )
+            .expect("expected to record the total credits");
+
+        assert_eq!(
+            platform
+                .drive
+                .fetch_total_credits_in_platform_a_day_ago(
+                    block_info.time_ms,
+                    Some(&transaction),
+                    platform_version,
+                )
+                .expect("expected to fetch"),
+            Some(RecordedTotalCredits {
+                time_ms: block_info.time_ms,
+                total_credits: dash_to_credits!(30000),
+            })
+        );
+    }
+
+    /// The dispatcher is a no-op for protocol versions without the history (slot is `None`).
+    #[test]
+    fn dispatcher_is_noop_when_the_slot_is_none() {
+        let mut platform_version = PlatformVersion::latest().clone();
+        platform_version
+            .drive_abci
+            .methods
+            .withdrawals
+            .record_total_credits_history_for_withdrawals = None;
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_initial_state_structure();
+        let transaction = platform.drive.grove.start_transaction();
+
+        let block_info = BlockInfo {
+            time_ms: 1_000_000_000,
+            ..Default::default()
+        };
+
+        platform
+            .record_total_credits_history_for_withdrawals(
+                &block_info,
+                &transaction,
+                &platform_version,
+            )
+            .expect("expected a no-op");
+
+        assert_eq!(
+            platform
+                .drive
+                .fetch_total_credits_in_platform_a_day_ago(
+                    block_info.time_ms,
+                    Some(&transaction),
+                    &platform_version,
+                )
+                .expect("expected to fetch"),
+            None
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/withdrawals/record_total_credits_history_for_withdrawals/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/withdrawals/record_total_credits_history_for_withdrawals/v0/mod.rs
@@ -37,7 +37,9 @@ mod tests {
     use dpp::block::block_info::BlockInfo;
     use dpp::dash_to_credits;
     use dpp::version::PlatformVersion;
-    use drive::drive::identity::withdrawals::fetch_total_credits_in_platform_a_day_ago::RecordedTotalCredits;
+    use drive::drive::identity::withdrawals::fetch_total_credits_in_platform_a_day_ago::{
+        RecordedTotalCredits, DAY_IN_MS,
+    };
 
     /// Every block leaves an entry holding the total credits in Platform at that block.
     #[test]
@@ -72,11 +74,12 @@ mod tests {
             )
             .expect("expected to record the total credits");
 
+        // Readable as the reference a day later
         assert_eq!(
             platform
                 .drive
                 .fetch_total_credits_in_platform_a_day_ago(
-                    block_info.time_ms,
+                    block_info.time_ms + DAY_IN_MS,
                     Some(&transaction),
                     platform_version,
                 )
@@ -120,7 +123,7 @@ mod tests {
             platform
                 .drive
                 .fetch_total_credits_in_platform_a_day_ago(
-                    block_info.time_ms,
+                    block_info.time_ms + DAY_IN_MS,
                     Some(&transaction),
                     &platform_version,
                 )

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/withdrawal_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/withdrawal_tests.rs
@@ -1,5 +1,6 @@
 mod tests {
     use crate::execution::{continue_chain_for_strategy, run_chain_for_strategy, GENESIS_TIME_MS};
+    use crate::strategy::CoreHeightIncrease::RandomCoreHeightIncrease;
     use crate::strategy::{
         ChainExecutionOutcome, ChainExecutionParameters, NetworkStrategy, StrategyRandomness,
     };
@@ -14,6 +15,7 @@ mod tests {
     use dpp::{dash_to_credits, dash_to_duffs};
     use drive::config::DEFAULT_QUERY_LIMIT;
     use drive::drive::balances::TOTAL_SYSTEM_CREDITS_STORAGE_KEY;
+    use drive::drive::identity::withdrawals::fetch_total_credits_in_platform_a_day_ago::DAY_IN_MS;
     use drive::drive::identity::withdrawals::paths::{
         get_withdrawal_root_path, WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY,
     };
@@ -3486,5 +3488,119 @@ mod tests {
             .unwrap();
 
         assert_eq!(withdrawal_documents_broadcasted.len(), 400);
+    }
+
+    /// Core rewards reach Platform at an epoch change, inside block fee processing. The total
+    /// credits history the daily withdrawal limit reads must be written after that, keyed by the
+    /// epoch change block itself; written before it, the reward would only show up a block later
+    /// (or a day later across a halt) and the limit would derive from a stale total.
+    #[tokio::test]
+    async fn should_record_the_total_credits_history_after_epoch_core_rewards() {
+        let platform_version = PlatformVersion::latest();
+        let strategy = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![],
+                operations: vec![],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo::default(),
+                identity_contract_nonce_gaps: None,
+                signer: None,
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+            // One Core block per Platform block, so the first epoch accrues Core rewards.
+            core_height_increase: RandomCoreHeightIncrease(Frequency {
+                times_per_block_range: 1..2,
+                chance_per_block: None,
+            }),
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: true,
+            ..Default::default()
+        };
+
+        let hour_in_ms = 1000 * 60 * 60;
+        let config = PlatformConfig {
+            validator_set: ValidatorSetConfig::default_100_67(),
+            chain_lock: ChainLockConfig::default_100_67(),
+            instant_lock: InstantLockConfig::default_100_67(),
+            execution: ExecutionConfig {
+                verify_sum_trees: true,
+                epoch_time_length_s: 60 * 60 * 24,
+                ..Default::default()
+            },
+            block_spacing_ms: hour_in_ms,
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .with_config(config.clone())
+            .build_with_mock_rpc();
+
+        // Hourly blocks with one-day epochs: block 25, at genesis + 24h, opens epoch 1 and
+        // distributes the Core rewards of epoch 0 — the only credits entering Platform here.
+        let outcome = run_chain_for_strategy(
+            &mut platform,
+            30,
+            strategy,
+            config,
+            15,
+            &mut None,
+            &mut None,
+        )
+        .await;
+
+        assert_eq!(outcome.end_epoch_index, 1);
+
+        let drive = &outcome.abci_app.platform.drive;
+
+        let total_credits_in_platform = drive
+            .grove_get_raw_value_u64_from_encoded_var_vec(
+                (&misc_path()).into(),
+                TOTAL_SYSTEM_CREDITS_STORAGE_KEY,
+                DirectQueryType::StatefulDirectQuery,
+                None,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("expected to get total credits in platform")
+            .expect("expected total credits in platform");
+
+        let epoch_change_time_ms = GENESIS_TIME_MS + 24 * hour_in_ms;
+
+        // The entry keyed by the epoch change block carries the post-reward total ...
+        let after_rewards = drive
+            .fetch_total_credits_in_platform_a_day_ago(
+                epoch_change_time_ms + DAY_IN_MS,
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch the history")
+            .expect("expected an entry keyed by the epoch change block");
+        assert_eq!(after_rewards.time_ms, epoch_change_time_ms);
+        assert_eq!(after_rewards.total_credits, total_credits_in_platform);
+
+        // ... and it is the first change since genesis, where Platform held nothing yet.
+        let before_rewards = drive
+            .fetch_total_credits_in_platform_a_day_ago(
+                epoch_change_time_ms + DAY_IN_MS - 1,
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch the history")
+            .expect("expected the genesis entry");
+        assert_eq!(before_rewards.time_ms, GENESIS_TIME_MS);
+        assert!(
+            before_rewards.total_credits < total_credits_in_platform,
+            "epoch 0 must have paid Core rewards into Platform"
+        );
     }
 }

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/withdrawal_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/withdrawal_tests.rs
@@ -2195,11 +2195,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_chain_withdraw_from_identities_too_many_withdrawals_within_a_day_hitting_relative_limit(
-    ) {
+    async fn should_cap_withdrawals_at_the_relative_daily_limit() {
         // Latest protocol version: the daily withdrawal limit is 15% of the total credits
-        // Platform held a day ago (oldest recorded total while the history is younger than a
-        // day), counted against the amounts pooled in the last 24 hours.
+        // Platform held a day ago (the flat 2000 Dash of the previous rule while no recorded
+        // total is a day old yet), counted against the amounts pooled in the last 24 hours.
         let platform_version = PlatformVersion::latest();
         let start_strategy = NetworkStrategy {
             strategy: Strategy {
@@ -2224,7 +2223,7 @@ mod tests {
                         [(SecurityLevel::CRITICAL, vec![KeyType::ECDSA_SECP256K1])].into(),
                     )]
                     .into(),
-                    start_balance_range: dash_to_duffs!(200)..=dash_to_duffs!(200),
+                    start_balance_range: dash_to_duffs!(500)..=dash_to_duffs!(500),
                 },
                 identity_contract_nonce_gaps: None,
                 signer: None,
@@ -2395,8 +2394,8 @@ mod tests {
 
             assert_eq!(
                 total_credits_balance.total_in_trees().unwrap(),
-                410000000000000
-            ); // Around 4100 Dash.
+                1010000000000000
+            ); // 10100 Dash: 20 identities of 500 Dash plus 10 top-ups of 10 Dash.
 
             let total_credits_in_platform = outcome
                 .abci_app
@@ -2412,7 +2411,7 @@ mod tests {
                 )
                 .expect("expected to get total credits in platform");
 
-            assert_eq!(total_credits_in_platform, Some(410000000000000));
+            assert_eq!(total_credits_in_platform, Some(1010000000000000));
 
             outcome
         };
@@ -2422,10 +2421,10 @@ mod tests {
                 start_contracts: vec![],
                 operations: vec![Operation {
                     op_type: OperationType::IdentityWithdrawal(
-                        dash_to_credits!(25)..=dash_to_credits!(25),
+                        dash_to_credits!(50)..=dash_to_credits!(50),
                     ),
                     frequency: Frequency {
-                        times_per_block_range: 4..5, // 25 Dash x 4 Withdrawals = 100 Dash
+                        times_per_block_range: 4..5, // 50 Dash x 4 Withdrawals = 200 Dash
                         chance_per_block: None,
                     },
                 }],
@@ -2553,8 +2552,8 @@ mod tests {
                 )
                 .unwrap();
 
-            // We have 68 out of 80 queued
-            assert_eq!(withdrawal_documents_queued.len(), 68);
+            // We have 40 out of 80 queued
+            assert_eq!(withdrawal_documents_queued.len(), 40);
 
             // Withdrawal documents with queued status should exist.
             let withdrawal_documents_completed = outcome
@@ -2601,17 +2600,12 @@ mod tests {
                 )
                 .unwrap();
 
-            // We have 12 broadcasted (68 queued + 12 broadcasted = 80 total)
-            // 12 broadcasted = 12 * 25 Dash = 300 Dash
-            // This is explained by the relative limit: the whole run is younger than a day, so
-            // the daily maximum derives from the oldest recorded total, the 2000 Dash Platform
-            // held after block 1 (the 10 identities created there), i.e. 15% = 300 Dash, and
-            // the 100 Dash topped up in block 2 and every withdrawal since leave it untouched.
-            // withdrawal block 1 : 4 withdrawals of 25 Dash, limit is 300, 4 pooled
-            // withdrawal block 2 : 4 withdrawals, limit is 300 - 100 = 200, 4 pooled
-            // withdrawal block 3 : 4 withdrawals, limit is 300 - 200 = 100, 4 pooled
-            // withdrawal block 4 onwards : limit is 300 - 300 = 0, nothing pooled
-            assert_eq!(withdrawal_documents_broadcasted.len(), 12);
+            // We have 40 broadcasted (40 queued + 40 broadcasted = 80 total)
+            // 40 broadcasted = 40 * 50 Dash = 2000 Dash
+            // The whole run is younger than a day, so no recorded total is a day old yet and
+            // the flat 2000 Dash of the previous rule still applies: the first ten withdrawal
+            // blocks pool their 4 withdrawals (200 Dash) each, then the limit is exhausted.
+            assert_eq!(withdrawal_documents_broadcasted.len(), 40);
 
             let locked_amount = outcome
                 .abci_app
@@ -2627,7 +2621,7 @@ mod tests {
                 )
                 .expect("expected to get locked amount");
 
-            assert_eq!(locked_amount, dash_to_credits!(300) as i64);
+            assert_eq!(locked_amount, dash_to_credits!(2000) as i64);
 
             outcome
         };
@@ -2684,12 +2678,13 @@ mod tests {
             )
             .await;
 
-            // The 300 Dash pooled in the first three withdrawal blocks unlocked 25 hours
-            // later, at the 26th hourly block. By then the history is older than a day and the
-            // reference total is the 2100 Dash left after all 80 withdrawals were executed
-            // (4100 - 80 * 25), so the daily maximum is 15% = 315 Dash: the next block pooled
-            // 12 more withdrawals (300 Dash, a 13th would exceed 315), which are locked again
-            // for 25 hours.
+            // From the 25th hourly block a recorded total is a day old, and the reference is
+            // the 6100 Dash left after all 80 withdrawals were executed (10100 - 80 * 50), so
+            // the daily maximum is 15% = 915 Dash. The 2000 Dash pooled on the first day
+            // unlocked 25 hours later (cleaned up at the 26th hourly block, after pooling), so
+            // from the 27th hourly block withdrawals pooled again, at most 4 (200 Dash) per
+            // block while they fit: 200, 400, 600, 800 Dash locked, then only two more fit in
+            // the 115 Dash left (900 Dash locked), and those locks outlive this phase.
             let locked_amount = outcome
                 .abci_app
                 .platform
@@ -2704,7 +2699,7 @@ mod tests {
                 )
                 .expect("expected to get locked amount");
 
-            assert_eq!(locked_amount, dash_to_credits!(300) as i64);
+            assert_eq!(locked_amount, dash_to_credits!(900) as i64);
 
             // Withdrawal documents with pooled status should not exist.
             let withdrawal_documents_pooled = outcome
@@ -2735,8 +2730,8 @@ mod tests {
                 )
                 .unwrap();
 
-            // We have 56 out of 80 queued
-            assert_eq!(withdrawal_documents_queued.len(), 56);
+            // We have 22 out of 80 queued
+            assert_eq!(withdrawal_documents_queued.len(), 22);
 
             // Withdrawal documents with queued status should exist.
             let withdrawal_documents_completed = outcome
@@ -2783,8 +2778,8 @@ mod tests {
                 )
                 .unwrap();
 
-            // 12 from the first day plus the 12 pooled once the first locks expired
-            assert_eq!(withdrawal_documents_broadcasted.len(), 24);
+            // 40 from the first day plus the 18 pooled once the first locks expired
+            assert_eq!(withdrawal_documents_broadcasted.len(), 58);
             outcome
         };
 
@@ -2839,9 +2834,9 @@ mod tests {
             )
             .expect("expected to get locked amount");
 
-        // Another 250 hourly blocks: every ~27 hours (25 hours of lock plus the block that
-        // cleans it up) 12 more withdrawals pool at 315 Dash per day, so the remaining 56
-        // drain in five rounds and the last locks expired long before the end.
+        // Another 250 hourly blocks: as each lock expires 25 hours later as many withdrawals
+        // fit again under the 915 Dash daily maximum, so the remaining 22 drain within a few
+        // days and the last locks expired long before the end.
         // We have nothing locked left
         assert_eq!(locked_amount, 0);
 

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/withdrawal_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/withdrawal_tests.rs
@@ -2195,6 +2195,737 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_chain_withdraw_from_identities_too_many_withdrawals_within_a_day_hitting_relative_limit(
+    ) {
+        // Latest protocol version: the daily withdrawal limit is 15% of the total credits
+        // Platform held a day ago (oldest recorded total while the history is younger than a
+        // day), counted against the amounts pooled in the last 24 hours.
+        let platform_version = PlatformVersion::latest();
+        let start_strategy = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![],
+                operations: vec![Operation {
+                    op_type: OperationType::IdentityTopUp(dash_to_duffs!(10)..=dash_to_duffs!(10)),
+                    frequency: Frequency {
+                        times_per_block_range: 10..11,
+                        chance_per_block: None,
+                    },
+                }],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo {
+                    frequency: Frequency {
+                        times_per_block_range: 10..11,
+                        chance_per_block: None,
+                    },
+                    start_keys: 3,
+                    extra_keys: [(
+                        Purpose::TRANSFER,
+                        [(SecurityLevel::CRITICAL, vec![KeyType::ECDSA_SECP256K1])].into(),
+                    )]
+                    .into(),
+                    start_balance_range: dash_to_duffs!(200)..=dash_to_duffs!(200),
+                },
+                identity_contract_nonce_gaps: None,
+                signer: None,
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: true,
+            ..Default::default()
+        };
+
+        let minute_in_ms = 1000 * 60;
+        let config = PlatformConfig {
+            validator_set: ValidatorSetConfig::default_100_67(),
+            chain_lock: ChainLockConfig::default_100_67(),
+            instant_lock: InstantLockConfig::default_100_67(),
+            execution: ExecutionConfig {
+                verify_sum_trees: true,
+                ..Default::default()
+            },
+            block_spacing_ms: minute_in_ms,
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .with_config(config.clone())
+            .build_with_mock_rpc();
+
+        platform
+            .core_rpc
+            .expect_send_raw_transaction()
+            .returning(move |_| Ok(Txid::all_zeros()));
+
+        let chain_locked_height = 1;
+
+        // Have to go with a complicated shared object for the core state because we need to change
+        // rpc response along the way but we can't mutate `platform.core_rpc` later
+        // because platform reference is moved into the AbciApplication.
+        let shared_core_state = Arc::new(Mutex::new(CoreState {
+            asset_unlock_statuses: BTreeMap::new(),
+            chain_lock: ChainLock {
+                block_height: chain_locked_height,
+                block_hash: BlockHash::from_byte_array([1; 32]),
+                signature: BLSSignature::from([2; 96]),
+            },
+        }));
+
+        // Set up Core RPC responses
+        {
+            let core_state = shared_core_state.clone();
+
+            platform
+                .core_rpc
+                .expect_get_asset_unlock_statuses()
+                .returning(move |indices, _| {
+                    Ok(indices
+                        .iter()
+                        .map(|index| {
+                            core_state
+                                .lock()
+                                .unwrap()
+                                .asset_unlock_statuses
+                                .get(index)
+                                .cloned()
+                                .unwrap()
+                        })
+                        .collect())
+                });
+
+            let core_state = shared_core_state.clone();
+            platform
+                .core_rpc
+                .expect_get_best_chain_lock()
+                .returning(move || Ok(core_state.lock().unwrap().chain_lock.clone()));
+        }
+
+        // Run first two blocks:
+        // - Block 1: creates identity
+        // - Block 2: tops up identity
+        let ChainExecutionOutcome {
+            abci_app,
+            proposers,
+            validator_quorums: quorums,
+            current_validator_quorum_hash: current_quorum_hash,
+            current_proposer_versions,
+            end_time_ms,
+            identity_nonce_counter,
+            identity_contract_nonce_counter,
+            instant_lock_quorums,
+            identities,
+            addresses_with_balance,
+            signer,
+            ..
+        } = {
+            let outcome = run_chain_for_strategy(
+                &mut platform,
+                2,
+                start_strategy,
+                config.clone(),
+                1,
+                &mut None,
+                &mut None,
+            )
+            .await;
+
+            for tx_results_per_block in outcome.state_transition_results_per_block.values() {
+                for (state_transition, result) in tx_results_per_block {
+                    assert_eq!(
+                        result.code, 0,
+                        "state transition got code {} : {:?}",
+                        result.code, state_transition
+                    );
+                }
+            }
+
+            // Withdrawal transactions are not populated to block execution context yet
+            assert_eq!(outcome.withdrawals.len(), 0);
+
+            // Withdrawal documents with pooled status should exist.
+            let withdrawal_documents_pooled = outcome
+                .abci_app
+                .platform
+                .drive
+                .fetch_oldest_withdrawal_documents_by_status(
+                    withdrawals_contract::WithdrawalStatus::POOLED.into(),
+                    DEFAULT_QUERY_LIMIT,
+                    None,
+                    platform_version,
+                )
+                .unwrap();
+            assert!(withdrawal_documents_pooled.is_empty());
+
+            let locked_amount = outcome
+                .abci_app
+                .platform
+                .drive
+                .grove_get_sum_tree_total_value(
+                    (&get_withdrawal_root_path()).into(),
+                    &WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY,
+                    DirectQueryType::StatefulDirectQuery,
+                    None,
+                    &mut vec![],
+                    &platform_version.drive,
+                )
+                .expect("expected to get locked amount");
+
+            assert_eq!(locked_amount, 0);
+
+            let pooled_withdrawals = withdrawal_documents_pooled.len();
+
+            assert_eq!(pooled_withdrawals, 0);
+
+            let total_credits_balance = outcome
+                .abci_app
+                .platform
+                .drive
+                .calculate_total_credits_balance(None, &platform_version.drive)
+                .expect("expected to get total credits balance");
+
+            assert_eq!(
+                total_credits_balance.total_in_trees().unwrap(),
+                410000000000000
+            ); // Around 4100 Dash.
+
+            let total_credits_in_platform = outcome
+                .abci_app
+                .platform
+                .drive
+                .grove_get_raw_value_u64_from_encoded_var_vec(
+                    (&misc_path()).into(),
+                    TOTAL_SYSTEM_CREDITS_STORAGE_KEY,
+                    DirectQueryType::StatefulDirectQuery,
+                    None,
+                    &mut vec![],
+                    &platform_version.drive,
+                )
+                .expect("expected to get total credits in platform");
+
+            assert_eq!(total_credits_in_platform, Some(410000000000000));
+
+            outcome
+        };
+
+        let continue_strategy_only_withdrawal = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![],
+                operations: vec![Operation {
+                    op_type: OperationType::IdentityWithdrawal(
+                        dash_to_credits!(25)..=dash_to_credits!(25),
+                    ),
+                    frequency: Frequency {
+                        times_per_block_range: 4..5, // 25 Dash x 4 Withdrawals = 100 Dash
+                        chance_per_block: None,
+                    },
+                }],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo::default(),
+                identity_contract_nonce_gaps: None,
+                signer: Some(signer.clone()),
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: true,
+            ..Default::default()
+        };
+
+        let continue_strategy_no_operations = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![],
+                operations: vec![],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo::default(),
+                identity_contract_nonce_gaps: None,
+                signer: Some(signer),
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: true,
+            ..Default::default()
+        };
+
+        // Run Block 3 onwards: initiates withdrawals
+        let ChainExecutionOutcome {
+            abci_app,
+            proposers,
+            validator_quorums: quorums,
+            current_validator_quorum_hash: current_quorum_hash,
+            current_proposer_versions,
+            end_time_ms,
+            identity_nonce_counter,
+            identity_contract_nonce_counter,
+            instant_lock_quorums,
+            identities,
+            addresses_with_balance,
+            ..
+        } = {
+            let outcome = continue_chain_for_strategy(
+                abci_app,
+                ChainExecutionParameters {
+                    block_start: 3,
+                    core_height_start: 1,
+                    block_count: 20,
+                    proposers,
+                    validator_quorums: quorums,
+                    current_validator_quorum_hash: current_quorum_hash,
+                    current_proposer_versions: Some(current_proposer_versions),
+                    current_identity_nonce_counter: identity_nonce_counter,
+                    current_identity_contract_nonce_counter: identity_contract_nonce_counter,
+                    current_votes: BTreeMap::default(),
+                    start_time_ms: GENESIS_TIME_MS,
+                    current_time_ms: end_time_ms,
+                    instant_lock_quorums,
+                    current_identities: identities,
+                    current_addresses_with_balance: addresses_with_balance,
+                },
+                continue_strategy_only_withdrawal.clone(),
+                config.clone(),
+                StrategyRandomness::SeedEntropy(2),
+            )
+            .await;
+
+            for tx_results_per_block in outcome.state_transition_results_per_block.values() {
+                assert_eq!(tx_results_per_block.len(), 4);
+                for (state_transition, result) in tx_results_per_block {
+                    assert_eq!(
+                        result.code, 0,
+                        "state transition got code {} : {:?}",
+                        result.code, state_transition
+                    );
+                }
+            }
+
+            // Withdrawal documents with pooled status should not exist.
+            let withdrawal_documents_pooled = outcome
+                .abci_app
+                .platform
+                .drive
+                .fetch_oldest_withdrawal_documents_by_status(
+                    withdrawals_contract::WithdrawalStatus::POOLED.into(),
+                    DEFAULT_QUERY_LIMIT,
+                    None,
+                    platform_version,
+                )
+                .unwrap();
+
+            // None are currently pooled since we have no more room
+            assert!(withdrawal_documents_pooled.is_empty());
+
+            // Withdrawal documents with queued status should exist.
+            let withdrawal_documents_queued = outcome
+                .abci_app
+                .platform
+                .drive
+                .fetch_oldest_withdrawal_documents_by_status(
+                    withdrawals_contract::WithdrawalStatus::QUEUED.into(),
+                    DEFAULT_QUERY_LIMIT,
+                    None,
+                    platform_version,
+                )
+                .unwrap();
+
+            // We have 68 out of 80 queued
+            assert_eq!(withdrawal_documents_queued.len(), 68);
+
+            // Withdrawal documents with queued status should exist.
+            let withdrawal_documents_completed = outcome
+                .abci_app
+                .platform
+                .drive
+                .fetch_oldest_withdrawal_documents_by_status(
+                    withdrawals_contract::WithdrawalStatus::COMPLETE.into(),
+                    DEFAULT_QUERY_LIMIT,
+                    None,
+                    platform_version,
+                )
+                .unwrap();
+
+            // None have completed because core didn't acknowledge them
+            assert_eq!(withdrawal_documents_completed.len(), 0);
+
+            // Withdrawal documents with EXPIRED status should not exist yet.
+            let withdrawal_documents_expired = outcome
+                .abci_app
+                .platform
+                .drive
+                .fetch_oldest_withdrawal_documents_by_status(
+                    withdrawals_contract::WithdrawalStatus::EXPIRED.into(),
+                    DEFAULT_QUERY_LIMIT,
+                    None,
+                    platform_version,
+                )
+                .unwrap();
+
+            // We have none expired yet
+            assert_eq!(withdrawal_documents_expired.len(), 0);
+
+            // Withdrawal documents with broadcasted status should exist.
+            let withdrawal_documents_broadcasted = outcome
+                .abci_app
+                .platform
+                .drive
+                .fetch_oldest_withdrawal_documents_by_status(
+                    withdrawals_contract::WithdrawalStatus::BROADCASTED.into(),
+                    DEFAULT_QUERY_LIMIT,
+                    None,
+                    platform_version,
+                )
+                .unwrap();
+
+            // We have 12 broadcasted (68 queued + 12 broadcasted = 80 total)
+            // 12 broadcasted = 12 * 25 Dash = 300 Dash
+            // This is explained by the relative limit: the whole run is younger than a day, so
+            // the daily maximum derives from the oldest recorded total, the 2000 Dash Platform
+            // held after block 1 (the 10 identities created there), i.e. 15% = 300 Dash, and
+            // the 100 Dash topped up in block 2 and every withdrawal since leave it untouched.
+            // withdrawal block 1 : 4 withdrawals of 25 Dash, limit is 300, 4 pooled
+            // withdrawal block 2 : 4 withdrawals, limit is 300 - 100 = 200, 4 pooled
+            // withdrawal block 3 : 4 withdrawals, limit is 300 - 200 = 100, 4 pooled
+            // withdrawal block 4 onwards : limit is 300 - 300 = 0, nothing pooled
+            assert_eq!(withdrawal_documents_broadcasted.len(), 12);
+
+            let locked_amount = outcome
+                .abci_app
+                .platform
+                .drive
+                .grove_get_sum_tree_total_value(
+                    (&get_withdrawal_root_path()).into(),
+                    &WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY,
+                    DirectQueryType::StatefulDirectQuery,
+                    None,
+                    &mut vec![],
+                    &platform_version.drive,
+                )
+                .expect("expected to get locked amount");
+
+            assert_eq!(locked_amount, dash_to_credits!(300) as i64);
+
+            outcome
+        };
+
+        let hour_in_ms = 1000 * 60 * 60;
+
+        let ChainExecutionOutcome {
+            abci_app,
+            proposers,
+            validator_quorums: quorums,
+            current_validator_quorum_hash: current_quorum_hash,
+            current_proposer_versions,
+            end_time_ms,
+            identity_nonce_counter,
+            identity_contract_nonce_counter,
+            instant_lock_quorums,
+            identities,
+            addresses_with_balance,
+            ..
+        } = {
+            let outcome = continue_chain_for_strategy(
+                abci_app,
+                ChainExecutionParameters {
+                    block_start: 23,
+                    core_height_start: 1,
+                    block_count: 48,
+                    proposers,
+                    validator_quorums: quorums,
+                    current_validator_quorum_hash: current_quorum_hash,
+                    current_proposer_versions: Some(current_proposer_versions),
+                    current_identity_nonce_counter: identity_nonce_counter,
+                    current_identity_contract_nonce_counter: identity_contract_nonce_counter,
+                    current_votes: BTreeMap::default(),
+                    start_time_ms: GENESIS_TIME_MS,
+                    current_time_ms: end_time_ms + 1000,
+                    instant_lock_quorums,
+                    current_identities: identities,
+                    current_addresses_with_balance: addresses_with_balance,
+                },
+                continue_strategy_no_operations.clone(),
+                PlatformConfig {
+                    validator_set: ValidatorSetConfig::default_100_67(),
+                    chain_lock: ChainLockConfig::default_100_67(),
+                    instant_lock: InstantLockConfig::default_100_67(),
+                    execution: ExecutionConfig {
+                        verify_sum_trees: true,
+                        ..Default::default()
+                    },
+                    block_spacing_ms: hour_in_ms,
+                    testing_configs: PlatformTestConfig::default_minimal_verifications(),
+                    ..Default::default()
+                },
+                StrategyRandomness::SeedEntropy(9),
+            )
+            .await;
+
+            // The 300 Dash pooled in the first three withdrawal blocks unlocked 25 hours
+            // later, at the 26th hourly block. By then the history is older than a day and the
+            // reference total is the 2100 Dash left after all 80 withdrawals were executed
+            // (4100 - 80 * 25), so the daily maximum is 15% = 315 Dash: the next block pooled
+            // 12 more withdrawals (300 Dash, a 13th would exceed 315), which are locked again
+            // for 25 hours.
+            let locked_amount = outcome
+                .abci_app
+                .platform
+                .drive
+                .grove_get_sum_tree_total_value(
+                    (&get_withdrawal_root_path()).into(),
+                    &WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY,
+                    DirectQueryType::StatefulDirectQuery,
+                    None,
+                    &mut vec![],
+                    &platform_version.drive,
+                )
+                .expect("expected to get locked amount");
+
+            assert_eq!(locked_amount, dash_to_credits!(300) as i64);
+
+            // Withdrawal documents with pooled status should not exist.
+            let withdrawal_documents_pooled = outcome
+                .abci_app
+                .platform
+                .drive
+                .fetch_oldest_withdrawal_documents_by_status(
+                    withdrawals_contract::WithdrawalStatus::POOLED.into(),
+                    DEFAULT_QUERY_LIMIT,
+                    None,
+                    platform_version,
+                )
+                .unwrap();
+
+            // None are currently pooled since we have no more room
+            assert!(withdrawal_documents_pooled.is_empty());
+
+            // Withdrawal documents with queued status should exist.
+            let withdrawal_documents_queued = outcome
+                .abci_app
+                .platform
+                .drive
+                .fetch_oldest_withdrawal_documents_by_status(
+                    withdrawals_contract::WithdrawalStatus::QUEUED.into(),
+                    DEFAULT_QUERY_LIMIT,
+                    None,
+                    platform_version,
+                )
+                .unwrap();
+
+            // We have 56 out of 80 queued
+            assert_eq!(withdrawal_documents_queued.len(), 56);
+
+            // Withdrawal documents with queued status should exist.
+            let withdrawal_documents_completed = outcome
+                .abci_app
+                .platform
+                .drive
+                .fetch_oldest_withdrawal_documents_by_status(
+                    withdrawals_contract::WithdrawalStatus::COMPLETE.into(),
+                    DEFAULT_QUERY_LIMIT,
+                    None,
+                    platform_version,
+                )
+                .unwrap();
+
+            // None have completed because core didn't acknowledge them
+            assert_eq!(withdrawal_documents_completed.len(), 0);
+
+            // Withdrawal documents with EXPIRED status should not exist yet.
+            let withdrawal_documents_expired = outcome
+                .abci_app
+                .platform
+                .drive
+                .fetch_oldest_withdrawal_documents_by_status(
+                    withdrawals_contract::WithdrawalStatus::EXPIRED.into(),
+                    DEFAULT_QUERY_LIMIT,
+                    None,
+                    platform_version,
+                )
+                .unwrap();
+
+            // We have none expired yet, because the core height never went up
+            assert_eq!(withdrawal_documents_expired.len(), 0);
+
+            // Withdrawal documents with broadcasted status should exist.
+            let withdrawal_documents_broadcasted = outcome
+                .abci_app
+                .platform
+                .drive
+                .fetch_oldest_withdrawal_documents_by_status(
+                    withdrawals_contract::WithdrawalStatus::BROADCASTED.into(),
+                    DEFAULT_QUERY_LIMIT,
+                    None,
+                    platform_version,
+                )
+                .unwrap();
+
+            // 12 from the first day plus the 12 pooled once the first locks expired
+            assert_eq!(withdrawal_documents_broadcasted.len(), 24);
+            outcome
+        };
+
+        let outcome = continue_chain_for_strategy(
+            abci_app,
+            ChainExecutionParameters {
+                block_start: 71,
+                core_height_start: 1,
+                block_count: 250,
+                proposers,
+                validator_quorums: quorums,
+                current_validator_quorum_hash: current_quorum_hash,
+                current_proposer_versions: Some(current_proposer_versions),
+                current_identity_nonce_counter: identity_nonce_counter,
+                current_identity_contract_nonce_counter: identity_contract_nonce_counter,
+                current_votes: BTreeMap::default(),
+                start_time_ms: GENESIS_TIME_MS,
+                current_time_ms: end_time_ms + 1000,
+                instant_lock_quorums,
+                current_identities: identities,
+                current_addresses_with_balance: addresses_with_balance,
+            },
+            continue_strategy_no_operations.clone(),
+            PlatformConfig {
+                validator_set: ValidatorSetConfig::default_100_67(),
+                chain_lock: ChainLockConfig::default_100_67(),
+                instant_lock: InstantLockConfig::default_100_67(),
+                execution: ExecutionConfig {
+                    verify_sum_trees: true,
+                    ..Default::default()
+                },
+                block_spacing_ms: hour_in_ms,
+                testing_configs: PlatformTestConfig::default_minimal_verifications(),
+                ..Default::default()
+            },
+            StrategyRandomness::SeedEntropy(9),
+        )
+        .await;
+
+        // We should have unlocked the amounts by now
+        let locked_amount = outcome
+            .abci_app
+            .platform
+            .drive
+            .grove_get_sum_tree_total_value(
+                (&get_withdrawal_root_path()).into(),
+                &WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY,
+                DirectQueryType::StatefulDirectQuery,
+                None,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("expected to get locked amount");
+
+        // Another 250 hourly blocks: every ~27 hours (25 hours of lock plus the block that
+        // cleans it up) 12 more withdrawals pool at 315 Dash per day, so the remaining 56
+        // drain in five rounds and the last locks expired long before the end.
+        // We have nothing locked left
+        assert_eq!(locked_amount, 0);
+
+        // Withdrawal documents with pooled status should not exist.
+        let withdrawal_documents_pooled = outcome
+            .abci_app
+            .platform
+            .drive
+            .fetch_oldest_withdrawal_documents_by_status(
+                withdrawals_contract::WithdrawalStatus::POOLED.into(),
+                DEFAULT_QUERY_LIMIT,
+                None,
+                platform_version,
+            )
+            .unwrap();
+
+        // None are currently pooled since we have no more room
+        assert!(withdrawal_documents_pooled.is_empty());
+
+        // Withdrawal documents with queued status should exist.
+        let withdrawal_documents_queued = outcome
+            .abci_app
+            .platform
+            .drive
+            .fetch_oldest_withdrawal_documents_by_status(
+                withdrawals_contract::WithdrawalStatus::QUEUED.into(),
+                DEFAULT_QUERY_LIMIT,
+                None,
+                platform_version,
+            )
+            .unwrap();
+
+        // Nothing is left in the queue
+        assert_eq!(withdrawal_documents_queued.len(), 0);
+
+        // Withdrawal documents with queued status should exist.
+        let withdrawal_documents_completed = outcome
+            .abci_app
+            .platform
+            .drive
+            .fetch_oldest_withdrawal_documents_by_status(
+                withdrawals_contract::WithdrawalStatus::COMPLETE.into(),
+                DEFAULT_QUERY_LIMIT,
+                None,
+                platform_version,
+            )
+            .unwrap();
+
+        // None have completed because core didn't acknowledge them
+        assert_eq!(withdrawal_documents_completed.len(), 0);
+
+        // Withdrawal documents with EXPIRED status should not exist yet.
+        let withdrawal_documents_expired = outcome
+            .abci_app
+            .platform
+            .drive
+            .fetch_oldest_withdrawal_documents_by_status(
+                withdrawals_contract::WithdrawalStatus::EXPIRED.into(),
+                DEFAULT_QUERY_LIMIT,
+                None,
+                platform_version,
+            )
+            .unwrap();
+
+        // We have none expired yet, because the core height never went up
+        assert_eq!(withdrawal_documents_expired.len(), 0);
+
+        // Withdrawal documents with broadcasted status should exist.
+        let withdrawal_documents_broadcasted = outcome
+            .abci_app
+            .platform
+            .drive
+            .fetch_oldest_withdrawal_documents_by_status(
+                withdrawals_contract::WithdrawalStatus::BROADCASTED.into(),
+                DEFAULT_QUERY_LIMIT,
+                None,
+                platform_version,
+            )
+            .unwrap();
+
+        assert_eq!(withdrawal_documents_broadcasted.len(), 80);
+    }
+
+    #[tokio::test]
     async fn run_chain_withdraw_from_identities_many_small_withdrawals() {
         // TEST_PLATFORM_V3 is like v4, but without the single quorum can sign withdrawals restriction
         let platform_version = PlatformVersion::get(TEST_PLATFORM_V3.protocol_version)

--- a/packages/rs-drive/src/drive/identity/withdrawals/calculate_current_withdrawal_limit/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/calculate_current_withdrawal_limit/mod.rs
@@ -1,11 +1,13 @@
 use crate::drive::Drive;
 use crate::error::drive::DriveError;
 use crate::error::Error;
+use dpp::block::block_info::BlockInfo;
 use dpp::fee::Credits;
 use grovedb::TransactionArg;
 use platform_version::version::PlatformVersion;
 
 mod v0;
+mod v1;
 
 /// Daily withdrawal limit information
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,11 +29,13 @@ impl Drive {
     /// Calculates the current withdrawal limit based on the total credits available in the platform
     /// and the amount already withdrawn in the last 24 hours, using the appropriate version-specific logic.
     ///
-    /// This function selects the version-specific implementation based on the provided `platform_version`.
-    /// It currently supports only version 0 (`calculate_current_withdrawal_limit_v0`).
+    /// This function selects the version-specific implementation based on the provided `platform_version`:
+    /// version 0 derives the daily maximum from the current total credits in Platform, version 1
+    /// from the total credits Platform held a day before `block_info.time_ms`.
     ///
     /// # Parameters
     ///
+    /// * `block_info`: The block the limit is calculated for.
     /// * `transaction`: The transaction context used for querying data.
     /// * `platform_version`: The version of the platform being used, which contains configuration details and version-specific methods.
     ///
@@ -48,6 +52,7 @@ impl Drive {
     /// * `Error`: Any error propagated from the version-specific implementation, such as issues in retrieving data or calculating the withdrawal limit.
     pub fn calculate_current_withdrawal_limit(
         &self,
+        block_info: &BlockInfo,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<WithdrawalLimitInfo, Error> {
@@ -59,9 +64,14 @@ impl Drive {
             .calculate_current_withdrawal_limit
         {
             0 => self.calculate_current_withdrawal_limit_v0(transaction, platform_version),
+            1 => self.calculate_current_withdrawal_limit_v1(
+                block_info,
+                transaction,
+                platform_version,
+            ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "calculate_current_withdrawal_limit".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             })),
         }

--- a/packages/rs-drive/src/drive/identity/withdrawals/calculate_current_withdrawal_limit/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/calculate_current_withdrawal_limit/v0/mod.rs
@@ -63,7 +63,8 @@ impl Drive {
             )))?;
 
         // Let's get the amount that we are allowed to get in the last 24 hours.
-        let daily_maximum = daily_withdrawal_limit(total_credits_in_platform, platform_version)?;
+        let daily_maximum =
+            daily_withdrawal_limit(Some(total_credits_in_platform), platform_version)?;
 
         let withdrawal_amount_in_last_day: u64 = self
             .grove_get_sum_tree_total_value(

--- a/packages/rs-drive/src/drive/identity/withdrawals/calculate_current_withdrawal_limit/v1/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/calculate_current_withdrawal_limit/v1/mod.rs
@@ -1,0 +1,159 @@
+use crate::drive::balances::TOTAL_SYSTEM_CREDITS_STORAGE_KEY;
+use crate::drive::identity::withdrawals::calculate_current_withdrawal_limit::WithdrawalLimitInfo;
+use crate::drive::identity::withdrawals::paths::{
+    get_withdrawal_root_path, WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY,
+};
+use crate::drive::system::misc_path;
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use crate::util::grove_operations::DirectQueryType;
+use dpp::block::block_info::BlockInfo;
+use dpp::withdrawal::daily_withdrawal_limit::daily_withdrawal_limit;
+use grovedb::TransactionArg;
+use platform_version::version::PlatformVersion;
+
+impl Drive {
+    /// Calculates the current withdrawal limit from the total credits Platform held a day ago
+    /// and the amount already withdrawn in the last 24 hours.
+    ///
+    /// Version 1 differs from version 0 only in the base of the daily maximum: instead of the
+    /// current total credits it uses the total credits recorded at the latest block at least
+    /// 24 hours before `block_info` (see `fetch_total_credits_in_platform_a_day_ago`), so a
+    /// sudden jump in the total credits does not raise the limit for a day. While no history
+    /// has been recorded yet the current total is used.
+    ///
+    /// The formula stays `daily_maximum - withdrawal_amount_in_last_day`, floored at zero.
+    pub(super) fn calculate_current_withdrawal_limit_v1(
+        &self,
+        block_info: &BlockInfo,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<WithdrawalLimitInfo, Error> {
+        let mut drive_operations = vec![];
+
+        let reference_total_credits = match self.fetch_total_credits_in_platform_a_day_ago(
+            block_info.time_ms,
+            transaction,
+            platform_version,
+        )? {
+            Some(recorded) => recorded.total_credits,
+            None => self
+                .grove_get_raw_value_u64_from_encoded_var_vec(
+                    (&misc_path()).into(),
+                    TOTAL_SYSTEM_CREDITS_STORAGE_KEY,
+                    DirectQueryType::StatefulDirectQuery,
+                    transaction,
+                    &mut drive_operations,
+                    &platform_version.drive,
+                )?
+                .ok_or(Error::Drive(DriveError::CriticalCorruptedState(
+                    "Credits not found in Platform",
+                )))?,
+        };
+
+        let daily_maximum = daily_withdrawal_limit(reference_total_credits, platform_version)?;
+
+        let withdrawal_amount_in_last_day: u64 = self
+            .grove_get_sum_tree_total_value(
+                (&get_withdrawal_root_path()).into(),
+                &WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY,
+                DirectQueryType::StatefulDirectQuery,
+                transaction,
+                &mut drive_operations,
+                &platform_version.drive,
+            )?
+            .try_into()
+            .map_err(|_| {
+                Error::Drive(DriveError::CriticalCorruptedState(
+                    "Withdrawal amount in last day is negative",
+                ))
+            })?;
+
+        Ok(WithdrawalLimitInfo {
+            daily_maximum,
+            withdrawals_amount: withdrawal_amount_in_last_day,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::drive::identity::withdrawals::fetch_total_credits_in_platform_a_day_ago::DAY_IN_MS;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::dash_to_credits;
+    use dpp::version::PlatformVersion;
+
+    #[test]
+    fn should_use_the_total_credits_a_day_ago_once_recorded_and_the_current_total_before() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let mut platform_version = PlatformVersion::latest().clone();
+        platform_version
+            .system_limits
+            .daily_withdrawal_limit_percent = Some(15);
+        let transaction = drive.grove.start_transaction();
+
+        let t0 = 10 * DAY_IN_MS;
+        let block = |time_ms: u64| BlockInfo {
+            time_ms,
+            ..Default::default()
+        };
+
+        drive
+            .add_to_system_credits(
+                dash_to_credits!(30000),
+                Some(&transaction),
+                &platform_version,
+            )
+            .expect("expected to add credits");
+
+        // Nothing recorded yet: the current total is the base.
+        let info = drive
+            .calculate_current_withdrawal_limit(&block(t0), Some(&transaction), &platform_version)
+            .expect("expected the limit");
+        assert_eq!(info.daily_maximum, dash_to_credits!(4500));
+        assert_eq!(info.withdrawals_amount, 0);
+        assert_eq!(info.available(), dash_to_credits!(4500));
+
+        drive
+            .record_total_credits_history(&block(t0), 64, Some(&transaction), &platform_version)
+            .expect("expected to record");
+
+        // The total jumps to 40000 Dash, but the limit a day later still derives from the
+        // 30000 Dash recorded a day ago.
+        drive
+            .add_to_system_credits(
+                dash_to_credits!(10000),
+                Some(&transaction),
+                &platform_version,
+            )
+            .expect("expected to add credits");
+        let info = drive
+            .calculate_current_withdrawal_limit(
+                &block(t0 + DAY_IN_MS),
+                Some(&transaction),
+                &platform_version,
+            )
+            .expect("expected the limit");
+        assert_eq!(info.daily_maximum, dash_to_credits!(4500));
+
+        // Once the larger total is a day old it becomes the base.
+        drive
+            .record_total_credits_history(
+                &block(t0 + DAY_IN_MS),
+                64,
+                Some(&transaction),
+                &platform_version,
+            )
+            .expect("expected to record");
+        let info = drive
+            .calculate_current_withdrawal_limit(
+                &block(t0 + 2 * DAY_IN_MS),
+                Some(&transaction),
+                &platform_version,
+            )
+            .expect("expected the limit");
+        assert_eq!(info.daily_maximum, dash_to_credits!(6000));
+    }
+}

--- a/packages/rs-drive/src/drive/identity/withdrawals/calculate_current_withdrawal_limit/v1/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/calculate_current_withdrawal_limit/v1/mod.rs
@@ -1,9 +1,7 @@
-use crate::drive::balances::TOTAL_SYSTEM_CREDITS_STORAGE_KEY;
 use crate::drive::identity::withdrawals::calculate_current_withdrawal_limit::WithdrawalLimitInfo;
 use crate::drive::identity::withdrawals::paths::{
     get_withdrawal_root_path, WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY,
 };
-use crate::drive::system::misc_path;
 use crate::drive::Drive;
 use crate::error::drive::DriveError;
 use crate::error::Error;
@@ -18,10 +16,11 @@ impl Drive {
     /// and the amount already withdrawn in the last 24 hours.
     ///
     /// Version 1 differs from version 0 only in the base of the daily maximum: instead of the
-    /// current total credits it uses the total credits recorded at the latest block at least
-    /// 24 hours before `block_info` (see `fetch_total_credits_in_platform_a_day_ago`), so a
-    /// sudden jump in the total credits does not raise the limit for a day. While no history
-    /// has been recorded yet the current total is used.
+    /// current total credits it hands `daily_withdrawal_limit` the total credits recorded at the
+    /// latest block at least 24 hours before `block_info` (see
+    /// `fetch_total_credits_in_platform_a_day_ago`), so a sudden jump in the total credits does
+    /// not raise the limit for a day. While no such entry exists (the history is younger than a
+    /// day) the limit method receives `None` and applies its bootstrap rule.
     ///
     /// The formula stays `daily_maximum - withdrawal_amount_in_last_day`, floored at zero.
     pub(super) fn calculate_current_withdrawal_limit_v1(
@@ -32,27 +31,15 @@ impl Drive {
     ) -> Result<WithdrawalLimitInfo, Error> {
         let mut drive_operations = vec![];
 
-        let reference_total_credits = match self.fetch_total_credits_in_platform_a_day_ago(
-            block_info.time_ms,
-            transaction,
-            platform_version,
-        )? {
-            Some(recorded) => recorded.total_credits,
-            None => self
-                .grove_get_raw_value_u64_from_encoded_var_vec(
-                    (&misc_path()).into(),
-                    TOTAL_SYSTEM_CREDITS_STORAGE_KEY,
-                    DirectQueryType::StatefulDirectQuery,
-                    transaction,
-                    &mut drive_operations,
-                    &platform_version.drive,
-                )?
-                .ok_or(Error::Drive(DriveError::CriticalCorruptedState(
-                    "Credits not found in Platform",
-                )))?,
-        };
+        let total_credits_a_day_ago = self
+            .fetch_total_credits_in_platform_a_day_ago(
+                block_info.time_ms,
+                transaction,
+                platform_version,
+            )?
+            .map(|recorded| recorded.total_credits);
 
-        let daily_maximum = daily_withdrawal_limit(reference_total_credits, platform_version)?;
+        let daily_maximum = daily_withdrawal_limit(total_credits_a_day_ago, platform_version)?;
 
         let withdrawal_amount_in_last_day: u64 = self
             .grove_get_sum_tree_total_value(
@@ -86,7 +73,7 @@ mod tests {
     use dpp::version::PlatformVersion;
 
     #[test]
-    fn should_use_the_total_credits_a_day_ago_once_recorded_and_the_current_total_before() {
+    fn should_use_the_total_credits_a_day_ago_once_known_and_the_flat_limit_before() {
         let drive = setup_drive_with_initial_state_structure(None);
         let mut platform_version = PlatformVersion::latest().clone();
         platform_version
@@ -99,6 +86,15 @@ mod tests {
             time_ms,
             ..Default::default()
         };
+        let limit = |time_ms: u64| {
+            drive
+                .calculate_current_withdrawal_limit(
+                    &block(time_ms),
+                    Some(&transaction),
+                    &platform_version,
+                )
+                .expect("expected the limit")
+        };
 
         drive
             .add_to_system_credits(
@@ -108,20 +104,24 @@ mod tests {
             )
             .expect("expected to add credits");
 
-        // Nothing recorded yet: the current total is the base.
-        let info = drive
-            .calculate_current_withdrawal_limit(&block(t0), Some(&transaction), &platform_version)
-            .expect("expected the limit");
-        assert_eq!(info.daily_maximum, dash_to_credits!(4500));
+        // Nothing recorded yet: the flat 2000 Dash of the previous rule applies.
+        let info = limit(t0);
+        assert_eq!(info.daily_maximum, dash_to_credits!(2000));
         assert_eq!(info.withdrawals_amount, 0);
-        assert_eq!(info.available(), dash_to_credits!(4500));
+        assert_eq!(info.available(), dash_to_credits!(2000));
 
         drive
             .record_total_credits_history(&block(t0), 64, Some(&transaction), &platform_version)
             .expect("expected to record");
 
-        // The total jumps to 40000 Dash, but the limit a day later still derives from the
-        // 30000 Dash recorded a day ago.
+        // Recorded, but younger than a day: still the flat limit.
+        assert_eq!(
+            limit(t0 + DAY_IN_MS - 1).daily_maximum,
+            dash_to_credits!(2000)
+        );
+
+        // The total jumps to 40000 Dash, but a day after the first record the limit derives
+        // from the 30000 Dash recorded then.
         drive
             .add_to_system_credits(
                 dash_to_credits!(10000),
@@ -129,14 +129,7 @@ mod tests {
                 &platform_version,
             )
             .expect("expected to add credits");
-        let info = drive
-            .calculate_current_withdrawal_limit(
-                &block(t0 + DAY_IN_MS),
-                Some(&transaction),
-                &platform_version,
-            )
-            .expect("expected the limit");
-        assert_eq!(info.daily_maximum, dash_to_credits!(4500));
+        assert_eq!(limit(t0 + DAY_IN_MS).daily_maximum, dash_to_credits!(4500));
 
         // Once the larger total is a day old it becomes the base.
         drive
@@ -147,13 +140,9 @@ mod tests {
                 &platform_version,
             )
             .expect("expected to record");
-        let info = drive
-            .calculate_current_withdrawal_limit(
-                &block(t0 + 2 * DAY_IN_MS),
-                Some(&transaction),
-                &platform_version,
-            )
-            .expect("expected the limit");
-        assert_eq!(info.daily_maximum, dash_to_credits!(6000));
+        assert_eq!(
+            limit(t0 + 2 * DAY_IN_MS).daily_maximum,
+            dash_to_credits!(6000)
+        );
     }
 }

--- a/packages/rs-drive/src/drive/identity/withdrawals/calculate_current_withdrawal_limit/v1/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/calculate_current_withdrawal_limit/v1/mod.rs
@@ -98,7 +98,7 @@ mod tests {
 
         drive
             .add_to_system_credits(
-                dash_to_credits!(30000),
+                dash_to_credits!(20000),
                 Some(&transaction),
                 &platform_version,
             )
@@ -120,16 +120,16 @@ mod tests {
             dash_to_credits!(2000)
         );
 
-        // The total jumps to 40000 Dash, but a day after the first record the limit derives
-        // from the 30000 Dash recorded then.
+        // The total jumps to 24000 Dash, but a day after the first record the limit derives
+        // from the 20000 Dash recorded then.
         drive
             .add_to_system_credits(
-                dash_to_credits!(10000),
+                dash_to_credits!(4000),
                 Some(&transaction),
                 &platform_version,
             )
             .expect("expected to add credits");
-        assert_eq!(limit(t0 + DAY_IN_MS).daily_maximum, dash_to_credits!(4500));
+        assert_eq!(limit(t0 + DAY_IN_MS).daily_maximum, dash_to_credits!(3000));
 
         // Once the larger total is a day old it becomes the base.
         drive
@@ -142,7 +142,7 @@ mod tests {
             .expect("expected to record");
         assert_eq!(
             limit(t0 + 2 * DAY_IN_MS).daily_maximum,
-            dash_to_credits!(6000)
+            dash_to_credits!(3600)
         );
     }
 }

--- a/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/mod.rs
@@ -1,0 +1,55 @@
+mod v0;
+
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use dpp::fee::Credits;
+use dpp::prelude::TimestampMillis;
+use grovedb::TransactionArg;
+use platform_version::version::PlatformVersion;
+
+/// A day in milliseconds: how far back the daily withdrawal limit looks for its reference total.
+pub const DAY_IN_MS: TimestampMillis = 86_400_000;
+
+/// One entry of the total credits history kept under the withdrawals tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecordedTotalCredits {
+    /// Time of the block the total was recorded at.
+    pub time_ms: TimestampMillis,
+    /// Total credits in Platform at that block.
+    pub total_credits: Credits,
+}
+
+impl Drive {
+    /// Returns the total credits Platform held a day before `time_ms`: the history entry
+    /// recorded at the latest block whose time is at least [`DAY_IN_MS`] before `time_ms`.
+    ///
+    /// While the history is younger than a day (right after the history started being
+    /// recorded), the oldest entry is returned instead, so the limit is derived from the
+    /// oldest total known. Returns `None` only when nothing has been recorded yet.
+    pub fn fetch_total_credits_in_platform_a_day_ago(
+        &self,
+        time_ms: TimestampMillis,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Option<RecordedTotalCredits>, Error> {
+        match platform_version
+            .drive
+            .methods
+            .identity
+            .withdrawals
+            .fetch_total_credits_in_platform_a_day_ago
+        {
+            0 => self.fetch_total_credits_in_platform_a_day_ago_v0(
+                time_ms,
+                transaction,
+                platform_version,
+            ),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "fetch_total_credits_in_platform_a_day_ago".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/mod.rs
@@ -41,15 +41,19 @@ impl Drive {
             .withdrawals
             .fetch_total_credits_in_platform_a_day_ago
         {
-            0 => self.fetch_total_credits_in_platform_a_day_ago_v0(
+            Some(0) => self.fetch_total_credits_in_platform_a_day_ago_v0(
                 time_ms,
                 transaction,
                 platform_version,
             ),
-            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+            Some(version) => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "fetch_total_credits_in_platform_a_day_ago".to_string(),
                 known_versions: vec![0],
                 received: version,
+            })),
+            None => Err(Error::Drive(DriveError::VersionNotActive {
+                method: "fetch_total_credits_in_platform_a_day_ago".to_string(),
+                known_versions: vec![0],
             })),
         }
     }

--- a/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/mod.rs
@@ -24,9 +24,10 @@ impl Drive {
     /// Returns the total credits Platform held a day before `time_ms`: the history entry
     /// recorded at the latest block whose time is at least [`DAY_IN_MS`] before `time_ms`.
     ///
-    /// While the history is younger than a day (right after the history started being
-    /// recorded), the oldest entry is returned instead, so the limit is derived from the
-    /// oldest total known. Returns `None` only when nothing has been recorded yet.
+    /// Returns `None` while no such entry exists, i.e. while the history is younger than a
+    /// day (right after it started being recorded); the daily withdrawal limit then falls back
+    /// to its bootstrap rule rather than to a younger total, so the lag cannot be skipped by
+    /// inflating the total before or at activation.
     pub fn fetch_total_credits_in_platform_a_day_ago(
         &self,
         time_ms: TimestampMillis,

--- a/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/v0/mod.rs
@@ -1,0 +1,189 @@
+use crate::drive::identity::withdrawals::fetch_total_credits_in_platform_a_day_ago::{
+    RecordedTotalCredits, DAY_IN_MS,
+};
+use crate::drive::identity::withdrawals::paths::get_withdrawal_total_credits_history_path_vec;
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use dpp::prelude::TimestampMillis;
+use grovedb::query_result_type::QueryResultType;
+use grovedb::{Element, PathQuery, Query, QueryItem, SizedQuery, TransactionArg};
+use platform_version::version::PlatformVersion;
+
+impl Drive {
+    pub(super) fn fetch_total_credits_in_platform_a_day_ago_v0(
+        &self,
+        time_ms: TimestampMillis,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Option<RecordedTotalCredits>, Error> {
+        let cutoff = time_ms.saturating_sub(DAY_IN_MS);
+
+        // The latest entry recorded at or before a day ago.
+        let mut at_least_a_day_old = Query::new_single_query_item(QueryItem::RangeToInclusive(
+            ..=cutoff.to_be_bytes().to_vec(),
+        ));
+        at_least_a_day_old.left_to_right = false;
+
+        if let Some(entry) = self.fetch_first_recorded_total_credits(
+            at_least_a_day_old,
+            transaction,
+            platform_version,
+        )? {
+            return Ok(Some(entry));
+        }
+
+        // The history is younger than a day: fall back to the oldest entry we have.
+        let mut oldest = Query::new();
+        oldest.insert_all();
+
+        self.fetch_first_recorded_total_credits(oldest, transaction, platform_version)
+    }
+
+    /// Runs `query` with a limit of one against the total credits history and decodes the
+    /// single entry it yields, if any.
+    fn fetch_first_recorded_total_credits(
+        &self,
+        query: Query,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Option<RecordedTotalCredits>, Error> {
+        let path_query = PathQuery::new(
+            get_withdrawal_total_credits_history_path_vec(),
+            SizedQuery::new(query, Some(1), None),
+        );
+
+        let (results, _) = self.grove_get_raw_path_query(
+            &path_query,
+            transaction,
+            QueryResultType::QueryKeyElementPairResultType,
+            &mut vec![],
+            &platform_version.drive,
+        )?;
+
+        match results.to_key_elements().into_iter().next() {
+            None => Ok(None),
+            Some((key, Element::Item(value, _))) => {
+                let time_ms =
+                    TimestampMillis::from_be_bytes(key.try_into().map_err(|_: Vec<u8>| {
+                        Error::Drive(DriveError::CorruptedDriveState(
+                            "total credits history key is not a u64 block time".to_string(),
+                        ))
+                    })?);
+                let total_credits =
+                    u64::from_be_bytes(value.try_into().map_err(|_: Vec<u8>| {
+                        Error::Drive(DriveError::CorruptedDriveState(
+                            "total credits history value is not a u64 amount".to_string(),
+                        ))
+                    })?);
+                Ok(Some(RecordedTotalCredits {
+                    time_ms,
+                    total_credits,
+                }))
+            }
+            Some(_) => Err(Error::Drive(DriveError::CorruptedElementType(
+                "total credits history entry is not an item",
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::drive::identity::withdrawals::fetch_total_credits_in_platform_a_day_ago::{
+        RecordedTotalCredits, DAY_IN_MS,
+    };
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::version::PlatformVersion;
+
+    const HOUR_IN_MS: u64 = 3_600_000;
+
+    #[test]
+    fn should_return_none_when_nothing_was_recorded() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let transaction = drive.grove.start_transaction();
+
+        assert_eq!(
+            drive
+                .fetch_total_credits_in_platform_a_day_ago(
+                    10 * DAY_IN_MS,
+                    Some(&transaction),
+                    platform_version,
+                )
+                .expect("expected to fetch"),
+            None
+        );
+    }
+
+    #[test]
+    fn should_return_the_latest_entry_at_least_a_day_old_or_the_oldest_one() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let transaction = drive.grove.start_transaction();
+
+        let t0 = 10 * DAY_IN_MS;
+        // Three blocks, each adding 1000 credits: t0 holds 1000, an hour later 2000, 25 hours
+        // later 3000.
+        for time_ms in [t0, t0 + HOUR_IN_MS, t0 + 25 * HOUR_IN_MS] {
+            drive
+                .add_to_system_credits(1_000, Some(&transaction), platform_version)
+                .expect("expected to add credits");
+            drive
+                .record_total_credits_history(
+                    &BlockInfo {
+                        time_ms,
+                        ..Default::default()
+                    },
+                    0,
+                    Some(&transaction),
+                    platform_version,
+                )
+                .expect("expected to record");
+        }
+
+        let fetch = |time_ms: u64| {
+            drive
+                .fetch_total_credits_in_platform_a_day_ago(
+                    time_ms,
+                    Some(&transaction),
+                    platform_version,
+                )
+                .expect("expected to fetch")
+        };
+
+        // History younger than a day: the oldest entry.
+        assert_eq!(
+            fetch(t0 + 10 * HOUR_IN_MS),
+            Some(RecordedTotalCredits {
+                time_ms: t0,
+                total_credits: 1_000
+            })
+        );
+        // Exactly a day after the second block: that block is the latest at least a day old.
+        assert_eq!(
+            fetch(t0 + 25 * HOUR_IN_MS),
+            Some(RecordedTotalCredits {
+                time_ms: t0 + HOUR_IN_MS,
+                total_credits: 2_000
+            })
+        );
+        // A millisecond earlier the second block is still too young.
+        assert_eq!(
+            fetch(t0 + 25 * HOUR_IN_MS - 1),
+            Some(RecordedTotalCredits {
+                time_ms: t0,
+                total_credits: 1_000
+            })
+        );
+        // Two days later the third block is the reference.
+        assert_eq!(
+            fetch(t0 + 49 * HOUR_IN_MS),
+            Some(RecordedTotalCredits {
+                time_ms: t0 + 25 * HOUR_IN_MS,
+                total_credits: 3_000
+            })
+        );
+    }
+}

--- a/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/v0/mod.rs
@@ -25,19 +25,7 @@ impl Drive {
         ));
         at_least_a_day_old.left_to_right = false;
 
-        if let Some(entry) = self.fetch_first_recorded_total_credits(
-            at_least_a_day_old,
-            transaction,
-            platform_version,
-        )? {
-            return Ok(Some(entry));
-        }
-
-        // The history is younger than a day: fall back to the oldest entry we have.
-        let mut oldest = Query::new();
-        oldest.insert_all();
-
-        self.fetch_first_recorded_total_credits(oldest, transaction, platform_version)
+        self.fetch_first_recorded_total_credits(at_least_a_day_old, transaction, platform_version)
     }
 
     /// Runs `query` with a limit of one against the total credits history and decodes the
@@ -118,7 +106,7 @@ mod tests {
     }
 
     #[test]
-    fn should_return_the_latest_entry_at_least_a_day_old_or_the_oldest_one() {
+    fn should_return_the_latest_entry_at_least_a_day_old_and_none_before() {
         let drive = setup_drive_with_initial_state_structure(None);
         let platform_version = PlatformVersion::latest();
         let transaction = drive.grove.start_transaction();
@@ -153,9 +141,12 @@ mod tests {
                 .expect("expected to fetch")
         };
 
-        // History younger than a day: the oldest entry.
+        // History younger than a day: nothing qualifies.
+        assert_eq!(fetch(t0 + 10 * HOUR_IN_MS), None);
+        assert_eq!(fetch(t0 + DAY_IN_MS - 1), None);
+        // Exactly a day after the first block it is the reference.
         assert_eq!(
-            fetch(t0 + 10 * HOUR_IN_MS),
+            fetch(t0 + DAY_IN_MS),
             Some(RecordedTotalCredits {
                 time_ms: t0,
                 total_credits: 1_000

--- a/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/fetch_total_credits_in_platform_a_day_ago/v0/mod.rs
@@ -42,7 +42,7 @@ impl Drive {
 
     /// Runs `query` with a limit of one against the total credits history and decodes the
     /// single entry it yields, if any.
-    fn fetch_first_recorded_total_credits(
+    pub(in crate::drive::identity::withdrawals) fn fetch_first_recorded_total_credits(
         &self,
         query: Query,
         transaction: TransactionArg,

--- a/packages/rs-drive/src/drive/identity/withdrawals/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/mod.rs
@@ -2,7 +2,11 @@
 pub mod document;
 
 mod calculate_current_withdrawal_limit;
+/// Functions related to the per-block record of total credits the daily withdrawal limit reads
+pub mod fetch_total_credits_in_platform_a_day_ago;
 /// Functions and constants related to GroveDB paths
 pub mod paths;
+/// Functions related to the per-block record of total credits the daily withdrawal limit reads
+pub mod record_total_credits_history;
 /// Functions related to withdrawal transactions
 pub mod transaction;

--- a/packages/rs-drive/src/drive/identity/withdrawals/paths.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/paths.rs
@@ -12,6 +12,10 @@ pub const WITHDRAWAL_TRANSACTIONS_QUEUE_KEY: [u8; 1] = [1];
 pub const WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY: [u8; 1] = [2];
 /// constant id for subtree containing the untied withdrawal transactions after they were broadcasted
 pub const WITHDRAWAL_TRANSACTIONS_BROADCASTED_KEY: [u8; 1] = [3];
+/// constant id for the subtree recording the total credits in Platform per block (key: block
+/// time in milliseconds, big-endian; value: total credits, big-endian), which the day-lagged
+/// daily withdrawal limit reads. Exists from protocol version 14.
+pub const WITHDRAWAL_TOTAL_CREDITS_HISTORY_KEY: [u8; 1] = [4];
 
 impl Drive {
     /// Add operations for creating initial withdrawal state structure
@@ -38,6 +42,13 @@ impl Drive {
             batch.add_insert_empty_sum_tree(
                 vec![vec![RootTree::WithdrawalTransactions as u8]],
                 WITHDRAWAL_TRANSACTIONS_BROADCASTED_KEY.to_vec(),
+            );
+        }
+
+        if platform_version.protocol_version >= 14 {
+            batch.add_insert_empty_tree(
+                vec![vec![RootTree::WithdrawalTransactions as u8]],
+                WITHDRAWAL_TOTAL_CREDITS_HISTORY_KEY.to_vec(),
             );
         }
     }
@@ -98,5 +109,21 @@ pub fn get_withdrawal_transactions_broadcasted_path() -> [&'static [u8]; 2] {
     [
         Into::<&[u8; 1]>::into(RootTree::WithdrawalTransactions),
         &WITHDRAWAL_TRANSACTIONS_BROADCASTED_KEY,
+    ]
+}
+
+/// Helper function to get the total credits history path as Vec
+pub fn get_withdrawal_total_credits_history_path_vec() -> Vec<Vec<u8>> {
+    vec![
+        vec![RootTree::WithdrawalTransactions as u8],
+        WITHDRAWAL_TOTAL_CREDITS_HISTORY_KEY.to_vec(),
+    ]
+}
+
+/// Helper function to get the total credits history path as [u8]
+pub fn get_withdrawal_total_credits_history_path() -> [&'static [u8]; 2] {
+    [
+        Into::<&[u8; 1]>::into(RootTree::WithdrawalTransactions),
+        &WITHDRAWAL_TOTAL_CREDITS_HISTORY_KEY,
     ]
 }

--- a/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/mod.rs
@@ -1,0 +1,43 @@
+mod v0;
+
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use dpp::block::block_info::BlockInfo;
+use grovedb::TransactionArg;
+use platform_version::version::PlatformVersion;
+
+impl Drive {
+    /// Records the current total credits in Platform in the total credits history under the
+    /// withdrawals tree, keyed by the block time, and prunes entries that the day-lagged daily
+    /// withdrawal limit can no longer read: everything older than the entry
+    /// [`Drive::fetch_total_credits_in_platform_a_day_ago`] resolves to for this block, at most
+    /// `prune_limit` entries per block (`0` disables pruning).
+    pub fn record_total_credits_history(
+        &self,
+        block_info: &BlockInfo,
+        prune_limit: u16,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        match platform_version
+            .drive
+            .methods
+            .identity
+            .withdrawals
+            .record_total_credits_history
+        {
+            0 => self.record_total_credits_history_v0(
+                block_info,
+                prune_limit,
+                transaction,
+                platform_version,
+            ),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "record_total_credits_history".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/mod.rs
@@ -30,16 +30,20 @@ impl Drive {
             .withdrawals
             .record_total_credits_history
         {
-            0 => self.record_total_credits_history_v0(
+            Some(0) => self.record_total_credits_history_v0(
                 block_info,
                 prune_limit,
                 transaction,
                 platform_version,
             ),
-            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+            Some(version) => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "record_total_credits_history".to_string(),
                 known_versions: vec![0],
                 received: version,
+            })),
+            None => Err(Error::Drive(DriveError::VersionNotActive {
+                method: "record_total_credits_history".to_string(),
+                known_versions: vec![0],
             })),
         }
     }

--- a/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/mod.rs
@@ -9,10 +9,13 @@ use platform_version::version::PlatformVersion;
 
 impl Drive {
     /// Records the current total credits in Platform in the total credits history under the
-    /// withdrawals tree, keyed by the block time, and prunes entries that the day-lagged daily
-    /// withdrawal limit can no longer read: everything older than the entry
+    /// withdrawals tree, keyed by the block time, if it differs from the latest recorded one,
+    /// and on doing so prunes entries that the day-lagged daily withdrawal limit can no longer
+    /// read: everything older than the entry
     /// [`Drive::fetch_total_credits_in_platform_a_day_ago`] resolves to for this block, at most
-    /// `prune_limit` entries per block (`0` disables pruning).
+    /// `prune_limit` entries per call (`0` disables pruning). Called every block; writes only
+    /// when the total changed, since the limit reads the latest entry at least a day old and an
+    /// entry describes the total until the next one.
     pub fn record_total_credits_history(
         &self,
         block_info: &BlockInfo,

--- a/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/v0/mod.rs
@@ -7,7 +7,7 @@ use crate::error::Error;
 use crate::util::grove_operations::{BatchDeleteApplyType, DirectQueryType};
 use crate::util::object_size_info::PathKeyElementInfo;
 use dpp::block::block_info::BlockInfo;
-use grovedb::{Element, MaybeTree, PathQuery, QueryItem, TransactionArg};
+use grovedb::{Element, MaybeTree, PathQuery, Query, QueryItem, TransactionArg};
 use platform_version::version::PlatformVersion;
 
 impl Drive {
@@ -32,6 +32,20 @@ impl Drive {
             .ok_or(Error::Drive(DriveError::CriticalCorruptedState(
                 "Credits not found in Platform",
             )))?;
+
+        // Only write when the total changed: the limit reads the latest entry at least a day
+        // old, so an entry already describes the total until the next one, and a block that
+        // leaves the total untouched (most blocks: document traffic and fees do not move it)
+        // costs a read here instead of a write.
+        let mut latest = Query::new();
+        latest.insert_all();
+        latest.left_to_right = false;
+        if self
+            .fetch_first_recorded_total_credits(latest, transaction, platform_version)?
+            .is_some_and(|recorded| recorded.total_credits == total_credits_in_platform)
+        {
+            return Ok(());
+        }
 
         // Resolve the reference entry for this block before adding to the history, so the
         // prune below can never remove the entry the limit reads this block (the new entry is
@@ -130,7 +144,11 @@ mod tests {
             .collect()
     }
 
+    /// Adds one credit so the total differs from the last record, then records at `time_ms`.
     fn record(drive: &Drive, time_ms: u64, prune_limit: u16, transaction: &Transaction) {
+        drive
+            .add_to_system_credits(1, Some(transaction), PlatformVersion::latest())
+            .expect("expected to add a credit");
         drive
             .record_total_credits_history(
                 &BlockInfo {
@@ -151,18 +169,57 @@ mod tests {
         let transaction = drive.grove.start_transaction();
 
         drive
-            .add_to_system_credits(5_000, Some(&transaction), platform_version)
+            .add_to_system_credits(4_999, Some(&transaction), platform_version)
             .expect("expected to add credits");
-        record(&drive, 123_456, 64, &transaction);
+        record(&drive, 123_456, 64, &transaction); // 5_000 after the helper's extra credit
 
         drive
-            .add_to_system_credits(2_500, Some(&transaction), platform_version)
+            .add_to_system_credits(2_499, Some(&transaction), platform_version)
             .expect("expected to add credits");
-        record(&drive, 123_457, 64, &transaction);
+        record(&drive, 123_457, 64, &transaction); // 7_500
 
         assert_eq!(
             recorded_entries(&drive, &transaction),
             vec![(123_456, 5_000), (123_457, 7_500)]
+        );
+    }
+
+    #[test]
+    fn should_not_write_when_the_total_is_unchanged() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let transaction = drive.grove.start_transaction();
+
+        drive
+            .add_to_system_credits(5_000, Some(&transaction), platform_version)
+            .expect("expected to add credits");
+        let block = |time_ms: u64| BlockInfo {
+            time_ms,
+            ..Default::default()
+        };
+        for time_ms in [100, 200, 300] {
+            drive
+                .record_total_credits_history(
+                    &block(time_ms),
+                    64,
+                    Some(&transaction),
+                    platform_version,
+                )
+                .expect("expected to record");
+        }
+        // One entry: the blocks that left the total untouched wrote nothing.
+        assert_eq!(recorded_entries(&drive, &transaction), vec![(100, 5_000)]);
+
+        // And the lookup still resolves the total in force from that single entry.
+        drive
+            .add_to_system_credits(1, Some(&transaction), platform_version)
+            .expect("expected to add a credit");
+        drive
+            .record_total_credits_history(&block(400), 64, Some(&transaction), platform_version)
+            .expect("expected to record");
+        assert_eq!(
+            recorded_entries(&drive, &transaction),
+            vec![(100, 5_000), (400, 5_001)]
         );
     }
 

--- a/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/v0/mod.rs
@@ -233,7 +233,7 @@ mod tests {
         record(&drive, t0 + HOUR_IN_MS, 64, &transaction);
         record(&drive, t0 + 2 * HOUR_IN_MS, 64, &transaction);
 
-        // Still within the first day: the oldest entry is the reference, nothing is pruned.
+        // Still within the first day: no entry is a day old yet, nothing is pruned.
         record(&drive, t0 + 23 * HOUR_IN_MS, 64, &transaction);
         assert_eq!(
             recorded_entries(&drive, &transaction)

--- a/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/record_total_credits_history/v0/mod.rs
@@ -1,0 +1,234 @@
+use crate::drive::balances::TOTAL_SYSTEM_CREDITS_STORAGE_KEY;
+use crate::drive::identity::withdrawals::paths::get_withdrawal_total_credits_history_path_vec;
+use crate::drive::system::misc_path;
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use crate::util::grove_operations::{BatchDeleteApplyType, DirectQueryType};
+use crate::util::object_size_info::PathKeyElementInfo;
+use dpp::block::block_info::BlockInfo;
+use grovedb::{Element, MaybeTree, PathQuery, QueryItem, TransactionArg};
+use platform_version::version::PlatformVersion;
+
+impl Drive {
+    pub(super) fn record_total_credits_history_v0(
+        &self,
+        block_info: &BlockInfo,
+        prune_limit: u16,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        let mut drive_operations = vec![];
+
+        let total_credits_in_platform = self
+            .grove_get_raw_value_u64_from_encoded_var_vec(
+                (&misc_path()).into(),
+                TOTAL_SYSTEM_CREDITS_STORAGE_KEY,
+                DirectQueryType::StatefulDirectQuery,
+                transaction,
+                &mut drive_operations,
+                &platform_version.drive,
+            )?
+            .ok_or(Error::Drive(DriveError::CriticalCorruptedState(
+                "Credits not found in Platform",
+            )))?;
+
+        // Resolve the reference entry for this block before adding to the history, so the
+        // prune below can never remove the entry the limit reads this block (the new entry is
+        // always younger than the reference, so it is never in the pruned range either).
+        let reference = self.fetch_total_credits_in_platform_a_day_ago(
+            block_info.time_ms,
+            transaction,
+            platform_version,
+        )?;
+
+        let history_path = get_withdrawal_total_credits_history_path_vec();
+
+        self.batch_insert(
+            PathKeyElementInfo::PathKeyElement::<0>((
+                history_path.clone(),
+                block_info.time_ms.to_be_bytes().to_vec(),
+                Element::new_item(total_credits_in_platform.to_be_bytes().to_vec()),
+            )),
+            &mut drive_operations,
+            &platform_version.drive,
+        )?;
+
+        if let (Some(reference), 1..) = (reference, prune_limit) {
+            let mut path_query = PathQuery::new_single_query_item(
+                history_path,
+                QueryItem::RangeTo(..reference.time_ms.to_be_bytes().to_vec()),
+            );
+            path_query.query.limit = Some(prune_limit);
+
+            self.batch_delete_items_in_path_query(
+                &path_query,
+                true,
+                // we know that we are not deleting a subtree
+                BatchDeleteApplyType::StatefulBatchDelete {
+                    is_known_to_be_subtree_with_sum: Some(MaybeTree::NotTree),
+                },
+                transaction,
+                &mut drive_operations,
+                &platform_version.drive,
+            )?;
+        }
+
+        self.apply_batch_low_level_drive_operations(
+            None,
+            transaction,
+            drive_operations,
+            &mut vec![],
+            &platform_version.drive,
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::drive::identity::withdrawals::fetch_total_credits_in_platform_a_day_ago::DAY_IN_MS;
+    use crate::drive::identity::withdrawals::paths::get_withdrawal_total_credits_history_path_vec;
+    use crate::drive::Drive;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::version::PlatformVersion;
+    use grovedb::query_result_type::QueryResultType;
+    use grovedb::{Element, PathQuery, Query, SizedQuery, Transaction};
+
+    const HOUR_IN_MS: u64 = 3_600_000;
+
+    fn recorded_entries(drive: &Drive, transaction: &Transaction) -> Vec<(u64, u64)> {
+        let mut query = Query::new();
+        query.insert_all();
+        let path_query = PathQuery::new(
+            get_withdrawal_total_credits_history_path_vec(),
+            SizedQuery::new(query, None, None),
+        );
+        let (results, _) = drive
+            .grove_get_raw_path_query(
+                &path_query,
+                Some(transaction),
+                QueryResultType::QueryKeyElementPairResultType,
+                &mut vec![],
+                &PlatformVersion::latest().drive,
+            )
+            .expect("expected to query the history");
+        results
+            .to_key_elements()
+            .into_iter()
+            .map(|(key, element)| {
+                let Element::Item(value, _) = element else {
+                    panic!("expected an item");
+                };
+                (
+                    u64::from_be_bytes(key.try_into().expect("8 byte key")),
+                    u64::from_be_bytes(value.try_into().expect("8 byte value")),
+                )
+            })
+            .collect()
+    }
+
+    fn record(drive: &Drive, time_ms: u64, prune_limit: u16, transaction: &Transaction) {
+        drive
+            .record_total_credits_history(
+                &BlockInfo {
+                    time_ms,
+                    ..Default::default()
+                },
+                prune_limit,
+                Some(transaction),
+                PlatformVersion::latest(),
+            )
+            .expect("expected to record the total credits");
+    }
+
+    #[test]
+    fn should_record_the_current_total_credits_keyed_by_block_time() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let transaction = drive.grove.start_transaction();
+
+        drive
+            .add_to_system_credits(5_000, Some(&transaction), platform_version)
+            .expect("expected to add credits");
+        record(&drive, 123_456, 64, &transaction);
+
+        drive
+            .add_to_system_credits(2_500, Some(&transaction), platform_version)
+            .expect("expected to add credits");
+        record(&drive, 123_457, 64, &transaction);
+
+        assert_eq!(
+            recorded_entries(&drive, &transaction),
+            vec![(123_456, 5_000), (123_457, 7_500)]
+        );
+    }
+
+    #[test]
+    fn should_prune_only_entries_older_than_the_reference_entry() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let transaction = drive.grove.start_transaction();
+
+        let t0 = 10 * DAY_IN_MS;
+        record(&drive, t0, 64, &transaction);
+        record(&drive, t0 + HOUR_IN_MS, 64, &transaction);
+        record(&drive, t0 + 2 * HOUR_IN_MS, 64, &transaction);
+
+        // Still within the first day: the oldest entry is the reference, nothing is pruned.
+        record(&drive, t0 + 23 * HOUR_IN_MS, 64, &transaction);
+        assert_eq!(
+            recorded_entries(&drive, &transaction)
+                .into_iter()
+                .map(|(time_ms, _)| time_ms)
+                .collect::<Vec<_>>(),
+            vec![
+                t0,
+                t0 + HOUR_IN_MS,
+                t0 + 2 * HOUR_IN_MS,
+                t0 + 23 * HOUR_IN_MS
+            ]
+        );
+
+        // A day and two hours in, the reference is the entry at t0 + 2h; the two older entries go,
+        // the reference itself and everything younger stay.
+        record(&drive, t0 + 26 * HOUR_IN_MS, 64, &transaction);
+        assert_eq!(
+            recorded_entries(&drive, &transaction)
+                .into_iter()
+                .map(|(time_ms, _)| time_ms)
+                .collect::<Vec<_>>(),
+            vec![
+                t0 + 2 * HOUR_IN_MS,
+                t0 + 23 * HOUR_IN_MS,
+                t0 + 26 * HOUR_IN_MS
+            ]
+        );
+    }
+
+    #[test]
+    fn should_bound_pruning_per_block_and_skip_it_when_the_limit_is_zero() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let transaction = drive.grove.start_transaction();
+
+        let t0 = 10 * DAY_IN_MS;
+        for hour in 0..5 {
+            record(&drive, t0 + hour * HOUR_IN_MS, 0, &transaction);
+        }
+
+        // Reference is t0 + 4h; four older entries are prunable but the limit is zero.
+        record(&drive, t0 + 28 * HOUR_IN_MS, 0, &transaction);
+        assert_eq!(recorded_entries(&drive, &transaction).len(), 6);
+
+        // With a limit of one, a single stale entry goes per block.
+        record(&drive, t0 + 28 * HOUR_IN_MS + 1, 1, &transaction);
+        assert_eq!(
+            recorded_entries(&drive, &transaction)
+                .first()
+                .map(|(time_ms, _)| *time_ms),
+            Some(t0 + HOUR_IN_MS)
+        );
+        assert_eq!(recorded_entries(&drive, &transaction).len(), 6);
+    }
+}

--- a/packages/rs-platform-version/src/version/dpp_versions/dpp_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions/dpp_method_versions/mod.rs
@@ -2,6 +2,7 @@ use versioned_feature_core::FeatureVersion;
 
 pub mod v1;
 pub mod v2;
+pub mod v3;
 
 #[derive(Clone, Debug, Default)]
 pub struct DPPMethodVersions {

--- a/packages/rs-platform-version/src/version/dpp_versions/dpp_method_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions/dpp_method_versions/v3.rs
@@ -1,0 +1,12 @@
+use crate::version::dpp_versions::dpp_method_versions::DPPMethodVersions;
+
+/// DPP method versions 3. Introduced in protocol v14: `daily_withdrawal_limit` 1 → 2 replaces the
+/// flat daily withdrawal limit with a percentage of the total credits Platform held a day ago
+/// (`SystemLimits::daily_withdrawal_limit_percent`). Everything else matches V2.
+pub const DPP_METHOD_VERSIONS_V3: DPPMethodVersions = DPPMethodVersions {
+    epoch_core_reward_credits_for_distribution: 0,
+    daily_withdrawal_limit: 2,
+    deduct_fee_from_outputs_or_remaining_balance_of_inputs: 0,
+    compute_minimum_shielded_fee: 0,
+    shielded_extra_sighash_data: 0,
+};

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
@@ -1,6 +1,7 @@
 use versioned_feature_core::{FeatureVersion, OptionalFeatureVersion};
 
 pub mod v1;
+pub mod v10;
 pub mod v2;
 pub mod v3;
 pub mod v4;
@@ -163,6 +164,7 @@ pub struct DriveAbciIdentityCreditWithdrawalMethodVersions {
     pub rebroadcast_expired_withdrawal_documents: FeatureVersion,
     pub append_signatures_and_broadcast_withdrawal_transactions: FeatureVersion,
     pub cleanup_expired_locks_of_withdrawal_amounts: FeatureVersion,
+    pub record_total_credits_history_for_withdrawals: OptionalFeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v1.rs
@@ -88,6 +88,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V1: DriveAbciMethodVersions = DriveAbciMeth
         rebroadcast_expired_withdrawal_documents: 0,
         append_signatures_and_broadcast_withdrawal_transactions: 0,
         cleanup_expired_locks_of_withdrawal_amounts: 0,
+        record_total_credits_history_for_withdrawals: None,
     },
     voting: DriveAbciVotingMethodVersions {
         keep_record_of_finished_contested_resource_vote_poll: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v10.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v10.rs
@@ -12,26 +12,6 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciVotingMethodVersions,
 };
 
-// Introduced in Protocol version 13.
-//
-// Identical to DRIVE_ABCI_METHOD_VERSIONS_V8 (the protocol-v12 method set)
-// except TWO fields are bumped from 0 to 1, both serving the same v13 recorded-set
-// expansion — enlarging the per-block address-balance set that v0 dropped:
-//   (1) `record_added_balance_outputs` 0 -> 1: folds shielded-spend transparent
-//       credits (the Unshield net output, the ShieldFromAssetLock surplus, and the
-//       IdentityCreateFromShieldedPool duplicate-key fallback); and
-//   (2) `process_validation_result` 0 -> 1: records the balance effects of
-//       paid-INVALID and unsuccessful-paid transitions (charged fees, adjusted
-//       input/output balances, applied chargeable-failure credits) that pre-v13
-//       nodes never tracked (they passed no map, and PaidConsensusError had no
-//       balance-changes field). Only this helper changed — `process_raw_state_transitions`
-//       (the outer loop) stays at v0 — and it lives in a real _v1, so the _v0
-//       stays byte-identical to old nodes with no version conditional.
-// The storage method `store_address_balances_to_recent_block_storage` is
-// deliberately UNCHANGED (stays Some(0)) — its _v0 implementation did not change;
-// only which changes feed its map did. The expanded recorded set changes the
-// committed state root, so both bumps MUST stay inactive on v12 (see
-// DRIVE_ABCI_METHOD_VERSIONS_V8, which keeps both fields at 0).
 /// Drive ABCI method versions 10. Introduced in protocol v14: turns on
 /// `record_total_credits_history_for_withdrawals` (`Some(0)`), the per-block record of the total
 /// credits in Platform that the day-lagged daily withdrawal limit reads. Everything else matches
@@ -127,21 +107,15 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V10: DriveAbciMethodVersions = DriveAbciMet
     },
     state_transition_processing: DriveAbciStateTransitionProcessingMethodVersions {
         execute_event: 0,
-        // Unchanged: the outer processing loop did not change at v13, so it stays at v0. Only the
-        // `process_validation_result` helper it dispatches to changed (below).
         process_raw_state_transitions: 0,
-        // changed: v1 records the balance effects of paid-INVALID / unsuccessful-paid transitions
-        // (charged fees, adjusted outputs, applied chargeable-failure credits) that v0 dropped. Same
-        // v13 recorded-set expansion as `record_added_balance_outputs` below; kept in a real _v1 so
-        // no version conditional lives inside the _v0 helper.
+        // unchanged from V9: v1 since v13 (records the balance effects of paid-INVALID /
+        // unsuccessful-paid transitions)
         process_validation_result: 1,
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: Some(0),
         cleanup_recent_block_storage_address_balances: Some(0),
-        // changed: v1 records shielded-spend transparent credits (Unshield net output,
-        // ShieldFromAssetLock surplus, identity-create fallback) folded at the executor. The storage
-        // method above is unchanged — only which credits feed its map did.
+        // unchanged from V9: v1 since v13 (records shielded-spend transparent credits)
         record_added_balance_outputs: 1,
     },
     epoch: DriveAbciEpochMethodVersions {

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v10.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v10.rs
@@ -12,7 +12,31 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciVotingMethodVersions,
 };
 
-pub const DRIVE_ABCI_METHOD_VERSIONS_V3: DriveAbciMethodVersions = DriveAbciMethodVersions {
+// Introduced in Protocol version 13.
+//
+// Identical to DRIVE_ABCI_METHOD_VERSIONS_V8 (the protocol-v12 method set)
+// except TWO fields are bumped from 0 to 1, both serving the same v13 recorded-set
+// expansion — enlarging the per-block address-balance set that v0 dropped:
+//   (1) `record_added_balance_outputs` 0 -> 1: folds shielded-spend transparent
+//       credits (the Unshield net output, the ShieldFromAssetLock surplus, and the
+//       IdentityCreateFromShieldedPool duplicate-key fallback); and
+//   (2) `process_validation_result` 0 -> 1: records the balance effects of
+//       paid-INVALID and unsuccessful-paid transitions (charged fees, adjusted
+//       input/output balances, applied chargeable-failure credits) that pre-v13
+//       nodes never tracked (they passed no map, and PaidConsensusError had no
+//       balance-changes field). Only this helper changed — `process_raw_state_transitions`
+//       (the outer loop) stays at v0 — and it lives in a real _v1, so the _v0
+//       stays byte-identical to old nodes with no version conditional.
+// The storage method `store_address_balances_to_recent_block_storage` is
+// deliberately UNCHANGED (stays Some(0)) — its _v0 implementation did not change;
+// only which changes feed its map did. The expanded recorded set changes the
+// committed state root, so both bumps MUST stay inactive on v12 (see
+// DRIVE_ABCI_METHOD_VERSIONS_V8, which keeps both fields at 0).
+/// Drive ABCI method versions 10. Introduced in protocol v14: turns on
+/// `record_total_credits_history_for_withdrawals` (`Some(0)`), the per-block record of the total
+/// credits in Platform that the day-lagged daily withdrawal limit reads. Everything else matches
+/// `DRIVE_ABCI_METHOD_VERSIONS_V9`.
+pub const DRIVE_ABCI_METHOD_VERSIONS_V10: DriveAbciMethodVersions = DriveAbciMethodVersions {
     engine: DriveAbciEngineMethodVersions {
         init_chain: 0,
         check_tx: 0,
@@ -22,7 +46,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V3: DriveAbciMethodVersions = DriveAbciMeth
     },
     initialization: DriveAbciInitializationMethodVersions {
         initial_core_height_and_time: 0,
-        create_genesis_state: 0,
+        create_genesis_state: 1,
     },
     core_based_updates: DriveAbciCoreBasedUpdatesMethodVersions {
         update_core_info: 0,
@@ -48,12 +72,12 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V3: DriveAbciMethodVersions = DriveAbciMeth
     protocol_upgrade: DriveAbciProtocolUpgradeMethodVersions {
         check_for_desired_protocol_upgrade: 1,
         upgrade_protocol_version_on_epoch_change: 0,
-        perform_events_on_first_block_of_protocol_change: Some(0),
+        perform_events_on_first_block_of_protocol_change: Some(1),
         protocol_version_upgrade_percentage_needed: 67,
     },
     block_fee_processing: DriveAbciBlockFeeProcessingMethodVersions {
         add_process_epoch_change_operations: 0,
-        process_block_fees_and_validate_sum_trees: 0,
+        process_block_fees_and_validate_sum_trees: 1,
     },
     tokens_processing: DriveAbciTokensProcessingMethodVersions {
         validate_token_aggregated_balance: 0,
@@ -74,7 +98,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V3: DriveAbciMethodVersions = DriveAbciMeth
         add_distribute_storage_fee_to_epochs_operations: 0,
     },
     fee_pool_outwards_distribution: DriveAbciFeePoolOutwardsDistributionMethodVersions {
-        add_distribute_fees_from_oldest_unpaid_epoch_pool_to_proposers_operations: 0,
+        add_distribute_fees_from_oldest_unpaid_epoch_pool_to_proposers_operations: 1,
         add_epoch_pool_to_proposers_payout_operations: 0,
         find_oldest_epoch_needing_payment: 0,
         fetch_reward_shares_list_for_masternode: 0,
@@ -83,17 +107,17 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V3: DriveAbciMethodVersions = DriveAbciMeth
         build_untied_withdrawal_transactions_from_documents: 0,
         dequeue_and_build_unsigned_withdrawal_transactions: 0,
         fetch_transactions_block_inclusion_status: 0,
-        pool_withdrawals_into_transactions_queue: 0,
+        pool_withdrawals_into_transactions_queue: 1,
         update_broadcasted_withdrawal_statuses: 0,
-        rebroadcast_expired_withdrawal_documents: 0,
+        rebroadcast_expired_withdrawal_documents: 1,
         append_signatures_and_broadcast_withdrawal_transactions: 0,
         cleanup_expired_locks_of_withdrawal_amounts: 0,
-        record_total_credits_history_for_withdrawals: None,
+        record_total_credits_history_for_withdrawals: Some(0), // changed in v14: per-block total credits history for the day-lagged daily withdrawal limit
     },
     voting: DriveAbciVotingMethodVersions {
         keep_record_of_finished_contested_resource_vote_poll: 0,
         clean_up_after_vote_poll_end: 0,
-        clean_up_after_contested_resources_vote_poll_end: 0,
+        clean_up_after_contested_resources_vote_poll_end: 1,
         check_for_ended_vote_polls: 0,
         tally_votes_for_contested_document_resource_vote_poll: 0,
         award_document_to_winner: 0,
@@ -103,13 +127,22 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V3: DriveAbciMethodVersions = DriveAbciMeth
     },
     state_transition_processing: DriveAbciStateTransitionProcessingMethodVersions {
         execute_event: 0,
+        // Unchanged: the outer processing loop did not change at v13, so it stays at v0. Only the
+        // `process_validation_result` helper it dispatches to changed (below).
         process_raw_state_transitions: 0,
-        process_validation_result: 0,
+        // changed: v1 records the balance effects of paid-INVALID / unsuccessful-paid transitions
+        // (charged fees, adjusted outputs, applied chargeable-failure credits) that v0 dropped. Same
+        // v13 recorded-set expansion as `record_added_balance_outputs` below; kept in a real _v1 so
+        // no version conditional lives inside the _v0 helper.
+        process_validation_result: 1,
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
-        store_address_balances_to_recent_block_storage: None,
-        cleanup_recent_block_storage_address_balances: None,
-        record_added_balance_outputs: 0,
+        store_address_balances_to_recent_block_storage: Some(0),
+        cleanup_recent_block_storage_address_balances: Some(0),
+        // changed: v1 records shielded-spend transparent credits (Unshield net output,
+        // ShieldFromAssetLock surplus, identity-create fallback) folded at the executor. The storage
+        // method above is unchanged — only which credits feed its map did.
+        record_added_balance_outputs: 1,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,
@@ -121,11 +154,11 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V3: DriveAbciMethodVersions = DriveAbciMeth
     block_end: DriveAbciBlockEndMethodVersions {
         update_state_cache: 0,
         update_drive_cache: 0,
-        validator_set_update: 1,
-        should_checkpoint: None,
-        update_checkpoints: None,
-        record_shielded_pool_anchor: None,
-        prune_shielded_pool_anchors: None,
+        validator_set_update: 2,
+        should_checkpoint: Some(0),
+        update_checkpoints: Some(0),
+        record_shielded_pool_anchor: Some(0),
+        prune_shielded_pool_anchors: Some(0),
     },
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v2.rs
@@ -89,6 +89,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V2: DriveAbciMethodVersions = DriveAbciMeth
         rebroadcast_expired_withdrawal_documents: 0,
         append_signatures_and_broadcast_withdrawal_transactions: 0,
         cleanup_expired_locks_of_withdrawal_amounts: 0,
+        record_total_credits_history_for_withdrawals: None,
     },
     voting: DriveAbciVotingMethodVersions {
         keep_record_of_finished_contested_resource_vote_poll: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v4.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v4.rs
@@ -88,6 +88,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V4: DriveAbciMethodVersions = DriveAbciMeth
         rebroadcast_expired_withdrawal_documents: 0,
         append_signatures_and_broadcast_withdrawal_transactions: 0,
         cleanup_expired_locks_of_withdrawal_amounts: 0,
+        record_total_credits_history_for_withdrawals: None,
     },
     voting: DriveAbciVotingMethodVersions {
         keep_record_of_finished_contested_resource_vote_poll: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v5.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v5.rs
@@ -92,6 +92,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V5: DriveAbciMethodVersions = DriveAbciMeth
         rebroadcast_expired_withdrawal_documents: 1,
         append_signatures_and_broadcast_withdrawal_transactions: 0,
         cleanup_expired_locks_of_withdrawal_amounts: 0,
+        record_total_credits_history_for_withdrawals: None,
     },
     voting: DriveAbciVotingMethodVersions {
         keep_record_of_finished_contested_resource_vote_poll: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v6.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v6.rs
@@ -90,6 +90,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V6: DriveAbciMethodVersions = DriveAbciMeth
         rebroadcast_expired_withdrawal_documents: 1,
         append_signatures_and_broadcast_withdrawal_transactions: 0,
         cleanup_expired_locks_of_withdrawal_amounts: 0,
+        record_total_credits_history_for_withdrawals: None,
     },
     voting: DriveAbciVotingMethodVersions {
         keep_record_of_finished_contested_resource_vote_poll: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v7.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v7.rs
@@ -97,6 +97,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V7: DriveAbciMethodVersions = DriveAbciMeth
         rebroadcast_expired_withdrawal_documents: 1,
         append_signatures_and_broadcast_withdrawal_transactions: 0,
         cleanup_expired_locks_of_withdrawal_amounts: 0,
+        record_total_credits_history_for_withdrawals: None,
     },
     voting: DriveAbciVotingMethodVersions {
         keep_record_of_finished_contested_resource_vote_poll: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v8.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v8.rs
@@ -99,6 +99,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V8: DriveAbciMethodVersions = DriveAbciMeth
         rebroadcast_expired_withdrawal_documents: 1,
         append_signatures_and_broadcast_withdrawal_transactions: 0,
         cleanup_expired_locks_of_withdrawal_amounts: 0,
+        record_total_credits_history_for_withdrawals: None,
     },
     voting: DriveAbciVotingMethodVersions {
         keep_record_of_finished_contested_resource_vote_poll: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v9.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v9.rs
@@ -108,6 +108,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V9: DriveAbciMethodVersions = DriveAbciMeth
         rebroadcast_expired_withdrawal_documents: 1,
         append_signatures_and_broadcast_withdrawal_transactions: 0,
         cleanup_expired_locks_of_withdrawal_amounts: 0,
+        record_total_credits_history_for_withdrawals: None,
     },
     voting: DriveAbciVotingMethodVersions {
         keep_record_of_finished_contested_resource_vote_poll: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_withdrawal_constants/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_withdrawal_constants/mod.rs
@@ -1,8 +1,12 @@
 pub mod v1;
 pub mod v2;
+pub mod v3;
 
 #[derive(Clone, Debug, Default)]
 pub struct DriveAbciWithdrawalConstants {
     pub core_expiration_blocks: u32,
     pub cleanup_expired_locks_of_withdrawal_amounts_limit: u16,
+    /// Maximum number of entries `record_total_credits_history_for_withdrawals` prunes from
+    /// the total credits history per block (`0` disables pruning).
+    pub total_credits_history_prune_limit: u16,
 }

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_withdrawal_constants/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_withdrawal_constants/v1.rs
@@ -3,5 +3,6 @@ use crate::version::drive_abci_versions::drive_abci_withdrawal_constants::DriveA
 pub const DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V1: DriveAbciWithdrawalConstants =
     DriveAbciWithdrawalConstants {
         core_expiration_blocks: 48,
+        total_credits_history_prune_limit: 0,
         cleanup_expired_locks_of_withdrawal_amounts_limit: 0,
     };

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_withdrawal_constants/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_withdrawal_constants/v2.rs
@@ -3,5 +3,6 @@ use crate::version::drive_abci_versions::drive_abci_withdrawal_constants::DriveA
 pub const DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2: DriveAbciWithdrawalConstants =
     DriveAbciWithdrawalConstants {
         core_expiration_blocks: 48,
+        total_credits_history_prune_limit: 0,
         cleanup_expired_locks_of_withdrawal_amounts_limit: 64,
     };

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_withdrawal_constants/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_withdrawal_constants/v3.rs
@@ -1,0 +1,12 @@
+use crate::version::drive_abci_versions::drive_abci_withdrawal_constants::DriveAbciWithdrawalConstants;
+
+/// Withdrawal constants for protocol version 14 and above: identical to
+/// [`super::v2::DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2`] plus `total_credits_history_prune_limit`,
+/// bounding how many stale entries the per-block total credits history (the base of the
+/// day-lagged daily withdrawal limit) drops per block.
+pub const DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V3: DriveAbciWithdrawalConstants =
+    DriveAbciWithdrawalConstants {
+        core_expiration_blocks: 48,
+        cleanup_expired_locks_of_withdrawal_amounts_limit: 64,
+        total_credits_history_prune_limit: 64,
+    };

--- a/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/mod.rs
@@ -20,6 +20,8 @@ pub struct DriveIdentityWithdrawalMethodVersions {
     pub document: DriveIdentityWithdrawalDocumentMethodVersions,
     pub transaction: DriveIdentityWithdrawalTransactionMethodVersions,
     pub calculate_current_withdrawal_limit: FeatureVersion,
+    pub record_total_credits_history: FeatureVersion,
+    pub fetch_total_credits_in_platform_a_day_ago: FeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/mod.rs
@@ -20,8 +20,9 @@ pub struct DriveIdentityWithdrawalMethodVersions {
     pub document: DriveIdentityWithdrawalDocumentMethodVersions,
     pub transaction: DriveIdentityWithdrawalTransactionMethodVersions,
     pub calculate_current_withdrawal_limit: FeatureVersion,
-    pub record_total_credits_history: FeatureVersion,
-    pub fetch_total_credits_in_platform_a_day_ago: FeatureVersion,
+    /// The total credits history under the withdrawals tree exists from protocol version 14.
+    pub record_total_credits_history: OptionalFeatureVersion,
+    pub fetch_total_credits_in_platform_a_day_ago: OptionalFeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v1.rs
@@ -157,5 +157,7 @@ pub const DRIVE_IDENTITY_METHOD_VERSIONS_V1: DriveIdentityMethodVersions =
                 },
             },
             calculate_current_withdrawal_limit: 0,
+            record_total_credits_history: 0,
+            fetch_total_credits_in_platform_a_day_ago: 0,
         },
     };

--- a/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v1.rs
@@ -157,7 +157,7 @@ pub const DRIVE_IDENTITY_METHOD_VERSIONS_V1: DriveIdentityMethodVersions =
                 },
             },
             calculate_current_withdrawal_limit: 0,
-            record_total_credits_history: 0,
-            fetch_total_credits_in_platform_a_day_ago: 0,
+            record_total_credits_history: None,
+            fetch_total_credits_in_platform_a_day_ago: None,
         },
     };

--- a/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v2.rs
@@ -168,7 +168,7 @@ pub const DRIVE_IDENTITY_METHOD_VERSIONS_V2: DriveIdentityMethodVersions =
                 },
             },
             calculate_current_withdrawal_limit: 1, // changed in v14: daily maximum is a percentage of the total credits a day ago
-            record_total_credits_history: 0,
-            fetch_total_credits_in_platform_a_day_ago: 0,
+            record_total_credits_history: Some(0), // new in v14: total credits history for the day-lagged daily withdrawal limit
+            fetch_total_credits_in_platform_a_day_ago: Some(0), // new in v14
         },
     };

--- a/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v2.rs
@@ -13,17 +13,25 @@ use crate::version::drive_versions::drive_identity_method_versions::{
     DriveIdentityWithdrawalTransactionQueueMethodVersions,
 };
 
-/// V2 is protocol version 14's identity-method table. It differs from V1
-/// in exactly one flip:
-/// `withdrawals.document.find_withdrawal_documents_by_status_and_transaction_indices`
-/// 0 -> 1, selecting the v1 withdrawal-by-transaction-index query builder
-/// that carries the transaction-index `In` clause in
-/// `InternalClauses.in_clauses` instead of smuggling it through
-/// `equal_clauses`. The two builders lower to the identical grovedb path
-/// query (pinned by
-/// `withdrawal_in_clause_placement_equivalence` in rs-drive's
-/// query tests), so this is a structural version bump, not a behavior
-/// change; v0 stays byte-frozen for protocol versions up to 13.
+/// V2 is protocol version 14's identity-method table. It differs from V1 in
+/// its withdrawal methods:
+///
+/// * `withdrawals.document.find_withdrawal_documents_by_status_and_transaction_indices`
+///   0 -> 1, selecting the v1 withdrawal-by-transaction-index query builder
+///   that carries the transaction-index `In` clause in
+///   `InternalClauses.in_clauses` instead of smuggling it through
+///   `equal_clauses`. The two builders lower to the identical grovedb path
+///   query (pinned by `withdrawal_in_clause_placement_equivalence` in
+///   rs-drive's query tests), so this is a structural version bump, not a
+///   behavior change; v0 stays byte-frozen for protocol versions up to 13.
+/// * `withdrawals.calculate_current_withdrawal_limit` 0 -> 1: the daily
+///   maximum derives from the total credits Platform held a day ago (the
+///   relative daily withdrawal limit) instead of the current total.
+/// * `withdrawals.record_total_credits_history` and
+///   `withdrawals.fetch_total_credits_in_platform_a_day_ago` `None -> Some(0)`:
+///   the per-block total credits history under the withdrawals tree that the
+///   lagged limit reads; the subtree does not exist before v14, so V1 keeps
+///   both slots `None`.
 pub const DRIVE_IDENTITY_METHOD_VERSIONS_V2: DriveIdentityMethodVersions =
     DriveIdentityMethodVersions {
         fetch: DriveIdentityFetchMethodVersions {

--- a/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v2.rs
@@ -167,6 +167,8 @@ pub const DRIVE_IDENTITY_METHOD_VERSIONS_V2: DriveIdentityMethodVersions =
                     move_broadcasted_withdrawal_transactions_back_to_queue_operations: 0,
                 },
             },
-            calculate_current_withdrawal_limit: 0,
+            calculate_current_withdrawal_limit: 1, // changed in v14: daily maximum is a percentage of the total credits a day ago
+            record_total_credits_history: 0,
+            fetch_total_credits_in_platform_a_day_ago: 0,
         },
     };

--- a/packages/rs-platform-version/src/version/mocks/v2_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v2_test.rs
@@ -509,7 +509,7 @@ pub const TEST_PLATFORM_V2: PlatformVersion = PlatformVersion {
         withdrawal_transactions_per_block_limit: 4,
         retry_signing_expired_withdrawal_documents_per_block_limit: 1,
         max_withdrawal_amount: 50_000_000_000_000,
-        daily_withdrawal_limit: 200_000_000_000_000, //2000 Dash
+        daily_withdrawal_limit_percent: None,
         min_withdrawal_amount: 190_000,
         max_contract_group_size: 256,
         max_token_redemption_cycles: 128,

--- a/packages/rs-platform-version/src/version/mocks/v2_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v2_test.rs
@@ -510,6 +510,7 @@ pub const TEST_PLATFORM_V2: PlatformVersion = PlatformVersion {
         retry_signing_expired_withdrawal_documents_per_block_limit: 1,
         max_withdrawal_amount: 50_000_000_000_000,
         daily_withdrawal_limit_percent: None,
+        max_daily_withdrawal_amount: None,
         min_withdrawal_amount: 190_000,
         max_contract_group_size: 256,
         max_token_redemption_cycles: 128,

--- a/packages/rs-platform-version/src/version/mocks/v3_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v3_test.rs
@@ -123,6 +123,7 @@ pub const TEST_PLATFORM_V3: PlatformVersion = PlatformVersion {
                 rebroadcast_expired_withdrawal_documents: 1,
                 append_signatures_and_broadcast_withdrawal_transactions: 0,
                 cleanup_expired_locks_of_withdrawal_amounts: 0,
+                record_total_credits_history_for_withdrawals: None,
             },
             voting: DriveAbciVotingMethodVersions {
                 keep_record_of_finished_contested_resource_vote_poll: 0,

--- a/packages/rs-platform-version/src/version/system_limits/mod.rs
+++ b/packages/rs-platform-version/src/version/system_limits/mod.rs
@@ -58,12 +58,15 @@ pub struct SystemLimits {
     pub withdrawal_transactions_per_block_limit: u16,
     pub retry_signing_expired_withdrawal_documents_per_block_limit: u16,
     pub max_withdrawal_amount: u64,
-    /// Flat cap (in credits) on the total amount Platform pools into asset unlock transactions
-    /// per 24 hours. Read by `daily_withdrawal_limit` method version 1 (protocol version 8 and
-    /// later); method version 0 (protocol versions 1–7) derived the limit from the total credits
-    /// in Platform instead and ignores this field. Versioned: see `daily_withdrawal_limit` in
+    /// Daily withdrawal limit as a percentage of the total credits Platform held a day ago.
+    /// From protocol version 14 Platform pools at most this share of the total credits recorded
+    /// at the latest block at least 24 hours before the current one into asset unlock
+    /// transactions per 24 hours (`daily_withdrawal_limit` method version 2; the history is
+    /// kept by `record_total_credits_history_for_withdrawals`). `None` for the protocol versions
+    /// that predate the rule: method version 0 derived the limit from the current total, method
+    /// version 1 applied a flat 2000 Dash. Versioned: see `daily_withdrawal_limit_percent` in
     /// each `SYSTEM_LIMITS_V*`.
-    pub daily_withdrawal_limit: u64,
+    pub daily_withdrawal_limit_percent: Option<u8>,
     /// Minimum net amount (in credits) a withdrawal may send to Core, shared by the
     /// transparent (identity + address) and shielded withdrawal paths. The dust floor that
     /// keeps Core from rejecting the resulting `TxOut`. Versioned: see `min_withdrawal_amount`

--- a/packages/rs-platform-version/src/version/system_limits/mod.rs
+++ b/packages/rs-platform-version/src/version/system_limits/mod.rs
@@ -67,6 +67,13 @@ pub struct SystemLimits {
     /// version 1 applied a flat 2000 Dash. Versioned: see `daily_withdrawal_limit_percent` in
     /// each `SYSTEM_LIMITS_V*`.
     pub daily_withdrawal_limit_percent: Option<u8>,
+    /// Upper bound (in credits) of the relative daily withdrawal limit from protocol version 14:
+    /// Core's credit-pool unlock capacity per day, `LimitAmountV24` = 4000 Dash per 576-block
+    /// window (Core v24). Platform cannot usefully pool more than Core will mine — the excess
+    /// only cycles through expiry and re-signing — so the limit never exceeds this whatever the
+    /// total credits are; raise it together with Core. Must be at least `max_withdrawal_amount`.
+    /// `None` for the protocol versions that predate the relative rule.
+    pub max_daily_withdrawal_amount: Option<u64>,
     /// Minimum net amount (in credits) a withdrawal may send to Core, shared by the
     /// transparent (identity + address) and shielded withdrawal paths. The dust floor that
     /// keeps Core from rejecting the resulting `TxOut`. Versioned: see `min_withdrawal_amount`

--- a/packages/rs-platform-version/src/version/system_limits/v1.rs
+++ b/packages/rs-platform-version/src/version/system_limits/v1.rs
@@ -26,8 +26,8 @@ pub const SYSTEM_LIMITS_V1: SystemLimits = SystemLimits {
     max_transitions_in_documents_batch: 1,
     withdrawal_transactions_per_block_limit: 4,
     retry_signing_expired_withdrawal_documents_per_block_limit: 1,
-    max_withdrawal_amount: 50_000_000_000_000,   //500 Dash
-    daily_withdrawal_limit: 200_000_000_000_000, //2000 Dash (Core v22 limit; unused before protocol version 8)
+    max_withdrawal_amount: 50_000_000_000_000, //500 Dash
+    daily_withdrawal_limit_percent: None,      // relative daily withdrawal limit arrives in v14
     // = dpp MIN_WITHDRAWAL_AMOUNT: ASSET_UNLOCK_TX_SIZE(190) * MIN_CORE_FEE_PER_BYTE(1)
     // * CREDITS_PER_DUFF(1000) = 190_000 credits = 190 duffs.
     min_withdrawal_amount: 190_000,

--- a/packages/rs-platform-version/src/version/system_limits/v1.rs
+++ b/packages/rs-platform-version/src/version/system_limits/v1.rs
@@ -28,6 +28,7 @@ pub const SYSTEM_LIMITS_V1: SystemLimits = SystemLimits {
     retry_signing_expired_withdrawal_documents_per_block_limit: 1,
     max_withdrawal_amount: 50_000_000_000_000, //500 Dash
     daily_withdrawal_limit_percent: None,      // relative daily withdrawal limit arrives in v14
+    max_daily_withdrawal_amount: None,
     // = dpp MIN_WITHDRAWAL_AMOUNT: ASSET_UNLOCK_TX_SIZE(190) * MIN_CORE_FEE_PER_BYTE(1)
     // * CREDITS_PER_DUFF(1000) = 190_000 credits = 190 duffs.
     min_withdrawal_amount: 190_000,

--- a/packages/rs-platform-version/src/version/system_limits/v2.rs
+++ b/packages/rs-platform-version/src/version/system_limits/v2.rs
@@ -16,9 +16,9 @@ pub const SYSTEM_LIMITS_V2: SystemLimits = SystemLimits {
     max_transitions_in_documents_batch: 1,
     withdrawal_transactions_per_block_limit: 4,
     retry_signing_expired_withdrawal_documents_per_block_limit: 1,
-    max_withdrawal_amount: 50_000_000_000_000,   //500 Dash
-    daily_withdrawal_limit: 200_000_000_000_000, //2000 Dash (Core v22 limit)
-    min_withdrawal_amount: 1_000_000,            //1000 duffs (raised from 190 in v12)
+    max_withdrawal_amount: 50_000_000_000_000, //500 Dash
+    daily_withdrawal_limit_percent: None,      // relative daily withdrawal limit arrives in v14
+    min_withdrawal_amount: 1_000_000,          //1000 duffs (raised from 190 in v12)
     max_contract_group_size: 256,
     max_token_redemption_cycles: 128,
     // NOTE: the Halo 2 proof grows with the action count (~2,273 B/action on

--- a/packages/rs-platform-version/src/version/system_limits/v2.rs
+++ b/packages/rs-platform-version/src/version/system_limits/v2.rs
@@ -18,7 +18,8 @@ pub const SYSTEM_LIMITS_V2: SystemLimits = SystemLimits {
     retry_signing_expired_withdrawal_documents_per_block_limit: 1,
     max_withdrawal_amount: 50_000_000_000_000, //500 Dash
     daily_withdrawal_limit_percent: None,      // relative daily withdrawal limit arrives in v14
-    min_withdrawal_amount: 1_000_000,          //1000 duffs (raised from 190 in v12)
+    max_daily_withdrawal_amount: None,
+    min_withdrawal_amount: 1_000_000, //1000 duffs (raised from 190 in v12)
     max_contract_group_size: 256,
     max_token_redemption_cycles: 128,
     // NOTE: the Halo 2 proof grows with the action count (~2,273 B/action on

--- a/packages/rs-platform-version/src/version/system_limits/v3.rs
+++ b/packages/rs-platform-version/src/version/system_limits/v3.rs
@@ -20,7 +20,8 @@ pub const SYSTEM_LIMITS_V3: SystemLimits = SystemLimits {
     retry_signing_expired_withdrawal_documents_per_block_limit: 1,
     max_withdrawal_amount: 50_000_000_000_000, //500 Dash
     daily_withdrawal_limit_percent: None,      // relative daily withdrawal limit arrives in v14
-    min_withdrawal_amount: 1_000_000,          //1000 duffs (raised from 190 in v12)
+    max_daily_withdrawal_amount: None,
+    min_withdrawal_amount: 1_000_000, //1000 duffs (raised from 190 in v12)
     max_contract_group_size: 256,
     max_token_redemption_cycles: 128,
     // NOTE: the Halo 2 proof grows with the action count (~2,273 B/action on

--- a/packages/rs-platform-version/src/version/system_limits/v3.rs
+++ b/packages/rs-platform-version/src/version/system_limits/v3.rs
@@ -18,9 +18,9 @@ pub const SYSTEM_LIMITS_V3: SystemLimits = SystemLimits {
     max_transitions_in_documents_batch: 1,
     withdrawal_transactions_per_block_limit: 4,
     retry_signing_expired_withdrawal_documents_per_block_limit: 1,
-    max_withdrawal_amount: 50_000_000_000_000,   //500 Dash
-    daily_withdrawal_limit: 200_000_000_000_000, //2000 Dash (Core v22 limit)
-    min_withdrawal_amount: 1_000_000,            //1000 duffs (raised from 190 in v12)
+    max_withdrawal_amount: 50_000_000_000_000, //500 Dash
+    daily_withdrawal_limit_percent: None,      // relative daily withdrawal limit arrives in v14
+    min_withdrawal_amount: 1_000_000,          //1000 duffs (raised from 190 in v12)
     max_contract_group_size: 256,
     max_token_redemption_cycles: 128,
     // NOTE: the Halo 2 proof grows with the action count (~2,273 B/action on

--- a/packages/rs-platform-version/src/version/system_limits/v4.rs
+++ b/packages/rs-platform-version/src/version/system_limits/v4.rs
@@ -2,10 +2,11 @@ use crate::version::system_limits::SystemLimits;
 
 /// System limits for protocol version 14 and above.
 ///
-/// Identical to [`super::v3::SYSTEM_LIMITS_V3`] except that `daily_withdrawal_limit` is raised
-/// from 2000 Dash to 4000 Dash, matching Core's doubled credit-pool unlock limit
-/// (`LimitAmountV24`, DIP-0165, dashpay/dash#6662). v13 is already live on networks with the
-/// 2000 Dash limit, so the change gates here.
+/// Identical to [`super::v3::SYSTEM_LIMITS_V3`] except that the daily withdrawal limit becomes
+/// relative: `daily_withdrawal_limit_percent` is set to 15, so Platform pools at most 15% of the
+/// total credits it held a day ago into asset unlock transactions per 24 hours, instead of the
+/// flat 2000 Dash that applied from v8 (matching Core v22's `LimitAmountV22`). v13 is already
+/// live on networks with the flat limit, so the change gates here.
 pub const SYSTEM_LIMITS_V4: SystemLimits = SystemLimits {
     estimated_contract_max_serialized_size: 16384,
     max_field_value_size: 5120, //5 KiB
@@ -18,9 +19,9 @@ pub const SYSTEM_LIMITS_V4: SystemLimits = SystemLimits {
     max_transitions_in_documents_batch: 1,
     withdrawal_transactions_per_block_limit: 4,
     retry_signing_expired_withdrawal_documents_per_block_limit: 1,
-    max_withdrawal_amount: 50_000_000_000_000,   //500 Dash
-    daily_withdrawal_limit: 400_000_000_000_000, //4000 Dash (Core v24 limit; raised from 2000 in v14)
-    min_withdrawal_amount: 1_000_000,            //1000 duffs (raised from 190 in v12)
+    max_withdrawal_amount: 50_000_000_000_000, //500 Dash
+    daily_withdrawal_limit_percent: Some(15), // 15% of the total credits a day ago (replaces the flat 2000 Dash in v14)
+    min_withdrawal_amount: 1_000_000,         //1000 duffs (raised from 190 in v12)
     max_contract_group_size: 256,
     max_token_redemption_cycles: 128,
     // NOTE: the Halo 2 proof grows with the action count (~2,273 B/action on

--- a/packages/rs-platform-version/src/version/system_limits/v4.rs
+++ b/packages/rs-platform-version/src/version/system_limits/v4.rs
@@ -4,9 +4,11 @@ use crate::version::system_limits::SystemLimits;
 ///
 /// Identical to [`super::v3::SYSTEM_LIMITS_V3`] except that the daily withdrawal limit becomes
 /// relative: `daily_withdrawal_limit_percent` is set to 15, so Platform pools at most 15% of the
-/// total credits it held a day ago into asset unlock transactions per 24 hours, instead of the
-/// flat 2000 Dash that applied from v8 (matching Core v22's `LimitAmountV22`). v13 is already
-/// live on networks with the flat limit, so the change gates here.
+/// total credits it held a day ago into asset unlock transactions per 24 hours — never below one
+/// maximal withdrawal and never above `max_daily_withdrawal_amount`, Core's 4000 Dash unlock
+/// capacity per day — instead of the flat 2000 Dash that applied from v8 (matching Core v22's
+/// `LimitAmountV22`). v13 is already live on networks with the flat limit, so the change gates
+/// here.
 pub const SYSTEM_LIMITS_V4: SystemLimits = SystemLimits {
     estimated_contract_max_serialized_size: 16384,
     max_field_value_size: 5120, //5 KiB
@@ -21,7 +23,8 @@ pub const SYSTEM_LIMITS_V4: SystemLimits = SystemLimits {
     retry_signing_expired_withdrawal_documents_per_block_limit: 1,
     max_withdrawal_amount: 50_000_000_000_000, //500 Dash
     daily_withdrawal_limit_percent: Some(15), // 15% of the total credits a day ago (replaces the flat 2000 Dash in v14)
-    min_withdrawal_amount: 1_000_000,         //1000 duffs (raised from 190 in v12)
+    max_daily_withdrawal_amount: Some(400_000_000_000_000), // 4000 Dash: Core's unlock capacity per day (LimitAmountV24)
+    min_withdrawal_amount: 1_000_000,                       //1000 duffs (raised from 190 in v12)
     max_contract_group_size: 256,
     max_token_redemption_cycles: 128,
     // NOTE: the Halo 2 proof grows with the action count (~2,273 B/action on

--- a/packages/rs-platform-version/src/version/v14.rs
+++ b/packages/rs-platform-version/src/version/v14.rs
@@ -71,7 +71,10 @@ pub const PROTOCOL_VERSION_14: ProtocolVersion = 14;
 ///    (`SYSTEM_LIMITS_V4.daily_withdrawal_limit_percent`, read by
 ///    `daily_withdrawal_limit` v2 through `DPP_METHOD_VERSIONS_V3`), never below
 ///    one maximal withdrawal (`max_withdrawal_amount`) so every accepted
-///    withdrawal eventually fits and cannot block the pooling queue. The base is
+///    withdrawal eventually fits and cannot block the pooling queue, and never
+///    above `max_daily_withdrawal_amount` (4000 Dash, Core's unlock capacity per
+///    day under V24) since pooling more than Core mines only cycles through
+///    expiry and re-signing. The base is
 ///    the total credits recorded at the latest block at least 24 hours before
 ///    the current one: `DRIVE_ABCI_METHOD_VERSIONS_V10` turns on
 ///    `record_total_credits_history_for_withdrawals`, which checks the total
@@ -88,7 +91,8 @@ pub const PROTOCOL_VERSION_14: ProtocolVersion = 14;
 ///    exactly as before. Core's own unlock limit is unaffected: pre-V24 Core
 ///    caps unlocks at `LimitAmountV22` (2000 Dash) per *block*, with the amount
 ///    checked only at block level, so any daily total is still minable across
-///    blocks; after V24 it enforces 4000 Dash per 576-block window.
+///    blocks; after V24 it enforces 4000 Dash per 576-block window, which the
+///    cap above never exceeds.
 ///
 /// The first two are orthogonal by construction: the ranked upgrade decides the
 /// *property-name* tree type, the demotion decides the *value* tree type

--- a/packages/rs-platform-version/src/version/v14.rs
+++ b/packages/rs-platform-version/src/version/v14.rs
@@ -69,23 +69,26 @@ pub const PROTOCOL_VERSION_14: ProtocolVersion = 14;
 /// 4. **Relative daily withdrawal limit**: the flat 2000 Dash per 24 hours that
 ///    applied from v8 becomes 15% of the total credits Platform held a day ago
 ///    (`SYSTEM_LIMITS_V4.daily_withdrawal_limit_percent`, read by
-///    `daily_withdrawal_limit` v2 through `DPP_METHOD_VERSIONS_V3`). The base is
+///    `daily_withdrawal_limit` v2 through `DPP_METHOD_VERSIONS_V3`), never below
+///    one maximal withdrawal (`max_withdrawal_amount`) so every accepted
+///    withdrawal eventually fits and cannot block the pooling queue. The base is
 ///    the total credits recorded at the latest block at least 24 hours before
 ///    the current one: `DRIVE_ABCI_METHOD_VERSIONS_V10` turns on
 ///    `record_total_credits_history_for_withdrawals`, which checks the total
-///    credits every block, writes it under the withdrawals tree keyed by block
-///    time whenever it changed (an entry describes the total until the next
-///    one) and prunes entries older than the one the limit reads, and
-///    `DRIVE_VERSION_V9`'s identity withdrawal table bumps
-///    `calculate_current_withdrawal_limit` to 1 to read that lagged value
-///    (falling back to the oldest recorded one while the history is younger
-///    than a day, i.e. right after activation). The lag is the guardrail: a
-///    sudden jump in the total credits does not raise the limit for a day.
-///    Amounts already pooled in the last 24 hours keep counting against the
-///    maximum exactly as before. Core's own unlock limit is unaffected: pre-V24
-///    Core caps unlocks at `LimitAmountV22` (2000 Dash) per *block*, with the
-///    amount checked only at block level, so any daily total is still minable
-///    across blocks; after V24 it enforces 4000 Dash per 576-block window.
+///    credits every block once fees and epoch rewards are in, writes it under
+///    the withdrawals tree keyed by block time whenever it changed (an entry
+///    describes the total until the next one) and prunes entries older than the
+///    one the limit reads, and `DRIVE_VERSION_V9`'s identity withdrawal table
+///    bumps `calculate_current_withdrawal_limit` to 1 to read that lagged
+///    value. Until an entry is a day old — the first day after activation — the
+///    flat 2000 Dash keeps applying, so the lag cannot be skipped by inflating
+///    the total before or at activation. The lag is the guardrail: a sudden
+///    jump in the total credits does not raise the limit for a day. Amounts
+///    already pooled in the last 24 hours keep counting against the maximum
+///    exactly as before. Core's own unlock limit is unaffected: pre-V24 Core
+///    caps unlocks at `LimitAmountV22` (2000 Dash) per *block*, with the amount
+///    checked only at block level, so any daily total is still minable across
+///    blocks; after V24 it enforces 4000 Dash per 576-block window.
 ///
 /// The first two are orthogonal by construction: the ranked upgrade decides the
 /// *property-name* tree type, the demotion decides the *value* tree type

--- a/packages/rs-platform-version/src/version/v14.rs
+++ b/packages/rs-platform-version/src/version/v14.rs
@@ -5,7 +5,7 @@ use crate::version::dpp_versions::dpp_costs_versions::v1::DPP_COSTS_VERSIONS_V1;
 use crate::version::dpp_versions::dpp_document_versions::v3::DOCUMENT_VERSIONS_V3;
 use crate::version::dpp_versions::dpp_factory_versions::v1::DPP_FACTORY_VERSIONS_V1;
 use crate::version::dpp_versions::dpp_identity_versions::v1::IDENTITY_VERSIONS_V1;
-use crate::version::dpp_versions::dpp_method_versions::v2::DPP_METHOD_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_method_versions::v3::DPP_METHOD_VERSIONS_V3;
 use crate::version::dpp_versions::dpp_state_transition_conversion_versions::v2::STATE_TRANSITION_CONVERSION_VERSIONS_V2;
 use crate::version::dpp_versions::dpp_state_transition_method_versions::v1::STATE_TRANSITION_METHOD_VERSIONS_V1;
 use crate::version::dpp_versions::dpp_state_transition_serialization_versions::v2::STATE_TRANSITION_SERIALIZATION_VERSIONS_V2;
@@ -15,11 +15,11 @@ use crate::version::dpp_versions::dpp_validation_versions::v5::DPP_VALIDATION_VE
 use crate::version::dpp_versions::dpp_voting_versions::v2::VOTING_VERSION_V2;
 use crate::version::dpp_versions::DPPVersion;
 use crate::version::drive_abci_versions::drive_abci_checkpoint_parameters::v1::DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1;
-use crate::version::drive_abci_versions::drive_abci_method_versions::v9::DRIVE_ABCI_METHOD_VERSIONS_V9;
+use crate::version::drive_abci_versions::drive_abci_method_versions::v10::DRIVE_ABCI_METHOD_VERSIONS_V10;
 use crate::version::drive_abci_versions::drive_abci_query_versions::v3::DRIVE_ABCI_QUERY_VERSIONS_V3;
 use crate::version::drive_abci_versions::drive_abci_structure_versions::v1::DRIVE_ABCI_STRUCTURE_VERSIONS_V1;
 use crate::version::drive_abci_versions::drive_abci_validation_versions::v10::DRIVE_ABCI_VALIDATION_VERSIONS_V10;
-use crate::version::drive_abci_versions::drive_abci_withdrawal_constants::v2::DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2;
+use crate::version::drive_abci_versions::drive_abci_withdrawal_constants::v3::DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V3;
 use crate::version::drive_abci_versions::DriveAbciVersion;
 use crate::version::drive_versions::v9::DRIVE_VERSION_V9;
 use crate::version::fee::v2::FEE_VERSION2;
@@ -66,19 +66,25 @@ pub const PROTOCOL_VERSION_14: ProtocolVersion = 14;
 ///    the contest was created on — which halts the chain when that poll
 ///    ends — or open a contest for a document that is not a contested
 ///    resource at all.
-/// 4. **Daily withdrawal limit 2000 → 4000 Dash**: `SYSTEM_LIMITS_V4` raises
-///    `daily_withdrawal_limit`, doubling the amount of credits Platform pools
-///    into asset unlock transactions per 24 hours (the `daily_withdrawal_limit`
-///    method stays at v1, which reads that system limit). This
-///    mirrors Core's doubled credit-pool unlock limit (`LimitAmountV24`,
-///    DIP-0165, dashpay/dash#6662), which Core gates on its own
-///    `DEPLOYMENT_V24` hard fork. v14 does not have to wait for that fork:
-///    pre-V24 Core caps unlocks at `LimitAmountV22` (2000 Dash) per *block*
-///    (no sliding window — the window only arrives with V24), and its mempool
-///    does not check the amount at all, so a day's 4000 Dash is still fully
-///    minable; unlocks above 2000 in one Core block simply wait for the next
-///    one. After V24, Core enforces 4000 Dash per 576-block window, which
-///    matches this limit.
+/// 4. **Relative daily withdrawal limit**: the flat 2000 Dash per 24 hours that
+///    applied from v8 becomes 15% of the total credits Platform held a day ago
+///    (`SYSTEM_LIMITS_V4.daily_withdrawal_limit_percent`, read by
+///    `daily_withdrawal_limit` v2 through `DPP_METHOD_VERSIONS_V3`). The base is
+///    the total credits recorded at the latest block at least 24 hours before
+///    the current one: `DRIVE_ABCI_METHOD_VERSIONS_V10` turns on
+///    `record_total_credits_history_for_withdrawals`, which writes the total
+///    credits under the withdrawals tree keyed by block time every block and
+///    prunes entries older than the one the limit reads, and
+///    `DRIVE_VERSION_V9`'s identity withdrawal table bumps
+///    `calculate_current_withdrawal_limit` to 1 to read that lagged value
+///    (falling back to the oldest recorded one while the history is younger
+///    than a day, i.e. right after activation). The lag is the guardrail: a
+///    sudden jump in the total credits does not raise the limit for a day.
+///    Amounts already pooled in the last 24 hours keep counting against the
+///    maximum exactly as before. Core's own unlock limit is unaffected: pre-V24
+///    Core caps unlocks at `LimitAmountV22` (2000 Dash) per *block*, with the
+///    amount checked only at block level, so any daily total is still minable
+///    across blocks; after V24 it enforces 4000 Dash per 576-block window.
 ///
 /// The first two are orthogonal by construction: the ranked upgrade decides the
 /// *property-name* tree type, the demotion decides the *value* tree type
@@ -89,7 +95,7 @@ pub const PROTOCOL_VERSION_14: ProtocolVersion = 14;
 ///
 /// Until a contract uses the ranked grammar, the only v14 behavior changes
 /// are the shared-prefix fix, the contested-index cross-check, the
-/// index-reorder schema-compatibility fix and the doubled daily withdrawal
+/// index-reorder schema-compatibility fix and the relative daily withdrawal
 /// limit; everything else matches v13:
 ///
 /// * `CONTRACT_VERSIONS_V6` points `document_type_schema` at the v3 document
@@ -140,9 +146,9 @@ pub const PLATFORM_V14: PlatformVersion = PlatformVersion {
     drive: DRIVE_VERSION_V9, // changed: drive document method versions v4 — v2 index walkers (shared-prefix aggregate indexes become insertable) + the detect_ranked_mode slot
     drive_abci: DriveAbciVersion {
         structs: DRIVE_ABCI_STRUCTURE_VERSIONS_V1,
-        methods: DRIVE_ABCI_METHOD_VERSIONS_V9,
+        methods: DRIVE_ABCI_METHOD_VERSIONS_V10, // changed: records the per-block total credits history for the daily withdrawal limit
         validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V10, // changed: contested-index cross-check + refersTo document reference validation
-        withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2,
+        withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V3, // changed: prune bound for the total credits history
         query: DRIVE_ABCI_QUERY_VERSIONS_V3, // changed: ranked + boolean-HAVING routing gate
         checkpoints: DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1,
     },
@@ -159,12 +165,12 @@ pub const PLATFORM_V14: PlatformVersion = PlatformVersion {
         voting_versions: VOTING_VERSION_V2,
         token_versions: TOKEN_VERSIONS_V2,
         asset_lock_versions: DPP_ASSET_LOCK_VERSIONS_V1,
-        methods: DPP_METHOD_VERSIONS_V2,
+        methods: DPP_METHOD_VERSIONS_V3, // changed: daily_withdrawal_limit v2 — a percentage of the total credits a day ago
         factory_versions: DPP_FACTORY_VERSIONS_V1,
     },
     system_data_contracts: SYSTEM_DATA_CONTRACT_VERSIONS_V3, // changed: DashPay v2 adds profile payment address fields (DIP-33)
     fee_version: FEE_VERSION2,
-    system_limits: SYSTEM_LIMITS_V4, // changed: daily_withdrawal_limit 2000 → 4000 Dash, matching Core's LimitAmountV24
+    system_limits: SYSTEM_LIMITS_V4, // changed: daily withdrawal limit becomes 15% of the total credits a day ago
     consensus: ConsensusVersions {
         tenderdash_consensus_version: 1,
     },

--- a/packages/rs-platform-version/src/version/v14.rs
+++ b/packages/rs-platform-version/src/version/v14.rs
@@ -72,9 +72,10 @@ pub const PROTOCOL_VERSION_14: ProtocolVersion = 14;
 ///    `daily_withdrawal_limit` v2 through `DPP_METHOD_VERSIONS_V3`). The base is
 ///    the total credits recorded at the latest block at least 24 hours before
 ///    the current one: `DRIVE_ABCI_METHOD_VERSIONS_V10` turns on
-///    `record_total_credits_history_for_withdrawals`, which writes the total
-///    credits under the withdrawals tree keyed by block time every block and
-///    prunes entries older than the one the limit reads, and
+///    `record_total_credits_history_for_withdrawals`, which checks the total
+///    credits every block, writes it under the withdrawals tree keyed by block
+///    time whenever it changed (an entry describes the total until the next
+///    one) and prunes entries older than the one the limit reads, and
 ///    `DRIVE_VERSION_V9`'s identity withdrawal table bumps
 ///    `calculate_current_withdrawal_limit` to 1 to read that lagged value
 ///    (falling back to the oldest recorded one while the history is younger


### PR DESCRIPTION
## Issue being fixed or feature implemented

The daily withdrawal limit is a flat amount (2000 Dash since PV8, 4000 Dash in the unreleased PV14 after #4452). With the current volume of Platform → Core withdrawals the flat cap is hit routinely, transfers sit "pending" for hours, and a flat number needs a protocol bump every time Platform grows. It exists as a guardrail against an undiscovered inflation bug, so it should scale with what Platform actually holds — but lag behind it, so a sudden jump in the total cannot lift the limit immediately.

This makes the limit relative for PV14: **Platform pools at most 15% of the total credits it held a day ago into asset unlock transactions per 24 hours**, never below one maximal withdrawal (`max_withdrawal_amount`, 500 Dash), never above Core's unlock capacity per day (`max_daily_withdrawal_amount`, 4000 Dash = `LimitAmountV24`), and with the flat 2000 Dash still applying for the first day after activation while no recorded total is a day old yet. Amounts pooled in the last 24 hours keep counting against the maximum exactly as before; only the base of the maximum changes.

## What was done?

**Rule (`rs-dpp`)** — `daily_withdrawal_limit` v2 takes the day-old total as an `Option`: `Some(total)` → `min(max(daily_withdrawal_limit_percent × total, max_withdrawal_amount), max_daily_withdrawal_amount)` (percent and cap are new `SystemLimits` fields, `Some(15)` / `Some(4000 Dash)` in `SYSTEM_LIMITS_V4`, `None` before; the floor guarantees every accepted withdrawal eventually fits and cannot block the FIFO pooling queue behind it; the cap is Core's credit-pool unlock capacity per day — pooling more than Core mines only cycles unlocks through expiry and re-signing — and is raised together with Core); `None` (no recorded total is a day old yet, i.e. the first day after activation) → the flat 2000 Dash of v1, so the 24h lag cannot be skipped by inflating the total before or at activation. v1 goes back to a frozen `const fn` of 2000 Dash, since that flat value is now history and never changes again (`SystemLimits::daily_withdrawal_limit` from #4452 is removed). `DPP_METHOD_VERSIONS_V3` (new, PV14) selects v2.

**Base (`rs-drive`)** — Platform keeps no history of its total credits, so PV14 adds one under the withdrawals root tree (`WITHDRAWAL_TOTAL_CREDITS_HISTORY_KEY = [4]`): key = block time (ms, big-endian), value = `TOTAL_SYSTEM_CREDITS` at the end of that block's state transitions, written **only when the total changed** — the limit reads the entry in force a day ago and an entry describes the total until the next one, so a block that leaves the total untouched (document traffic and fees don't move it; asset locks, withdrawals and epoch core rewards do) costs one reverse `limit 1` read and no write.
* `Drive::record_total_credits_history` — compares with the latest entry, and on a change inserts this block's entry and prunes, bounded, every entry older than the one the limit reads this block (so the reference entry is never pruned, even across a chain halt).
* `Drive::fetch_total_credits_in_platform_a_day_ago` — the entry recorded at the latest block at least 24h before the given time (`RangeToInclusive(..=now-24h)`, reverse, limit 1); `None` while no entry is that old (no younger fallback).
* `calculate_current_withdrawal_limit` v1 — hands that lagged total (or `None`) to `daily_withdrawal_limit`, keeps `available = daily_maximum - pooled_in_last_24h`. The dispatcher now takes `&BlockInfo`.
* The tree is created at genesis for PV ≥ 14 (`add_initial_withdrawal_state_structure_operations`) and by `transition_to_version_14` for upgrading networks.

**Per-block event (`rs-drive-abci`)** — `record_total_credits_history_for_withdrawals` (`OptionalFeatureVersion`, `Some(0)` in the new `DRIVE_ABCI_METHOD_VERSIONS_V10`, `None` before) runs in `run_block_proposal` after `process_block_fees_and_validate_sum_trees` — the last thing in a block that can move the total (epoch Core rewards land there) — and before the app hash is taken, so the entry carries the block's final total and is part of its state; it only writes when the total moved. `DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V3` adds `total_credits_history_prune_limit: 64`.

**Tables** — `DRIVE_VERSION_V9` (PV14's own) bumps `calculate_current_withdrawal_limit` to 1 and gains the two new slots as `OptionalFeatureVersion` (`Some(0)` in V2, `None` in V1, whose dispatchers return `VersionNotActive` — the history subtree does not exist before PV14); PV13 and earlier keep every table they shipped with, so replay is unchanged. PV14's doc header describes the rule.

### Why a day-old base
`TOTAL_SYSTEM_CREDITS` is the tracked total (it grows with asset locks and epoch core rewards, shrinks when withdrawal state transitions execute). Reading it live would let an inflated total raise the limit at once; the 24h lag gives a day to notice — including across activation, which is why the first day keeps the old flat limit instead of using a younger total. Same-day inflows do not raise the limit either; the percent is meant to be generous enough (today ~30k Dash held → ~4500 Dash/day, up from 2000).

### Core
Unchanged and not a dependency: pre-V24 Core caps unlocks at `LimitAmountV22` (2000 Dash) **per block** (`min(credit_pool, 2000)`, no sliding window — the window only arrives with V24) and checks the amount only at block level, so any daily total is minable across blocks; after V24 Core enforces 4000 Dash per 576-block window, which `max_daily_withdrawal_amount` never exceeds. Today's mainnet total (~30k Dash) would give 4500 Dash/day uncapped, so the effective limit there is the 4000 cap until Core raises its capacity; the percent governs below ~26.7k Dash.

## How Has This Been Tested?

* `cargo test -p dpp --all-features daily_withdrawal_limit` — v2 formula, `None` percent error, PV13 flat vs PV14 relative through the dispatcher.
* `cargo test -p drive` (withdrawals) — history record (incl. no write when the total is unchanged)/prune bounds, a-day-ago lookup incl. oldest fallback and the inclusive 24h boundary, `calculate_current_withdrawal_limit` v1 lag behaviour.
* `cargo test -p drive-abci --lib` — event records/no-ops by slot, `transition_to_version_14` creates the tree idempotently.
* `cargo test -p drive-abci --test strategy_tests should_record_the_total_credits_history_after_epoch_core_rewards` — production-path regression: hourly blocks, one-day epochs, +1 Core height per block; the history entry keyed by the epoch-change block (block 25) holds the post-reward total and the only earlier entry is genesis — written before fee processing, the reward would be keyed a block later and this fails.
* `cargo test -p drive-abci --test strategy_tests should_cap_withdrawals_at_the_relative_daily_limit` — new PV14 chain test cloned from the flat-limit one: 80 withdrawals of 50 Dash against 10,100 Dash held; day one still runs under the flat 2000 Dash (40 pool, 40 queue, 2000 locked); once a recorded total is a day old the reference is the 6,100 Dash left → 915 Dash/day, and after the first locks expire 18 more pool (58 broadcast / 22 queued / 900 locked); all 80 broadcast over the following 250 hourly blocks. The existing TEST_PLATFORM_V3 withdrawal tests are unchanged.
* `cargo check --workspace --all-targets`, clippy `-D warnings` on the touched crates.

## Breaking Changes

Consensus change gated on PV14: the amount of withdrawals pooled per day changes, and the withdrawals root tree gains a child (state root differs from PV14 builds before this PR). PV14 is unreleased.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Protocol version 14 introduces a dynamic daily withdrawal limit based on 15% of platform credits recorded at least 24 hours earlier.
  * Limits include a 2,000-Dash minimum bootstrap amount and a 4,000-Dash maximum cap.
  * Credit history is recorded after fees and rewards are processed, with automatic retention management.

* **Bug Fixes**
  * Corrected withdrawal-limit calculations to use historical rather than current credit totals.
  * Improved handling when historical data or limit configuration is unavailable.

* **Tests**
  * Added coverage for bootstrap behavior, rounding, minimum and maximum limits, history recording, and withdrawal processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->