### PR TITLE
ci(kotlin-sdk): run tests on dedicated self-hosted runner

### DIFF
--- a/.github/workflows/kotlin-sdk-build.yml
+++ b/.github/workflows/kotlin-sdk-build.yml
@@ -24,6 +24,9 @@ on:
       - 'scripts/tests/**'
       - '.github/workflows/kotlin-sdk-build.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: kotlin-sdk-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -31,45 +34,55 @@ concurrency:
 jobs:
   kotlin-sdk-build:
     name: Kotlin SDK build + tests (x86_64 emulator)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, kotlin-ci]
+    # Fork PRs must not execute on a persistent runner. Keep this guard in sync
+    # with tests-rs-workspace.yml.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
+      || github.event.pull_request.head.repo.owner.login == 'thepastaclaw'
     timeout-minutes: 120
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Preserve target/ and other untracked build outputs between runs.
+          clean: false
+
+      - name: Ensure runner dependencies
+        run: |
+          set -euo pipefail
+
+          MISSING=()
+          for pkg in build-essential cmake curl jq libgmp-dev libssl-dev pkg-config python3 unzip zip; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || MISSING+=("$pkg")
+          done
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "Installing: ${MISSING[*]}"
+            sudo apt-get update -qq
+            sudo apt-get install -qq --yes "${MISSING[@]}"
+          fi
+
+          if ! command -v rustup >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --no-modify-path --default-toolchain none
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
 
       - name: Validate executable SDK parity manifest
         run: |
           python3 scripts/check_sdk_parity_manifest.py
           python3 -m unittest discover -s scripts/tests -p 'test_*.py'
 
-      - name: Free disk space
+      - name: Verify JDK 17
         run: |
-          # The API-35 x86_64 system image + the shielded .so's cargo target
-          # dir (halo2/Orchard) + gradle outputs overflow the ~21 GB free on
-          # the runner root fs, surfacing as "No space left on device" during
-          # system-image install (the emulator then never boots). Reclaim the
-          # large preinstalled toolchains we don't use before building. None of
-          # these are needed by this job (JDK via setup-java, Android SDK via
-          # setup-android, Rust via rustup, NDK reinstalled below).
-          echo "Before:"; df -h /
-          sudo rm -rf \
-            /usr/share/dotnet \
-            /usr/local/.ghcup \
-            /opt/ghc \
-            /opt/hostedtoolcache/CodeQL \
-            /usr/local/lib/android/sdk/ndk \
-            /usr/local/share/powershell \
-            /usr/share/swift \
-            /opt/microsoft 2>/dev/null || true
-          sudo docker image prune --all --force 2>/dev/null || true
-          echo "After:"; df -h /
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '17'
+          JAVA_HOME_RESOLVED=$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")
+          JAVA_VERSION_OUTPUT=$("$JAVA_HOME_RESOLVED/bin/java" -version 2>&1)
+          printf '%s\n' "$JAVA_VERSION_OUTPUT"
+          printf '%s\n' "$JAVA_VERSION_OUTPUT" | grep -Eq 'version "17([.]|\")'
+          echo "JAVA_HOME=$JAVA_HOME_RESOLVED" >> "$GITHUB_ENV"
+          echo "$JAVA_HOME_RESOLVED/bin" >> "$GITHUB_PATH"
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
@@ -85,24 +98,19 @@ jobs:
         with:
           targets: x86_64-linux-android
 
-      - name: Restore cargo cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: kotlin-sdk-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            kotlin-sdk-cargo-
-
-      - name: Install cargo-ndk
-        run: cargo install cargo-ndk --locked
-
-      - name: Install protoc v32.0 (repo-standard; apt's 3.21 breaks tenderdash-proto)
+      - name: Ensure cargo-ndk is installed
         run: |
-          curl -fsSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip
-          sudo unzip -o /tmp/protoc.zip -d /usr/local 'bin/protoc' 'include/*'
+          if ! cargo ndk --version >/dev/null 2>&1; then
+            cargo install cargo-ndk --locked
+          fi
+          cargo ndk --version
+
+      - name: Ensure protoc v32.0 is installed (repo-standard; apt's 3.21 breaks tenderdash-proto)
+        run: |
+          if ! protoc --version 2>/dev/null | grep -qx 'libprotoc 32.0'; then
+            curl -fsSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip
+            sudo unzip -o /tmp/protoc.zip -d /usr/local 'bin/protoc' 'include/*'
+          fi
           protoc --version
 
       - name: Build native library (x86_64, dev profile)
@@ -126,12 +134,12 @@ jobs:
         working-directory: packages/kotlin-sdk
         run: ./gradlew :sdk:compileDebugAndroidTestKotlin --stacktrace
 
-      - name: Enable KVM for emulator
+      - name: Verify KVM access
         run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+          test -c /dev/kvm
+          test -r /dev/kvm
+          test -w /dev/kvm
+          ls -l /dev/kvm
 
       - name: Run instrumented FFI smoke test (API 35 emulator)
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
## Issue being fixed or feature implemented

The Kotlin SDK CI job currently runs on an ephemeral `ubuntu-latest` runner, so every run repeats toolchain setup, restores a large Cargo cache, and rebuilds without a persistent local `target/`. The dedicated `ubuntu-runner-1` host is now provisioned with KVM and the `kotlin-ci` runner label.

## What was done?

- Route the job to `[self-hosted, kotlin-ci]`.
- Copy the persistent-runner fork guard from `tests-rs-workspace.yml` so untrusted fork code is never dispatched to the host.
- Use `actions/checkout` with `clean: false` and remove the hosted cache restore so Cargo, Gradle, and workspace build outputs remain warm locally.
- Replace destructive hosted-runner disk cleanup and the permissive KVM udev rule with explicit JDK 17 and `/dev/kvm` access checks.
- Make Linux build dependencies, Rust, `cargo-ndk`, Android SDK/NDK, and protoc provisioning idempotent for a persistent runner.
- Restrict the workflow token to read-only repository contents.

## How Has This Been Tested?

- Parsed the workflow as YAML and asserted the runner labels, fork guard, persistent checkout setting, and required provisioning/KVM steps.
- `git diff --check`
- `python3 scripts/check_sdk_parity_manifest.py`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (11 tests passed)
- Independent review confirmed that the fork guard matches `tests-rs-workspace.yml` and that Linux `build_android.sh` keeps its Cargo target under the persistent repository workspace.

The first cold/warm runtime benchmark is intentionally left to CI on `ubuntu-runner-1`. Because this PR originates from a fork, the new security guard will skip its Kotlin job; a collaborator must mirror commit `2aba69dee` to a same-repository branch to run that benchmark without weakening the guard.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests — workflow-only change; existing parity tests pass
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any — not applicable
- [ ] I have made corresponding changes to the documentation if needed — not applicable

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Kotlin SDK build automation to run on designated self-hosted infrastructure.
  - Improved pull request validation and access controls.
  - Added checks and setup for required JDK, Rust, `cargo-ndk`, and Protocol Buffers tooling.
  - Enhanced emulator test readiness by validating available KVM access.
  - Preserved build outputs to support more reliable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->