### PR TITLE
fix(platform-wallet): use dash-spv's own acceptance timeout instead of a 30s override

### DIFF
--- a/packages/rs-platform-wallet/src/broadcaster.rs
+++ b/packages/rs-platform-wallet/src/broadcaster.rs
@@ -124,13 +124,6 @@ impl TransactionBroadcaster for DapiBroadcaster {
     }
 }
 
-/// How long the SPV broadcast waits for a network-acceptance verdict before
-/// reporting the outcome as unknown. Shorter than dash-spv's own default so a
-/// user-facing send does not hang for a full minute. On live Dash networks
-/// acceptance usually resolves in seconds via the InstantSend lock or the
-/// withheld-peer echo, well inside this bound.
-const SPV_ACCEPTANCE_TIMEOUT: Duration = Duration::from_secs(30);
-
 /// The SPV broadcast channel: send through P2P peers and await dash-spv's
 /// network-acceptance verdict (rust-dashcore#913).
 #[async_trait]
@@ -188,11 +181,7 @@ impl SpvBroadcaster {
 impl TransactionBroadcaster for SpvBroadcaster {
     async fn broadcast(&self, transaction: &Transaction) -> Result<Txid, BroadcastError> {
         let txid = transaction.txid();
-        match self
-            .spv
-            .broadcast_and_wait(transaction, Some(SPV_ACCEPTANCE_TIMEOUT))
-            .await
-        {
+        match self.spv.broadcast_and_wait(transaction, None).await {
             Ok(BroadcastResult::Accepted { relayed_by }) => {
                 tracing::info!(
                     txid = %txid,
@@ -208,9 +197,9 @@ impl TransactionBroadcaster for SpvBroadcaster {
             // later echo/IS-lock/confirmation or the reservation-TTL
             // backstop reconciles the reservation.
             Ok(BroadcastResult::Uncertain) => Err(BroadcastError::MaybeSent {
-                reason: format!(
-                    "SPV broadcast saw no acceptance signal within {SPV_ACCEPTANCE_TIMEOUT:?}"
-                ),
+                reason:
+                    "SPV broadcast saw no acceptance signal before dash-spv's acceptance timeout"
+                        .to_string(),
             }),
             // Provably never sent (per the SpvChannel error contract): no
             // bytes reached the network, so the reservation is safe to


### PR DESCRIPTION
## TL;DR

`SpvBroadcaster` handed dash-spv a 30s deadline that expired *before* dash-spv's own 60s acceptance timeout even fired, throwing away the entire late-echo window the mechanism was built around. Pass `None` and defer to dash-spv's configured window (60s + 5s grace).

## User story

As a wallet user sending a transaction, I want a send that the network actually accepted to be reported as accepted — not as "outcome unknown" — so my inputs aren't held hostage by the reservation TTL and I'm not left wondering whether my money moved.

## Scenario

1. User sends a transaction through an SPV-backed platform wallet.
2. dash-spv dispatches it to a subset of peers, withholding it from the rest, and waits for a withheld peer to echo the txid back (or an InstantSend lock / confirmation).
3. The echo arrives at, say, 38s — well inside dash-spv's designed window.
4. **Before:** platform-wallet had already given up at 30s. The send surfaced as `TransactionBroadcastUnconfirmed`, and the reserved inputs stayed locked until the reservation TTL backstop cleaned up.
5. **After:** the wait runs to dash-spv's own deadline, the echo lands, and the send is correctly reported as `Accepted`.

## Detailed discussion

`packages/rs-platform-wallet/src/broadcaster.rs` defined a local `SPV_ACCEPTANCE_TIMEOUT = 30s` and passed `Some(SPV_ACCEPTANCE_TIMEOUT)` into `broadcast_transaction_and_wait`. Its stated rationale was that 30s is "shorter than dash-spv's own default so a user-facing send does not hang for a full minute" — but that reasoning misses how the await loop actually works.

In dash-spv (`dash-spv/src/client/transactions.rs`, pinned rev `a97b32c`):

```rust
let wait = timeout.unwrap_or(config_timeout + AWAIT_GRACE);
```

with `config_timeout = broadcast_acceptance_timeout` (60s default) and `AWAIT_GRACE = 5s`. The decisive detail is in the loop itself:

```rust
Ok(Ok(SyncEvent::TransactionBroadcastResult { txid: event_txid, result }))
    if event_txid == txid && !matches!(result, BroadcastResult::Uncertain) => { return Ok(result) }
```

The mempool manager's interim `Uncertain` event is **deliberately filtered out** and does not end the wait — a late echo can still upgrade the verdict to `Accepted`, so the wait deliberately runs to the caller's deadline. This was an explicit design choice in dashpay/rust-dashcore#913, precisely so that callers willing to wait longer keep waiting rather than bailing early.

That makes the 30s override strictly lossy. It doesn't merely trade latency for certainty — it expires before the manager's own 60s timeout has even fired, so the only verdict platform-wallet could ever observe past 30s was the deadline-elapsed `Uncertain` it manufactured itself. Every acceptance signal in the 30–65s band was discarded unread.

The fix is to pass `None`, which is already the API's "use dash-spv's own default" expression (`Option<Duration>` → `unwrap_or(config_timeout + AWAIT_GRACE)`). The now-unused constant is removed, and the `Uncertain` message no longer names a duration it no longer controls.

### Provenance

Found while investigating a `dash-evo-tool` `TransactionBroadcastUnconfirmed` report — transactions that the network had in fact accepted were being reported back to the user as unconfirmed.

### Scope

Deliberately minimal: 1 file, +4/-15, no behavioural changes beyond the deadline. The stale asset-lock test assertions noticed nearby are **not** touched here — they're landing separately in #3549.

### Testing

Existing `broadcaster::tests::spv_broadcast_maps_dash_spv_verdicts` passes; the verdict-mapping contract is unchanged by this fix (only the deadline handed to dash-spv changes, and the test's channel spy ignores the timeout argument). No new test added: meaningfully exercising the 30s-vs-65s window needs a live P2P peer echo, which isn't available in unit scope.

```
cargo test -p platform-wallet --lib broadcaster   # exit 0, 1 passed
cargo clippy -p platform-wallet --lib --all-features   # exit 0, clean
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated transaction broadcasting to use the platform’s default acceptance timeout.
  * Improved timeout-related error messaging when transaction acceptance cannot be confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->