### PR TITLE
fix(swift-sdk)!: bound contested username loading

### DIFF
--- a/packages/rs-sdk-ffi/src/dpns/queries/contested.rs
+++ b/packages/rs-sdk-ffi/src/dpns/queries/contested.rs
@@ -5,6 +5,7 @@ use dash_sdk::dpp::document::DocumentV0Getters;
 use dash_sdk::dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
+use std::time::Duration;
 
 use crate::sdk::SDKWrapper;
 use crate::types::{
@@ -15,6 +16,10 @@ use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
 use dash_sdk::dpp::identifier::Identifier;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use serde_json::json; // Still used by other functions
+
+/// A list query fans out to the vote state of every current contest. Keep one
+/// slow or unreachable DAPI node from pinning an FFI caller indefinitely.
+const DPNS_ACTIVE_CONTESTS_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Get all contested DPNS usernames where an identity is a contender
 ///
@@ -637,9 +642,19 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_contested_non_resolved_usernames(
 
     let limit_opt = if limit > 0 { Some(limit) } else { None };
 
-    let result = sdk_wrapper
-        .runtime
-        .block_on(async { sdk.get_contested_non_resolved_usernames(limit_opt).await });
+    let result = sdk_wrapper.runtime.block_on(async {
+        tokio::time::timeout(
+            DPNS_ACTIVE_CONTESTS_TIMEOUT,
+            sdk.get_contested_non_resolved_usernames(limit_opt),
+        )
+        .await
+        .map_err(|_| {
+            dash_sdk::Error::TimeoutReached(
+                DPNS_ACTIVE_CONTESTS_TIMEOUT,
+                "fetching active DPNS contests".to_string(),
+            )
+        })?
+    });
 
     match result {
         Ok(names_with_contest_info) => {

--- a/packages/rs-sdk/src/platform/dpns_usernames/contested_queries.rs
+++ b/packages/rs-sdk/src/platform/dpns_usernames/contested_queries.rs
@@ -18,10 +18,14 @@ use drive::query::vote_poll_vote_state_query::{
 use drive::query::vote_polls_by_document_type_query::VotePollsByDocumentTypeQuery;
 use drive::query::VotePollsByEndDateDriveQuery;
 use drive_proof_verifier::types::{Contenders, ContestedResource, VotePollsGroupedByTimestamp};
+use futures::{stream, StreamExt};
 use std::collections::BTreeMap;
 
 // DPNS parent domain constant
 const DPNS_PARENT_DOMAIN: &str = "dash";
+/// Keep the fan-out small enough not to overwhelm one DAPI node while avoiding
+/// the previous one-network-round-trip-per-contest serial load.
+const DPNS_VOTE_STATE_QUERY_CONCURRENCY: usize = 8;
 
 /// Represents contest information including contenders and end time
 #[derive(Debug, Clone)]
@@ -327,12 +331,20 @@ impl Sdk {
             .get_current_dpns_contests(None, None, Some(100))
             .await?;
 
-        // Check each name to see if it's resolved and collect contenders with end times
+        // Check each name to see if it's resolved and collect contenders with
+        // end times. `buffered` runs a bounded number of requests concurrently
+        // while yielding them in the BTreeMap's deterministic name order. That
+        // preserves the old limit semantics (the first N unresolved names) and
+        // avoids an unbounded burst against DAPI.
         let mut non_resolved_names: BTreeMap<String, ContestInfo> = BTreeMap::new();
+        let vote_states = stream::iter(current_contests).map(|(name, end_time)| async move {
+            let state = self.get_contested_dpns_vote_state(&name, None).await;
+            (name, end_time, state)
+        });
+        let mut vote_states = vote_states.buffered(DPNS_VOTE_STATE_QUERY_CONCURRENCY);
 
-        for (name, end_time) in current_contests {
-            // Get the vote state for this name
-            match self.get_contested_dpns_vote_state(&name, None).await {
+        while let Some((name, end_time, state)) = vote_states.next().await {
+            match state {
                 Ok(contenders) => {
                     // Check if there's a winner - if not, it's unresolved
                     if contenders.winner.is_none() {

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
@@ -1,6 +1,44 @@
 import Foundation
 import DashSDKFFI
 
+private final class DPNSActiveContestsRequest: @unchecked Sendable {
+  private enum Phase {
+    case queued
+    case running
+    case cancelled
+  }
+
+  let sdk: SDK
+  let sdkHandle: OpaquePointer
+
+  private let lock = NSLock()
+  private var phase = Phase.queued
+
+  init(sdk: SDK, sdkHandle: OpaquePointer) {
+    self.sdk = sdk
+    self.sdkHandle = sdkHandle
+  }
+
+  func begin() -> Bool {
+    lock.withLock {
+      guard case .queued = phase else { return false }
+      phase = .running
+      return true
+    }
+  }
+
+  func cancel() {
+    lock.withLock { phase = .cancelled }
+  }
+
+  var isCancelled: Bool {
+    lock.withLock {
+      if case .cancelled = phase { return true }
+      return false
+    }
+  }
+}
+
 // MARK: - DPNS contested-username browsing
 //
 // Typed reads for the *voter's* view of DPNS username contests: every open
@@ -21,6 +59,14 @@ import DashSDKFFI
 
 @MainActor
 extension SDK {
+
+  /// Serializes the blocking active-contest FFI call on a GCD worker rather
+  /// than occupying Swift's cooperative executor. Serial execution also lets
+  /// canceled refreshes waiting behind an in-flight query skip entering Rust.
+  nonisolated private static let activeContestsQueue = DispatchQueue(
+    label: "org.dash.swiftdashsdk.dpns-active-contests",
+    qos: .userInitiated
+  )
 
   // MARK: - Label normalization
 
@@ -75,34 +121,46 @@ extension SDK {
       throw SDKError.invalidState("SDK not initialized")
     }
 
-    let task = Task.detached(priority: .userInitiated) { [self] in
-      try Task.checkCancellation()
-
-      // `SDK` owns `sdkHandle`; pin it until the synchronous FFI call has
-      // returned and any owned result has been copied and freed.
-      let contests: [DPNSContest]? = withExtendedLifetime(self) {
-        guard let listPtr = dash_sdk_dpns_get_contested_non_resolved_usernames(
-          sdkHandle, limit
-        ) else { return nil }
-        return Self.consumeContestedNamesList(listPtr)
-      }
-
-      // The FFI call cannot be interrupted. Check only after consuming the
-      // result so cancellation cannot leak an allocated list.
-      try Task.checkCancellation()
-      guard let contests else {
-        throw SDKError.internalError("Failed to fetch contested DPNS usernames")
-      }
-      return contests
-    }
+    let request = DPNSActiveContestsRequest(sdk: self, sdkHandle: sdkHandle)
 
     return try await withTaskCancellationHandler {
-      let contests = try await task.value
+      try Task.checkCancellation()
+
+      let contests = try await withCheckedThrowingContinuation {
+        (continuation: CheckedContinuation<[DPNSContest], Error>) in
+        Self.activeContestsQueue.async {
+          guard request.begin() else {
+            continuation.resume(throwing: CancellationError())
+            return
+          }
+
+          // `SDK` owns its handle; pin it until the synchronous FFI call has
+          // returned and any owned result has been copied and freed.
+          let contests: [DPNSContest]? = withExtendedLifetime(request.sdk) {
+            guard let listPtr = dash_sdk_dpns_get_contested_non_resolved_usernames(
+              request.sdkHandle, limit
+            ) else { return nil }
+            return Self.consumeContestedNamesList(listPtr)
+          }
+
+          // The FFI call cannot be interrupted. Check only after consuming the
+          // result so cancellation cannot leak an allocated list.
+          if request.isCancelled {
+            continuation.resume(throwing: CancellationError())
+          } else if let contests {
+            continuation.resume(returning: contests)
+          } else {
+            continuation.resume(
+              throwing: SDKError.internalError("Failed to fetch contested DPNS usernames")
+            )
+          }
+        }
+      }
       // Cover cancellation after the worker's check but before this task resumes.
       try Task.checkCancellation()
       return contests
     } onCancel: {
-      task.cancel()
+      request.cancel()
     }
   }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
@@ -60,7 +60,10 @@ extension SDK {
   ///
   /// The Rust bridge lists current contests, then loads their vote states with
   /// bounded concurrency and an overall timeout. This async wrapper keeps that
-  /// blocking FFI operation off the caller's actor.
+  /// blocking FFI operation off the caller's actor. Cancellation is cooperative
+  /// at the FFI boundary: it prevents work that has not entered Rust, but once
+  /// the synchronous call starts this method waits for it to return (bounded by
+  /// the Rust timeout), frees any result, then throws `CancellationError`.
   ///
   /// - Parameter limit: Maximum contests to return. The FFI has no
   ///   start-after cursor on this query, so this is a hard ceiling, not a
@@ -71,12 +74,36 @@ extension SDK {
     guard let sdkHandle = handle else {
       throw SDKError.invalidState("SDK not initialized")
     }
-    return try await Task.detached(priority: .userInitiated) {
-      guard let listPtr = dash_sdk_dpns_get_contested_non_resolved_usernames(sdkHandle, limit) else {
+
+    let task = Task.detached(priority: .userInitiated) { [self] in
+      try Task.checkCancellation()
+
+      // `SDK` owns `sdkHandle`; pin it until the synchronous FFI call has
+      // returned and any owned result has been copied and freed.
+      let contests: [DPNSContest]? = withExtendedLifetime(self) {
+        guard let listPtr = dash_sdk_dpns_get_contested_non_resolved_usernames(
+          sdkHandle, limit
+        ) else { return nil }
+        return Self.consumeContestedNamesList(listPtr)
+      }
+
+      // The FFI call cannot be interrupted. Check only after consuming the
+      // result so cancellation cannot leak an allocated list.
+      try Task.checkCancellation()
+      guard let contests else {
         throw SDKError.internalError("Failed to fetch contested DPNS usernames")
       }
-      return Self.consumeContestedNamesList(listPtr)
-    }.value
+      return contests
+    }
+
+    return try await withTaskCancellationHandler {
+      let contests = try await task.value
+      // Cover cancellation after the worker's check but before this task resumes.
+      try Task.checkCancellation()
+      return contests
+    } onCancel: {
+      task.cancel()
+    }
   }
 
   /// The open contests **this identity is contending in** — the "how are my

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
@@ -58,22 +58,25 @@ extension SDK {
   /// Every DPNS username contest that is still open, with its contenders,
   /// tallies and end time.
   ///
-  /// One round trip. Reads the FFI's `DashSDKContestedNamesList` structure
-  /// directly, so contender tallies arrive as integers.
+  /// The Rust bridge lists current contests, then loads their vote states with
+  /// bounded concurrency and an overall timeout. This async wrapper keeps that
+  /// blocking FFI operation off the caller's actor.
   ///
   /// - Parameter limit: Maximum contests to return. The FFI has no
   ///   start-after cursor on this query, so this is a hard ceiling, not a
   ///   page size — raise it rather than trying to page.
   /// - Returns: Contests sorted by normalized label. Empty when nothing is
   ///   contested.
-  public func dpnsActiveContests(limit: UInt32 = 200) throws -> [DPNSContest] {
-    guard let handle = handle else {
+  public func dpnsActiveContests(limit: UInt32 = 200) async throws -> [DPNSContest] {
+    guard let sdkHandle = handle else {
       throw SDKError.invalidState("SDK not initialized")
     }
-    guard let listPtr = dash_sdk_dpns_get_contested_non_resolved_usernames(handle, limit) else {
-      throw SDKError.internalError("Failed to fetch contested DPNS usernames")
-    }
-    return Self.consumeContestedNamesList(listPtr)
+    return try await Task.detached(priority: .userInitiated) {
+      guard let listPtr = dash_sdk_dpns_get_contested_non_resolved_usernames(sdkHandle, limit) else {
+        throw SDKError.internalError("Failed to fetch contested DPNS usernames")
+      }
+      return Self.consumeContestedNamesList(listPtr)
+    }.value
   }
 
   /// The open contests **this identity is contending in** — the "how are my
@@ -105,7 +108,7 @@ extension SDK {
   /// the null-label handling to drift.
   ///
   /// Takes ownership: the list is freed before returning, on every path.
-  private static func consumeContestedNamesList(
+  nonisolated private static func consumeContestedNamesList(
     _ listPtr: UnsafeMutablePointer<DashSDKContestedNamesList>
   ) -> [DPNSContest] {
     defer { dash_sdk_contested_names_list_free(listPtr) }


### PR DESCRIPTION
## Issue being fixed or feature implemented

DashWallet's Username voting screen can become unresponsive while loading active DPNS contests. The Swift call enters a blocking FFI function, while the Rust SDK fetches every contest's vote state serially without an overall deadline. A slow or unreachable DAPI node can therefore pin the caller indefinitely.

## What was done?

- Load contest vote states with bounded concurrency of eight while preserving deterministic ordering and first-N limit behavior.
- Apply a 30-second deadline to the complete active-contest FFI operation.
- Make `SDK.dpnsActiveContests` asynchronous and move the blocking FFI call to a detached task.

## How Has This Been Tested?

- `cargo fmt --all -- --check`
- `cargo check -p dash-sdk -p rs-sdk-ffi`
- `cargo test -p dash-sdk -p rs-sdk-ffi --lib` (508 passed, 1 ignored)
- `SKIP_EXAMPLE_APP_BUILD=1 ./build_ios.sh --target sim --profile dev`
- Full downstream DashWallet simulator build, install, and launch on iOS 26.5
- Reproduced the original loading path without masternode keys; it completed with the empty state, Back remained responsive during loading, and a process sample showed the main thread idle in UIKit while Rust work ran off-main

## Breaking Changes

`SDK.dpnsActiveContests(limit:)` now returns asynchronously. Swift callers must add `await`.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a timeout when loading active contested DPNS usernames, preventing requests from waiting indefinitely.
  * Improved handling of contest status checks while preserving result ordering and existing limits.
  * Cancelled Swift contest requests now stop before processing when possible and report cancellation consistently.

* **Improvements**
  * Contest queries now process multiple checks efficiently with controlled concurrency.
  * Swift contest retrieval is now asynchronous, improving responsiveness during potentially long-running requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->