### PR TITLE
feat(dpp)!: add indexOnly document types with terminal index keys

### DIFF
--- a/packages/rs-dpp/schema/meta_schemas/document/v3/document-meta.json
+++ b/packages/rs-dpp/schema/meta_schemas/document/v3/document-meta.json
@@ -622,6 +622,12 @@
             "required": ["on", "range", "step"],
             "additionalProperties": false,
             "description": "Buckets the first index property's timestamp into fixed-length, regularly-spaced (possibly overlapping) time ranges. The window parameters (`range`, `step`, `phase`) are declared in seconds, since a bucket is selected from block time and the target block interval is five seconds; the stored key is the range start as a u64 millisecond timestamp, so it stays directly comparable to the source timestamp it buckets. Enables trending/leaderboard queries within the newest/oldest active range. A system-timestamp source must be listed in the document type's required fields. Several indexes may bucket the same timestamp with different grids — each grid gets its own index subtree, keyed by the property name qualified with the grid parameters. Available from protocol version 14."
+          },
+          "terminal": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "Only on indexOnly document types: names the property whose value is this index entry's member key — the docId-analog terminal key under the index's storage marker, stored as an Item instead of a Reference because there is no primary-storage row. Either \"$ownerId\" (the default when omitted) or an identifier property carrying a refersTo declaration (identity, contract, token, or permanentDocument). Must not repeat one of the index's listed properties. Available from protocol version 14."
           }
         },
         "required": [
@@ -765,6 +771,10 @@
     "rangeAverageable": {
       "type": "boolean",
       "description": "Syntactic sugar: `rangeAverageable: true` is shorthand for `rangeCountable: true` + `rangeSummable: true`. Requires `documentsAverageable` to be set. Same caveat as `rangeSummable` — rarely useful on the primary key; per-index `rangeAverageable` is what most callers want."
+    },
+    "indexOnly": {
+      "type": "boolean",
+      "description": "When true, documents of this type are never written to primary storage: the index entries are the rows, each terminating in an Item keyed by the index's `terminal` property instead of a Reference keyed by the document id. Only what is in the indexes exists and is recoverable. Requires: every property required and appearing in at least one index, $ownerId in at least one index (as a property or terminal), documentsMutable: false, no transfers/trading/history/transient properties, and no doctype-level aggregate keywords (use the index-level count flags). Available from protocol version 14."
     },
     "tokenCost": {
       "type": "object",

--- a/packages/rs-dpp/src/data_contract/document_type/accessors/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/accessors/mod.rs
@@ -1014,14 +1014,6 @@ impl DocumentTypeV2Setters for DocumentType {
             DocumentType::V2(v2) => v2.set_range_summable(range_summable),
         }
     }
-
-    fn set_index_only(&mut self, index_only: bool) {
-        match self {
-            DocumentType::V0(_) => { /* no-op */ }
-            DocumentType::V1(_) => { /* no-op */ }
-            DocumentType::V2(v2) => v2.set_index_only(index_only),
-        }
-    }
 }
 
 impl DocumentTypeV2Getters for DocumentTypeRef<'_> {

--- a/packages/rs-dpp/src/data_contract/document_type/accessors/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/accessors/mod.rs
@@ -972,6 +972,14 @@ impl DocumentTypeV2Getters for DocumentType {
             DocumentType::V2(v2) => v2.range_summable(),
         }
     }
+
+    fn index_only(&self) -> bool {
+        match self {
+            DocumentType::V0(_) => false,
+            DocumentType::V1(_) => false,
+            DocumentType::V2(v2) => v2.index_only(),
+        }
+    }
 }
 
 impl DocumentTypeV2Setters for DocumentType {
@@ -1004,6 +1012,14 @@ impl DocumentTypeV2Setters for DocumentType {
             DocumentType::V0(_) => { /* no-op */ }
             DocumentType::V1(_) => { /* no-op */ }
             DocumentType::V2(v2) => v2.set_range_summable(range_summable),
+        }
+    }
+
+    fn set_index_only(&mut self, index_only: bool) {
+        match self {
+            DocumentType::V0(_) => { /* no-op */ }
+            DocumentType::V1(_) => { /* no-op */ }
+            DocumentType::V2(v2) => v2.set_index_only(index_only),
         }
     }
 }
@@ -1040,6 +1056,14 @@ impl DocumentTypeV2Getters for DocumentTypeRef<'_> {
             DocumentTypeRef::V2(v2) => v2.range_summable(),
         }
     }
+
+    fn index_only(&self) -> bool {
+        match self {
+            DocumentTypeRef::V0(_) => false,
+            DocumentTypeRef::V1(_) => false,
+            DocumentTypeRef::V2(v2) => v2.index_only(),
+        }
+    }
 }
 
 impl DocumentTypeV2Getters for DocumentTypeMutRef<'_> {
@@ -1072,6 +1096,14 @@ impl DocumentTypeV2Getters for DocumentTypeMutRef<'_> {
             DocumentTypeMutRef::V0(_) => false,
             DocumentTypeMutRef::V1(_) => false,
             DocumentTypeMutRef::V2(v2) => v2.range_summable(),
+        }
+    }
+
+    fn index_only(&self) -> bool {
+        match self {
+            DocumentTypeMutRef::V0(_) => false,
+            DocumentTypeMutRef::V1(_) => false,
+            DocumentTypeMutRef::V2(v2) => v2.index_only(),
         }
     }
 }

--- a/packages/rs-dpp/src/data_contract/document_type/accessors/v2/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/accessors/v2/mod.rs
@@ -24,6 +24,12 @@ pub trait DocumentTypeV2Getters {
     /// true, the primary-key sum tree is a `ProvableSumTree` (per-node
     /// aggregated sums). Implies [`Self::documents_summable`] is `Some`.
     fn range_summable(&self) -> bool;
+
+    /// Returns whether this document type is **indexOnly**: documents are
+    /// never written to primary storage — the index entries are the rows,
+    /// each terminating in an `Item` keyed by the index's `terminal`
+    /// property. Only what is in the indexes exists and is recoverable.
+    fn index_only(&self) -> bool;
 }
 
 /// Trait providing setters for DocumentTypeV2-specific fields.
@@ -45,4 +51,8 @@ pub trait DocumentTypeV2Setters {
     /// be set to `Some(_)`; setters MAY enforce this by panicking or by
     /// silently no-op'ing — refer to the impl docs.
     fn set_range_summable(&mut self, range_summable: bool);
+
+    /// Sets whether this document type is indexOnly. Only the parser should
+    /// call this — the flag's structural invariants are enforced there.
+    fn set_index_only(&mut self, index_only: bool);
 }

--- a/packages/rs-dpp/src/data_contract/document_type/accessors/v2/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/accessors/v2/mod.rs
@@ -51,8 +51,4 @@ pub trait DocumentTypeV2Setters {
     /// be set to `Some(_)`; setters MAY enforce this by panicking or by
     /// silently no-op'ing — refer to the impl docs.
     fn set_range_summable(&mut self, range_summable: bool);
-
-    /// Sets whether this document type is indexOnly. Only the parser should
-    /// call this — the flag's structural invariants are enforced there.
-    fn set_index_only(&mut self, index_only: bool);
 }

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
@@ -834,9 +834,11 @@ fn parse_indices(
                             .to_map()
                             .map_err(consensus_or_protocol_value_error)?
                             .as_slice(),
-                        ctx.generation.admit_ranked,
-                        ctx.generation.admit_time_range,
-                        ctx.generation.admit_index_terminal,
+                        crate::data_contract::document_type::index::IndexGrammarAdmissions {
+                            ranked: ctx.generation.admit_ranked,
+                            time_range: ctx.generation.admit_time_range,
+                            terminal: ctx.generation.admit_index_terminal,
+                        },
                     )
                     .map_err(consensus_or_protocol_data_contract_error)?;
 
@@ -1983,7 +1985,6 @@ pub(super) fn apply_index_only(
     }
 
     // ---- per-index rules ------------------------------------------------
-    let mut owner_id_indexed = false;
     for (index_name, index) in document_type.indices.iter() {
         if index.properties.is_empty() {
             return Err(structure_error(format!(
@@ -2053,22 +2054,35 @@ pub(super) fn apply_index_only(
 
         // The terminal is the member key — it must be a referable entity id:
         // the owner identity, or a property carrying a refersTo declaration
-        // (identity, contract, token, or permanent document — all kinds that
-        // can never dangle).
+        // whose value alone IS the referenced entity's id (identity,
+        // contract, token, or permanent document — all kinds that can never
+        // dangle). `identityPublicKey` is deliberately NOT admitted: it is a
+        // compound reference — this property carries the identity id while a
+        // separate `keyIdProperty` carries the key id — so a terminal keyed
+        // by it would conflate references to different keys of the same
+        // identity.
         if terminal != OWNER_ID {
+            use crate::data_contract::document_type::property::DocumentPropertyReferenceTarget;
             match document_type.flattened_properties.get(terminal) {
                 Some(property)
                     if matches!(
                         property.property_type,
-                        DocumentPropertyType::IdentifierWithReference(_)
+                        DocumentPropertyType::IdentifierWithReference(
+                            DocumentPropertyReferenceTarget::Identity
+                                | DocumentPropertyReferenceTarget::Contract
+                                | DocumentPropertyReferenceTarget::Token
+                                | DocumentPropertyReferenceTarget::PermanentDocument { .. }
+                        )
                     ) => {}
                 Some(_) => {
                     return Err(structure_error(format!(
                         "terminal \"{}\" of index \"{}\" on indexOnly document type \"{}\" \
                          must be \"$ownerId\" or an identifier property with a refersTo \
-                         declaration (identity, contract, token, or permanentDocument): \
-                         the terminal is the entry's member key and must be a referable \
-                         entity id",
+                         declaration targeting identity, contract, token, or \
+                         permanentDocument: the terminal is the entry's member key and must \
+                         alone be a referable entity id (an identityPublicKey reference is \
+                         compound — its key id lives in a separate property — and is not \
+                         admitted)",
                         terminal, index_name, name,
                     )));
                 }
@@ -2102,13 +2116,48 @@ pub(super) fn apply_index_only(
             }
         }
 
-        if terminal == OWNER_ID
-            || index
+        // EVERY index must embed `$ownerId` (as a prefix property or the
+        // terminal). This is what makes each entry self-authorizing: a
+        // delete recomputes entries with owner = signer, so an entry the
+        // signer does not own is simply not there. With an owner-less
+        // index, a crafted delete could splice values from two different
+        // documents — its own owner-bearing row and a victim's owner-less
+        // row — and remove an entry it never created; binding every entry
+        // to its owner closes that, at the cost of the (unneeded) global-
+        // uniqueness-without-owner shape.
+        if terminal != OWNER_ID
+            && !index
                 .properties
                 .iter()
                 .any(|property| property.name == OWNER_ID)
         {
-            owner_id_indexed = true;
+            return Err(structure_error(format!(
+                "index \"{}\" on indexOnly document type \"{}\" must include $ownerId (as \
+                 a property or as the terminal): every entry must be bound to its owner so \
+                 deletes can only ever remove the signer's own entries",
+                index_name, name,
+            )));
+        }
+
+        // `$createdAt` in an index is only coherent when the document
+        // actually carries a timestamp — and document creation assigns
+        // `created_at` only when `$createdAt` is in `required`. Without
+        // this, an indexed `$createdAt` would silently take the missing-
+        // value branch instead of storing block time.
+        if (terminal == CREATED_AT
+            || index
+                .properties
+                .iter()
+                .any(|property| property.name == CREATED_AT))
+            && !document_type.required_fields.contains(CREATED_AT)
+        {
+            return Err(structure_error(format!(
+                "index \"{}\" on indexOnly document type \"{}\" involves $createdAt, so \
+                 \"$createdAt\" must be listed in `required`: document creation only \
+                 assigns the timestamp for required system times, and an indexOnly entry \
+                 cannot represent a missing value",
+                index_name, name,
+            )));
         }
     }
 
@@ -2145,19 +2194,27 @@ pub(super) fn apply_index_only(
                 property_name, name,
             )));
         }
-    }
 
-    // Ownership must be recoverable: a delete is authorized by probing an
-    // $ownerId-bearing entry computed with owner = signer, so at least one
-    // index has to embed the owner.
-    if !owner_id_indexed {
-        return Err(structure_error(format!(
-            "indexOnly document type \"{}\" must include $ownerId in at least one index \
-             (as a property or as the terminal): delete authorization recovers ownership \
-             from an owner-bearing index entry, and without one no document of this type \
-             could ever be deleted by its owner",
-            name,
-        )));
+        // A required nested leaf inside an OPTIONAL ancestor object is only
+        // conditionally present — `required: ["targetId"]` inside an
+        // unrequired `profile` lets a valid document omit the whole object.
+        // Every ancestor path of an indexed dotted property must therefore
+        // be required too, or the no-null invariant silently breaks.
+        let mut ancestor = String::new();
+        for segment in property_name.split('.') {
+            if !ancestor.is_empty() {
+                if !document_type.required_fields.contains(&ancestor) {
+                    return Err(structure_error(format!(
+                        "property \"{}\" on indexOnly document type \"{}\" sits inside \
+                         \"{}\", which is not listed in `required`: a valid document could \
+                         omit the whole object, leaving the indexed leaf absent",
+                        property_name, name, ancestor,
+                    )));
+                }
+                ancestor.push('.');
+            }
+            ancestor.push_str(segment);
+        }
     }
 
     Ok(())

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
@@ -27,9 +27,9 @@ use crate::data_contract::document_type::property::DocumentProperty;
 use crate::data_contract::document_type::property::DocumentPropertyType;
 use crate::data_contract::document_type::property_names::{
     CAN_BE_DELETED, CREATION_RESTRICTION_MODE, DOCUMENTS_AVERAGEABLE, DOCUMENTS_COUNTABLE,
-    DOCUMENTS_KEEP_HISTORY, DOCUMENTS_MUTABLE, DOCUMENTS_SUMMABLE, KEEPS_PRICING_HISTORY,
-    KEEPS_PURCHASE_HISTORY, KEEPS_TRANSFER_HISTORY, RANGE_AVERAGEABLE, RANGE_COUNTABLE,
-    RANGE_SUMMABLE, TRADE_MODE, TRANSFERABLE,
+    DOCUMENTS_KEEP_HISTORY, DOCUMENTS_MUTABLE, DOCUMENTS_SUMMABLE, INDEX_ONLY,
+    KEEPS_PRICING_HISTORY, KEEPS_PURCHASE_HISTORY, KEEPS_TRANSFER_HISTORY, RANGE_AVERAGEABLE,
+    RANGE_COUNTABLE, RANGE_SUMMABLE, TRADE_MODE, TRANSFERABLE,
 };
 use crate::data_contract::document_type::restricted_creation::CreationRestrictionMode;
 use crate::data_contract::document_type::token_costs::v0::TokenCostsV0;
@@ -199,6 +199,16 @@ pub(super) struct ParserGeneration {
     /// the key falls through to the unknown-key arm and is rejected as any
     /// pre-generation-3 node rejected it.
     pub admit_time_range: bool,
+
+    // ---- INDEX ONLY: the third generation-3 addition ----
+    /// Whether the index grammar admits the `terminal` keyword (indexOnly
+    /// document types). Forwarded to [`Index::try_from_value_map`] exactly
+    /// like `admit_ranked` and `admit_time_range`. The doc-type-level
+    /// `indexOnly` keyword needs no admission flag of its own: it is read
+    /// only by the generation-3 driver (`parse_index_only_keyword`), so
+    /// earlier generations ignore it exactly as they ignore every other
+    /// doctype-level keyword they predate.
+    pub admit_index_terminal: bool,
 }
 
 /// Reject a document type whose name is not a non-empty ASCII
@@ -826,6 +836,7 @@ fn parse_indices(
                             .as_slice(),
                         ctx.generation.admit_ranked,
                         ctx.generation.admit_time_range,
+                        ctx.generation.admit_index_terminal,
                     )
                     .map_err(consensus_or_protocol_data_contract_error)?;
 
@@ -1816,6 +1827,337 @@ pub(super) fn apply_doctype_aggregates(
                 )),
             ));
         }
+    }
+
+    Ok(())
+}
+
+/// Read the doctype-level `indexOnly` keyword off the raw schema.
+///
+/// Runs before the core parse because the core takes `schema` by value —
+/// same shape as [`parse_doctype_aggregate_keywords`]. Only the generation-3
+/// driver calls this; earlier generations ignore the keyword exactly as they
+/// ignore every doctype-level keyword they predate (their meta-schemas still
+/// reject it under `full_validation`).
+pub(super) fn parse_index_only_keyword(schema: &Value) -> Result<bool, ProtocolError> {
+    let schema_map_opt = schema.to_map().ok();
+
+    Ok(schema_map_opt
+        .as_ref()
+        .and_then(|schema_map| {
+            Value::inner_optional_bool_value(schema_map, INDEX_ONLY)
+                .map_err(consensus_or_protocol_value_error)
+                .transpose()
+        })
+        .transpose()?
+        .unwrap_or(false))
+}
+
+/// Write the `indexOnly` flag onto the parsed document type, normalize each
+/// index's `terminal` (an omitted terminal defaults to `$ownerId`), and run
+/// the structural cross-checks the index-only on-disk layout depends on.
+///
+/// An indexOnly document type has no primary-storage row: the index entries
+/// ARE the rows, each terminating in an `Item` keyed by the index's terminal
+/// property. Only what is in the indexes exists and is recoverable, which is
+/// why every check below is a storage-layout invariant rather than a schema
+/// lint. Like [`apply_doctype_aggregates`], this runs regardless of
+/// `full_validation`: this function sits on the untrusted-contract boundary,
+/// and admitting a malformed indexOnly type through a non-validating parse
+/// would brick the first document insert or make deletes unauthorizable.
+///
+/// Must run AFTER [`apply_doctype_aggregates`] — it rejects the doctype-level
+/// aggregate flags, which describe the primary-key tree an indexOnly type
+/// does not have.
+pub(super) fn apply_index_only(
+    document_type: &mut DocumentTypeV2,
+    index_only: bool,
+    name: &str,
+) -> Result<(), ProtocolError> {
+    use crate::document::property_names::{CREATED_AT, OWNER_ID};
+
+    let structure_error = |message: String| {
+        ProtocolError::DataContractError(DataContractError::InvalidContractStructure(message))
+    };
+
+    if !index_only {
+        // `terminal` is only meaningful on indexOnly document types: it names
+        // the member key that replaces the document id, and a non-indexOnly
+        // index keys its members by document id unconditionally.
+        if let Some((index_name, _)) = document_type
+            .indices
+            .iter()
+            .find(|(_, index)| index.terminal.is_some())
+        {
+            return Err(structure_error(format!(
+                "index \"{}\" on document type \"{}\" declares `terminal`, which is only \
+                 allowed on indexOnly document types (set `indexOnly: true` on the document \
+                 type, or remove the terminal)",
+                index_name, name,
+            )));
+        }
+        return Ok(());
+    }
+
+    document_type.index_only = true;
+
+    // ---- doctype-level flags -------------------------------------------
+    // Every rejection here names the flag the author must change: silently
+    // overriding a flag would emit a document type whose declared behavior
+    // and on-disk layout disagree.
+    if document_type.documents_mutable {
+        return Err(structure_error(format!(
+            "indexOnly document type \"{}\" must set documentsMutable: false: there is no \
+             stored row (and no revision) to mutate",
+            name,
+        )));
+    }
+    if document_type.documents_transferable != Transferable::Never {
+        return Err(structure_error(format!(
+            "indexOnly document type \"{}\" must not be transferable: ownership is embedded \
+             in the index entries themselves and cannot be reassigned",
+            name,
+        )));
+    }
+    if document_type.trade_mode != TradeMode::None {
+        return Err(structure_error(format!(
+            "indexOnly document type \"{}\" must set tradeMode to none: there is no stored \
+             row to trade",
+            name,
+        )));
+    }
+    if document_type.documents_keep_history
+        || document_type.documents_keep_transfer_history
+        || document_type.documents_keep_purchase_history
+        || document_type.documents_keep_pricing_history
+    {
+        return Err(structure_error(format!(
+            "indexOnly document type \"{}\" cannot keep history (documentsKeepHistory / \
+             keepsTransferHistory / keepsPurchaseHistory / keepsPricingHistory): documents \
+             of this type are only ever created and deleted, and have no stored body to \
+             version",
+            name,
+        )));
+    }
+    if !document_type.transient_fields.is_empty() {
+        return Err(structure_error(format!(
+            "indexOnly document type \"{}\" cannot declare transient properties: on an \
+             indexOnly type only indexed values exist, and a transient property is by \
+             definition not stored — the two declarations contradict each other",
+            name,
+        )));
+    }
+    if document_type.documents_countable
+        || document_type.range_countable
+        || document_type.documents_summable.is_some()
+        || document_type.range_summable
+    {
+        return Err(structure_error(format!(
+            "indexOnly document type \"{}\" cannot use the doctype-level aggregate keywords \
+             (documentsCountable / rangeCountable / documentsSummable / rangeSummable / \
+             the averageable sugar): they describe the primary-key tree, which an indexOnly \
+             type does not have. Use the index-level `countable` / `rangeCountable` / \
+             `rankedCountable` flags instead",
+            name,
+        )));
+    }
+
+    if document_type.indices.is_empty() {
+        return Err(structure_error(format!(
+            "indexOnly document type \"{}\" must declare at least one index: the indexes \
+             are the storage",
+            name,
+        )));
+    }
+
+    // ---- terminal normalization ----------------------------------------
+    // An omitted terminal defaults to `$ownerId`. Normalizing here (rather
+    // than leaving `None` to mean the default) keeps every downstream
+    // consumer — the walkers, the query planner, the update-immutability
+    // comparison — reading one canonical spelling, and both spellings of the
+    // same index parse to equal `Index` values.
+    for index in document_type.indices.values_mut() {
+        if index.terminal.is_none() {
+            index.terminal = Some(OWNER_ID.to_string());
+        }
+    }
+
+    // ---- per-index rules ------------------------------------------------
+    let mut owner_id_indexed = false;
+    for (index_name, index) in document_type.indices.iter() {
+        if index.properties.is_empty() {
+            return Err(structure_error(format!(
+                "index \"{}\" on indexOnly document type \"{}\" has no properties: an \
+                 indexOnly entry is `[…property values, 0, terminal value]`, so at least \
+                 one prefix property is required above the terminal",
+                index_name, name,
+            )));
+        }
+        if index.unique {
+            return Err(structure_error(format!(
+                "index \"{}\" on indexOnly document type \"{}\" cannot be unique: \
+                 uniqueness is structural on an indexOnly type — one entry per value tuple \
+                 and terminal, enforced at insert — and an index without $ownerId already \
+                 enforces global uniqueness of its value tuple",
+                index_name, name,
+            )));
+        }
+        if index.contested_index.is_some() {
+            return Err(structure_error(format!(
+                "index \"{}\" on indexOnly document type \"{}\" cannot be contested: the \
+                 contested-resource machinery is document-based",
+                index_name, name,
+            )));
+        }
+        if !index.null_searchable {
+            return Err(structure_error(format!(
+                "index \"{}\" on indexOnly document type \"{}\" cannot set nullSearchable: \
+                 false: every property of an indexOnly type is required, so no null entries \
+                 exist to suppress",
+                index_name, name,
+            )));
+        }
+        if index.time_range.is_some() {
+            return Err(structure_error(format!(
+                "index \"{}\" on indexOnly document type \"{}\" cannot declare a timeRange: \
+                 bucketed indexOnly indexes are not yet supported",
+                index_name, name,
+            )));
+        }
+        if index.summable.is_some() || index.ranked_summable || index.ranked_averageable {
+            return Err(structure_error(format!(
+                "index \"{}\" on indexOnly document type \"{}\" cannot use the sum axes \
+                 (summable / rangeSummable / rankedSummable / rankedAverageable / the \
+                 averageable sugar): indexOnly terminals are plain Items carrying no sum \
+                 contribution; only the count axes (countable / rangeCountable / \
+                 rankedCountable) are supported",
+                index_name, name,
+            )));
+        }
+
+        let terminal = index.terminal.as_deref().expect("normalized to Some above");
+
+        if index
+            .properties
+            .iter()
+            .any(|property| property.name == terminal)
+        {
+            return Err(structure_error(format!(
+                "index \"{}\" on indexOnly document type \"{}\" repeats its terminal \
+                 (\"{}\") in its properties: the terminal is the member key below the \
+                 listed properties, so listing it again would index the same dimension \
+                 twice",
+                index_name, name, terminal,
+            )));
+        }
+
+        // The terminal is the member key — it must be a referable entity id:
+        // the owner identity, or a property carrying a refersTo declaration
+        // (identity, contract, token, or permanent document — all kinds that
+        // can never dangle).
+        if terminal != OWNER_ID {
+            match document_type.flattened_properties.get(terminal) {
+                Some(property)
+                    if matches!(
+                        property.property_type,
+                        DocumentPropertyType::IdentifierWithReference(_)
+                    ) => {}
+                Some(_) => {
+                    return Err(structure_error(format!(
+                        "terminal \"{}\" of index \"{}\" on indexOnly document type \"{}\" \
+                         must be \"$ownerId\" or an identifier property with a refersTo \
+                         declaration (identity, contract, token, or permanentDocument): \
+                         the terminal is the entry's member key and must be a referable \
+                         entity id",
+                        terminal, index_name, name,
+                    )));
+                }
+                None => {
+                    return Err(structure_error(format!(
+                        "terminal \"{}\" of index \"{}\" on indexOnly document type \"{}\" \
+                         does not name a property of the document type",
+                        terminal, index_name, name,
+                    )));
+                }
+            }
+        }
+
+        // Prefix properties: schema properties plus exactly two system
+        // properties — `$ownerId` (ownership) and `$createdAt` (assigned
+        // from block time at create, recoverable from the path). Every
+        // other system property either cannot exist on an immutable type
+        // ($updatedAt and friends) or has no stored home ($revision &co).
+        for property in index.properties.iter() {
+            if property.name.starts_with('$')
+                && property.name != OWNER_ID
+                && property.name != CREATED_AT
+            {
+                return Err(structure_error(format!(
+                    "index \"{}\" on indexOnly document type \"{}\" indexes system property \
+                     \"{}\": only $ownerId and $createdAt may be indexed on an indexOnly \
+                     type (documents are immutable, so no other system property can carry \
+                     information)",
+                    index_name, name, property.name,
+                )));
+            }
+        }
+
+        if terminal == OWNER_ID
+            || index
+                .properties
+                .iter()
+                .any(|property| property.name == OWNER_ID)
+        {
+            owner_id_indexed = true;
+        }
+    }
+
+    // ---- coverage and requiredness --------------------------------------
+    // The index content IS the document: a property in no index would not
+    // exist, and an optional property would need the null-layout machinery
+    // this mode deliberately sidesteps.
+    for (property_name, property) in document_type.flattened_properties.iter() {
+        if matches!(property.property_type, DocumentPropertyType::Object(_)) {
+            // Containers are covered through their flattened leaves.
+            continue;
+        }
+        let covered = document_type.indices.values().any(|index| {
+            index.terminal.as_deref() == Some(property_name.as_str())
+                || index
+                    .properties
+                    .iter()
+                    .any(|index_property| index_property.name == *property_name)
+        });
+        if !covered {
+            return Err(structure_error(format!(
+                "property \"{}\" on indexOnly document type \"{}\" does not appear in any \
+                 index (as a property or terminal): on an indexOnly type only indexed \
+                 values exist and are recoverable, so an unindexed property would be \
+                 silently dropped",
+                property_name, name,
+            )));
+        }
+        if !document_type.required_fields.contains(property_name) {
+            return Err(structure_error(format!(
+                "property \"{}\" on indexOnly document type \"{}\" must be listed in \
+                 `required`: the index path is the storage, and an absent value would need \
+                 the null index layout this mode deliberately has no equivalent of",
+                property_name, name,
+            )));
+        }
+    }
+
+    // Ownership must be recoverable: a delete is authorized by probing an
+    // $ownerId-bearing entry computed with owner = signer, so at least one
+    // index has to embed the owner.
+    if !owner_id_indexed {
+        return Err(structure_error(format!(
+            "indexOnly document type \"{}\" must include $ownerId in at least one index \
+             (as a property or as the terminal): delete authorization recovers ownership \
+             from an owner-bearing index entry, and without one no document of this type \
+             could ever be deleted by its owner",
+            name,
+        )));
     }
 
     Ok(())

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
@@ -104,6 +104,8 @@ impl DocumentTypeV1 {
                 ranked_index_structure_check: common::no_ranked_index_structure_check,
                 // TIME RANGE: also a generation-3 keyword; not in this grammar.
                 admit_time_range: false,
+                // INDEX ONLY: also a generation-3 keyword; not in this grammar.
+                admit_index_terminal: false,
             },
             platform_version,
         )

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
@@ -1,0 +1,489 @@
+//! indexOnly document types — parser-generation gating and the structural
+//! constraint matrix.
+//!
+//! The `indexOnly` doctype keyword and the `terminal` index keyword joined
+//! the grammar at generation 3 (meta-schema v3, protocol version 14), like
+//! the ranked keywords next door. The same two-sided gating has to hold on
+//! the pre-PV14 side:
+//!
+//!   * `terminal` (index-level, strict grammar): rejected as an unknown key
+//!     on BOTH validation modes below generation 3.
+//!   * `indexOnly` (doctype-level, loose grammar): ignored by earlier
+//!     generations on the non-validating path — exactly how every
+//!     doctype-level keyword they predate behaves — and rejected by their
+//!     meta-schemas under `full_validation`.
+//!
+//! The constraint matrix itself (`apply_index_only`) runs regardless of
+//! `full_validation` because the on-disk layout depends on it, so every
+//! rejection test here goes through the non-validating parse — the
+//! smuggling path — and the happy path is additionally exercised under full
+//! validation to pin the meta-schema admission.
+
+use super::*;
+use crate::data_contract::document_type::accessors::DocumentTypeV2Getters;
+use crate::data_contract::errors::DataContractError;
+use platform_value::platform_value;
+
+/// Parse through this generation with validation mode spelled out.
+fn parse_with(
+    schema: Value,
+    platform_version: &PlatformVersion,
+    full_validation: bool,
+) -> Result<DocumentTypeV2, ProtocolError> {
+    let config = DataContractConfig::default_for_version(platform_version)
+        .expect("default config available on this platform version");
+    try_from_schema_generation_3(
+        Identifier::new([1; 32]),
+        1,
+        config.version(),
+        "like",
+        schema,
+        None,
+        &BTreeMap::new(),
+        &config,
+        full_validation,
+        &mut vec![],
+        platform_version,
+    )
+}
+
+/// Parse through the real dispatcher, which picks the parser generation out
+/// of the platform version's `try_from_schema` table value (generation 2 at
+/// PV13, generation 3 at PV14).
+fn parse_dispatched(
+    schema: Value,
+    platform_version: &PlatformVersion,
+    full_validation: bool,
+) -> Result<DocumentType, ProtocolError> {
+    let config = DataContractConfig::default_for_version(platform_version)
+        .expect("default config available on this platform version");
+    DocumentType::try_from_schema(
+        Identifier::new([1; 32]),
+        1,
+        config.version(),
+        "like",
+        schema,
+        None,
+        &BTreeMap::new(),
+        &config,
+        full_validation,
+        &mut vec![],
+        platform_version,
+    )
+}
+
+/// The worked example from the design: a Yappr-style `like` type. Two
+/// schema properties (`hashtag`, `postId` — the latter a refersTo-typed
+/// identifier), three indexes:
+///
+///   * `byHashtagPost` — ranked per-hashtag top posts, terminal `$ownerId`
+///   * `byPost` — global ranking + one-like-per-(post, owner) constraint;
+///     terminal omitted to exercise the `$ownerId` default
+///   * `byLiker` — "what did I like", `$ownerId` prefix, `postId` terminal
+fn likes_schema() -> Value {
+    platform_value!({
+        "type": "object",
+        "indexOnly": true,
+        "documentsMutable": false,
+        "properties": {
+            "hashtag": {
+                "type": "string",
+                "maxLength": 63,
+                "position": 0
+            },
+            "postId": {
+                "type": "array",
+                "byteArray": true,
+                "minItems": 32,
+                "maxItems": 32,
+                "contentMediaType": "application/x.dash.dpp.identifier",
+                "refersTo": { "type": "identity" },
+                "position": 1
+            }
+        },
+        "required": ["hashtag", "postId"],
+        "indices": [
+            {
+                "name": "byHashtagPost",
+                "properties": [{ "hashtag": "asc" }, { "postId": "asc" }],
+                "terminal": "$ownerId",
+                "countable": true,
+                "rangeCountable": true,
+                "rankedCountable": true
+            },
+            {
+                "name": "byPost",
+                "properties": [{ "postId": "asc" }],
+                "countable": true,
+                "rangeCountable": true,
+                "rankedCountable": true
+            },
+            {
+                "name": "byLiker",
+                "properties": [{ "$ownerId": "asc" }],
+                "terminal": "postId"
+            }
+        ],
+        "additionalProperties": false
+    })
+}
+
+/// The base schema with one doctype-level key set (added or replaced).
+fn likes_schema_with(key: &str, value: Value) -> Value {
+    let mut schema = likes_schema();
+    schema.set_value(key, value).expect("doctype key applies");
+    schema
+}
+
+/// The base schema with one key set (added or replaced) on the index at
+/// `index_position` (0 = byHashtagPost, 1 = byPost, 2 = byLiker).
+fn likes_schema_with_index_key(index_position: usize, key: &str, value: Value) -> Value {
+    let mut schema = likes_schema();
+    schema
+        .get_mut("indices")
+        .expect("indices accessible")
+        .expect("indices present")
+        .as_array_mut()
+        .expect("indices is an array")
+        .get_mut(index_position)
+        .expect("index exists")
+        .set_value(key, value)
+        .expect("index key applies");
+    schema
+}
+
+fn expect_structure_error(result: Result<DocumentTypeV2, ProtocolError>, needle: &str) {
+    match result {
+        Err(ProtocolError::DataContractError(DataContractError::InvalidContractStructure(
+            message,
+        ))) => {
+            assert!(
+                message.contains(needle),
+                "expected structure error containing {needle:?}, got: {message}"
+            );
+        }
+        Err(other) => {
+            panic!("expected InvalidContractStructure containing {needle:?}, got {other}")
+        }
+        Ok(_) => panic!("expected rejection containing {needle:?}, but the schema parsed"),
+    }
+}
+
+// ── the happy path ──────────────────────────────────────────────────────
+
+#[test]
+fn likes_schema_parses_on_both_validation_modes() {
+    let platform_version = PlatformVersion::latest();
+
+    for full_validation in [false, true] {
+        let document_type = parse_with(likes_schema(), platform_version, full_validation)
+            .unwrap_or_else(|error| {
+                panic!("likes schema should parse (full_validation: {full_validation}): {error}")
+            });
+
+        assert!(document_type.index_only());
+        assert!(!document_type.documents_mutable);
+        assert_eq!(document_type.indices.len(), 3);
+    }
+}
+
+#[test]
+fn terminal_defaults_to_owner_id() {
+    let document_type =
+        parse_with(likes_schema(), PlatformVersion::latest(), false).expect("should parse");
+
+    // `byPost` omits its terminal; normalization spells it out, so the
+    // omitted and explicit forms parse to equal indexes.
+    assert_eq!(
+        document_type.indices["byPost"].terminal.as_deref(),
+        Some("$ownerId")
+    );
+    assert_eq!(
+        document_type.indices["byHashtagPost"].terminal.as_deref(),
+        Some("$ownerId")
+    );
+    assert_eq!(
+        document_type.indices["byLiker"].terminal.as_deref(),
+        Some("postId")
+    );
+}
+
+// ── doctype-level constraint matrix (non-validating parse: the checks are
+//    structural, not meta-schema lints) ─────────────────────────────────
+
+#[test]
+fn rejects_mutable_documents() {
+    let schema = likes_schema_with("documentsMutable", Value::Bool(true));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "documentsMutable: false",
+    );
+}
+
+#[test]
+fn rejects_transferable_documents() {
+    let schema = likes_schema_with("transferable", Value::U8(1));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "must not be transferable",
+    );
+}
+
+#[test]
+fn rejects_keep_history() {
+    let schema = likes_schema_with("documentsKeepHistory", Value::Bool(true));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "cannot keep history",
+    );
+}
+
+#[test]
+fn rejects_transient_properties() {
+    let schema = likes_schema_with("transient", platform_value!(["hashtag"]));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "transient",
+    );
+}
+
+#[test]
+fn rejects_doctype_level_aggregates() {
+    let schema = likes_schema_with("documentsCountable", Value::Bool(true));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "doctype-level aggregate keywords",
+    );
+}
+
+#[test]
+fn rejects_missing_indices() {
+    let schema = likes_schema_with("indices", platform_value!([]));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "at least one index",
+    );
+}
+
+// ── per-index constraint matrix ─────────────────────────────────────────
+
+#[test]
+fn rejects_unique_indexes() {
+    let schema = likes_schema_with_index_key(2, "unique", Value::Bool(true));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "cannot be unique",
+    );
+}
+
+#[test]
+fn rejects_null_searchable_false() {
+    let schema = likes_schema_with_index_key(2, "nullSearchable", Value::Bool(false));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "nullSearchable",
+    );
+}
+
+#[test]
+fn rejects_sum_axes() {
+    // The summable declaration itself has to survive the aggregate
+    // cross-checks (integer type, required) so that the indexOnly-specific
+    // rejection is the one that fires.
+    let mut schema = likes_schema_with_index_key(2, "summable", platform_value!("likeWeight"));
+    schema
+        .get_mut("properties")
+        .expect("properties accessible")
+        .expect("properties present")
+        .set_value(
+            "likeWeight",
+            platform_value!({ "type": "integer", "minimum": 0, "maximum": 100, "position": 2 }),
+        )
+        .expect("property applies");
+    schema
+        .set_value(
+            "required",
+            platform_value!(["hashtag", "postId", "likeWeight"]),
+        )
+        .expect("required applies");
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "sum axes",
+    );
+}
+
+#[test]
+fn rejects_terminal_repeating_an_index_property() {
+    // byLiker's prefix is [$ownerId]; making $ownerId its terminal too
+    // indexes the same dimension twice.
+    let schema = likes_schema_with_index_key(2, "terminal", platform_value!("$ownerId"));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "repeats its terminal",
+    );
+}
+
+#[test]
+fn rejects_terminal_without_refers_to() {
+    // `hashtag` is a plain string — not `$ownerId`, not a refersTo-typed
+    // identifier — so it cannot be a member key.
+    let schema = likes_schema_with_index_key(2, "terminal", platform_value!("hashtag"));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "refersTo",
+    );
+}
+
+#[test]
+fn rejects_terminal_naming_unknown_property() {
+    let schema = likes_schema_with_index_key(2, "terminal", platform_value!("nonsense"));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "does not name a property",
+    );
+}
+
+#[test]
+fn rejects_disallowed_system_properties_in_prefix() {
+    let schema =
+        likes_schema_with_index_key(2, "properties", platform_value!([{ "$updatedAt": "asc" }]));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "$ownerId and $createdAt",
+    );
+}
+
+#[test]
+fn accepts_created_at_in_prefix() {
+    // `$createdAt` is assigned from block time at create and recoverable
+    // from the entry path — the one system property besides `$ownerId`
+    // an indexOnly index may carry.
+    let schema = likes_schema_with_index_key(
+        2,
+        "properties",
+        platform_value!([{ "$ownerId": "asc" }, { "$createdAt": "asc" }]),
+    );
+    parse_with(schema, PlatformVersion::latest(), false)
+        .expect("$createdAt in an index prefix should be accepted");
+}
+
+// ── coverage, requiredness, ownership ───────────────────────────────────
+
+#[test]
+fn rejects_unindexed_property() {
+    // Drop `hashtag` from every index; it would be silently unrecoverable.
+    // ($createdAt keeps the reshaped index distinct from `byPost` — two
+    // indexes over the same properties are rejected as duplicates before
+    // the indexOnly checks run — and clear of the ranked prefix-overlap
+    // rule that a [postId, …] compound would trip next to countable
+    // `byPost`.)
+    let schema =
+        likes_schema_with_index_key(0, "properties", platform_value!([{ "$createdAt": "asc" }]));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "does not appear in any index",
+    );
+}
+
+#[test]
+fn rejects_optional_property() {
+    let schema = likes_schema_with("required", platform_value!(["postId"]));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "must be listed in `required`",
+    );
+}
+
+#[test]
+fn rejects_missing_owner_id() {
+    // Rewrite all three indexes so no prefix or terminal carries $ownerId:
+    // no owner-bearing entry means no delete could ever be authorized.
+    let schema = likes_schema_with(
+        "indices",
+        platform_value!([
+            {
+                "name": "byHashtag",
+                "properties": [{ "hashtag": "asc" }],
+                "terminal": "postId"
+            }
+        ]),
+    );
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "$ownerId in at least one index",
+    );
+}
+
+// ── terminal without indexOnly ──────────────────────────────────────────
+
+#[test]
+fn rejects_terminal_on_non_index_only_type() {
+    let mut schema = likes_schema();
+    schema
+        .remove_optional_value("indexOnly")
+        .expect("removal applies");
+    // Without indexOnly the doctype-flag constraints don't apply, but the
+    // dangling `terminal` declarations must be rejected.
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "declares `terminal`",
+    );
+}
+
+// ── cross-generation gating ─────────────────────────────────────────────
+
+#[test]
+fn terminal_keyword_is_rejected_below_generation_3_on_both_modes() {
+    let platform_version_13 = PlatformVersion::get(13).expect("PV13 exists");
+
+    for full_validation in [false, true] {
+        let result = parse_dispatched(likes_schema(), platform_version_13, full_validation);
+        assert!(
+            result.is_err(),
+            "PV13 must reject the likes schema (full_validation: {full_validation}): \
+             `terminal` is not part of generation 2's index grammar"
+        );
+    }
+}
+
+#[test]
+fn index_only_keyword_is_inert_below_generation_3_without_validation() {
+    let platform_version_13 = PlatformVersion::get(13).expect("PV13 exists");
+
+    // A doctype-level `indexOnly` with no `terminal` keywords: generation 2
+    // ignores unknown doctype keys on the non-validating path — exactly how
+    // it treats every keyword it predates — so the parse succeeds and the
+    // flag is NOT set.
+    let mut schema = likes_schema();
+    for index_value in schema
+        .get_mut("indices")
+        .expect("indices accessible")
+        .expect("indices present")
+        .as_array_mut()
+        .expect("indices is an array")
+    {
+        // Strip the generation-3 index grammar so only `indexOnly` remains.
+        let _ = index_value.remove_optional_value("terminal");
+        let _ = index_value.remove_optional_value("rankedCountable");
+    }
+
+    let document_type = parse_dispatched(schema.clone(), platform_version_13, false)
+        .expect("generation 2 ignores unknown doctype-level keywords when not validating");
+    assert!(
+        !document_type.index_only(),
+        "generation 2 must not set index_only"
+    );
+
+    // Under full validation the v2 meta-schema rejects the unknown key.
+    assert!(
+        parse_dispatched(schema, platform_version_13, true).is_err(),
+        "meta-schema v2 must reject the indexOnly keyword"
+    );
+}
+
+#[test]
+fn index_only_flag_survives_the_dispatcher_at_latest() {
+    let document_type = parse_dispatched(likes_schema(), PlatformVersion::latest(), true)
+        .expect("likes schema parses through the dispatcher at PV14");
+    assert!(document_type.index_only());
+}

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
@@ -354,31 +354,122 @@ fn rejects_disallowed_system_properties_in_prefix() {
 }
 
 #[test]
-fn accepts_created_at_in_prefix() {
-    // `$createdAt` is assigned from block time at create and recoverable
-    // from the entry path — the one system property besides `$ownerId`
-    // an indexOnly index may carry.
+fn accepts_created_at_in_prefix_when_required() {
+    // `$createdAt` is assigned from block time at create (only when it is
+    // required — which indexing it therefore demands) and recoverable from
+    // the entry path — the one system property besides `$ownerId` an
+    // indexOnly index may carry.
+    let mut schema = likes_schema_with_index_key(
+        2,
+        "properties",
+        platform_value!([{ "$ownerId": "asc" }, { "$createdAt": "asc" }]),
+    );
+    schema
+        .set_value(
+            "required",
+            platform_value!(["hashtag", "postId", "$createdAt"]),
+        )
+        .expect("required applies");
+    parse_with(schema, PlatformVersion::latest(), false)
+        .expect("$createdAt in an index prefix should be accepted when required");
+}
+
+#[test]
+fn rejects_indexed_created_at_that_is_not_required() {
+    // Document creation assigns `created_at` only for a REQUIRED
+    // $createdAt; indexing an unrequired one would silently take the
+    // missing-value branch instead of storing block time.
     let schema = likes_schema_with_index_key(
         2,
         "properties",
         platform_value!([{ "$ownerId": "asc" }, { "$createdAt": "asc" }]),
     );
-    parse_with(schema, PlatformVersion::latest(), false)
-        .expect("$createdAt in an index prefix should be accepted");
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "\"$createdAt\" must be listed in `required`",
+    );
+}
+
+#[test]
+fn rejects_identity_public_key_reference_terminals() {
+    // identityPublicKey is a compound reference (identity id here, key id
+    // in a companion property) — the member key alone cannot identify the
+    // referenced key, so it is not a legal terminal.
+    let mut schema = likes_schema_with_index_key(2, "terminal", platform_value!("keyRef"));
+    schema
+        .get_mut("properties")
+        .expect("properties accessible")
+        .expect("properties present")
+        .set_value(
+            "keyRef",
+            platform_value!({
+                "type": "array",
+                "byteArray": true,
+                "minItems": 32,
+                "maxItems": 32,
+                "contentMediaType": "application/x.dash.dpp.identifier",
+                "refersTo": { "type": "identityPublicKey", "keyIdProperty": "keyId" },
+                "position": 2
+            }),
+        )
+        .expect("property applies");
+    schema
+        .get_mut("properties")
+        .expect("properties accessible")
+        .expect("properties present")
+        .set_value(
+            "keyId",
+            platform_value!({ "type": "integer", "minimum": 0, "maximum": 100, "position": 3 }),
+        )
+        .expect("property applies");
+    schema
+        .set_value(
+            "required",
+            platform_value!(["hashtag", "postId", "keyRef", "keyId"]),
+        )
+        .expect("required applies");
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "identityPublicKey",
+    );
+}
+
+#[test]
+fn rejects_owner_less_indexes() {
+    // Every index must be bound to its owner: an owner-less index would
+    // let a crafted delete splice a victim's row in with the signer's own
+    // owner-bearing row.
+    let schema =
+        likes_schema_with_index_key(2, "properties", platform_value!([{ "hashtag": "asc" }]));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "must include $ownerId",
+    );
 }
 
 // ── coverage, requiredness, ownership ───────────────────────────────────
 
 #[test]
 fn rejects_unindexed_property() {
-    // Drop `hashtag` from every index; it would be silently unrecoverable.
-    // ($createdAt keeps the reshaped index distinct from `byPost` — two
-    // indexes over the same properties are rejected as duplicates before
-    // the indexOnly checks run — and clear of the ranked prefix-overlap
-    // rule that a [postId, …] compound would trip next to countable
-    // `byPost`.)
-    let schema =
-        likes_schema_with_index_key(0, "properties", platform_value!([{ "$createdAt": "asc" }]));
+    // Drop the compound index entirely: `hashtag` then appears in no
+    // index and would be silently unrecoverable.
+    let schema = likes_schema_with(
+        "indices",
+        platform_value!([
+            {
+                "name": "byPost",
+                "properties": [{ "postId": "asc" }],
+                "countable": true,
+                "rangeCountable": true,
+                "rankedCountable": true
+            },
+            {
+                "name": "byLiker",
+                "properties": [{ "$ownerId": "asc" }],
+                "terminal": "postId"
+            }
+        ]),
+    );
     expect_structure_error(
         parse_with(schema, PlatformVersion::latest(), false),
         "does not appear in any index",
@@ -396,8 +487,8 @@ fn rejects_optional_property() {
 
 #[test]
 fn rejects_missing_owner_id() {
-    // Rewrite all three indexes so no prefix or terminal carries $ownerId:
-    // no owner-bearing entry means no delete could ever be authorized.
+    // An index carrying no $ownerId anywhere is refused outright — every
+    // entry must be self-authorizing for deletes.
     let schema = likes_schema_with(
         "indices",
         platform_value!([
@@ -410,7 +501,7 @@ fn rejects_missing_owner_id() {
     );
     expect_structure_error(
         parse_with(schema, PlatformVersion::latest(), false),
-        "$ownerId in at least one index",
+        "must include $ownerId",
     );
 }
 

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/mod.rs
@@ -226,8 +226,10 @@ fn try_from_schema_generation_3(
     validation_operations: &mut impl Extend<ProtocolValidationOperation>,
     platform_version: &PlatformVersion,
 ) -> Result<DocumentTypeV2, ProtocolError> {
-    // Read the aggregate keywords before the core parser consumes `schema`.
+    // Read the aggregate and indexOnly keywords before the core parser
+    // consumes `schema`.
     let aggregates = common::parse_doctype_aggregate_keywords(&schema, name)?;
+    let index_only = common::parse_index_only_keyword(&schema)?;
 
     let v1 = common::parse_document_type_core(
         data_contract_id,
@@ -264,12 +266,19 @@ fn try_from_schema_generation_3(
             ranked_index_key_length_check: RANKED_INDEX_KEY_LENGTH_CHECK,
             ranked_index_structure_check: validate_no_ranked_prefix_overlap,
             admit_time_range: IndexGrammarAdmissions::for_schema_generation(3).time_range,
+            // INDEX ONLY: the `terminal` index keyword, admitted from the
+            // same shared generation → admission mapping as the two above.
+            admit_index_terminal: IndexGrammarAdmissions::for_schema_generation(3).terminal,
         },
         platform_version,
     )?;
 
     let mut v2: DocumentTypeV2 = v1.into();
     common::apply_doctype_aggregates(&mut v2, aggregates, name)?;
+    // After the aggregates: `apply_index_only` rejects the doctype-level
+    // aggregate flags (they describe the primary-key tree, which an
+    // indexOnly type does not have), so it has to see them already applied.
+    common::apply_index_only(&mut v2, index_only, name)?;
 
     Ok(v2)
 }
@@ -306,6 +315,9 @@ impl DocumentType {
         .map(DocumentType::V2)
     }
 }
+
+#[cfg(test)]
+mod index_only_tests;
 
 #[cfg(test)]
 mod tests {

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -69,6 +69,15 @@ pub const TIME_RANGE: &str = "timeRange";
 /// `range % step == 0`), not a versioned limit: it is part of what makes a
 /// transform well-formed at all.
 pub const MAX_TIME_RANGE_PHASE_SECONDS: u64 = 31_536_000;
+/// Index-level keyword naming the property whose value is the index entry's
+/// **member key** on an `indexOnly` document type — the docId-analog terminal
+/// key stored under the `0` storage marker, where a normal index stores the
+/// document id. `"$ownerId"` (the default) or a refersTo-typed identifier
+/// property (identity, contract, token, or permanent document — the permanent
+/// kinds `refersTo` targets). Only allowed on indexOnly document types; the
+/// doc-type-level validation rejects it elsewhere. Meta-schema v3+ (protocol
+/// version 14).
+pub const TERMINAL: &str = "terminal";
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd)]
@@ -513,6 +522,21 @@ pub struct Index {
     // JSON must still deserialize.
     #[cfg_attr(feature = "serde-conversion", serde(default))]
     pub time_range: Option<TimeRangeTransform>,
+    /// On an `indexOnly` document type, the property whose value is this
+    /// index's member key: the terminal key under the `0` storage marker,
+    /// sitting exactly where a normal index stores the document id — except
+    /// the element is an `Item` instead of a `Reference`, because there is no
+    /// primary-storage row to reference. `"$ownerId"` or a refersTo-typed
+    /// identifier property; the doc-type-level validation
+    /// (`apply_index_only`) normalizes an omitted value to `"$ownerId"` and
+    /// rejects the keyword entirely on non-indexOnly document types, so on a
+    /// parsed non-indexOnly type this is always `None`.
+    //
+    // `serde(default)`: added after the struct's serde shape was in the wild
+    // (see the note on `countable` above), so pre-existing JSON must still
+    // deserialize.
+    #[cfg_attr(feature = "serde-conversion", serde(default))]
+    pub terminal: Option<String>,
 }
 
 /// Which grammar keywords a document meta-schema generation admits for
@@ -527,6 +551,9 @@ pub(crate) struct IndexGrammarAdmissions {
     pub(crate) ranked: bool,
     /// The `timeRange` keyword (generation 3 and later).
     pub(crate) time_range: bool,
+    /// The `terminal` keyword (indexOnly document types; generation 3 and
+    /// later).
+    pub(crate) terminal: bool,
 }
 
 impl IndexGrammarAdmissions {
@@ -538,6 +565,7 @@ impl IndexGrammarAdmissions {
         Self {
             ranked: generation >= 3,
             time_range: generation >= 3,
+            terminal: generation >= 3,
         }
     }
 }
@@ -769,7 +797,7 @@ impl TryFrom<&[(Value, Value)]> for Index {
     /// `document_type_schema` version must go through
     /// [`Index::try_from_value_map`] instead so PV14+ contracts can use them.
     fn try_from(index_type_value_map: &[(Value, Value)]) -> Result<Self, Self::Error> {
-        Index::try_from_value_map(index_type_value_map, false, false)
+        Index::try_from_value_map(index_type_value_map, false, false, false)
     }
 }
 
@@ -791,13 +819,17 @@ impl Index {
     ///
     /// `time_range_allowed` gates the `timeRange` keyword exactly the same
     /// way: it also joined the grammar at meta-schema v3 (protocol version
-    /// 14). The two flags are separate parameters because they are separate
+    /// 14). The flags are separate parameters because they are separate
     /// grammar admissions — a future generation may admit one without the
     /// other.
+    ///
+    /// `terminal_allowed` gates the `terminal` keyword (indexOnly document
+    /// types), which also joined the grammar at meta-schema v3.
     pub fn try_from_value_map(
         index_type_value_map: &[(Value, Value)],
         ranked_aggregates_allowed: bool,
         time_range_allowed: bool,
+        terminal_allowed: bool,
     ) -> Result<Self, DataContractError> {
         // Decouple the map
         // It contains properties and a unique key
@@ -852,6 +884,7 @@ impl Index {
         let mut ranked_summable = false;
         let mut ranked_averageable = false;
         let mut time_range: Option<TimeRangeTransform> = None;
+        let mut terminal: Option<String> = None;
 
         for (key_value, value_value) in index_type_value_map {
             let key = key_value.to_str()?;
@@ -1190,6 +1223,28 @@ impl Index {
                         step_seconds,
                         phase_seconds,
                     });
+                }
+                // `terminal` is guarded the same way as the ranking keywords
+                // above: it joined the grammar at meta-schema v3, so below
+                // that the key falls through to the unknown-property arm.
+                // Whether the declaring document type is actually indexOnly —
+                // the only place the keyword is legal — is a doc-type-level
+                // fact this parser cannot see; `apply_index_only` in
+                // `try_from_schema::common` enforces it.
+                TERMINAL if terminal_allowed => {
+                    let terminal_name =
+                        value_value
+                            .as_text()
+                            .ok_or(DataContractError::ValueWrongType(
+                                "terminal value must be a string naming a property".to_string(),
+                            ))?;
+                    if terminal_name.is_empty() {
+                        return Err(DataContractError::InvalidContractStructure(
+                            "terminal must name a property; an empty string names nothing"
+                                .to_string(),
+                        ));
+                    }
+                    terminal = Some(terminal_name.to_owned());
                 }
                 "properties" => {
                     let properties =
@@ -1670,6 +1725,7 @@ impl Index {
             ranked_summable,
             ranked_averageable,
             time_range,
+            terminal,
         })
     }
 }
@@ -1741,6 +1797,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }
     }
 
@@ -1815,21 +1872,22 @@ mod tests {
     #[test]
     fn time_range_phase_parses_and_must_be_less_than_step() {
         let map = index_value_map_with_extra_time_range_key(21_600, 7_200, "phase", 3_600);
-        let index = Index::try_from_value_map(map.as_slice(), false, true).expect("should parse");
+        let index =
+            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
         let transform = index.time_range.expect("time_range should be set");
         assert_eq!(transform.phase_seconds, 3_600);
 
         // phase == step: one whole step of shift reproduces the identical
         // grid, so this is the smallest redundant spelling.
         let map = index_value_map_with_extra_time_range_key(21_600, 7_200, "phase", 7_200);
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
         ));
 
         let map = index_value_map_with_extra_time_range_key(21_600, 7_200, "phase", 10_000);
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -1853,7 +1911,7 @@ mod tests {
             "phase",
             1_900_000_000,
         );
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -1866,7 +1924,8 @@ mod tests {
             "phase",
             MAX_TIME_RANGE_PHASE_SECONDS - 1,
         );
-        let index = Index::try_from_value_map(map.as_slice(), false, true).expect("should parse");
+        let index =
+            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
         assert_eq!(
             index.time_range.expect("transform set").phase_seconds,
             MAX_TIME_RANGE_PHASE_SECONDS - 1
@@ -1879,7 +1938,7 @@ mod tests {
             "phase",
             MAX_TIME_RANGE_PHASE_SECONDS,
         );
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -1893,7 +1952,7 @@ mod tests {
     #[test]
     fn time_range_rejects_the_removed_origin_key() {
         let map = index_value_map_with_extra_time_range_key(21_600, 7_200, "origin", 3_600);
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -1908,7 +1967,8 @@ mod tests {
     #[test]
     fn time_range_storage_keys_are_grid_qualified() {
         let map = index_value_map("$createdAt", Some(("$createdAt", 21_600, 7_200)));
-        let index = Index::try_from_value_map(map.as_slice(), false, true).expect("should parse");
+        let index =
+            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
         assert_eq!(index.level_key(0, "$createdAt"), "$createdAt#21600#7200");
         assert_eq!(
             index.level_key_for_property("$createdAt"),
@@ -1919,7 +1979,8 @@ mod tests {
         assert_eq!(index.level_key_for_property("hashtag"), "hashtag");
 
         let map = index_value_map_with_extra_time_range_key(21_600, 7_200, "phase", 3_600);
-        let phased = Index::try_from_value_map(map.as_slice(), false, true).expect("should parse");
+        let phased =
+            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
         assert_eq!(
             phased.level_key(0, "$createdAt"),
             "$createdAt#21600#7200#3600"
@@ -1935,7 +1996,8 @@ mod tests {
     fn time_range_index_parses() {
         // A six-hour window refreshed every two hours.
         let map = index_value_map("$createdAt", Some(("$createdAt", 21_600, 7_200)));
-        let index = Index::try_from_value_map(map.as_slice(), false, true).expect("should parse");
+        let index =
+            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
         let transform = index.time_range.expect("time_range should be set");
         assert_eq!(transform.source, "$createdAt");
         assert_eq!(transform.range_seconds, 21_600);
@@ -1951,7 +2013,7 @@ mod tests {
     #[test]
     fn time_range_rejects_non_multiple_range() {
         let map = index_value_map("$createdAt", Some(("$createdAt", 21_600, 7_000)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -1965,7 +2027,7 @@ mod tests {
         // that can reject this transform.
         let too_large = u64::MAX / 1_000 + 1;
         let map = index_value_map("$createdAt", Some(("$createdAt", too_large, too_large)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         match err {
             DataContractError::InvalidContractStructure(message) => {
                 assert!(
@@ -1984,7 +2046,7 @@ mod tests {
         // rule — this parser has no platform version to read it from. A
         // huge factor must therefore parse; registration is what rejects it.
         let map = index_value_map("$createdAt", Some(("$createdAt", 300, 1)));
-        let index = Index::try_from_value_map(map.as_slice(), false, true)
+        let index = Index::try_from_value_map(map.as_slice(), false, true, false)
             .expect("the parser applies structural rules only");
         assert_eq!(
             index
@@ -1999,7 +2061,7 @@ mod tests {
     fn time_range_rejects_source_not_first_property() {
         // `on` names a property that is not the first index property
         let map = index_value_map("$createdAt", Some(("hashtag", 60, 20)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -2009,7 +2071,7 @@ mod tests {
     #[test]
     fn time_range_rejects_zero_step() {
         let map = index_value_map("$createdAt", Some(("$createdAt", 60, 0)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -2023,7 +2085,7 @@ mod tests {
             Value::Text("nullSearchable".to_string()),
             Value::Bool(false),
         ));
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -2068,7 +2130,7 @@ mod tests {
                 ]),
             ),
         ];
-        let err = Index::try_from_value_map(map.as_slice(), true, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), true, true, true).unwrap_err();
         match err {
             DataContractError::InvalidContractStructure(message) => {
                 assert!(
@@ -2095,7 +2157,8 @@ mod tests {
             Some(("$createdAt", ONE_DAY_SECONDS, ONE_DAY_SECONDS)),
         );
         map.push((Value::Text("unique".to_string()), Value::Bool(true)));
-        let index = Index::try_from_value_map(map.as_slice(), false, true).expect("should parse");
+        let index =
+            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
         assert!(index.unique, "the unique flag must survive parsing");
         let transform = index.time_range.expect("time_range should be set");
         assert_eq!(transform.source, "$createdAt");
@@ -2115,7 +2178,7 @@ mod tests {
             Some(("$createdAt", 3 * ONE_DAY_SECONDS, ONE_DAY_SECONDS)),
         );
         map.push((Value::Text("unique".to_string()), Value::Bool(true)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         match err {
             DataContractError::InvalidContractStructure(message) => {
                 assert!(
@@ -2137,7 +2200,7 @@ mod tests {
             Some(("$updatedAt", ONE_DAY_SECONDS, ONE_DAY_SECONDS)),
         );
         map.push((Value::Text("unique".to_string()), Value::Bool(true)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
         match err {
             DataContractError::InvalidContractStructure(message) => {
                 assert!(
@@ -2153,7 +2216,7 @@ mod tests {
             "$updatedAt",
             Some(("$updatedAt", ONE_DAY_SECONDS, ONE_DAY_SECONDS)),
         );
-        Index::try_from_value_map(map.as_slice(), false, true)
+        Index::try_from_value_map(map.as_slice(), false, true, false)
             .expect("a non-unique $updatedAt bucketing stays legal");
     }
 
@@ -2165,7 +2228,7 @@ mod tests {
         let map = index_value_map("$createdAt", Some(("$createdAt", 21_600, 7_200)));
         let err = Index::try_from(map.as_slice()).unwrap_err();
         assert!(matches!(err, DataContractError::ValueWrongType(_)));
-        let err = Index::try_from_value_map(map.as_slice(), true, false).unwrap_err();
+        let err = Index::try_from_value_map(map.as_slice(), true, false, false).unwrap_err();
         assert!(matches!(err, DataContractError::ValueWrongType(_)));
     }
 
@@ -3138,7 +3201,7 @@ mod tests {
             ("rankedSummable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let index = Index::try_from_value_map(index_map.as_slice(), true, true)
+        let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
             .expect("all three ranked keywords must parse when the grammar allows them");
         assert!(index.ranked_countable);
         assert!(index.ranked_summable);
@@ -3156,7 +3219,7 @@ mod tests {
             ("averageable", Value::Text("score".to_string())),
             ("rangeAverageable", Value::Bool(true)),
         ]);
-        let index = Index::try_from_value_map(index_map.as_slice(), true, true)
+        let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
             .expect("index without ranked keywords must parse");
         assert!(!index.ranked_countable);
         assert!(!index.ranked_summable);
@@ -3190,7 +3253,7 @@ mod tests {
                 Value::Text("asc".to_string()),
             )]),
         ]);
-        let index = Index::try_from_value_map(index_map.as_slice(), true, true)
+        let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
             .expect("ranked flags on a compound index must be accepted");
         assert!(index.ranked_averageable);
         assert_eq!(index.properties.len(), 2);
@@ -3212,7 +3275,7 @@ mod tests {
                 Value::Text("asc".to_string()),
             )]),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true);
+        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
         assert!(
             result.is_err(),
             "rankedCountable without rangeCountable must be rejected on a compound index too"
@@ -3235,7 +3298,7 @@ mod tests {
             ("rangeAverageable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true);
+        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
         assert!(
             result.is_err(),
             "ranked flags on a unique index must be rejected"
@@ -3256,7 +3319,7 @@ mod tests {
             ("countable", Value::Text("countable".to_string())),
             ("rankedCountable", Value::Bool(true)),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true);
+        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
         assert!(
             result.is_err(),
             "rankedCountable without rangeCountable must be rejected"
@@ -3274,7 +3337,7 @@ mod tests {
             ("summable", Value::Text("score".to_string())),
             ("rankedSummable", Value::Bool(true)),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true);
+        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
         assert!(
             result.is_err(),
             "rankedSummable without rangeSummable must be rejected"
@@ -3294,7 +3357,7 @@ mod tests {
             ("rangeCountable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true);
+        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
         assert!(
             result.is_err(),
             "rankedAverageable with only the count range axis must be rejected"
@@ -3314,7 +3377,7 @@ mod tests {
             ("rangeSummable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true);
+        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
         assert!(
             result.is_err(),
             "rankedAverageable with only the sum range axis must be rejected"
@@ -3336,7 +3399,7 @@ mod tests {
             ("rangeAverageable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let index = Index::try_from_value_map(index_map.as_slice(), true, true)
+        let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
             .expect("rankedAverageable on the averageable sugar form must parse");
         assert!(index.ranked_averageable);
         assert!(index.countable.is_countable());
@@ -3364,7 +3427,7 @@ mod tests {
             ("rangeSummable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let index = Index::try_from_value_map(index_map.as_slice(), true, true)
+        let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
             .expect("rankedAverageable on the explicit longhand form must parse");
         assert!(index.ranked_averageable);
         assert!(index.range_countable);
@@ -3382,7 +3445,7 @@ mod tests {
                 ("rangeAverageable", Value::Bool(true)),
                 (key, Value::Text("yes".to_string())),
             ]);
-            let result = Index::try_from_value_map(index_map.as_slice(), true, true);
+            let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
             assert!(result.is_err(), "{key} must reject a non-boolean value");
             let msg = format!("{:?}", result.unwrap_err());
             assert!(
@@ -3406,7 +3469,7 @@ mod tests {
                     ("rangeAverageable", Value::Bool(true)),
                     (key, value.clone()),
                 ]);
-                let result = Index::try_from_value_map(index_map.as_slice(), false, false);
+                let result = Index::try_from_value_map(index_map.as_slice(), false, false, false);
                 assert!(
                     result.is_err(),
                     "{key}: {value:?} must be rejected when the ranked grammar is off"
@@ -3479,7 +3542,7 @@ mod tests {
         for (axis, mut extra) in ranked_axis_fixtures() {
             extra.push(("nullSearchable", Value::Bool(false)));
             let index_map = ranked_index_map(extra);
-            let result = Index::try_from_value_map(index_map.as_slice(), true, true);
+            let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
             assert!(
                 result.is_err(),
                 "{axis} with nullSearchable: false must be rejected"
@@ -3499,7 +3562,7 @@ mod tests {
     fn test_index_try_from_ranked_without_null_searchable_key_accepted() {
         for (axis, extra) in ranked_axis_fixtures() {
             let index_map = ranked_index_map(extra);
-            let index = Index::try_from_value_map(index_map.as_slice(), true, true)
+            let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
                 .unwrap_or_else(|e| panic!("{axis} with no nullSearchable key must parse: {e:?}"));
             assert!(
                 index.null_searchable,
@@ -3515,8 +3578,8 @@ mod tests {
         for (axis, mut extra) in ranked_axis_fixtures() {
             extra.push(("nullSearchable", Value::Bool(true)));
             let index_map = ranked_index_map(extra);
-            let index =
-                Index::try_from_value_map(index_map.as_slice(), true, true).unwrap_or_else(|e| {
+            let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
+                .unwrap_or_else(|e| {
                     panic!("{axis} with an explicit nullSearchable: true must parse: {e:?}")
                 });
             assert!(index.null_searchable);
@@ -3529,7 +3592,7 @@ mod tests {
     #[test]
     fn test_index_try_from_non_ranked_with_null_searchable_false_still_accepted() {
         let plain = ranked_index_map(vec![("nullSearchable", Value::Bool(false))]);
-        let index = Index::try_from_value_map(plain.as_slice(), true, true)
+        let index = Index::try_from_value_map(plain.as_slice(), true, true, true)
             .expect("nullSearchable: false on a plain index must still parse");
         assert!(!index.null_searchable);
 
@@ -3538,7 +3601,7 @@ mod tests {
             ("rangeAverageable", Value::Bool(true)),
             ("nullSearchable", Value::Bool(false)),
         ]);
-        let index = Index::try_from_value_map(aggregating.as_slice(), true, true)
+        let index = Index::try_from_value_map(aggregating.as_slice(), true, true, true)
             .expect("nullSearchable: false on a range-averageable index must still parse");
         assert!(!index.null_searchable);
         assert!(!index.ranked_averageable);
@@ -4022,6 +4085,7 @@ mod json_convertible_tests {
             ranked_summable: false,
             ranked_averageable: true,
             time_range: None,
+            terminal: None,
         }
     }
 
@@ -4052,6 +4116,7 @@ mod json_convertible_tests {
                 "ranked_summable": false,
                 "ranked_averageable": true,
                 "time_range": serde_json::Value::Null,
+                "terminal": serde_json::Value::Null,
             })
         );
         let recovered = Index::from_json(json).expect("from_json");

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -546,6 +546,7 @@ pub struct Index {
 /// and the registration-cost re-parse. Deriving the flags anywhere else
 /// invites the two to drift, and then an index the validator parses is
 /// billed nothing (or a rejected one is billed).
+#[derive(Clone, Copy)]
 pub(crate) struct IndexGrammarAdmissions {
     /// The `ranked*` keyword family (generation 3 and later).
     pub(crate) ranked: bool,
@@ -797,7 +798,14 @@ impl TryFrom<&[(Value, Value)]> for Index {
     /// `document_type_schema` version must go through
     /// [`Index::try_from_value_map`] instead so PV14+ contracts can use them.
     fn try_from(index_type_value_map: &[(Value, Value)]) -> Result<Self, Self::Error> {
-        Index::try_from_value_map(index_type_value_map, false, false, false)
+        Index::try_from_value_map(
+            index_type_value_map,
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: false,
+                terminal: false,
+            },
+        )
     }
 }
 
@@ -825,12 +833,15 @@ impl Index {
     ///
     /// `terminal_allowed` gates the `terminal` keyword (indexOnly document
     /// types), which also joined the grammar at meta-schema v3.
-    pub fn try_from_value_map(
+    pub(crate) fn try_from_value_map(
         index_type_value_map: &[(Value, Value)],
-        ranked_aggregates_allowed: bool,
-        time_range_allowed: bool,
-        terminal_allowed: bool,
+        admissions: IndexGrammarAdmissions,
     ) -> Result<Self, DataContractError> {
+        let IndexGrammarAdmissions {
+            ranked: ranked_aggregates_allowed,
+            time_range: time_range_allowed,
+            terminal: terminal_allowed,
+        } = admissions;
         // Decouple the map
         // It contains properties and a unique key
         // If the unique key is absent, then unique is false
@@ -1872,22 +1883,45 @@ mod tests {
     #[test]
     fn time_range_phase_parses_and_must_be_less_than_step() {
         let map = index_value_map_with_extra_time_range_key(21_600, 7_200, "phase", 3_600);
-        let index =
-            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
+        let index = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .expect("should parse");
         let transform = index.time_range.expect("time_range should be set");
         assert_eq!(transform.phase_seconds, 3_600);
 
         // phase == step: one whole step of shift reproduces the identical
         // grid, so this is the smallest redundant spelling.
         let map = index_value_map_with_extra_time_range_key(21_600, 7_200, "phase", 7_200);
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
         ));
 
         let map = index_value_map_with_extra_time_range_key(21_600, 7_200, "phase", 10_000);
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -1911,7 +1945,15 @@ mod tests {
             "phase",
             1_900_000_000,
         );
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -1924,8 +1966,15 @@ mod tests {
             "phase",
             MAX_TIME_RANGE_PHASE_SECONDS - 1,
         );
-        let index =
-            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
+        let index = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .expect("should parse");
         assert_eq!(
             index.time_range.expect("transform set").phase_seconds,
             MAX_TIME_RANGE_PHASE_SECONDS - 1
@@ -1938,7 +1987,15 @@ mod tests {
             "phase",
             MAX_TIME_RANGE_PHASE_SECONDS,
         );
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -1952,7 +2009,15 @@ mod tests {
     #[test]
     fn time_range_rejects_the_removed_origin_key() {
         let map = index_value_map_with_extra_time_range_key(21_600, 7_200, "origin", 3_600);
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -1967,8 +2032,15 @@ mod tests {
     #[test]
     fn time_range_storage_keys_are_grid_qualified() {
         let map = index_value_map("$createdAt", Some(("$createdAt", 21_600, 7_200)));
-        let index =
-            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
+        let index = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .expect("should parse");
         assert_eq!(index.level_key(0, "$createdAt"), "$createdAt#21600#7200");
         assert_eq!(
             index.level_key_for_property("$createdAt"),
@@ -1979,8 +2051,15 @@ mod tests {
         assert_eq!(index.level_key_for_property("hashtag"), "hashtag");
 
         let map = index_value_map_with_extra_time_range_key(21_600, 7_200, "phase", 3_600);
-        let phased =
-            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
+        let phased = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .expect("should parse");
         assert_eq!(
             phased.level_key(0, "$createdAt"),
             "$createdAt#21600#7200#3600"
@@ -1996,8 +2075,15 @@ mod tests {
     fn time_range_index_parses() {
         // A six-hour window refreshed every two hours.
         let map = index_value_map("$createdAt", Some(("$createdAt", 21_600, 7_200)));
-        let index =
-            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
+        let index = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .expect("should parse");
         let transform = index.time_range.expect("time_range should be set");
         assert_eq!(transform.source, "$createdAt");
         assert_eq!(transform.range_seconds, 21_600);
@@ -2013,7 +2099,15 @@ mod tests {
     #[test]
     fn time_range_rejects_non_multiple_range() {
         let map = index_value_map("$createdAt", Some(("$createdAt", 21_600, 7_000)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -2027,7 +2121,15 @@ mod tests {
         // that can reject this transform.
         let too_large = u64::MAX / 1_000 + 1;
         let map = index_value_map("$createdAt", Some(("$createdAt", too_large, too_large)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         match err {
             DataContractError::InvalidContractStructure(message) => {
                 assert!(
@@ -2046,8 +2148,15 @@ mod tests {
         // rule — this parser has no platform version to read it from. A
         // huge factor must therefore parse; registration is what rejects it.
         let map = index_value_map("$createdAt", Some(("$createdAt", 300, 1)));
-        let index = Index::try_from_value_map(map.as_slice(), false, true, false)
-            .expect("the parser applies structural rules only");
+        let index = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .expect("the parser applies structural rules only");
         assert_eq!(
             index
                 .time_range
@@ -2061,7 +2170,15 @@ mod tests {
     fn time_range_rejects_source_not_first_property() {
         // `on` names a property that is not the first index property
         let map = index_value_map("$createdAt", Some(("hashtag", 60, 20)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -2071,7 +2188,15 @@ mod tests {
     #[test]
     fn time_range_rejects_zero_step() {
         let map = index_value_map("$createdAt", Some(("$createdAt", 60, 0)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -2085,7 +2210,15 @@ mod tests {
             Value::Text("nullSearchable".to_string()),
             Value::Bool(false),
         ));
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             DataContractError::InvalidContractStructure(_)
@@ -2130,7 +2263,15 @@ mod tests {
                 ]),
             ),
         ];
-        let err = Index::try_from_value_map(map.as_slice(), true, true, true).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        )
+        .unwrap_err();
         match err {
             DataContractError::InvalidContractStructure(message) => {
                 assert!(
@@ -2157,8 +2298,15 @@ mod tests {
             Some(("$createdAt", ONE_DAY_SECONDS, ONE_DAY_SECONDS)),
         );
         map.push((Value::Text("unique".to_string()), Value::Bool(true)));
-        let index =
-            Index::try_from_value_map(map.as_slice(), false, true, false).expect("should parse");
+        let index = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .expect("should parse");
         assert!(index.unique, "the unique flag must survive parsing");
         let transform = index.time_range.expect("time_range should be set");
         assert_eq!(transform.source, "$createdAt");
@@ -2178,7 +2326,15 @@ mod tests {
             Some(("$createdAt", 3 * ONE_DAY_SECONDS, ONE_DAY_SECONDS)),
         );
         map.push((Value::Text("unique".to_string()), Value::Bool(true)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         match err {
             DataContractError::InvalidContractStructure(message) => {
                 assert!(
@@ -2200,7 +2356,15 @@ mod tests {
             Some(("$updatedAt", ONE_DAY_SECONDS, ONE_DAY_SECONDS)),
         );
         map.push((Value::Text("unique".to_string()), Value::Bool(true)));
-        let err = Index::try_from_value_map(map.as_slice(), false, true, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         match err {
             DataContractError::InvalidContractStructure(message) => {
                 assert!(
@@ -2216,8 +2380,15 @@ mod tests {
             "$updatedAt",
             Some(("$updatedAt", ONE_DAY_SECONDS, ONE_DAY_SECONDS)),
         );
-        Index::try_from_value_map(map.as_slice(), false, true, false)
-            .expect("a non-unique $updatedAt bucketing stays legal");
+        Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: true,
+                terminal: false,
+            },
+        )
+        .expect("a non-unique $updatedAt bucketing stays legal");
     }
 
     #[test]
@@ -2228,7 +2399,15 @@ mod tests {
         let map = index_value_map("$createdAt", Some(("$createdAt", 21_600, 7_200)));
         let err = Index::try_from(map.as_slice()).unwrap_err();
         assert!(matches!(err, DataContractError::ValueWrongType(_)));
-        let err = Index::try_from_value_map(map.as_slice(), true, false, false).unwrap_err();
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: false,
+                terminal: false,
+            },
+        )
+        .unwrap_err();
         assert!(matches!(err, DataContractError::ValueWrongType(_)));
     }
 
@@ -3201,8 +3380,15 @@ mod tests {
             ("rankedSummable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
-            .expect("all three ranked keywords must parse when the grammar allows them");
+        let index = Index::try_from_value_map(
+            index_map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        )
+        .expect("all three ranked keywords must parse when the grammar allows them");
         assert!(index.ranked_countable);
         assert!(index.ranked_summable);
         assert!(index.ranked_averageable);
@@ -3219,8 +3405,15 @@ mod tests {
             ("averageable", Value::Text("score".to_string())),
             ("rangeAverageable", Value::Bool(true)),
         ]);
-        let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
-            .expect("index without ranked keywords must parse");
+        let index = Index::try_from_value_map(
+            index_map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        )
+        .expect("index without ranked keywords must parse");
         assert!(!index.ranked_countable);
         assert!(!index.ranked_summable);
         assert!(!index.ranked_averageable);
@@ -3253,8 +3446,15 @@ mod tests {
                 Value::Text("asc".to_string()),
             )]),
         ]);
-        let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
-            .expect("ranked flags on a compound index must be accepted");
+        let index = Index::try_from_value_map(
+            index_map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        )
+        .expect("ranked flags on a compound index must be accepted");
         assert!(index.ranked_averageable);
         assert_eq!(index.properties.len(), 2);
         assert_eq!(index.properties[1].name, "score");
@@ -3275,7 +3475,14 @@ mod tests {
                 Value::Text("asc".to_string()),
             )]),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
+        let result = Index::try_from_value_map(
+            index_map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        );
         assert!(
             result.is_err(),
             "rankedCountable without rangeCountable must be rejected on a compound index too"
@@ -3298,7 +3505,14 @@ mod tests {
             ("rangeAverageable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
+        let result = Index::try_from_value_map(
+            index_map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        );
         assert!(
             result.is_err(),
             "ranked flags on a unique index must be rejected"
@@ -3319,7 +3533,14 @@ mod tests {
             ("countable", Value::Text("countable".to_string())),
             ("rankedCountable", Value::Bool(true)),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
+        let result = Index::try_from_value_map(
+            index_map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        );
         assert!(
             result.is_err(),
             "rankedCountable without rangeCountable must be rejected"
@@ -3337,7 +3558,14 @@ mod tests {
             ("summable", Value::Text("score".to_string())),
             ("rankedSummable", Value::Bool(true)),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
+        let result = Index::try_from_value_map(
+            index_map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        );
         assert!(
             result.is_err(),
             "rankedSummable without rangeSummable must be rejected"
@@ -3357,7 +3585,14 @@ mod tests {
             ("rangeCountable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
+        let result = Index::try_from_value_map(
+            index_map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        );
         assert!(
             result.is_err(),
             "rankedAverageable with only the count range axis must be rejected"
@@ -3377,7 +3612,14 @@ mod tests {
             ("rangeSummable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
+        let result = Index::try_from_value_map(
+            index_map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        );
         assert!(
             result.is_err(),
             "rankedAverageable with only the sum range axis must be rejected"
@@ -3399,8 +3641,15 @@ mod tests {
             ("rangeAverageable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
-            .expect("rankedAverageable on the averageable sugar form must parse");
+        let index = Index::try_from_value_map(
+            index_map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        )
+        .expect("rankedAverageable on the averageable sugar form must parse");
         assert!(index.ranked_averageable);
         assert!(index.countable.is_countable());
         assert_eq!(index.summable.as_deref(), Some("score"));
@@ -3427,8 +3676,15 @@ mod tests {
             ("rangeSummable", Value::Bool(true)),
             ("rankedAverageable", Value::Bool(true)),
         ]);
-        let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
-            .expect("rankedAverageable on the explicit longhand form must parse");
+        let index = Index::try_from_value_map(
+            index_map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        )
+        .expect("rankedAverageable on the explicit longhand form must parse");
         assert!(index.ranked_averageable);
         assert!(index.range_countable);
         assert!(index.range_summable);
@@ -3445,7 +3701,14 @@ mod tests {
                 ("rangeAverageable", Value::Bool(true)),
                 (key, Value::Text("yes".to_string())),
             ]);
-            let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
+            let result = Index::try_from_value_map(
+                index_map.as_slice(),
+                IndexGrammarAdmissions {
+                    ranked: true,
+                    time_range: true,
+                    terminal: true,
+                },
+            );
             assert!(result.is_err(), "{key} must reject a non-boolean value");
             let msg = format!("{:?}", result.unwrap_err());
             assert!(
@@ -3469,7 +3732,14 @@ mod tests {
                     ("rangeAverageable", Value::Bool(true)),
                     (key, value.clone()),
                 ]);
-                let result = Index::try_from_value_map(index_map.as_slice(), false, false, false);
+                let result = Index::try_from_value_map(
+                    index_map.as_slice(),
+                    IndexGrammarAdmissions {
+                        ranked: false,
+                        time_range: false,
+                        terminal: false,
+                    },
+                );
                 assert!(
                     result.is_err(),
                     "{key}: {value:?} must be rejected when the ranked grammar is off"
@@ -3542,7 +3812,14 @@ mod tests {
         for (axis, mut extra) in ranked_axis_fixtures() {
             extra.push(("nullSearchable", Value::Bool(false)));
             let index_map = ranked_index_map(extra);
-            let result = Index::try_from_value_map(index_map.as_slice(), true, true, true);
+            let result = Index::try_from_value_map(
+                index_map.as_slice(),
+                IndexGrammarAdmissions {
+                    ranked: true,
+                    time_range: true,
+                    terminal: true,
+                },
+            );
             assert!(
                 result.is_err(),
                 "{axis} with nullSearchable: false must be rejected"
@@ -3562,8 +3839,15 @@ mod tests {
     fn test_index_try_from_ranked_without_null_searchable_key_accepted() {
         for (axis, extra) in ranked_axis_fixtures() {
             let index_map = ranked_index_map(extra);
-            let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
-                .unwrap_or_else(|e| panic!("{axis} with no nullSearchable key must parse: {e:?}"));
+            let index = Index::try_from_value_map(
+                index_map.as_slice(),
+                IndexGrammarAdmissions {
+                    ranked: true,
+                    time_range: true,
+                    terminal: true,
+                },
+            )
+            .unwrap_or_else(|e| panic!("{axis} with no nullSearchable key must parse: {e:?}"));
             assert!(
                 index.null_searchable,
                 "{axis}: the absent key must still default to true"
@@ -3578,10 +3862,17 @@ mod tests {
         for (axis, mut extra) in ranked_axis_fixtures() {
             extra.push(("nullSearchable", Value::Bool(true)));
             let index_map = ranked_index_map(extra);
-            let index = Index::try_from_value_map(index_map.as_slice(), true, true, true)
-                .unwrap_or_else(|e| {
-                    panic!("{axis} with an explicit nullSearchable: true must parse: {e:?}")
-                });
+            let index = Index::try_from_value_map(
+                index_map.as_slice(),
+                IndexGrammarAdmissions {
+                    ranked: true,
+                    time_range: true,
+                    terminal: true,
+                },
+            )
+            .unwrap_or_else(|e| {
+                panic!("{axis} with an explicit nullSearchable: true must parse: {e:?}")
+            });
             assert!(index.null_searchable);
         }
     }
@@ -3592,8 +3883,15 @@ mod tests {
     #[test]
     fn test_index_try_from_non_ranked_with_null_searchable_false_still_accepted() {
         let plain = ranked_index_map(vec![("nullSearchable", Value::Bool(false))]);
-        let index = Index::try_from_value_map(plain.as_slice(), true, true, true)
-            .expect("nullSearchable: false on a plain index must still parse");
+        let index = Index::try_from_value_map(
+            plain.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        )
+        .expect("nullSearchable: false on a plain index must still parse");
         assert!(!index.null_searchable);
 
         let aggregating = ranked_index_map(vec![
@@ -3601,8 +3899,15 @@ mod tests {
             ("rangeAverageable", Value::Bool(true)),
             ("nullSearchable", Value::Bool(false)),
         ]);
-        let index = Index::try_from_value_map(aggregating.as_slice(), true, true, true)
-            .expect("nullSearchable: false on a range-averageable index must still parse");
+        let index = Index::try_from_value_map(
+            aggregating.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: true,
+                time_range: true,
+                terminal: true,
+            },
+        )
+        .expect("nullSearchable: false on a range-averageable index must still parse");
         assert!(!index.null_searchable);
         assert!(!index.ranked_averageable);
     }

--- a/packages/rs-dpp/src/data_contract/document_type/index/random_index.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/random_index.rs
@@ -68,6 +68,7 @@ impl Index {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         })
     }
 }

--- a/packages/rs-dpp/src/data_contract/document_type/index_level/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index_level/mod.rs
@@ -479,6 +479,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let old_index_structure =
@@ -514,6 +515,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let new_indices = vec![
@@ -534,6 +536,7 @@ mod tests {
                 ranked_summable: false,
                 ranked_averageable: false,
                 time_range: None,
+                terminal: None,
             },
             Index {
                 name: "test2".to_string(),
@@ -552,6 +555,7 @@ mod tests {
                 ranked_summable: false,
                 ranked_averageable: false,
                 time_range: None,
+                terminal: None,
             },
         ];
 
@@ -596,6 +600,7 @@ mod tests {
                 ranked_summable: false,
                 ranked_averageable: false,
                 time_range: None,
+                terminal: None,
             },
             Index {
                 name: "test2".to_string(),
@@ -614,6 +619,7 @@ mod tests {
                 ranked_summable: false,
                 ranked_averageable: false,
                 time_range: None,
+                terminal: None,
             },
         ];
 
@@ -634,6 +640,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let old_index_structure =
@@ -676,6 +683,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let new_indices = vec![Index {
@@ -701,6 +709,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let old_index_structure =
@@ -749,6 +758,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let new_indices = vec![Index {
@@ -768,6 +778,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let old_index_structure =
@@ -810,6 +821,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let new_indices = vec![Index {
@@ -829,6 +841,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let old_index_structure =
@@ -871,6 +884,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let new_indices = vec![Index {
@@ -890,6 +904,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let old_index_structure =
@@ -932,6 +947,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let old_index_structure =
@@ -974,6 +990,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let new_indices = vec![Index {
@@ -993,6 +1010,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let old_index_structure =
@@ -1035,6 +1053,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let new_indices = vec![Index {
@@ -1054,6 +1073,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let old_index_structure =
@@ -1102,6 +1122,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let new_indices = vec![Index {
@@ -1127,6 +1148,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let old_index_structure =
@@ -1175,6 +1197,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let new_indices = vec![Index {
@@ -1200,6 +1223,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let old_index_structure =
@@ -1256,6 +1280,7 @@ mod tests {
             ranked_summable,
             ranked_averageable,
             time_range: None,
+            terminal: None,
         }
     }
 
@@ -1413,6 +1438,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }];
 
         let mut new_indices = old_indices.clone();

--- a/packages/rs-dpp/src/data_contract/document_type/methods/validate_update/common/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/methods/validate_update/common/mod.rs
@@ -346,6 +346,29 @@ impl DocumentTypeRef<'_> {
             );
         }
 
+        // indexOnly immutability: the flag selects the entire storage layout
+        // (no primary-key tree, index terminals are Items keyed by the
+        // terminal property). Flipping it in either direction would strand
+        // every existing entry: rows with no primary storage to dereference,
+        // or references whose primary rows were never written. The per-index
+        // `terminal` needs no separate check here — it is a field of `Index`,
+        // so `validate_index_definitions_unchanged`'s full equality
+        // comparison already rejects any change to it.
+        if new_document_type.index_only() != self.index_only() {
+            return SimpleConsensusValidationResult::new_with_error(
+                DocumentTypeUpdateError::new(
+                    self.data_contract_id(),
+                    self.name(),
+                    format!(
+                        "document type can not change whether it is indexOnly: changing from {} to {}",
+                        self.index_only(),
+                        new_document_type.index_only()
+                    ),
+                )
+                    .into(),
+            );
+        }
+
         SimpleConsensusValidationResult::new()
     }
 
@@ -1193,6 +1216,100 @@ mod tests {
                 [ConsensusError::StateError(
                     StateError::DocumentTypeUpdateError(e)
                 )] if e.additional_message() == "document type can not change whether its documents are countable: changing from true to false"
+            );
+        }
+
+        #[test]
+        fn should_return_invalid_result_when_index_only_is_changed() {
+            let platform_version = PlatformVersion::latest();
+            let data_contract_id = Identifier::random();
+            let document_type_name = "like";
+
+            // A minimal valid indexOnly type: one refersTo-typed property,
+            // one index over it, terminal defaulting to $ownerId.
+            let index_only_schema = platform_value!({
+                "type": "object",
+                "indexOnly": true,
+                "documentsMutable": false,
+                "properties": {
+                    "postId": {
+                        "type": "array",
+                        "byteArray": true,
+                        "minItems": 32,
+                        "maxItems": 32,
+                        "contentMediaType": "application/x.dash.dpp.identifier",
+                        "refersTo": { "type": "identity" },
+                        "position": 0,
+                    }
+                },
+                "required": ["postId"],
+                "indices": [
+                    {
+                        "name": "byPost",
+                        "properties": [{ "postId": "asc" }],
+                    }
+                ],
+                "additionalProperties": false,
+            });
+
+            // The same type without indexOnly (documentsMutable kept equal
+            // so the earlier mutability check doesn't fire first).
+            let plain_schema = platform_value!({
+                "type": "object",
+                "documentsMutable": false,
+                "properties": {
+                    "postId": {
+                        "type": "array",
+                        "byteArray": true,
+                        "minItems": 32,
+                        "maxItems": 32,
+                        "contentMediaType": "application/x.dash.dpp.identifier",
+                        "refersTo": { "type": "identity" },
+                        "position": 0,
+                    }
+                },
+                "required": ["postId"],
+                "indices": [
+                    {
+                        "name": "byPost",
+                        "properties": [{ "postId": "asc" }],
+                    }
+                ],
+                "additionalProperties": false,
+            });
+
+            let config = DataContractConfig::default_for_version(platform_version)
+                .expect("should create a default config");
+
+            let make_document_type = |schema: platform_value::Value| {
+                DocumentType::try_from_schema(
+                    data_contract_id,
+                    1,
+                    config.version(),
+                    document_type_name,
+                    schema,
+                    None,
+                    &BTreeMap::new(),
+                    &config,
+                    false,
+                    &mut Vec::new(),
+                    platform_version,
+                )
+                .expect("document type should parse")
+            };
+
+            let old_document_type = make_document_type(index_only_schema);
+            let new_document_type = make_document_type(plain_schema);
+
+            let result = old_document_type
+                .as_ref()
+                .validate_config(new_document_type.as_ref());
+
+            assert_matches!(
+                result.errors.as_slice(),
+                [ConsensusError::StateError(
+                    StateError::DocumentTypeUpdateError(e)
+                )] if e.additional_message() == "document type can not change whether it is indexOnly: changing from true to false"
             );
         }
 

--- a/packages/rs-dpp/src/data_contract/document_type/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/mod.rs
@@ -117,6 +117,14 @@ pub(crate) mod property_names {
     /// to be set (parallels the count/sum-individually rules: range
     /// axes require the corresponding base flag).
     pub const RANGE_AVERAGEABLE: &str = "rangeAverageable";
+    /// Doctype-level flag declaring an **indexOnly** document type: documents
+    /// are never written to primary storage — the index entries are the rows,
+    /// each terminating in an `Item` keyed by the index's `terminal` property
+    /// instead of a `Reference` keyed by the document id. Only what is in the
+    /// indexes exists and is recoverable. Meta-schema v3+ (protocol version
+    /// 14). See `apply_index_only` in `try_from_schema::common` for the
+    /// structural constraints the flag imposes.
+    pub const INDEX_ONLY: &str = "indexOnly";
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/packages/rs-dpp/src/data_contract/document_type/v2/accessors.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/v2/accessors.rs
@@ -226,6 +226,10 @@ impl DocumentTypeV2Getters for DocumentTypeV2 {
     fn range_summable(&self) -> bool {
         self.range_summable
     }
+
+    fn index_only(&self) -> bool {
+        self.index_only
+    }
 }
 
 impl DocumentTypeV2Setters for DocumentTypeV2 {
@@ -260,5 +264,9 @@ impl DocumentTypeV2Setters for DocumentTypeV2 {
         // This way an existing-true-but-inconsistent state can't survive
         // a setter call — the invariant always holds after this returns.
         self.range_summable = range_summable && self.documents_summable.is_some();
+    }
+
+    fn set_index_only(&mut self, index_only: bool) {
+        self.index_only = index_only;
     }
 }

--- a/packages/rs-dpp/src/data_contract/document_type/v2/accessors.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/v2/accessors.rs
@@ -265,8 +265,4 @@ impl DocumentTypeV2Setters for DocumentTypeV2 {
         // a setter call — the invariant always holds after this returns.
         self.range_summable = range_summable && self.documents_summable.is_some();
     }
-
-    fn set_index_only(&mut self, index_only: bool) {
-        self.index_only = index_only;
-    }
 }

--- a/packages/rs-dpp/src/data_contract/document_type/v2/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/v2/mod.rs
@@ -99,6 +99,16 @@ pub struct DocumentTypeV2 {
     /// [`Self::documents_summable`] is `Some` — enforced by
     /// [`crate::data_contract::document_type::accessors::DocumentTypeV2Setters::set_range_summable`].
     pub(in crate::data_contract) range_summable: bool,
+    /// When true, documents of this type are **indexOnly**: nothing is
+    /// written to primary storage (there is no `[0]` primary-key tree at
+    /// all) — the index entries are the rows, each terminating in an `Item`
+    /// keyed by the index's `terminal` property instead of a `Reference`
+    /// keyed by the document id. Only what is in the indexes exists and is
+    /// recoverable. The parser (`apply_index_only`) enforces the structural
+    /// constraints this layout depends on: every property required and
+    /// indexed, `$ownerId` recoverable from at least one index, immutable /
+    /// non-transferable / no history, and per-index terminal typing.
+    pub(in crate::data_contract) index_only: bool,
 }
 
 impl DocumentTypeBasicMethods for DocumentTypeV2 {}
@@ -166,6 +176,7 @@ impl From<DocumentTypeV0> for DocumentTypeV2 {
             range_countable: false,
             documents_summable: None,
             range_summable: false,
+            index_only: false,
         }
     }
 }
@@ -205,6 +216,7 @@ impl From<DocumentTypeV1> for DocumentTypeV2 {
             range_countable: false,
             documents_summable: None,
             range_summable: false,
+            index_only: false,
         }
     }
 }

--- a/packages/rs-dpp/src/data_contract/methods/registration_cost/v1/mod.rs
+++ b/packages/rs-dpp/src/data_contract/methods/registration_cost/v1/mod.rs
@@ -132,6 +132,7 @@ impl DataContractInSerializationFormat {
                                 index_value_map.as_slice(),
                                 admissions.ranked,
                                 admissions.time_range,
+                                admissions.terminal,
                             ) {
                                 let base_index_fee = if index.contested_index.is_some() {
                                     fee_version.document_type_base_contested_index_registration_fee

--- a/packages/rs-dpp/src/data_contract/methods/registration_cost/v1/mod.rs
+++ b/packages/rs-dpp/src/data_contract/methods/registration_cost/v1/mod.rs
@@ -128,12 +128,9 @@ impl DataContractInSerializationFormat {
                                     .schema
                                     .document_type_schema,
                             );
-                            if let Ok(index) = Index::try_from_value_map(
-                                index_value_map.as_slice(),
-                                admissions.ranked,
-                                admissions.time_range,
-                                admissions.terminal,
-                            ) {
+                            if let Ok(index) =
+                                Index::try_from_value_map(index_value_map.as_slice(), admissions)
+                            {
                                 let base_index_fee = if index.contested_index.is_some() {
                                     fee_version.document_type_base_contested_index_registration_fee
                                 } else if index.unique {

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/ranked_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/ranked_index_e2e_tests.rs
@@ -802,6 +802,7 @@ fn compound_ranked_index_resolves_its_terminal_level_to_an_indexed_tree() {
         ranked_summable: false,
         ranked_averageable: true,
         time_range: None,
+        terminal: None,
     };
     let index_structure =
         IndexLevel::try_from_indices([&compound_ranked_index], "dish", platform_version())
@@ -1018,6 +1019,7 @@ fn a_null_unsearchable_ranked_level_is_what_makes_a_phantom_group_possible() {
         ranked_summable: false,
         ranked_averageable: false,
         time_range: None,
+        terminal: None,
     };
 
     for null_searchable in [false, true] {

--- a/packages/rs-drive/src/drive/document/index_level_tree_types.rs
+++ b/packages/rs-drive/src/drive/document/index_level_tree_types.rs
@@ -395,6 +395,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: true,
             time_range: None,
+            terminal: None,
         };
         let compound = Index {
             name: "byRestaurantChef".to_string(),
@@ -419,6 +420,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         };
 
         let index_structure =

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -2170,6 +2170,7 @@ mod range_countable_picker_tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
+            terminal: None,
         }
     }
 

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -3543,6 +3543,7 @@ mod time_range_picker_tests {
             ranked_summable: false,
             ranked_averageable: false,
             time_range,
+            terminal: None,
         }
     }
 

--- a/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
@@ -701,6 +701,7 @@ fn test_index(name: &str, properties: &[&str], summable: Option<&str>) -> Index 
         ranked_summable: false,
         ranked_averageable: false,
         time_range: None,
+        terminal: None,
     }
 }
 

--- a/packages/rs-drive/src/query/drive_document_sum_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_sum_query/tests.rs
@@ -46,6 +46,7 @@ fn summable_index(name: &str, props: &[&str], summable: Option<&str>) -> Index {
         ranked_summable: false,
         ranked_averageable: false,
         time_range: None,
+        terminal: None,
     }
 }
 
@@ -66,6 +67,7 @@ fn range_summable_index(name: &str, props: &[&str], summable: &str) -> Index {
         ranked_summable: false,
         ranked_averageable: false,
         time_range: None,
+        terminal: None,
     }
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

First of five PRs implementing **indexOnly document types**: a storage mode where documents are never written to primary storage — the index entries *are* the rows, each terminating in an `Item` keyed by the index's **terminal** property instead of a `Reference` keyed by the document id. Motivating case: Yappr likes (a like is an identityId in an index, not a stored document); composes with the PV14 `rankedCountable` machinery for "most liked post in #hashtag" in O(log n + k) with proof.

Governing principle: **only what is in the indexes exists and is recoverable.**

PV14 has not activated on testnet or mainnet, so parser generation 3 / meta-schema v3 are extended in place — no new protocol version, no new parser generation. No version-table changes in this PR (`CONTRACT_VERSIONS_V6` unchanged).

## What was done?

**Schema surface (generation 3 / meta-schema v3 only):**
- Doc-type keyword `indexOnly: true`; index keyword `terminal: "<property>"` (defaults to `$ownerId`, normalized at parse).
- `Index` gains a `terminal: Option<String>` field (serde-defaulted); `Index::try_from_value_map` gains a `terminal_allowed` admission gated exactly like `rankedCountable`/`timeRange` — generations ≤ 2 reject it byte-identically to any unknown index key, and ignore `indexOnly` non-validating exactly as they ignore every doctype keyword they predate. `IndexGrammarAdmissions` carries the mapping so the registration-cost re-parse can't drift.
- `DocumentTypeV2` gains `index_only: bool` + `DocumentTypeV2Getters/Setters` accessors (V0/V1 arms return `false`).

**Structural constraint matrix** (`apply_index_only`, runs regardless of `full_validation` — the on-disk layout depends on it):
- every property `required` and appearing in ≥ 1 index (prefix or terminal); no nulls, no `transient`
- `$ownerId` in ≥ 1 index — delete authorization recovers ownership from an owner-bearing entry
- each `terminal` is `$ownerId` or a refersTo-typed identifier (identity / contract / token / permanentDocument), and doesn't repeat a listed property; ≥ 1 prefix property per index
- `documentsMutable: false`, non-transferable, no trade mode, no history flags, no doctype-level aggregate keywords (they describe the primary-key tree, which an indexOnly type does not have)
- per index: non-unique (uniqueness is structural; owner-less indexes are globally unique per value tuple), non-contested, `nullSearchable` default only, count axes only (`summable`/ranked sum/avg rejected), no `timeRange` (v1)
- only `$ownerId` and `$createdAt` may be indexed among system properties
- `indexOnly` immutable across contract updates (`validate_config`); `terminal` covered by existing index full-equality immutability

## How Has This Been Tested?

- 23 new parser tests (`try_from_schema/v3/index_only_tests.rs`) covering the full accept/reject matrix on both validation modes, terminal normalization, and cross-generation gating (PV13 rejects `terminal` on both modes; ignores `indexOnly` non-validating without setting the flag)
- new `validate_config` immutability test; wire-shape round-trip test extended for the new field
- full `cargo test -p dpp --all-features`: 4074 passed
- `cargo check -p drive --all-features` green against the new API

## Breaking Changes

Consensus grammar extension inside unreleased PV14 — no released network accepts these keywords, and pre-PV14 behavior is pinned byte-identical by tests.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**Stack**: storage layout (rs-drive), transitions/ABCI validation, query+proofs, and SDK/e2e land as follow-up PRs per the indexOnly implementation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for index-only document types in protocol version 14 and later.
  * Added configurable terminal properties for index entries, defaulting to `$ownerId`.
  * Index-only documents are stored and recovered through index entries rather than primary storage.

* **Validation**
  * Added checks for required properties, ownership, immutability, and incompatible document or index settings.
  * Prevents changing a document type’s index-only status after creation.

* **Bug Fixes**
  * Improved schema-generation compatibility and rejection of unsupported index-only options in earlier protocol versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->