### PR TITLE
ci(kotlin-sdk): run tests on dedicated self-hosted runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,9 +1,11 @@
 # Custom labels carried by this repo's self-hosted runners. Without this,
-# actionlint flags `runs-on: [self-hosted, rust-ci]` as an unknown label
+# actionlint flags `runs-on: [self-hosted, <label>]` as an unknown label
 # because it can't resolve it against the GitHub-hosted runner names.
 #
 # `rust-ci` must be applied to every runner allowed to take the Rust workspace
-# test job (Settings -> Actions -> Runners -> <runner> -> Labels).
+# test job, and `kotlin-ci` to every runner allowed to take the Kotlin SDK job
+# (Settings -> Actions -> Runners -> <runner> -> Labels).
 self-hosted-runner:
   labels:
     - rust-ci
+    - kotlin-ci

--- a/.github/workflows/kotlin-sdk-build.yml
+++ b/.github/workflows/kotlin-sdk-build.yml
@@ -24,6 +24,9 @@ on:
       - 'scripts/tests/**'
       - '.github/workflows/kotlin-sdk-build.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: kotlin-sdk-${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -31,45 +34,55 @@ concurrency:
 jobs:
   kotlin-sdk-build:
     name: Kotlin SDK build + tests (x86_64 emulator)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, kotlin-ci]
+    # Fork PRs must not execute on a persistent runner. Keep this guard in sync
+    # with tests-rs-workspace.yml.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
+      || github.event.pull_request.head.repo.owner.login == 'thepastaclaw'
     timeout-minutes: 120
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Preserve target/ and other untracked build outputs between runs.
+          clean: false
+
+      - name: Ensure runner dependencies
+        run: |
+          set -euo pipefail
+
+          MISSING=()
+          for pkg in build-essential cmake curl jq libgmp-dev libssl-dev pkg-config python3 unzip zip; do
+            dpkg -s "$pkg" >/dev/null 2>&1 || MISSING+=("$pkg")
+          done
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "Installing: ${MISSING[*]}"
+            sudo apt-get update -qq
+            sudo apt-get install -qq --yes "${MISSING[@]}"
+          fi
+
+          if ! command -v rustup >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --no-modify-path --default-toolchain none
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
 
       - name: Validate executable SDK parity manifest
         run: |
           python3 scripts/check_sdk_parity_manifest.py
           python3 -m unittest discover -s scripts/tests -p 'test_*.py'
 
-      - name: Free disk space
+      - name: Verify JDK 17
         run: |
-          # The API-35 x86_64 system image + the shielded .so's cargo target
-          # dir (halo2/Orchard) + gradle outputs overflow the ~21 GB free on
-          # the runner root fs, surfacing as "No space left on device" during
-          # system-image install (the emulator then never boots). Reclaim the
-          # large preinstalled toolchains we don't use before building. None of
-          # these are needed by this job (JDK via setup-java, Android SDK via
-          # setup-android, Rust via rustup, NDK reinstalled below).
-          echo "Before:"; df -h /
-          sudo rm -rf \
-            /usr/share/dotnet \
-            /usr/local/.ghcup \
-            /opt/ghc \
-            /opt/hostedtoolcache/CodeQL \
-            /usr/local/lib/android/sdk/ndk \
-            /usr/local/share/powershell \
-            /usr/share/swift \
-            /opt/microsoft 2>/dev/null || true
-          sudo docker image prune --all --force 2>/dev/null || true
-          echo "After:"; df -h /
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '17'
+          JAVA_HOME_RESOLVED=$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")
+          JAVA_VERSION_OUTPUT=$("$JAVA_HOME_RESOLVED/bin/java" -version 2>&1)
+          printf '%s\n' "$JAVA_VERSION_OUTPUT"
+          printf '%s\n' "$JAVA_VERSION_OUTPUT" | grep -Eq 'version "17([.]|\")'
+          echo "JAVA_HOME=$JAVA_HOME_RESOLVED" >> "$GITHUB_ENV"
+          echo "$JAVA_HOME_RESOLVED/bin" >> "$GITHUB_PATH"
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
@@ -85,24 +98,19 @@ jobs:
         with:
           targets: x86_64-linux-android
 
-      - name: Restore cargo cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: kotlin-sdk-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            kotlin-sdk-cargo-
-
-      - name: Install cargo-ndk
-        run: cargo install cargo-ndk --locked
-
-      - name: Install protoc v32.0 (repo-standard; apt's 3.21 breaks tenderdash-proto)
+      - name: Ensure cargo-ndk is installed
         run: |
-          curl -fsSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip
-          sudo unzip -o /tmp/protoc.zip -d /usr/local 'bin/protoc' 'include/*'
+          if ! cargo ndk --version >/dev/null 2>&1; then
+            cargo install cargo-ndk --locked
+          fi
+          cargo ndk --version
+
+      - name: Ensure protoc v32.0 is installed (repo-standard; apt's 3.21 breaks tenderdash-proto)
+        run: |
+          if ! protoc --version 2>/dev/null | grep -qx 'libprotoc 32.0'; then
+            curl -fsSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip
+            sudo unzip -o /tmp/protoc.zip -d /usr/local 'bin/protoc' 'include/*'
+          fi
           protoc --version
 
       - name: Build native library (x86_64, dev profile)
@@ -126,12 +134,12 @@ jobs:
         working-directory: packages/kotlin-sdk
         run: ./gradlew :sdk:compileDebugAndroidTestKotlin --stacktrace
 
-      - name: Enable KVM for emulator
+      - name: Verify KVM access
         run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+          test -c /dev/kvm
+          test -r /dev/kvm
+          test -w /dev/kvm
+          ls -l /dev/kvm
 
       - name: Run instrumented FFI smoke test (API 35 emulator)
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/kotlin-sdk-build.yml
+++ b/.github/workflows/kotlin-sdk-build.yml
@@ -55,7 +55,7 @@ jobs:
           set -euo pipefail
 
           MISSING=()
-          for pkg in build-essential cmake curl jq libgmp-dev libssl-dev pkg-config python3 unzip zip; do
+          for pkg in build-essential cmake curl jq libgmp-dev libpulse0 libssl-dev libx11-xcb1 pkg-config python3 unzip zip; do
             dpkg -s "$pkg" >/dev/null 2>&1 || MISSING+=("$pkg")
           done
           if [ ${#MISSING[@]} -gt 0 ]; then

--- a/.github/workflows/kotlin-sdk-build.yml
+++ b/.github/workflows/kotlin-sdk-build.yml
@@ -98,20 +98,30 @@ jobs:
         with:
           targets: x86_64-linux-android
 
-      - name: Ensure cargo-ndk is installed
+      # Pinned: this runner is persistent, so an unpinned `cargo install`
+      # leaves whatever version happened to be current on the day it first ran,
+      # and every later job silently builds with it. Assert after installing so
+      # a drifted host fails here instead of somewhere in the NDK build.
+      - name: Ensure cargo-ndk v4.1.2 is installed
         run: |
-          if ! cargo ndk --version >/dev/null 2>&1; then
-            cargo install cargo-ndk --locked
+          set -euo pipefail
+          if ! cargo ndk --version 2>/dev/null | grep -qx 'cargo-ndk 4.1.2'; then
+            cargo install cargo-ndk --version 4.1.2 --locked --force
           fi
           cargo ndk --version
+          cargo ndk --version | grep -qx 'cargo-ndk 4.1.2'
 
       - name: Ensure protoc v32.0 is installed (repo-standard; apt's 3.21 breaks tenderdash-proto)
         run: |
+          set -euo pipefail
           if ! protoc --version 2>/dev/null | grep -qx 'libprotoc 32.0'; then
             curl -fsSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip
             sudo unzip -o /tmp/protoc.zip -d /usr/local 'bin/protoc' 'include/*'
           fi
           protoc --version
+          # A stale protoc earlier on PATH would shadow the one just unpacked
+          # into /usr/local; catch that here rather than in a codegen failure.
+          protoc --version | grep -qx 'libprotoc 32.0'
 
       - name: Build native library (x86_64, dev profile)
         working-directory: packages/kotlin-sdk

--- a/.github/workflows/kotlin-sdk-build.yml
+++ b/.github/workflows/kotlin-sdk-build.yml
@@ -64,11 +64,11 @@ jobs:
             sudo apt-get install -qq --yes "${MISSING[@]}"
           fi
 
-          if ! command -v rustup >/dev/null 2>&1; then
+          if [ ! -x "$HOME/.cargo/bin/rustup" ]; then
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
               | sh -s -- -y --no-modify-path --default-toolchain none
-            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           fi
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Validate executable SDK parity manifest
         run: |


### PR DESCRIPTION
## Summary
- mirror #4466 onto an internal `dashpay/platform` branch so the guarded self-hosted job can run
- target the dedicated `[self-hosted, kotlin-ci]` runner
- copy the persistent-runner fork guard from Rust CI
- preserve local Cargo and Gradle outputs and make host setup idempotent
- verify JDK 17 and read/write KVM access before starting the emulator
- resolve Rustup through the persistent `$HOME/.cargo/bin` installation
- install the headless Android emulator runtime libraries idempotently

## Validation
- KVM API version 12 verified as `vivek`, including after host reboot
- runner service has effective `kvm` group membership
- JDK 17 and cargo-ndk 4.1.2 installed persistently
- Android API 35 x86_64 emulator booted with KVM and completed the instrumented FFI test
- YAML parse and workflow assertions passed
- `git diff --check` passed

## Benchmark
- First cold-cache attempt reached the emulator in 5m36s; it exposed missing `libx11-xcb1` and `libpulse0` on the minimal Ubuntu image
- After adding those packages, the representative warm-cache run passed end to end in 2m24s
- Warm breakdown: native Rust 59s, SDK and example Gradle tests 18s combined, emulator and instrumented test 54s
- Successful run: https://github.com/dashpay/platform/actions/runs/32726699767/job/97429497735

Supersedes the fork-only execution path in #4466.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kotlin build automation to run on dedicated infrastructure with improved permission controls.
  * Standardized required tool versions for Rust, Protocol Buffers, and Java validation.
  * Improved checks for system dependencies, emulator access, and build environment readiness.
  * Updated workflow validation to recognize the Kotlin CI runner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->