### PR TITLE
feat(swift-sdk): add async off-main wallet manager shutdown

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
@@ -9,8 +9,8 @@ import os.log
 /// generation already superseded by a `stop`/`clear`/`reset`, even when a
 /// restart happens in the same `@MainActor` turn (a plain boolean gate
 /// can't, because the restart re-opens the gate before the stale,
-/// previously-enqueued completion task runs). Shared by the shielded and
-/// platform-address sync paths.
+/// previously-enqueued completion task runs). Shared by the shielded,
+/// platform-address, and DPNS sync paths.
 final class SyncGenerationCounter: @unchecked Sendable {
     private let lock = NSLock()
     private var value: UInt64 = 0
@@ -120,6 +120,33 @@ public struct PlatformWalletShutdownMetrics: Sendable {
         self.totalMilliseconds = totalMilliseconds
         self.ranOffMainThread = ranOffMainThread
     }
+}
+
+/// Native entry points used by the production teardown orchestration.
+///
+/// Keeping the functions injectable as a group lets tests exercise the real
+/// ordering, timing, result mapping, and logging in
+/// [`PlatformWalletManager.performNativeTeardown`] without calling Rust. The
+/// unchecked conformance is intentional: these closures are immutable C-entry
+/// wrappers, and the whole value is copied onto the dedicated destroy queue.
+struct PlatformWalletNativeTeardownCalls: @unchecked Sendable {
+    typealias Call = @Sendable (Handle) -> PlatformWalletFFIResult
+
+    let spvStop: Call
+    let platformAddressSyncStop: Call
+    let shieldedSyncStop: Call
+    let dashPaySyncStop: Call
+    let dpnsSyncStop: Call
+    let destroy: Call
+
+    static let live = PlatformWalletNativeTeardownCalls(
+        spvStop: platform_wallet_manager_spv_stop,
+        platformAddressSyncStop: platform_wallet_manager_platform_address_sync_stop,
+        shieldedSyncStop: platform_wallet_manager_shielded_sync_stop,
+        dashPaySyncStop: platform_wallet_manager_dashpay_sync_stop,
+        dpnsSyncStop: platform_wallet_manager_dpns_sync_stop,
+        destroy: platform_wallet_manager_destroy
+    )
 }
 
 /// The one thing SwiftUI needs for all wallet operations.
@@ -255,6 +282,12 @@ public class PlatformWalletManager: ObservableObject {
     /// sync-status UI.
     nonisolated let platformAddressSyncGeneration = SyncGenerationCounter()
 
+    /// Generation guard for DPNS marketplace completion events. A native
+    /// completion can already be queued for the main actor when shutdown
+    /// begins; bumping this generation when the handle is consumed prevents
+    /// that trailing callback from publishing after the manager is stopped.
+    nonisolated let dpnsSyncGeneration = SyncGenerationCounter()
+
     /// All wallets currently held by the Rust-side
     /// `PlatformWalletManager`, keyed by the 32-byte wallet id.
     ///
@@ -318,10 +351,10 @@ public class PlatformWalletManager: ObservableObject {
     /// an uncached no-op because the manager can still be configured later.
     private var shutdownTask: Task<PlatformWalletShutdownMetrics, Never>?
 
-    /// Test seam: replaces [`performNativeTeardown(_:)`] when set. Internal,
-    /// test-only — production code never assigns it. Lets the shutdown tests
-    /// count invocations and hold completion without touching real FFI.
-    internal var nativeTeardownOverride: (@Sendable (Handle) -> PlatformWalletShutdownMetrics)?
+    /// Test seam for the individual native calls. Production keeps `.live`;
+    /// tests replace the function table while still running the production
+    /// teardown orchestration end-to-end.
+    internal var nativeTeardownCalls = PlatformWalletNativeTeardownCalls.live
 
     /// Dedicated serial queue for the blocking native teardown. The Rust
     /// `destroy` runs `block_on(shutdown())` on the calling thread and can
@@ -367,12 +400,12 @@ public class PlatformWalletManager: ObservableObject {
         // Rust releases it when the worker exits.
         if handle != NULL_HANDLE {
             let h = handle
-            let teardown = nativeTeardownOverride ?? { Self.performNativeTeardown($0) }
+            let calls = nativeTeardownCalls
             Self.log.warning(
                 "PlatformWalletManager deallocated without shutdown(); scheduling fallback native teardown off-main for handle \(h, privacy: .public)"
             )
             Self.destroyQueue.async {
-                _ = teardown(h)
+                _ = Self.performNativeTeardown(h, calls: calls)
             }
         }
     }
@@ -427,12 +460,13 @@ public class PlatformWalletManager: ObservableObject {
         progressPollTask?.cancel()
         shieldedSyncGeneration.bump()
         platformAddressSyncGeneration.bump()
+        dpnsSyncGeneration.bump()
 
-        let teardown = nativeTeardownOverride ?? { Self.performNativeTeardown($0) }
+        let calls = nativeTeardownCalls
         let task = Task {
             await withCheckedContinuation { (continuation: CheckedContinuation<PlatformWalletShutdownMetrics, Never>) in
                 Self.destroyQueue.async {
-                    continuation.resume(returning: teardown(h))
+                    continuation.resume(returning: Self.performNativeTeardown(h, calls: calls))
                 }
             }
         }
@@ -450,7 +484,10 @@ public class PlatformWalletManager: ObservableObject {
     /// in depth (`spv_stop` is itself a blocking, abort-escalating join, so
     /// it too must run on this queue, never the main thread). Rust's destroy
     /// path provides the authoritative join barrier.
-    nonisolated static func performNativeTeardown(_ handle: Handle) -> PlatformWalletShutdownMetrics {
+    nonisolated static func performNativeTeardown(
+        _ handle: Handle,
+        calls: PlatformWalletNativeTeardownCalls = .live
+    ) -> PlatformWalletShutdownMetrics {
         let offMain = !Thread.isMainThread
         let totalStart = CFAbsoluteTimeGetCurrent()
         var steps: [PlatformWalletShutdownMetrics.Step] = []
@@ -471,17 +508,17 @@ public class PlatformWalletManager: ObservableObject {
         // Stop the network event source first as defense in depth for the
         // teardown order; Rust's destroy path provides the authoritative
         // join barrier.
-        run("spv_stop", platform_wallet_manager_spv_stop)
-        run("platform_address_sync_stop", platform_wallet_manager_platform_address_sync_stop)
-        run("shielded_sync_stop", platform_wallet_manager_shielded_sync_stop)
-        run("dashpay_sync_stop", platform_wallet_manager_dashpay_sync_stop)
-        run("dpns_sync_stop", platform_wallet_manager_dpns_sync_stop)
+        run("spv_stop", calls.spvStop)
+        run("platform_address_sync_stop", calls.platformAddressSyncStop)
+        run("shielded_sync_stop", calls.shieldedSyncStop)
+        run("dashpay_sync_stop", calls.dashPaySyncStop)
+        run("dpns_sync_stop", calls.dpnsSyncStop)
         // Rust OWNS the persistence/event callback handlers (handed over
         // retained at `configure`, with a `release_fn`): any worker that
         // outlives destroy keeps its handler alive through that retain and
         // Rust releases it when the worker exits. Nothing to leak, retain,
         // or gate on here.
-        run("destroy", platform_wallet_manager_destroy)
+        run("destroy", calls.destroy)
 
         let metrics = PlatformWalletShutdownMetrics(
             steps: steps,
@@ -498,16 +535,17 @@ public class PlatformWalletManager: ObservableObject {
     }
 
     /// Test-only factory: a manager carrying a fake non-null handle and an
-    /// injected teardown, so the shutdown tests can exercise the real
-    /// take-once / exactly-once / idempotency paths without any FFI.
+    /// injected native-call table, so shutdown tests exercise the real
+    /// take-once / exactly-once / idempotency and teardown-orchestration paths
+    /// without calling FFI.
     /// Internal on purpose — never call from production code (`configure`
     /// is the only production path that assigns a handle).
     static func makeForTesting(
         handle: Handle,
-        teardown: @escaping @Sendable (Handle) -> PlatformWalletShutdownMetrics
+        calls: PlatformWalletNativeTeardownCalls
     ) -> PlatformWalletManager {
         let manager = PlatformWalletManager()
-        manager.configureForTesting(handle: handle, teardown: teardown)
+        try! manager.configureForTesting(handle: handle, calls: calls)
         return manager
     }
 
@@ -515,12 +553,13 @@ public class PlatformWalletManager: ObservableObject {
     /// separate from the factory lets tests cover shutdown-before-configure.
     func configureForTesting(
         handle: Handle,
-        teardown: @escaping @Sendable (Handle) -> PlatformWalletShutdownMetrics
-    ) {
+        calls: PlatformWalletNativeTeardownCalls
+    ) throws {
+        try ensureConfigurationAllowed()
         precondition(handle != NULL_HANDLE)
         self.handle = handle
         isConfigured = true
-        nativeTeardownOverride = teardown
+        nativeTeardownCalls = calls
     }
 
     // MARK: - Configuration
@@ -531,7 +570,7 @@ public class PlatformWalletManager: ObservableObject {
     /// Spawns a background task that polls SPV sync progress every
     /// second and publishes it to [`spvProgress`].
     public func configure(sdk: SDK, modelContainer: ModelContainer? = nil) throws {
-        precondition(!isConfigured, "PlatformWalletManager already configured")
+        try ensureConfigurationAllowed()
         guard let sdkHandle = sdk.handle else {
             throw PlatformWalletError.invalidParameter("SDK has no handle")
         }
@@ -558,6 +597,7 @@ public class PlatformWalletManager: ObservableObject {
         modelContainer: ModelContainer? = nil,
         network: Network? = nil
     ) throws {
+        try ensureConfigurationAllowed()
         var handle: Handle = NULL_HANDLE
 
         let handler: PlatformWalletPersistenceHandler?
@@ -641,6 +681,19 @@ public class PlatformWalletManager: ObservableObject {
         self.isConfigured = true
 
         startProgressPolling()
+    }
+
+    /// A manager owns at most one configured native lifetime. A no-op shutdown
+    /// before first configuration is allowed, but once a live handle has been
+    /// consumed its cached shutdown result makes the instance terminal; a new
+    /// native handle must be owned by a new manager.
+    private func ensureConfigurationAllowed() throws {
+        precondition(!isConfigured, "PlatformWalletManager already configured")
+        guard shutdownTask == nil else {
+            throw PlatformWalletError.invalidHandle(
+                "PlatformWalletManager cannot be configured after shutdown"
+            )
+        }
     }
 
     /// Access the persistence handler for loading cached data.

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
@@ -83,6 +83,45 @@ public struct PlatformWalletPersistenceCapabilities: Equatable, Sendable {
     }
 }
 
+/// Timing + FFI-result record of one native manager teardown, returned by
+/// [`PlatformWalletManager/shutdown()`] so the host can log it (the SDK has
+/// no dependency on any app-side logger).
+///
+/// Deliberately NOT a worker-level shutdown report: the Rust FFI returns
+/// `Success` for a live handle even when a worker missed its join budget
+/// (that outcome is a Rust-side WARN, not an error), so Swift cannot know
+/// clean-vs-timed-out per worker. These metrics report only what Swift
+/// observes — the result code and wall time of each FFI call, and the
+/// thread the teardown ran on.
+public struct PlatformWalletShutdownMetrics: Sendable {
+    public struct Step: Sendable {
+        /// FFI entry point, e.g. "spv_stop", "destroy".
+        public let name: String
+        /// Raw `PlatformWalletResultCode` of the call (0 = success).
+        public let ffiCode: Int32
+        public let milliseconds: Int
+
+        public init(name: String, ffiCode: Int32, milliseconds: Int) {
+            self.name = name
+            self.ffiCode = ffiCode
+            self.milliseconds = milliseconds
+        }
+    }
+
+    /// The six teardown calls in execution order (5× sync stop + destroy).
+    public let steps: [Step]
+    public let totalMilliseconds: Int
+    /// Whether the blocking native teardown ran off the main thread. The
+    /// whole point of `shutdown()` is that this is `true`.
+    public let ranOffMainThread: Bool
+
+    public init(steps: [Step], totalMilliseconds: Int, ranOffMainThread: Bool) {
+        self.steps = steps
+        self.totalMilliseconds = totalMilliseconds
+        self.ranOffMainThread = ranOffMainThread
+    }
+}
+
 /// The one thing SwiftUI needs for all wallet operations.
 ///
 /// Owns the Rust-side `PlatformWalletManager` handle which drives:
@@ -271,6 +310,29 @@ public class PlatformWalletManager: ObservableObject {
     /// Background task that polls SPV progress.
     private var progressPollTask: Task<Void, Never>?
 
+    /// The single in-flight (or completed) [`shutdown()`] operation. Set
+    /// exactly once by the first `shutdown()` caller; later callers await the
+    /// same task and receive the same metrics. MainActor isolation serializes
+    /// the check-and-set (no suspension point between them), so no lock is
+    /// needed.
+    private var shutdownTask: Task<PlatformWalletShutdownMetrics, Never>?
+
+    /// Test seam: replaces [`performNativeTeardown(_:)`] when set. Internal,
+    /// test-only — production code never assigns it. Lets the shutdown tests
+    /// count invocations and hold completion without touching real FFI.
+    internal var nativeTeardownOverride: (@Sendable (Handle) -> PlatformWalletShutdownMetrics)?
+
+    /// Dedicated serial queue for the blocking native teardown. The Rust
+    /// `destroy` runs `block_on(shutdown())` on the calling thread and can
+    /// legitimately take tens of seconds when an in-flight sync pass ignores
+    /// cancellation, so it must park a plain GCD thread — never the main
+    /// thread, and never a Swift Concurrency cooperative-pool thread (which
+    /// is why this is a DispatchQueue and not `Task.detached`).
+    nonisolated static let destroyQueue = DispatchQueue(
+        label: "org.dash.platform-wallet.destroy",
+        qos: .userInitiated
+    )
+
     // MARK: - Init
 
     /// Empty init for `@StateObject` usage. Call [`configure`] before
@@ -285,28 +347,168 @@ public class PlatformWalletManager: ObservableObject {
 
     deinit {
         progressPollTask?.cancel()
+        // Emergency fallback ONLY. The supported teardown path is an explicit
+        // `await shutdown()` before dropping the last reference — it takes the
+        // handle exactly once and runs the blocking native teardown off-main
+        // deterministically. Reaching this branch means a code path dropped a
+        // configured manager without shutting it down; schedule the same
+        // teardown fire-and-forget on the dedicated queue rather than
+        // blocking whatever thread ARC happens to release on (the destroy's
+        // Rust-side `block_on(shutdown())` can take tens of seconds when a
+        // sync pass is wedged — running it inline here is the historical
+        // network-switch UI freeze).
+        //
+        // Safe without `self`: `Handle` is a registry key from a monotonic
+        // counter (never reused), destroying an already-removed handle is an
+        // Ok no-op, and Rust owns the persistence/event callback contexts
+        // (handed over retained at `configure`, with a `release_fn`) — a
+        // straggling worker keeps its handler alive through that retain and
+        // Rust releases it when the worker exits.
         if handle != NULL_HANDLE {
-            // Stop the network event source first as defense in depth for
-            // the teardown order; Rust's destroy path provides the
-            // authoritative join barrier.
-            platform_wallet_manager_spv_stop(handle).discard()
-            platform_wallet_manager_platform_address_sync_stop(handle).discard()
-            platform_wallet_manager_shielded_sync_stop(handle).discard()
-            platform_wallet_manager_dashpay_sync_stop(handle).discard()
-            platform_wallet_manager_dpns_sync_stop(handle).discard()
-            // Rust OWNS the persistence/event callback handlers (they were
-            // handed over retained at `configure`, with a `release_fn`):
-            // any worker that outlives destroy keeps its handler alive
-            // through that retain and Rust releases it when the worker
-            // exits. Nothing to leak, retain, or gate on here — ARC
-            // releasing this class's own references below is always safe.
-            let destroyResult = PlatformWalletResult(platform_wallet_manager_destroy(handle))
-            if !destroyResult.isSuccess {
+            let h = handle
+            let teardown = nativeTeardownOverride ?? { Self.performNativeTeardown($0) }
+            Self.log.warning(
+                "PlatformWalletManager deallocated without shutdown(); scheduling fallback native teardown off-main for handle \(h, privacy: .public)"
+            )
+            Self.destroyQueue.async {
+                _ = teardown(h)
+            }
+        }
+    }
+
+    // MARK: - Shutdown
+
+    /// Tear down the native manager without blocking the main thread.
+    ///
+    /// Takes ownership of the FFI handle exactly once on the main actor
+    /// (zeroing [`handle`] and flipping [`isConfigured`] so every later
+    /// operation fails fast through `ensureConfigured()`), then runs the
+    /// full native teardown — the same five sync stops plus
+    /// `platform_wallet_manager_destroy` the old `deinit` performed, in the
+    /// same order — on [`destroyQueue`]. The Rust destroy `block_on`s its
+    /// bounded lifecycle shutdown on that queue's thread, which can take
+    /// tens of seconds when an in-flight sync pass ignores cancellation;
+    /// the caller awaits a continuation instead of blocking.
+    ///
+    /// Idempotent: the first caller starts the teardown, every later caller
+    /// awaits the same task and receives the same metrics. Cancellation of
+    /// a calling task does not interrupt the teardown (`Task<_, Never>.value`
+    /// is a non-throwing await), so the native teardown always runs to
+    /// completion once started.
+    ///
+    /// Never throws by design: `platform_wallet_manager_destroy` returns
+    /// `Success` for a live handle even when a worker misses its join budget
+    /// (a Rust-side WARN, not an error), so a thrown error would carry no
+    /// actionable signal. Per-step FFI codes travel in the returned metrics
+    /// for the host to log.
+    @discardableResult
+    public func shutdown() async -> PlatformWalletShutdownMetrics {
+        if let task = shutdownTask {
+            return await task.value
+        }
+        guard handle != NULL_HANDLE else {
+            // Never configured (or a test double without a handle): nothing
+            // to tear down. Record the no-op so repeat callers stay uniform;
+            // the empty `steps` marks it (no thread claim — no teardown ran).
+            let task = Task { PlatformWalletShutdownMetrics(steps: [], totalMilliseconds: 0, ranOffMainThread: false) }
+            shutdownTask = task
+            return await task.value
+        }
+
+        // Take-once: from this point every FFI entry gated on
+        // `ensureConfigured()` / `handle != NULL_HANDLE` rejects cleanly,
+        // and the generation bumps drop any trailing sync event the main
+        // actor delivers after this turn.
+        let h = handle
+        handle = NULL_HANDLE
+        isConfigured = false
+        progressPollTask?.cancel()
+        shieldedSyncGeneration.bump()
+        platformAddressSyncGeneration.bump()
+
+        let teardown = nativeTeardownOverride ?? { Self.performNativeTeardown($0) }
+        let task = Task {
+            await withCheckedContinuation { (continuation: CheckedContinuation<PlatformWalletShutdownMetrics, Never>) in
+                Self.destroyQueue.async {
+                    continuation.resume(returning: teardown(h))
+                }
+            }
+        }
+        shutdownTask = task
+        return await task.value
+    }
+
+    /// The blocking native teardown body, shared by [`shutdown()`] and the
+    /// `deinit` fallback: exactly the five sync stops plus destroy the old
+    /// synchronous `deinit` ran, in the same order, each timed and its FFI
+    /// code recorded.
+    ///
+    /// The stops are kept even though Rust's `shutdown()` inside destroy is
+    /// a superset — they preserve the historical teardown order as defense
+    /// in depth (`spv_stop` is itself a blocking, abort-escalating join, so
+    /// it too must run on this queue, never the main thread). Rust's destroy
+    /// path provides the authoritative join barrier.
+    nonisolated static func performNativeTeardown(_ handle: Handle) -> PlatformWalletShutdownMetrics {
+        let offMain = !Thread.isMainThread
+        let totalStart = CFAbsoluteTimeGetCurrent()
+        var steps: [PlatformWalletShutdownMetrics.Step] = []
+        steps.reserveCapacity(6)
+
+        func run(_ name: String, _ call: (Handle) -> PlatformWalletFFIResult) {
+            let start = CFAbsoluteTimeGetCurrent()
+            let result = PlatformWalletResult(call(handle))
+            let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
+            steps.append(.init(name: name, ffiCode: result.code.rawValue, milliseconds: ms))
+            if !result.isSuccess {
                 Self.log.error(
-                    "Platform wallet manager teardown failed with \(String(describing: destroyResult.code), privacy: .public): \(destroyResult.message ?? "<no detail from Rust>", privacy: .public)"
+                    "native teardown step \(name, privacy: .public) failed with \(String(describing: result.code), privacy: .public): \(result.message ?? "<no detail from Rust>", privacy: .public)"
                 )
             }
         }
+
+        // Stop the network event source first as defense in depth for the
+        // teardown order; Rust's destroy path provides the authoritative
+        // join barrier.
+        run("spv_stop", platform_wallet_manager_spv_stop)
+        run("platform_address_sync_stop", platform_wallet_manager_platform_address_sync_stop)
+        run("shielded_sync_stop", platform_wallet_manager_shielded_sync_stop)
+        run("dashpay_sync_stop", platform_wallet_manager_dashpay_sync_stop)
+        run("dpns_sync_stop", platform_wallet_manager_dpns_sync_stop)
+        // Rust OWNS the persistence/event callback handlers (handed over
+        // retained at `configure`, with a `release_fn`): any worker that
+        // outlives destroy keeps its handler alive through that retain and
+        // Rust releases it when the worker exits. Nothing to leak, retain,
+        // or gate on here.
+        run("destroy", platform_wallet_manager_destroy)
+
+        let metrics = PlatformWalletShutdownMetrics(
+            steps: steps,
+            totalMilliseconds: Int((CFAbsoluteTimeGetCurrent() - totalStart) * 1000),
+            ranOffMainThread: offMain
+        )
+        let stepSummary = steps
+            .map { "\($0.name)=\($0.milliseconds)ms(code \($0.ffiCode))" }
+            .joined(separator: " ")
+        Self.log.info(
+            "native teardown finished in \(metrics.totalMilliseconds, privacy: .public)ms offMain=\(offMain, privacy: .public): \(stepSummary, privacy: .public)"
+        )
+        return metrics
+    }
+
+    /// Test-only factory: a manager carrying a fake non-null handle and an
+    /// injected teardown, so the shutdown tests can exercise the real
+    /// take-once / exactly-once / idempotency paths without any FFI.
+    /// Internal on purpose — never call from production code (`configure`
+    /// is the only production path that assigns a handle).
+    static func makeForTesting(
+        handle: Handle,
+        teardown: @escaping @Sendable (Handle) -> PlatformWalletShutdownMetrics
+    ) -> PlatformWalletManager {
+        let manager = PlatformWalletManager()
+        manager.handle = handle
+        manager.isConfigured = true
+        manager.nativeTeardownOverride = teardown
+        return manager
     }
 
     // MARK: - Configuration

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
@@ -311,10 +311,11 @@ public class PlatformWalletManager: ObservableObject {
     private var progressPollTask: Task<Void, Never>?
 
     /// The single in-flight (or completed) [`shutdown()`] operation. Set
-    /// exactly once by the first `shutdown()` caller; later callers await the
-    /// same task and receive the same metrics. MainActor isolation serializes
-    /// the check-and-set (no suspension point between them), so no lock is
-    /// needed.
+    /// exactly once by the first caller that takes a live handle; later
+    /// callers await the same task and receive the same metrics. MainActor
+    /// isolation serializes the check-and-set (no suspension point between
+    /// them), so no lock is needed. A shutdown before configuration remains
+    /// an uncached no-op because the manager can still be configured later.
     private var shutdownTask: Task<PlatformWalletShutdownMetrics, Never>?
 
     /// Test seam: replaces [`performNativeTeardown(_:)`] when set. Internal,
@@ -408,11 +409,12 @@ public class PlatformWalletManager: ObservableObject {
         }
         guard handle != NULL_HANDLE else {
             // Never configured (or a test double without a handle): nothing
-            // to tear down. Record the no-op so repeat callers stay uniform;
-            // the empty `steps` marks it (no thread claim — no teardown ran).
-            let task = Task { PlatformWalletShutdownMetrics(steps: [], totalMilliseconds: 0, ranOffMainThread: false) }
-            shutdownTask = task
-            return await task.value
+            // to tear down. Do not cache this no-op: a manager may still be
+            // configured later, and that live handle must then be torn down.
+            return PlatformWalletShutdownMetrics(
+                steps: [],
+                totalMilliseconds: 0,
+                ranOffMainThread: false)
         }
 
         // Take-once: from this point every FFI entry gated on
@@ -505,10 +507,20 @@ public class PlatformWalletManager: ObservableObject {
         teardown: @escaping @Sendable (Handle) -> PlatformWalletShutdownMetrics
     ) -> PlatformWalletManager {
         let manager = PlatformWalletManager()
-        manager.handle = handle
-        manager.isConfigured = true
-        manager.nativeTeardownOverride = teardown
+        manager.configureForTesting(handle: handle, teardown: teardown)
         return manager
+    }
+
+    /// Test-only equivalent of a successful native configuration. Keeping it
+    /// separate from the factory lets tests cover shutdown-before-configure.
+    func configureForTesting(
+        handle: Handle,
+        teardown: @escaping @Sendable (Handle) -> PlatformWalletShutdownMetrics
+    ) {
+        precondition(handle != NULL_HANDLE)
+        self.handle = handle
+        isConfigured = true
+        nativeTeardownOverride = teardown
     }
 
     // MARK: - Configuration

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerDpnsSync.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerDpnsSync.swift
@@ -116,8 +116,14 @@ func dpnsMarketplaceSyncCompletedCallback(
         syncUnixSeconds: syncUnixSeconds,
         walletResults: results
     )
+
+    // Snapshot before the main-actor hop. Shutdown bumps the generation as it
+    // consumes the native handle, invalidating a completion Rust had already
+    // dispatched but Swift has not published yet.
+    let generation = handler.manager?.dpnsSyncGeneration.current() ?? 0
+
     Task { @MainActor [weak manager = handler.manager] in
-        manager?.handleDpnsSyncCompleted(event)
+        manager?.handleDpnsSyncCompleted(event, generation: generation)
     }
 }
 
@@ -133,7 +139,11 @@ extension PlatformWalletManager {
     // cadence (60s) than DashPay's 15s because marketplace state changes
     // are rare.
 
-    func handleDpnsSyncCompleted(_ event: DpnsSyncEvent) {
+    func handleDpnsSyncCompleted(_ event: DpnsSyncEvent, generation: UInt64) {
+        // The generation rejects callbacks queued before shutdown. The
+        // configured-state check also rejects a callback native teardown
+        // dispatches after shutdown already bumped the counter.
+        guard isConfigured, generation == dpnsSyncGeneration.current() else { return }
         lastDpnsSyncEvent = event
     }
 

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DpnsMarketplaceDecodingTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DpnsMarketplaceDecodingTests.swift
@@ -178,6 +178,23 @@ final class DpnsMarketplaceDecodingTests: XCTestCase {
 
 @MainActor
 final class DpnsMarketplaceManagerWrapperTests: XCTestCase {
+    private nonisolated static func noOpTeardownCalls() -> PlatformWalletNativeTeardownCalls {
+        let success: PlatformWalletNativeTeardownCalls.Call = { _ in
+            PlatformWalletFFIResult(
+                code: PLATFORM_WALLET_FFI_RESULT_CODE_SUCCESS,
+                message: nil
+            )
+        }
+        return PlatformWalletNativeTeardownCalls(
+            spvStop: success,
+            platformAddressSyncStop: success,
+            shieldedSyncStop: success,
+            dashPaySyncStop: success,
+            dpnsSyncStop: success,
+            destroy: success
+        )
+    }
+
     private func assertInvalidHandle(
         file: StaticString = #filePath,
         line: UInt = #line,
@@ -215,7 +232,10 @@ final class DpnsMarketplaceManagerWrapperTests: XCTestCase {
     }
 
     func testEventExtensionPublishesOwnedWalletResults() async {
-        let manager = PlatformWalletManager()
+        let manager = PlatformWalletManager.makeForTesting(
+            handle: 72,
+            calls: Self.noOpTeardownCalls()
+        )
         let handler = PlatformWalletEventHandler(manager: manager)
         let eventExtension = handler.makeCallbacksExtension()
         XCTAssertEqual(
@@ -255,5 +275,6 @@ final class DpnsMarketplaceManagerWrapperTests: XCTestCase {
         let event = manager.lastDpnsSyncEvent
         XCTAssertEqual(event?.syncUnixSeconds, 123)
         XCTAssertEqual(event?.result(for: walletId)?.errorMessage, "ephemeral error")
+        await manager.shutdown()
     }
 }

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DpnsSyncGenerationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DpnsSyncGenerationTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+import DashSDKFFI
+@testable import SwiftDashSDK
+
+/// Regression coverage for DPNS completion callbacks that cross the native
+/// teardown → main-actor boundary.
+@MainActor
+final class DpnsSyncGenerationTests: XCTestCase {
+
+    private nonisolated static func noOpCalls() -> PlatformWalletNativeTeardownCalls {
+        let success: PlatformWalletNativeTeardownCalls.Call = { _ in
+            PlatformWalletFFIResult(
+                code: PLATFORM_WALLET_FFI_RESULT_CODE_SUCCESS,
+                message: nil
+            )
+        }
+        return PlatformWalletNativeTeardownCalls(
+            spvStop: success,
+            platformAddressSyncStop: success,
+            shieldedSyncStop: success,
+            dashPaySyncStop: success,
+            dpnsSyncStop: success,
+            destroy: success
+        )
+    }
+
+    private func makeManager() -> PlatformWalletManager {
+        PlatformWalletManager.makeForTesting(handle: 71, calls: Self.noOpCalls())
+    }
+
+    private func makeEvent(_ timestamp: UInt64) -> DpnsSyncEvent {
+        DpnsSyncEvent(syncUnixSeconds: timestamp, walletResults: [])
+    }
+
+    func testCurrentGenerationCompletionPublishesWhileConfigured() async {
+        let manager = makeManager()
+        let generation = manager.dpnsSyncGeneration.current()
+
+        manager.handleDpnsSyncCompleted(makeEvent(1_000), generation: generation)
+
+        XCTAssertEqual(manager.lastDpnsSyncEvent?.syncUnixSeconds, 1_000)
+        await manager.shutdown()
+    }
+
+    func testStaleCompletionIsDroppedAfterGenerationBump() async {
+        let manager = makeManager()
+        let staleGeneration = manager.dpnsSyncGeneration.current()
+        manager.dpnsSyncGeneration.bump()
+
+        manager.handleDpnsSyncCompleted(makeEvent(2_000), generation: staleGeneration)
+
+        XCTAssertNil(manager.lastDpnsSyncEvent)
+        await manager.shutdown()
+    }
+
+    /// A generation check alone is insufficient: native teardown can dispatch
+    /// a callback after shutdown has bumped the counter. Its snapshot then
+    /// matches the current generation, so terminal `isConfigured` must reject
+    /// it as well.
+    func testPostShutdownCurrentGenerationCompletionIsDropped() async {
+        let manager = makeManager()
+        let beforeShutdown = manager.dpnsSyncGeneration.current()
+
+        await manager.shutdown()
+
+        let afterShutdown = manager.dpnsSyncGeneration.current()
+        XCTAssertNotEqual(beforeShutdown, afterShutdown)
+        manager.handleDpnsSyncCompleted(makeEvent(3_000), generation: afterShutdown)
+        XCTAssertNil(manager.lastDpnsSyncEvent)
+    }
+
+    func testStaleCompletionDoesNotOverwritePublishedEvent() async {
+        let manager = makeManager()
+        let staleGeneration = manager.dpnsSyncGeneration.current()
+        manager.handleDpnsSyncCompleted(makeEvent(4_000), generation: staleGeneration)
+        manager.dpnsSyncGeneration.bump()
+
+        manager.handleDpnsSyncCompleted(makeEvent(5_000), generation: staleGeneration)
+
+        XCTAssertEqual(manager.lastDpnsSyncEvent?.syncUnixSeconds, 4_000)
+        await manager.shutdown()
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/PlatformWalletShutdownTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/PlatformWalletShutdownTests.swift
@@ -1,110 +1,120 @@
 import XCTest
+import DashSDKFFI
 @testable import SwiftDashSDK
 
 /// Coverage for `PlatformWalletManager.shutdown()` — the explicit, off-main
 /// replacement for the old synchronous `deinit` teardown.
 ///
-/// Every test runs on the internal test seam (`makeForTesting(handle:teardown:)`
-/// + `nativeTeardownOverride`): a fake non-null handle exercises the real
-/// take-once / exactly-once / idempotency paths, while the injected teardown
-/// closure counts invocations and can hold completion — no FFI is touched, so
-/// the tests are deterministic and need no configured SDK.
-///
-/// Isolation: each test that leaves a live manager behind finishes it with an
-/// explicit `await manager.shutdown()` (or drains `destroyQueue`), so the
-/// asynchronous deinit fallback of one test can never overlap the next.
+/// Tests inject the six individual native functions, not the teardown result.
+/// The production `performNativeTeardown` orchestration therefore remains
+/// under test: order, handle propagation, result mapping, off-main execution,
+/// take-once behavior, and idempotency are all exercised without calling FFI.
 @MainActor
 final class PlatformWalletShutdownTests: XCTestCase {
 
-    /// Thread-safe invocation recorder shared with the injected teardown
-    /// closure (which runs on the SDK's destroy queue, off the main actor).
     private final class TeardownRecorder: @unchecked Sendable {
         private let lock = NSLock()
-        private var callCount = 0
-        private var handles: [Handle] = []
-        private var ranOnMainThread: [Bool] = []
+        private let failingStep: String?
+        private let firstCallGate: DispatchSemaphore?
+        private var invocations: [(name: String, handle: Handle, ranOnMainThread: Bool)] = []
 
-        func record(handle: Handle) {
-            lock.withLock {
-                callCount += 1
-                handles.append(handle)
-                ranOnMainThread.append(Thread.isMainThread)
-            }
+        init(failingStep: String? = nil, firstCallGate: DispatchSemaphore? = nil) {
+            self.failingStep = failingStep
+            self.firstCallGate = firstCallGate
         }
 
-        var count: Int { lock.withLock { callCount } }
-        var recordedHandles: [Handle] { lock.withLock { handles } }
-        var recordedMainThread: [Bool] { lock.withLock { ranOnMainThread } }
+        func record(name: String, handle: Handle) -> PlatformWalletFFIResult {
+            if name == "spv_stop" {
+                firstCallGate?.wait()
+            }
+            lock.withLock {
+                invocations.append((name, handle, Thread.isMainThread))
+            }
+            let code = name == failingStep
+                ? PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_INVALID_HANDLE
+                : PLATFORM_WALLET_FFI_RESULT_CODE_SUCCESS
+            return PlatformWalletFFIResult(code: code, message: nil)
+        }
+
+        var names: [String] { lock.withLock { invocations.map(\.name) } }
+        var handles: [Handle] { lock.withLock { invocations.map(\.handle) } }
+        var mainThreadFlags: [Bool] { lock.withLock { invocations.map(\.ranOnMainThread) } }
+        func count(named name: String) -> Int {
+            lock.withLock { invocations.count { $0.name == name } }
+        }
     }
 
-    /// `nonisolated static` on purpose: the injected teardown closures are
-    /// `@Sendable` and run on the destroy queue, off the main actor.
-    private nonisolated static func makeMetrics(code: Int32 = 0) -> PlatformWalletShutdownMetrics {
-        PlatformWalletShutdownMetrics(
-            steps: [.init(name: "destroy", ffiCode: code, milliseconds: 1)],
-            totalMilliseconds: 1,
-            ranOffMainThread: !Thread.isMainThread
+    private static let expectedOrder = [
+        "spv_stop",
+        "platform_address_sync_stop",
+        "shielded_sync_stop",
+        "dashpay_sync_stop",
+        "dpns_sync_stop",
+        "destroy",
+    ]
+
+    private nonisolated static func makeCalls(
+        recorder: TeardownRecorder
+    ) -> PlatformWalletNativeTeardownCalls {
+        PlatformWalletNativeTeardownCalls(
+            spvStop: { recorder.record(name: "spv_stop", handle: $0) },
+            platformAddressSyncStop: {
+                recorder.record(name: "platform_address_sync_stop", handle: $0)
+            },
+            shieldedSyncStop: { recorder.record(name: "shielded_sync_stop", handle: $0) },
+            dashPaySyncStop: { recorder.record(name: "dashpay_sync_stop", handle: $0) },
+            dpnsSyncStop: { recorder.record(name: "dpns_sync_stop", handle: $0) },
+            destroy: { recorder.record(name: "destroy", handle: $0) }
         )
     }
 
-    /// Drain the destroy queue so any scheduled (fallback) teardown has
-    /// provably run before the test asserts.
     private func drainDestroyQueue() {
         PlatformWalletManager.destroyQueue.sync {}
     }
 
     // MARK: - Idempotency
 
-    /// Two concurrent callers await ONE teardown and receive the same metrics.
     func testConcurrentShutdownRunsTeardownExactlyOnce() async {
         let recorder = TeardownRecorder()
-        let manager = PlatformWalletManager.makeForTesting(handle: 42) { handle in
-            recorder.record(handle: handle)
-            return PlatformWalletShutdownMetrics(
-                steps: [.init(name: "destroy", ffiCode: 0, milliseconds: 7)],
-                totalMilliseconds: 7,
-                ranOffMainThread: !Thread.isMainThread
-            )
-        }
+        let manager = PlatformWalletManager.makeForTesting(
+            handle: 42,
+            calls: Self.makeCalls(recorder: recorder)
+        )
 
         async let first = manager.shutdown()
         async let second = manager.shutdown()
         let (m1, m2) = await (first, second)
 
-        XCTAssertEqual(recorder.count, 1, "one native teardown for two callers")
-        XCTAssertEqual(recorder.recordedHandles, [42], "the taken handle reaches the teardown")
-        XCTAssertEqual(m1.totalMilliseconds, m2.totalMilliseconds, "both callers get the same metrics")
+        XCTAssertEqual(recorder.names, Self.expectedOrder)
+        XCTAssertEqual(recorder.handles, Array(repeating: 42, count: 6))
+        XCTAssertEqual(recorder.count(named: "destroy"), 1)
+        XCTAssertEqual(m1.totalMilliseconds, m2.totalMilliseconds)
         XCTAssertEqual(m1.steps.map(\.name), m2.steps.map(\.name))
 
-        // A third, late caller still gets the recorded outcome, no new run.
         let third = await manager.shutdown()
-        XCTAssertEqual(recorder.count, 1)
+        XCTAssertEqual(recorder.names, Self.expectedOrder, "a late caller must not start teardown again")
         XCTAssertEqual(third.totalMilliseconds, m1.totalMilliseconds)
     }
 
     // MARK: - Take-once handle
 
-    /// The first `shutdown()` consumes the handle: it reads NULL afterwards
-    /// and every guarded entry point rejects.
     func testShutdownConsumesHandleExactlyOnce() async {
         let recorder = TeardownRecorder()
-        let manager = PlatformWalletManager.makeForTesting(handle: 7) { handle in
-            recorder.record(handle: handle)
-            return Self.makeMetrics()
-        }
+        let manager = PlatformWalletManager.makeForTesting(
+            handle: 7,
+            calls: Self.makeCalls(recorder: recorder)
+        )
         XCTAssertEqual(manager.handle, 7)
         XCTAssertTrue(manager.isConfigured)
 
         await manager.shutdown()
 
-        XCTAssertEqual(manager.handle, NULL_HANDLE, "handle is zeroed by the take-once")
+        XCTAssertEqual(manager.handle, NULL_HANDLE)
         XCTAssertFalse(manager.isConfigured)
-        XCTAssertThrowsError(try manager.ensureConfigured(), "operations must fail fast after shutdown")
-        XCTAssertEqual(recorder.count, 1)
+        XCTAssertThrowsError(try manager.ensureConfigured())
+        XCTAssertEqual(recorder.count(named: "destroy"), 1)
     }
 
-    /// A never-configured manager (NULL handle) shuts down as a no-op —
-    /// no teardown call, empty metrics — and stays idempotent.
     func testShutdownWithoutHandleIsANoOp() async {
         let manager = PlatformWalletManager()
         let metrics = await manager.shutdown()
@@ -113,111 +123,126 @@ final class PlatformWalletShutdownTests: XCTestCase {
         XCTAssertTrue(again.steps.isEmpty)
     }
 
-    /// A no-op before configuration must not occupy the idempotency slot: if
-    /// the same manager is configured later, its live handle still tears down.
-    func testShutdownBeforeConfigurationDoesNotSuppressLaterTeardown() async {
+    func testShutdownBeforeConfigurationDoesNotSuppressLaterTeardown() async throws {
         let recorder = TeardownRecorder()
         let manager = PlatformWalletManager()
 
         let noOp = await manager.shutdown()
         XCTAssertTrue(noOp.steps.isEmpty)
 
-        manager.configureForTesting(handle: 17) { handle in
-            recorder.record(handle: handle)
-            return Self.makeMetrics()
-        }
+        try manager.configureForTesting(
+            handle: 17,
+            calls: Self.makeCalls(recorder: recorder)
+        )
 
         let metrics = await manager.shutdown()
-        XCTAssertEqual(recorder.count, 1)
-        XCTAssertEqual(recorder.recordedHandles, [17])
-        XCTAssertEqual(metrics.steps.map(\.name), ["destroy"])
+        XCTAssertEqual(recorder.names, Self.expectedOrder)
+        XCTAssertEqual(recorder.handles, Array(repeating: 17, count: 6))
+        XCTAssertEqual(metrics.steps.map(\.name), Self.expectedOrder)
+    }
+
+    /// A completed real shutdown makes this manager terminal. Reconfiguration
+    /// must fail before another native handle or callback context is installed.
+    func testConfigurationAfterRealShutdownIsRejected() async {
+        let recorder = TeardownRecorder()
+        let calls = Self.makeCalls(recorder: recorder)
+        let manager = PlatformWalletManager.makeForTesting(handle: 17, calls: calls)
+
+        let first = await manager.shutdown()
+        XCTAssertEqual(first.steps.map(\.name), Self.expectedOrder)
+
+        XCTAssertThrowsError(try manager.configureForTesting(handle: 18, calls: calls)) { error in
+            guard let walletError = error as? PlatformWalletError else {
+                return XCTFail("unexpected error: \(error)")
+            }
+            guard case .invalidHandle(let message) = walletError else {
+                return XCTFail("expected invalidHandle, got \(walletError)")
+            }
+            XCTAssertTrue(message.contains("cannot be configured after shutdown"))
+        }
+
+        XCTAssertEqual(manager.handle, NULL_HANDLE)
+        XCTAssertFalse(manager.isConfigured)
+        let repeated = await manager.shutdown()
+        XCTAssertEqual(repeated.steps.map(\.name), Self.expectedOrder)
+        XCTAssertEqual(recorder.names, Self.expectedOrder, "rejected configuration must not add teardown calls")
     }
 
     // MARK: - Caller cancellation
 
-    /// Cancelling the calling task does not interrupt the native teardown:
-    /// it runs to completion exactly once and the cancelled caller still
-    /// receives the metrics.
     func testCallerCancellationDoesNotInterruptTeardown() async {
-        let recorder = TeardownRecorder()
         let gate = DispatchSemaphore(value: 0)
-        let manager = PlatformWalletManager.makeForTesting(handle: 9) { handle in
-            gate.wait() // hold completion until the test releases it
-            recorder.record(handle: handle)
-            return Self.makeMetrics()
-        }
+        let recorder = TeardownRecorder(firstCallGate: gate)
+        let manager = PlatformWalletManager.makeForTesting(
+            handle: 9,
+            calls: Self.makeCalls(recorder: recorder)
+        )
 
         let caller = Task { await manager.shutdown() }
         caller.cancel()
         gate.signal()
 
         let metrics = await caller.value
-        XCTAssertEqual(recorder.count, 1, "teardown ran despite the cancelled caller")
-        XCTAssertEqual(metrics.steps.map(\.name), ["destroy"])
+        XCTAssertEqual(recorder.names, Self.expectedOrder)
+        XCTAssertEqual(recorder.count(named: "destroy"), 1)
+        XCTAssertEqual(metrics.steps.map(\.name), Self.expectedOrder)
     }
 
     // MARK: - Deinit interplay
 
-    /// After an explicit `shutdown()`, deallocating the manager schedules no
-    /// second teardown (the handle was already consumed).
     func testDeinitAfterShutdownRunsNoSecondTeardown() async {
         let recorder = TeardownRecorder()
-        var manager: PlatformWalletManager? = PlatformWalletManager.makeForTesting(handle: 11) { handle in
-            recorder.record(handle: handle)
-            return Self.makeMetrics()
-        }
+        var manager: PlatformWalletManager? = PlatformWalletManager.makeForTesting(
+            handle: 11,
+            calls: Self.makeCalls(recorder: recorder)
+        )
 
         await manager?.shutdown()
-        XCTAssertEqual(recorder.count, 1)
+        XCTAssertEqual(recorder.names, Self.expectedOrder)
 
         manager = nil
         drainDestroyQueue()
-        XCTAssertEqual(recorder.count, 1, "deinit must not run a second teardown")
+        XCTAssertEqual(recorder.names, Self.expectedOrder)
+        XCTAssertEqual(recorder.count(named: "destroy"), 1)
     }
 
-    /// Dropping a live manager WITHOUT `shutdown()` triggers the emergency
-    /// fallback: exactly one teardown, off the main thread (the whole point —
-    /// the blocking destroy must never run on whatever thread ARC releases on).
     func testDeinitFallbackRunsTeardownOffMainExactlyOnce() {
         let recorder = TeardownRecorder()
-        var manager: PlatformWalletManager? = PlatformWalletManager.makeForTesting(handle: 13) { handle in
-            recorder.record(handle: handle)
-            return PlatformWalletShutdownMetrics(
-                steps: [], totalMilliseconds: 0, ranOffMainThread: !Thread.isMainThread)
-        }
+        var manager: PlatformWalletManager? = PlatformWalletManager.makeForTesting(
+            handle: 13,
+            calls: Self.makeCalls(recorder: recorder)
+        )
         withExtendedLifetime(manager) {}
 
-        manager = nil // MainActor release → deinit schedules the fallback
+        manager = nil
         drainDestroyQueue()
 
-        XCTAssertEqual(recorder.count, 1, "fallback teardown runs exactly once")
-        XCTAssertEqual(recorder.recordedMainThread, [false], "fallback teardown must not run on the main thread")
-        XCTAssertEqual(recorder.recordedHandles, [13])
+        XCTAssertEqual(recorder.names, Self.expectedOrder)
+        XCTAssertEqual(recorder.mainThreadFlags, Array(repeating: false, count: 6))
+        XCTAssertEqual(recorder.handles, Array(repeating: 13, count: 6))
+        XCTAssertEqual(recorder.count(named: "destroy"), 1)
     }
 
-    // MARK: - Error propagation
+    // MARK: - Production orchestration
 
-    /// A failing FFI step's code travels in the returned metrics — the
-    /// lifecycle layer logs it; it never turns into a thrown error (destroy
-    /// of a live handle reports Success by Rust contract, and step failures
-    /// carry no control-flow decision).
-    func testFailingStepCodeLandsInMetrics() async {
-        let failingCode = PlatformWalletResultCode.errorInvalidHandle.rawValue
-        let manager = PlatformWalletManager.makeForTesting(handle: 21) { _ in
-            PlatformWalletShutdownMetrics(
-                steps: [
-                    .init(name: "spv_stop", ffiCode: 0, milliseconds: 2),
-                    .init(name: "destroy", ffiCode: failingCode, milliseconds: 3),
-                ],
-                totalMilliseconds: 5,
-                ranOffMainThread: !Thread.isMainThread
-            )
-        }
+    /// The injected calls still run through `performNativeTeardown`, proving
+    /// its exact order and association of each native result with its metric.
+    func testNativeTeardownOrderAndResultMapping() async {
+        let recorder = TeardownRecorder(failingStep: "shielded_sync_stop")
+        let manager = PlatformWalletManager.makeForTesting(
+            handle: 21,
+            calls: Self.makeCalls(recorder: recorder)
+        )
 
         let metrics = await manager.shutdown()
 
-        XCTAssertEqual(metrics.steps.count, 2)
-        XCTAssertEqual(metrics.steps.last?.ffiCode, failingCode, "step failure code is preserved for the host to log")
+        XCTAssertEqual(recorder.names, Self.expectedOrder)
+        XCTAssertEqual(recorder.handles, Array(repeating: 21, count: 6))
+        XCTAssertEqual(metrics.steps.map(\.name), Self.expectedOrder)
+        XCTAssertEqual(
+            metrics.steps.map(\.ffiCode),
+            [0, 0, PlatformWalletResultCode.errorInvalidHandle.rawValue, 0, 0, 0]
+        )
         XCTAssertTrue(metrics.ranOffMainThread)
     }
 }

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/PlatformWalletShutdownTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/PlatformWalletShutdownTests.swift
@@ -113,6 +113,26 @@ final class PlatformWalletShutdownTests: XCTestCase {
         XCTAssertTrue(again.steps.isEmpty)
     }
 
+    /// A no-op before configuration must not occupy the idempotency slot: if
+    /// the same manager is configured later, its live handle still tears down.
+    func testShutdownBeforeConfigurationDoesNotSuppressLaterTeardown() async {
+        let recorder = TeardownRecorder()
+        let manager = PlatformWalletManager()
+
+        let noOp = await manager.shutdown()
+        XCTAssertTrue(noOp.steps.isEmpty)
+
+        manager.configureForTesting(handle: 17) { handle in
+            recorder.record(handle: handle)
+            return Self.makeMetrics()
+        }
+
+        let metrics = await manager.shutdown()
+        XCTAssertEqual(recorder.count, 1)
+        XCTAssertEqual(recorder.recordedHandles, [17])
+        XCTAssertEqual(metrics.steps.map(\.name), ["destroy"])
+    }
+
     // MARK: - Caller cancellation
 
     /// Cancelling the calling task does not interrupt the native teardown:

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/PlatformWalletShutdownTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/PlatformWalletShutdownTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+@testable import SwiftDashSDK
+
+/// Coverage for `PlatformWalletManager.shutdown()` — the explicit, off-main
+/// replacement for the old synchronous `deinit` teardown.
+///
+/// Every test runs on the internal test seam (`makeForTesting(handle:teardown:)`
+/// + `nativeTeardownOverride`): a fake non-null handle exercises the real
+/// take-once / exactly-once / idempotency paths, while the injected teardown
+/// closure counts invocations and can hold completion — no FFI is touched, so
+/// the tests are deterministic and need no configured SDK.
+///
+/// Isolation: each test that leaves a live manager behind finishes it with an
+/// explicit `await manager.shutdown()` (or drains `destroyQueue`), so the
+/// asynchronous deinit fallback of one test can never overlap the next.
+@MainActor
+final class PlatformWalletShutdownTests: XCTestCase {
+
+    /// Thread-safe invocation recorder shared with the injected teardown
+    /// closure (which runs on the SDK's destroy queue, off the main actor).
+    private final class TeardownRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var callCount = 0
+        private var handles: [Handle] = []
+        private var ranOnMainThread: [Bool] = []
+
+        func record(handle: Handle) {
+            lock.withLock {
+                callCount += 1
+                handles.append(handle)
+                ranOnMainThread.append(Thread.isMainThread)
+            }
+        }
+
+        var count: Int { lock.withLock { callCount } }
+        var recordedHandles: [Handle] { lock.withLock { handles } }
+        var recordedMainThread: [Bool] { lock.withLock { ranOnMainThread } }
+    }
+
+    /// `nonisolated static` on purpose: the injected teardown closures are
+    /// `@Sendable` and run on the destroy queue, off the main actor.
+    private nonisolated static func makeMetrics(code: Int32 = 0) -> PlatformWalletShutdownMetrics {
+        PlatformWalletShutdownMetrics(
+            steps: [.init(name: "destroy", ffiCode: code, milliseconds: 1)],
+            totalMilliseconds: 1,
+            ranOffMainThread: !Thread.isMainThread
+        )
+    }
+
+    /// Drain the destroy queue so any scheduled (fallback) teardown has
+    /// provably run before the test asserts.
+    private func drainDestroyQueue() {
+        PlatformWalletManager.destroyQueue.sync {}
+    }
+
+    // MARK: - Idempotency
+
+    /// Two concurrent callers await ONE teardown and receive the same metrics.
+    func testConcurrentShutdownRunsTeardownExactlyOnce() async {
+        let recorder = TeardownRecorder()
+        let manager = PlatformWalletManager.makeForTesting(handle: 42) { handle in
+            recorder.record(handle: handle)
+            return PlatformWalletShutdownMetrics(
+                steps: [.init(name: "destroy", ffiCode: 0, milliseconds: 7)],
+                totalMilliseconds: 7,
+                ranOffMainThread: !Thread.isMainThread
+            )
+        }
+
+        async let first = manager.shutdown()
+        async let second = manager.shutdown()
+        let (m1, m2) = await (first, second)
+
+        XCTAssertEqual(recorder.count, 1, "one native teardown for two callers")
+        XCTAssertEqual(recorder.recordedHandles, [42], "the taken handle reaches the teardown")
+        XCTAssertEqual(m1.totalMilliseconds, m2.totalMilliseconds, "both callers get the same metrics")
+        XCTAssertEqual(m1.steps.map(\.name), m2.steps.map(\.name))
+
+        // A third, late caller still gets the recorded outcome, no new run.
+        let third = await manager.shutdown()
+        XCTAssertEqual(recorder.count, 1)
+        XCTAssertEqual(third.totalMilliseconds, m1.totalMilliseconds)
+    }
+
+    // MARK: - Take-once handle
+
+    /// The first `shutdown()` consumes the handle: it reads NULL afterwards
+    /// and every guarded entry point rejects.
+    func testShutdownConsumesHandleExactlyOnce() async {
+        let recorder = TeardownRecorder()
+        let manager = PlatformWalletManager.makeForTesting(handle: 7) { handle in
+            recorder.record(handle: handle)
+            return Self.makeMetrics()
+        }
+        XCTAssertEqual(manager.handle, 7)
+        XCTAssertTrue(manager.isConfigured)
+
+        await manager.shutdown()
+
+        XCTAssertEqual(manager.handle, NULL_HANDLE, "handle is zeroed by the take-once")
+        XCTAssertFalse(manager.isConfigured)
+        XCTAssertThrowsError(try manager.ensureConfigured(), "operations must fail fast after shutdown")
+        XCTAssertEqual(recorder.count, 1)
+    }
+
+    /// A never-configured manager (NULL handle) shuts down as a no-op —
+    /// no teardown call, empty metrics — and stays idempotent.
+    func testShutdownWithoutHandleIsANoOp() async {
+        let manager = PlatformWalletManager()
+        let metrics = await manager.shutdown()
+        XCTAssertTrue(metrics.steps.isEmpty)
+        let again = await manager.shutdown()
+        XCTAssertTrue(again.steps.isEmpty)
+    }
+
+    // MARK: - Caller cancellation
+
+    /// Cancelling the calling task does not interrupt the native teardown:
+    /// it runs to completion exactly once and the cancelled caller still
+    /// receives the metrics.
+    func testCallerCancellationDoesNotInterruptTeardown() async {
+        let recorder = TeardownRecorder()
+        let gate = DispatchSemaphore(value: 0)
+        let manager = PlatformWalletManager.makeForTesting(handle: 9) { handle in
+            gate.wait() // hold completion until the test releases it
+            recorder.record(handle: handle)
+            return Self.makeMetrics()
+        }
+
+        let caller = Task { await manager.shutdown() }
+        caller.cancel()
+        gate.signal()
+
+        let metrics = await caller.value
+        XCTAssertEqual(recorder.count, 1, "teardown ran despite the cancelled caller")
+        XCTAssertEqual(metrics.steps.map(\.name), ["destroy"])
+    }
+
+    // MARK: - Deinit interplay
+
+    /// After an explicit `shutdown()`, deallocating the manager schedules no
+    /// second teardown (the handle was already consumed).
+    func testDeinitAfterShutdownRunsNoSecondTeardown() async {
+        let recorder = TeardownRecorder()
+        var manager: PlatformWalletManager? = PlatformWalletManager.makeForTesting(handle: 11) { handle in
+            recorder.record(handle: handle)
+            return Self.makeMetrics()
+        }
+
+        await manager?.shutdown()
+        XCTAssertEqual(recorder.count, 1)
+
+        manager = nil
+        drainDestroyQueue()
+        XCTAssertEqual(recorder.count, 1, "deinit must not run a second teardown")
+    }
+
+    /// Dropping a live manager WITHOUT `shutdown()` triggers the emergency
+    /// fallback: exactly one teardown, off the main thread (the whole point —
+    /// the blocking destroy must never run on whatever thread ARC releases on).
+    func testDeinitFallbackRunsTeardownOffMainExactlyOnce() {
+        let recorder = TeardownRecorder()
+        var manager: PlatformWalletManager? = PlatformWalletManager.makeForTesting(handle: 13) { handle in
+            recorder.record(handle: handle)
+            return PlatformWalletShutdownMetrics(
+                steps: [], totalMilliseconds: 0, ranOffMainThread: !Thread.isMainThread)
+        }
+        withExtendedLifetime(manager) {}
+
+        manager = nil // MainActor release → deinit schedules the fallback
+        drainDestroyQueue()
+
+        XCTAssertEqual(recorder.count, 1, "fallback teardown runs exactly once")
+        XCTAssertEqual(recorder.recordedMainThread, [false], "fallback teardown must not run on the main thread")
+        XCTAssertEqual(recorder.recordedHandles, [13])
+    }
+
+    // MARK: - Error propagation
+
+    /// A failing FFI step's code travels in the returned metrics — the
+    /// lifecycle layer logs it; it never turns into a thrown error (destroy
+    /// of a live handle reports Success by Rust contract, and step failures
+    /// carry no control-flow decision).
+    func testFailingStepCodeLandsInMetrics() async {
+        let failingCode = PlatformWalletResultCode.errorInvalidHandle.rawValue
+        let manager = PlatformWalletManager.makeForTesting(handle: 21) { _ in
+            PlatformWalletShutdownMetrics(
+                steps: [
+                    .init(name: "spv_stop", ffiCode: 0, milliseconds: 2),
+                    .init(name: "destroy", ffiCode: failingCode, milliseconds: 3),
+                ],
+                totalMilliseconds: 5,
+                ranOffMainThread: !Thread.isMainThread
+            )
+        }
+
+        let metrics = await manager.shutdown()
+
+        XCTAssertEqual(metrics.steps.count, 2)
+        XCTAssertEqual(metrics.steps.last?.ffiCode, failingCode, "step failure code is preserved for the host to log")
+        XCTAssertTrue(metrics.ranOffMainThread)
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

PlatformWalletManager previously performed five native sync stops plus destroy synchronously from deinit. When ARC released the last manager reference on the main thread during a network switch, a delayed Rust shutdown could freeze the iOS UI for tens of seconds.

## What was done?

- Added an explicit, idempotent async shutdown API that takes the FFI handle exactly once.
- Runs the blocking native teardown on a dedicated serial DispatchQueue instead of the main or cooperative concurrency threads.
- Returns per-step FFI codes, timings, total duration, and an off-main thread stamp for app telemetry.
- Keeps deinit as an off-main emergency fallback for callers that omit explicit shutdown.
- Added focused shutdown tests covering idempotency, concurrent callers, ordering, metrics, and the fallback path.

## How Has This Been Tested?

- SwiftDashSDK compiled and linked successfully as part of the DashPay Debug build for an iOS Simulator.
- Repeated mainnet/testnet switches completed smoothly; exported logs reported offMain=true and successful FFI teardown codes.
- The focused SwiftPM test command was attempted, but the standalone package setup cannot resolve the generated DashSDKFFI module in this local checkout. The test source is included for CI, where the FFI artifact is provisioned.

## Breaking Changes

None. The new API is additive; deinit retains a safe fallback.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added asynchronous wallet shutdown with detailed metrics for cleanup duration, execution context, and individual steps.
  - Shutdown now supports safe repeated calls, cancellation, active polling, and deallocation cleanup.
  - Wallet configuration is validated consistently, including terminal behavior after shutdown.

- **Bug Fixes**
  - Prevented stale DPNS synchronization results from appearing after shutdown or newer synchronization cycles.
  - Improved native resource cleanup reliability and prevented duplicate teardown operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->