### PR TITLE
test(dashmate): make ZeroSSL provider-change test deterministic

### DIFF
--- a/packages/dashmate/test/unit/helper/scheduleRenewZeroSslCertificateFactory.spec.js
+++ b/packages/dashmate/test/unit/helper/scheduleRenewZeroSslCertificateFactory.spec.js
@@ -160,7 +160,12 @@ describe('scheduleRenewZeroSslCertificateFactory', () => {
       expect(onConfigurationChanged).to.have.been.calledOnceWith(config);
       expect(obtainZeroSSLCertificateTask).to.not.have.been.called();
 
-      await clock.tickAsync(64 * 24 * 60 * 60 * 1000);
+      // The handoff must leave nothing armed for ZeroSSL, so running every
+      // remaining timer proves the old renewal can never fire. Ticking a blanket
+      // 64 days here instead would replay ~92k config-refresh firings (one real
+      // event-loop hop each) whenever a poll timer survives, blowing the test
+      // timeout on a slow runner rather than failing on the assertion below.
+      await clock.runAllAsync();
 
       expect(onConfigurationChanged).to.have.been.calledOnce();
       expect(obtainZeroSSLCertificateTask).to.not.have.been.called();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The dashmate unit test "should detect a provider change before the old certificate renewal date" intermittently fails with `Timeout of 10000ms exceeded` on GitHub-hosted runners ([example failure](https://github.com/dashpay/platform/actions/runs/32935417801/job/98077319782), on a PR with zero JS changes).

The test ends with a blanket `clock.tickAsync(64 days)`. That tick is free when the provider handoff cleared every timer, but whenever the 60-second config-refresh timer survives into it, sinon must replay ~92k firings — each one a real event-loop hop plus stub call bookkeeping — which blows the 10s mocha timeout on a slow shared runner instead of failing on an assertion. The CI log shows exactly this shape: 10.00s of silence between the test's scheduling log line and the timeout, while the structurally identical sibling test passed in 6ms right after.

## What was done?
<!--- Describe your changes in detail -->

- Replaced the `await clock.tickAsync(64 * 24 * 60 * 60 * 1000)` in `packages/dashmate/test/unit/helper/scheduleRenewZeroSslCertificateFactory.spec.js` with `await clock.runAllAsync()`, with a comment explaining why.
- This preserves — and strengthens — what the test proves: instead of "no ZeroSSL obtain task runs within 64 days of the provider switch", it now proves the handoff leaves nothing armed at all, so the old renewal can never fire. It is the only long tick in the file; sibling tests tick single 60-second refresh periods, which are unaffected.
- Failure modes are now fast and attributable: a cron job surviving the handoff fires during `runAllAsync` and trips the `calledOnce`/`not.called` assertions (~50ms); a surviving refresh interval trips fake-timers' 1000-timer infinite-loop guard (~170ms). Both verified by temporarily seeding those regressions into `scheduleRenewalJob.js`/`watchCertificateConfig.js`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `yarn workspace dashmate mocha test/unit/helper/scheduleRenewZeroSslCertificateFactory.spec.js` run 18× (mixed `TZ=UTC` and local timezone to match CI): 16 passing every run, 42–61ms per run.
- Mutation checks: with `job.stop()` removed from the config-change handoff the test fails on the assertion in ~50ms; with `clearInterval` removed from the watcher it fails with sinon's infinite-loop guard in ~170ms — instead of a 10s timeout in both cases.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate renewal scheduling behavior when switching providers.
  * Confirmed that outdated ZeroSSL renewal timers do not run after the provider handoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->