### PR TITLE
feat(drive)!: indexOnly read surface — synthesize documents from index positions

### DIFF
--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
@@ -2183,6 +2183,31 @@ pub(super) fn apply_index_only(
         }
     }
 
+    // At least one index must involve no `$createdAt` at all — the PROOF
+    // index. Executed-transition proofs (waitForStateTransitionResult)
+    // locate the entry a create or delete produced from the transition's
+    // values alone, and a client verifier cannot know the block timestamp
+    // an entry was keyed with; if every index were time-keyed, creates and
+    // deletes of the type would work while every transition-proof request
+    // failed. (Every index already embeds `$ownerId`, so any
+    // `$createdAt`-free index qualifies as the proof index.)
+    let has_proof_index = document_type.indices.values().any(|index| {
+        index.terminal.as_deref() != Some(CREATED_AT)
+            && !index
+                .properties
+                .iter()
+                .any(|property| property.name == CREATED_AT)
+    });
+    if !has_proof_index {
+        return Err(structure_error(format!(
+            "indexOnly document type \"{}\" must declare at least one index that does \
+             not involve $createdAt: executed-transition proofs locate entries from the \
+             transition's values alone and cannot reproduce the block timestamp a \
+             time-keyed entry was written with",
+            name,
+        )));
+    }
+
     // ---- coverage and requiredness --------------------------------------
     // The index content IS the document: a property in no index would not
     // exist, and an optional property would need the null-layout machinery

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
@@ -375,6 +375,40 @@ fn accepts_created_at_in_prefix_when_required() {
 }
 
 #[test]
+fn rejects_when_every_index_involves_created_at() {
+    // Executed-transition proofs locate an entry from the transition's
+    // values alone — a client verifier cannot reproduce the block
+    // timestamp a time-keyed entry was written with. At least one index
+    // must therefore stay $createdAt-free (the proof index); with every
+    // index time-keyed, creates and deletes would work while every
+    // wait-for-transition proof failed.
+    let mut schema = likes_schema_with(
+        "indices",
+        platform_value!([
+            {
+                "name": "byHashtagPostTime",
+                "properties": [
+                    { "hashtag": "asc" },
+                    { "postId": "asc" },
+                    { "$createdAt": "asc" }
+                ],
+                "terminal": "$ownerId"
+            }
+        ]),
+    );
+    schema
+        .set_value(
+            "required",
+            platform_value!(["hashtag", "postId", "$createdAt"]),
+        )
+        .expect("required applies");
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "at least one index that does not involve $createdAt",
+    );
+}
+
+#[test]
 fn rejects_indexed_created_at_that_is_not_required() {
     // Document creation assigns `created_at` only for a REQUIRED
     // $createdAt; indexing an unrequired one would silently take the

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
@@ -739,10 +739,13 @@ pub(super) mod index_only_tests {
 mod index_only_executed_proof_tests {
     use super::index_only_tests::*;
     use super::*;
-    use crate::rpc::core::MockCoreRPCLike;
-    use crate::test::helpers::setup::TempPlatform;
+    use dpp::document::Document;
+    use dpp::identifier::Identifier;
+    use dpp::prelude::DataContract;
     use dpp::state_transition::proof_result::StateTransitionProofResult;
+    use dpp::state_transition::StateTransition;
     use drive::drive::Drive;
+    use simple_signer::signer::SimpleSigner;
     use std::sync::Arc;
 
     /// waitForStateTransitionResult proofs: an executed indexOnly create is
@@ -885,5 +888,195 @@ mod index_only_executed_proof_tests {
         };
         let (_, absent) = documents.into_iter().next().expect("one entry");
         assert!(absent.is_none(), "the unliked entry must be proven absent");
+    }
+
+    /// A helper for the negative-path tests below: a signed `mark` create
+    /// for the given property values (the `mark` doctype's two
+    /// single-property indexes make it the shape where the proof index —
+    /// `byA` — covers only a SUBSET of the document, so a forged tuple can
+    /// share the proof-index position while differing elsewhere).
+    async fn signed_mark_create(
+        contract: &DataContract,
+        owner: Identifier,
+        a: &str,
+        b: &str,
+        nonce: u64,
+        key: &dpp::identity::IdentityPublicKey,
+        signer: &SimpleSigner,
+        rng: &mut StdRng,
+        platform_version: &PlatformVersion,
+    ) -> (StateTransition, Document) {
+        use dpp::document::DocumentV0Setters;
+        let mark_type = contract
+            .document_type_for_name("mark")
+            .expect("mark doctype exists");
+        let entropy = Bytes32::random_with_rng(rng);
+        let mut mark = mark_type
+            .random_document_with_identifier_and_entropy(
+                rng,
+                owner,
+                entropy,
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                platform_version,
+            )
+            .expect("expected a random mark");
+        mark.set("a", a.into());
+        mark.set("b", b.into());
+        let create = BatchTransition::new_document_creation_transition_from_document(
+            mark.clone(),
+            mark_type,
+            entropy.0,
+            key,
+            nonce,
+            0,
+            None,
+            signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the create transition");
+        (create, mark)
+    }
+
+    /// The row-commitment binding refuses a forged create: a transition
+    /// whose values share the PROOF index's projection with an existing
+    /// row (same `a`, same owner ⇒ same `byA` entry) but differ elsewhere
+    /// (`b`) finds the entry present — and its Item carries the REAL row's
+    /// commitment, not the forged tuple's, so verification must fail
+    /// instead of returning the forged document as "executed".
+    #[tokio::test]
+    async fn test_forged_create_proof_is_refused_by_row_commitment() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let platform_state = platform.state.load();
+        let mut rng = StdRng::seed_from_u64(90210);
+
+        let (alice, alice_signer, alice_key) =
+            setup_identity(&mut platform, 958, dash_to_credits!(1.0));
+        let contract = register_likes(&platform, alice.id(), platform_version);
+        let contract_arc = Arc::new(contract.clone());
+
+        let (real_create, _mark) = signed_mark_create(
+            &contract,
+            alice.id(),
+            "x",
+            "one",
+            2,
+            &alice_key,
+            &alice_signer,
+            &mut rng,
+            platform_version,
+        )
+        .await;
+        let result = process_and_commit(&platform, &platform_state, &real_create, platform_version);
+        assert_eq!(result.valid_count(), 1);
+
+        // Never processed — same `a` (same proof-index entry), different `b`.
+        let (forged_create, _forged_mark) = signed_mark_create(
+            &contract,
+            alice.id(),
+            "x",
+            "two",
+            3,
+            &alice_key,
+            &alice_signer,
+            &mut rng,
+            platform_version,
+        )
+        .await;
+
+        let proof = platform
+            .drive
+            .prove_state_transition(&forged_create, None, platform_version)
+            .expect("expected to prove the entry position")
+            .into_data()
+            .expect("expected proof bytes");
+        let lookup = |_id: &dpp::identifier::Identifier| Ok(Some(Arc::clone(&contract_arc)));
+        let error = Drive::verify_state_transition_was_executed_with_proof(
+            &forged_create,
+            &BlockInfo::default(),
+            proof.as_slice(),
+            &lookup,
+            platform_version,
+        )
+        .expect_err("a forged create must not verify as executed");
+        assert!(
+            error.to_string().contains("row commitment"),
+            "expected the row-commitment refusal, got: {error}"
+        );
+    }
+
+    /// A delete that never executed cannot verify: the entry its values
+    /// address is still present, so the absence check must refuse.
+    #[tokio::test]
+    async fn test_unexecuted_delete_proof_is_refused() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let platform_state = platform.state.load();
+        let mut rng = StdRng::seed_from_u64(90211);
+
+        let (alice, alice_signer, alice_key) =
+            setup_identity(&mut platform, 958, dash_to_credits!(1.0));
+        let contract = register_likes(&platform, alice.id(), platform_version);
+        let contract_arc = Arc::new(contract.clone());
+
+        let (create, mark) = signed_mark_create(
+            &contract,
+            alice.id(),
+            "y",
+            "kept",
+            2,
+            &alice_key,
+            &alice_signer,
+            &mut rng,
+            platform_version,
+        )
+        .await;
+        let result = process_and_commit(&platform, &platform_state, &create, platform_version);
+        assert_eq!(result.valid_count(), 1);
+
+        // Signed but never processed — the entry is still there.
+        let mark_type = contract
+            .document_type_for_name("mark")
+            .expect("mark doctype exists");
+        let unexecuted_delete = BatchTransition::new_document_deletion_transition_from_document(
+            mark,
+            mark_type,
+            &alice_key,
+            3,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the delete transition");
+
+        let proof = platform
+            .drive
+            .prove_state_transition(&unexecuted_delete, None, platform_version)
+            .expect("expected to prove the entry position")
+            .into_data()
+            .expect("expected proof bytes");
+        let lookup = |_id: &dpp::identifier::Identifier| Ok(Some(Arc::clone(&contract_arc)));
+        let error = Drive::verify_state_transition_was_executed_with_proof(
+            &unexecuted_delete,
+            &BlockInfo::default(),
+            proof.as_slice(),
+            &lookup,
+            platform_version,
+        )
+        .expect_err("an unexecuted delete must not verify as executed");
+        assert!(
+            error.to_string().contains("still contained"),
+            "expected the entry-still-present refusal, got: {error}"
+        );
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
@@ -822,6 +822,13 @@ mod index_only_executed_proof_tests {
         )
         .expect("expected the executed-create proof to verify");
         assert_ne!(root_hash, [0u8; 32]);
+        // An indexOnly snapshot authenticates the resulting STATE (the
+        // commitment-checked entry), never THIS transition's execution —
+        // a second create with identical values shares the entry.
+        assert_matches!(
+            &outcome,
+            dpp::state_transition::proof_result::StateTransitionProofOutcome::AffectedState(_)
+        );
         let StateTransitionProofResult::VerifiedDocuments(documents) = outcome.into_result() else {
             panic!("expected verified documents");
         };
@@ -869,6 +876,10 @@ mod index_only_executed_proof_tests {
         )
         .expect("expected the executed-delete proof to verify");
         assert_ne!(root_hash, [0u8; 32]);
+        assert_matches!(
+            &outcome,
+            dpp::state_transition::proof_result::StateTransitionProofOutcome::AffectedState(_)
+        );
         let StateTransitionProofResult::VerifiedDocuments(documents) = outcome.into_result() else {
             panic!("expected verified documents");
         };

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
@@ -11,7 +11,7 @@
 
 use super::*;
 
-mod index_only_tests {
+pub(super) mod index_only_tests {
     use super::*;
     use crate::platform_types::platform_state::PlatformState;
     use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
@@ -43,7 +43,7 @@ mod index_only_tests {
     const YAPPR_LIKES_CONTRACT: &str =
         "../rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json";
 
-    fn register_likes(
+    pub(super) fn register_likes(
         platform: &TempPlatform<MockCoreRPCLike>,
         owner_id: Identifier,
         platform_version: &PlatformVersion,
@@ -67,7 +67,7 @@ mod index_only_tests {
 
     /// A like on `POST_A` under `#dash` owned by `owner`, with its id
     /// derived from `entropy` exactly as the create transition demands.
-    fn build_like(
+    pub(super) fn build_like(
         contract: &DataContract,
         owner: Identifier,
         post_id: Identifier,
@@ -100,7 +100,9 @@ mod index_only_tests {
     /// return it — the like's `postId` carries a `refersTo`, so a like on a
     /// nonexistent post is rejected with ReferencedEntityNotFoundError (as
     /// this suite's first draft usefully proved).
-    async fn create_post<S: dpp::identity::signer::Signer<dpp::identity::IdentityPublicKey>>(
+    pub(super) async fn create_post<
+        S: dpp::identity::signer::Signer<dpp::identity::IdentityPublicKey>,
+    >(
         platform: &TempPlatform<MockCoreRPCLike>,
         platform_state: &PlatformState,
         contract: &DataContract,
@@ -150,7 +152,7 @@ mod index_only_tests {
         post
     }
 
-    fn process_and_commit(
+    pub(super) fn process_and_commit(
         platform: &TempPlatform<MockCoreRPCLike>,
         platform_state: &PlatformState,
         transition: &StateTransition,
@@ -731,5 +733,146 @@ mod index_only_tests {
                 result.execution_results()
             );
         }
+    }
+}
+
+mod index_only_executed_proof_tests {
+    use super::index_only_tests::*;
+    use super::*;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TempPlatform;
+    use dpp::state_transition::proof_result::StateTransitionProofResult;
+    use drive::drive::Drive;
+    use std::sync::Arc;
+
+    /// waitForStateTransitionResult proofs: an executed indexOnly create is
+    /// proven by the presence of the entry its values produce (and a delete
+    /// by its absence) — no primary row exists to prove by id. Prover and
+    /// verifier build the same single-entry path query from the transition.
+    #[tokio::test]
+    async fn test_executed_index_only_create_and_delete_proofs() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let platform_state = platform.state.load();
+        let mut rng = StdRng::seed_from_u64(31337);
+
+        let (alice, alice_signer, alice_key) =
+            setup_identity(&mut platform, 958, dash_to_credits!(1.0));
+        let contract = register_likes(&platform, alice.id(), platform_version);
+        let like_type = contract
+            .document_type_for_name("like")
+            .expect("like doctype exists");
+        let contract_arc = Arc::new(contract.clone());
+
+        let post = create_post(
+            &platform,
+            &platform_state,
+            &contract,
+            alice.id(),
+            &alice_key,
+            2,
+            &alice_signer,
+            &mut rng,
+            platform_version,
+        )
+        .await;
+
+        let entropy = Bytes32::random_with_rng(&mut rng);
+        let alice_like = build_like(
+            &contract,
+            alice.id(),
+            post.id(),
+            entropy,
+            &mut rng,
+            platform_version,
+        );
+        let create = BatchTransition::new_document_creation_transition_from_document(
+            alice_like.clone(),
+            like_type,
+            entropy.0,
+            &alice_key,
+            3,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the create transition");
+        let result = process_and_commit(&platform, &platform_state, &create, platform_version);
+        assert_eq!(result.valid_count(), 1);
+
+        // ── prove + verify the executed create ─────────────────────────
+        let proof = platform
+            .drive
+            .prove_state_transition(&create, None, platform_version)
+            .expect("expected to prove the executed create")
+            .into_data()
+            .expect("expected proof bytes");
+        let lookup = |_id: &dpp::identifier::Identifier| Ok(Some(Arc::clone(&contract_arc)));
+        let (root_hash, outcome) = Drive::verify_state_transition_was_executed_with_proof(
+            &create,
+            &BlockInfo::default(),
+            proof.as_slice(),
+            &lookup,
+            platform_version,
+        )
+        .expect("expected the executed-create proof to verify");
+        assert_ne!(root_hash, [0u8; 32]);
+        let StateTransitionProofResult::VerifiedDocuments(documents) = outcome.into_result() else {
+            panic!("expected verified documents");
+        };
+        let (_, verified_like) = documents.into_iter().next().expect("one document");
+        let verified_like = verified_like.expect("the created like is present");
+        assert_eq!(
+            verified_like
+                .properties()
+                .get("postId")
+                .expect("postId present")
+                .to_identifier_bytes()
+                .expect("identifier"),
+            post.id().to_vec()
+        );
+
+        // ── prove + verify the executed delete ─────────────────────────
+        let delete = BatchTransition::new_document_deletion_transition_from_document(
+            alice_like,
+            like_type,
+            &alice_key,
+            4,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the delete transition");
+        let result = process_and_commit(&platform, &platform_state, &delete, platform_version);
+        assert_eq!(result.valid_count(), 1);
+
+        let proof = platform
+            .drive
+            .prove_state_transition(&delete, None, platform_version)
+            .expect("expected to prove the executed delete")
+            .into_data()
+            .expect("expected proof bytes");
+        let (root_hash, outcome) = Drive::verify_state_transition_was_executed_with_proof(
+            &delete,
+            &BlockInfo::default(),
+            proof.as_slice(),
+            &lookup,
+            platform_version,
+        )
+        .expect("expected the executed-delete proof to verify");
+        assert_ne!(root_hash, [0u8; 32]);
+        let StateTransitionProofResult::VerifiedDocuments(documents) = outcome.into_result() else {
+            panic!("expected verified documents");
+        };
+        let (_, absent) = documents.into_iter().next().expect("one entry");
+        assert!(absent.is_none(), "the unliked entry must be proven absent");
     }
 }

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -528,7 +528,7 @@ fn likes_query<'a>(
 /// proof verification must synthesize identical documents, and each
 /// synthesized document must carry exactly what its index recovers.
 #[test]
-fn queries_synthesize_documents_and_proofs_agree() {
+fn should_synthesize_query_documents_with_proof_parity() {
     use crate::query::{WhereClause, WhereOperator};
     use dpp::document::DocumentV0Getters;
     use dpp::platform_value::Value;
@@ -648,7 +648,7 @@ fn queries_synthesize_documents_and_proofs_agree() {
 
 /// By-id fetches have no tree to land on and are refused with guidance.
 #[test]
-fn by_id_queries_are_refused() {
+fn should_refuse_by_id_queries() {
     use crate::query::{WhereClause, WhereOperator};
     use assert_matches::assert_matches;
     use dpp::platform_value::Value;
@@ -672,6 +672,39 @@ fn by_id_queries_are_refused() {
         &error,
         crate::error::Error::Query(crate::error::query::QuerySyntaxError::Unsupported(message))
             if message.contains("cannot be fetched by id"),
+        "unexpected error: {error}"
+    );
+}
+
+/// A cursor (`startAt`/`startAfter`) would be resolved through the
+/// primary-key tree an indexOnly type does not have — the path
+/// constructors must refuse it with the typed `Unsupported` error before
+/// any cursor storage lookup can turn it into `StartDocumentNotFound`.
+#[test]
+fn should_refuse_cursor_queries() {
+    use crate::error::query::QuerySyntaxError;
+    use crate::query::{WhereClause, WhereOperator};
+    use assert_matches::assert_matches;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    let mut query = likes_query(
+        &contract,
+        vec![WhereClause {
+            field: "hashtag".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Text("dash".to_string()),
+        }],
+        None,
+    );
+    query.start_at = Some([7u8; 32]);
+    let error = drive
+        .query_documents(query, None, false, None, None)
+        .expect_err("cursor queries on indexOnly types must be refused");
+    assert_matches!(
+        &error,
+        crate::error::Error::Query(QuerySyntaxError::Unsupported(message))
+            if message.contains("startAt/startAfter is not yet supported"),
         "unexpected error: {error}"
     );
 }

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -492,6 +492,185 @@ fn estimated_fees_upper_bound_actual_fees() {
     assert_grovedb_is_consistent(&drive);
 }
 
+// ---------------------------------------------------------------------------
+// Queries and proofs (Phase 4): synthesis from proved index positions
+// ---------------------------------------------------------------------------
+
+use crate::drive::document::query::QueryDocumentsOutcomeV0Methods;
+
+fn likes_query<'a>(
+    contract: &'a dpp::prelude::DataContract,
+    clauses: Vec<crate::query::WhereClause>,
+    limit: Option<u16>,
+) -> crate::query::DriveDocumentQuery<'a> {
+    let document_type = contract
+        .document_type_for_name(DOCTYPE)
+        .expect("like doctype exists");
+    crate::query::DriveDocumentQuery {
+        contract,
+        document_type,
+        internal_clauses: crate::query::InternalClauses::extract_from_clauses(
+            clauses,
+            platform_version(),
+        )
+        .expect("clauses extract"),
+        offset: None,
+        limit,
+        order_by: Default::default(),
+        start_at: None,
+        start_at_included: false,
+        block_time_ms: None,
+        resolved_time_ranges: vec![],
+    }
+}
+
+/// The one builder both sides call: the server's no-proof execution and the
+/// proof verification must synthesize identical documents, and each
+/// synthesized document must carry exactly what its index recovers.
+#[test]
+fn queries_synthesize_documents_and_proofs_agree() {
+    use crate::query::{WhereClause, WhereOperator};
+    use dpp::document::DocumentV0Getters;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    for (post, owner, seed) in [
+        (POST_A, OWNER_1, 1u64),
+        (POST_A, OWNER_2, 2),
+        (POST_B, OWNER_3, 3),
+    ] {
+        let like = build_like(&contract, "dash", post, owner, seed);
+        insert_like(&drive, &contract, &like, true).expect("insert like");
+    }
+
+    // ── who liked anything under #dash (compound index, full synthesis) ──
+    let query = likes_query(
+        &contract,
+        vec![WhereClause {
+            field: "hashtag".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Text("dash".to_string()),
+        }],
+        Some(10),
+    );
+
+    let outcome = drive
+        .query_documents(query.clone(), None, false, None, None)
+        .expect("indexOnly query executes");
+    let documents = outcome.documents();
+    assert_eq!(documents.len(), 3, "three likes under #dash");
+    let mut seen: Vec<([u8; 32], [u8; 32])> = documents
+        .iter()
+        .map(|document| {
+            assert_eq!(
+                document.properties().get("hashtag"),
+                Some(&Value::Text("dash".to_string())),
+                "prefix property must be recovered from the path"
+            );
+            let post: [u8; 32] = document
+                .properties()
+                .get("postId")
+                .expect("postId recovered")
+                .to_identifier_bytes()
+                .expect("postId is an identifier")
+                .try_into()
+                .expect("32 bytes");
+            (post, document.owner_id().to_buffer())
+        })
+        .collect();
+    seen.sort();
+    assert_eq!(
+        seen,
+        vec![(POST_A, OWNER_1), (POST_A, OWNER_2), (POST_B, OWNER_3)],
+        "synthesis must recover every (post, owner) pair"
+    );
+
+    // ── proof parity: the verifier synthesizes the same documents ──
+    let (proof, _) = query
+        .clone()
+        .execute_with_proof(&drive, None, None, platform_version())
+        .expect("proof generation");
+    let (_root_hash, verified) = query
+        .verify_proof(proof.as_slice(), platform_version())
+        .expect("proof verification synthesizes");
+    let mut verified_ids: Vec<_> = verified.iter().map(|d| d.id()).collect();
+    let mut queried_ids: Vec<_> = documents.iter().map(|d| d.id()).collect();
+    verified_ids.sort();
+    queried_ids.sort();
+    assert_eq!(
+        verified_ids, queried_ids,
+        "proved and unproved synthesis must agree document for document"
+    );
+
+    // ── projection through byLiker: what did OWNER_1 like ──
+    let my_likes = likes_query(
+        &contract,
+        vec![WhereClause {
+            field: "$ownerId".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Identifier(OWNER_1),
+        }],
+        Some(10),
+    );
+    let outcome = drive
+        .query_documents(my_likes.clone(), None, false, None, None)
+        .expect("projection query executes");
+    let documents = outcome.documents();
+    assert_eq!(documents.len(), 1);
+    let projection = &documents[0];
+    assert_eq!(projection.owner_id().to_buffer(), OWNER_1);
+    assert_eq!(
+        projection
+            .properties()
+            .get("postId")
+            .expect("terminal recovered")
+            .to_identifier_bytes()
+            .expect("identifier"),
+        POST_A.to_vec()
+    );
+    assert!(
+        !projection.properties().contains_key("hashtag"),
+        "a subset index yields a projection — hashtag is not in byLiker"
+    );
+    // Projection proofs agree too.
+    let (proof, _) = my_likes
+        .clone()
+        .execute_with_proof(&drive, None, None, platform_version())
+        .expect("projection proof generation");
+    let (_root, verified) = my_likes
+        .verify_proof(proof.as_slice(), platform_version())
+        .expect("projection proof verification");
+    assert_eq!(verified.len(), 1);
+    assert_eq!(verified[0].id(), projection.id());
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// By-id fetches have no tree to land on and are refused with guidance.
+#[test]
+fn by_id_queries_are_refused() {
+    use crate::query::{WhereClause, WhereOperator};
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    let query = likes_query(
+        &contract,
+        vec![WhereClause {
+            field: "$id".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Identifier([9u8; 32]),
+        }],
+        None,
+    );
+    let error = drive
+        .query_documents(query, None, false, None, None)
+        .expect_err("by-id queries on indexOnly types must be refused");
+    assert!(
+        error.to_string().contains("cannot be fetched by id"),
+        "unexpected error: {error}"
+    );
+}
+
 /// Terminal items carry owner-and-epoch storage flags, so deleting them in
 /// a later epoch must refund the freed bytes to the inserting owner,
 /// attributed to the insertion epoch — the same refund contract stored

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -650,6 +650,7 @@ fn queries_synthesize_documents_and_proofs_agree() {
 #[test]
 fn by_id_queries_are_refused() {
     use crate::query::{WhereClause, WhereOperator};
+    use assert_matches::assert_matches;
     use dpp::platform_value::Value;
 
     let (drive, contract) = setup_likes();
@@ -665,8 +666,12 @@ fn by_id_queries_are_refused() {
     let error = drive
         .query_documents(query, None, false, None, None)
         .expect_err("by-id queries on indexOnly types must be refused");
-    assert!(
-        error.to_string().contains("cannot be fetched by id"),
+    // Pin the typed variant, not just the display text: another error
+    // carrying the same wording must not satisfy this test.
+    assert_matches!(
+        &error,
+        crate::error::Error::Query(crate::error::query::QuerySyntaxError::Unsupported(message))
+            if message.contains("cannot be fetched by id"),
         "unexpected error: {error}"
     );
 }

--- a/packages/rs-drive/src/drive/document/index_only_row_commitment.rs
+++ b/packages/rs-drive/src/drive/document/index_only_row_commitment.rs
@@ -2,21 +2,21 @@
 //! item stores, binding the independently stored index projections of one
 //! document back into one logical row.
 
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 use crate::error::drive::DriveError;
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 use crate::error::Error;
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 use dpp::data_contract::document_type::{DocumentPropertyType, DocumentTypeRef};
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 use dpp::document::document_methods::DocumentMethodsV0;
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 use dpp::document::{Document, DocumentV0Getters};
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 use dpp::util::hash::hash_double;
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 use dpp::version::PlatformVersion;
 
 /// The byte length of an indexOnly terminal item's payload: the row
@@ -35,7 +35,7 @@ pub const INDEX_ONLY_ROW_COMMITMENT_SIZE: u32 = 32;
 /// other row. Without it, entry existence alone cannot distinguish "one
 /// document's projections" from "several documents' projections that
 /// happen to coexist".
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 pub fn index_only_row_commitment(
     document: &Document,
     document_type: DocumentTypeRef,
@@ -49,7 +49,7 @@ pub fn index_only_row_commitment(
 /// preimage — the length is what fee accounting sizes the double-SHA256
 /// by (`FunctionOp::new_with_byte_count`), so a validation path that
 /// computes the commitment can bill the hash it just performed.
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 pub fn index_only_row_commitment_with_preimage_size(
     document: &Document,
     document_type: DocumentTypeRef,

--- a/packages/rs-drive/src/drive/document/mod.rs
+++ b/packages/rs-drive/src/drive/document/mod.rs
@@ -71,7 +71,7 @@ pub mod index_only;
 #[cfg(any(feature = "server", feature = "verify"))]
 pub mod index_only_row_commitment;
 
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 pub use index_only_row_commitment::index_only_row_commitment;
 #[cfg(feature = "server")]
 pub use index_only_row_commitment::index_only_row_commitment_with_preimage_size;

--- a/packages/rs-drive/src/drive/document/query/query_documents/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/query/query_documents/v0/mod.rs
@@ -82,6 +82,40 @@ impl Drive {
             return Ok(QueryDocumentsOutcomeV0::default());
         }
         let mut drive_operations: Vec<LowLevelDriveOperation> = vec![];
+
+        // indexOnly documents are synthesized from their index positions —
+        // there are no stored bodies to fetch, so the raw serialized path
+        // below does not apply.
+        {
+            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+            if query.document_type.index_only() {
+                let documents = query.execute_index_only_documents_no_proof_internal(
+                    self,
+                    transaction,
+                    &mut drive_operations,
+                    platform_version,
+                )?;
+                let cost = if let Some(epoch) = epoch {
+                    Drive::calculate_fee(
+                        None,
+                        Some(drive_operations),
+                        epoch,
+                        self.config.epochs_per_era,
+                        platform_version,
+                        None,
+                    )?
+                    .processing_fee
+                } else {
+                    0
+                };
+                return Ok(QueryDocumentsOutcomeV0 {
+                    documents,
+                    skipped: 0,
+                    cost,
+                });
+            }
+        }
+
         let (items, skipped) = query.execute_raw_results_no_proof_internal(
             self,
             transaction,

--- a/packages/rs-drive/src/drive/document/query/query_documents/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/query/query_documents/v0/mod.rs
@@ -89,7 +89,7 @@ impl Drive {
         {
             use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
             if query.document_type.index_only() {
-                let documents = query.execute_index_only_documents_no_proof_internal(
+                let (documents, skipped) = query.execute_index_only_documents_no_proof_internal(
                     self,
                     transaction,
                     &mut drive_operations,
@@ -110,7 +110,7 @@ impl Drive {
                 };
                 return Ok(QueryDocumentsOutcomeV0 {
                     documents,
-                    skipped: 0,
+                    skipped,
                     cost,
                 });
             }

--- a/packages/rs-drive/src/prove/prove_state_transition/v0/mod.rs
+++ b/packages/rs-drive/src/prove/prove_state_transition/v0/mod.rs
@@ -127,31 +127,75 @@ impl Drive {
                                 )))
                             })?;
 
-                        let contested_status =
-                            if let DocumentTransition::Create(create_transition) =
-                                document_transition
-                            {
-                                if create_transition.prefunded_voting_balance().is_some() {
-                                    SingleDocumentDriveQueryContestedStatus::Contested
-                                } else {
-                                    SingleDocumentDriveQueryContestedStatus::NotContested
-                                }
+                        // indexOnly documents have no primary row to prove by
+                        // id: the executed transition is proven against the
+                        // entry its values produce under the proof index —
+                        // the same single-entry path query the verifier
+                        // rebuilds from the transition.
+                        {
+                            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+                            use dpp::state_transition::batch_transition::batched_transition::document_index_only_delete_transition::v0::v0_methods::DocumentIndexOnlyDeleteTransitionV0Methods;
+                            if document_type.index_only() {
+                                let values = match document_transition {
+                                    DocumentTransition::Create(create_transition) => {
+                                        create_transition.data().clone()
+                                    }
+                                    // The indexOnlyDelete kind always carries
+                                    // its values — no fallible access needed.
+                                    DocumentTransition::IndexOnlyDelete(delete_transition) => {
+                                        delete_transition.data().clone()
+                                    }
+                                    _ => {
+                                        return Ok(ProofCreationResult::new_with_error(
+                                            ProofError::InvalidTransition(
+                                                "indexOnly documents only support create and \
+                                                 indexOnlyDelete"
+                                                    .to_string(),
+                                            ),
+                                        ));
+                                    }
+                                };
+                                crate::query::index_only_synthesis::index_only_transition_entry_path_query(
+                                    contract.id(),
+                                    document_type,
+                                    &values,
+                                    owner_id,
+                                    platform_version,
+                                )?
                             } else {
-                                SingleDocumentDriveQueryContestedStatus::NotContested
-                            };
+                                let contested_status =
+                                    if let DocumentTransition::Create(create_transition) =
+                                        document_transition
+                                    {
+                                        if create_transition.prefunded_voting_balance().is_some() {
+                                            SingleDocumentDriveQueryContestedStatus::Contested
+                                        } else {
+                                            SingleDocumentDriveQueryContestedStatus::NotContested
+                                        }
+                                    } else {
+                                        SingleDocumentDriveQueryContestedStatus::NotContested
+                                    };
 
-                        let query = SingleDocumentDriveQuery {
-                            contract_id: document_transition.data_contract_id().into_buffer(),
-                            document_type_name: document_transition.document_type_name().clone(),
-                            document_type_keeps_history: document_type.documents_keep_history(),
-                            document_id: document_transition.base().id().into_buffer(),
-                            block_time_ms: None, //None because we want latest
-                            contested_status,
-                        };
+                                let query = SingleDocumentDriveQuery {
+                                    contract_id: document_transition
+                                        .data_contract_id()
+                                        .into_buffer(),
+                                    document_type_name: document_transition
+                                        .document_type_name()
+                                        .clone(),
+                                    document_type_keeps_history: document_type
+                                        .documents_keep_history(),
+                                    document_id: document_transition.base().id().into_buffer(),
+                                    block_time_ms: None, //None because we want latest
+                                    contested_status,
+                                };
 
-                        let mut path_query = query.construct_path_query(platform_version)?;
-                        path_query.query.limit = None;
-                        path_query
+                                let mut path_query =
+                                    query.construct_path_query(platform_version)?;
+                                path_query.query.limit = None;
+                                path_query
+                            }
+                        }
                     }
                     BatchedTransitionRef::Token(token_transition) => {
                         let data_contract_id = token_transition.data_contract_id();

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -1,0 +1,384 @@
+//! Document synthesis for indexOnly queries.
+//!
+//! An indexOnly entry is `[…prefix values, 0, <terminal value>] → Item(row
+//! commitment)` — the row IS its grove position, and the 32-byte payload
+//! binds the entry to its document's full tuple (see
+//! `index_only_row_commitment`; synthesis itself has no use for it, since
+//! the proved position already carries every recoverable field). A query
+//! result therefore arrives as a
+//! `(path, key, element)` trio whose path segments and member key carry
+//! every recoverable field, and this module turns one trio back into a
+//! `Document`. It is the single builder BOTH sides call — the server's
+//! no-proof execution and the proof verifier — so prover and verifier agree
+//! on the synthesized shape by construction (the same one-builder rule the
+//! ranked query's `path.rs` follows).
+//!
+//! Field recovery:
+//! * prefix properties — decoded from the value path segments via
+//!   [`DocumentPropertyType::decode_value_for_tree_keys`], the inverse of
+//!   the key encoding the write path used;
+//! * the terminal property — decoded from the member key the same way;
+//! * `$ownerId` / `$createdAt` — from whichever position (prefix or
+//!   terminal) the index carries them.
+//!
+//! The synthesized `$id` is deterministic over the synthesized content:
+//! `hash_double(contract_id ‖ owner_id ‖ doctype ‖ (name ‖ key-bytes)*)`
+//! in property-name order. Nothing on chain is ever addressed by it — a
+//! query over a subset index yields a *projection*, and its id is scoped to
+//! that projection's content. Member keys are unique within any single
+//! query, so ids are unique within a result set.
+//!
+//! Fail-closed: any arity or property-name mismatch between the trio and
+//! the index the query resolved is an error, never a partial document.
+
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use crate::query::DriveDocumentQuery;
+use crate::verify::RootHash;
+use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
+use dpp::data_contract::document_type::{DocumentTypeRef, Index};
+use dpp::document::{Document, DocumentV0};
+use dpp::identifier::Identifier;
+use dpp::platform_value::Value;
+use dpp::util::hash::hash_double;
+use dpp::version::PlatformVersion;
+use grovedb::GroveDb;
+use std::collections::BTreeMap;
+
+impl DriveDocumentQuery<'_> {
+    /// Verify a proof for an indexOnly query, synthesizing the documents
+    /// from the proved `(path, key)` positions. The mirror of the server's
+    /// no-proof synthesis path — both call the one builder below.
+    pub(crate) fn verify_index_only_proof(
+        &self,
+        proof: &[u8],
+        platform_version: &PlatformVersion,
+    ) -> Result<(RootHash, Vec<Document>), Error> {
+        if self.start_at.is_some() {
+            return Err(Error::Query(
+                crate::error::query::QuerySyntaxError::Unsupported(
+                    "startAt/startAfter is not yet supported for indexOnly document types"
+                        .to_string(),
+                ),
+            ));
+        }
+
+        let path_query = self.construct_path_query(None, platform_version)?;
+        let (root_hash, proved_key_values) =
+            GroveDb::verify_query(proof, &path_query, &platform_version.drive.grove_version)?;
+
+        let index = self.find_best_index(platform_version)?;
+        let documents = proved_key_values
+            .into_iter()
+            .filter_map(|(path, key, element)| element.map(|_| (path, key)))
+            .map(|(path, key)| {
+                synthesize_index_only_document(
+                    self.contract.id(),
+                    self.document_type,
+                    index,
+                    &path,
+                    &key,
+                )
+            })
+            .collect::<Result<Vec<Document>, Error>>()?;
+
+        Ok((root_hash, documents))
+    }
+}
+
+#[cfg(feature = "server")]
+impl DriveDocumentQuery<'_> {
+    /// Execute an indexOnly query without a proof, synthesizing the
+    /// documents from the `(path, key)` positions grove returns. The
+    /// server-side mirror of [`DriveDocumentQuery::verify_index_only_proof`]
+    /// — both call the one builder below.
+    pub(crate) fn execute_index_only_documents_no_proof_internal(
+        &self,
+        drive: &crate::drive::Drive,
+        transaction: grovedb::TransactionArg,
+        drive_operations: &mut Vec<crate::fees::op::LowLevelDriveOperation>,
+        platform_version: &PlatformVersion,
+    ) -> Result<Vec<Document>, Error> {
+        use grovedb::query_result_type::QueryResultType;
+
+        if self.start_at.is_some() {
+            return Err(Error::Query(
+                crate::error::query::QuerySyntaxError::Unsupported(
+                    "startAt/startAfter is not yet supported for indexOnly document types"
+                        .to_string(),
+                ),
+            ));
+        }
+
+        let path_query = self.construct_path_query_operations(
+            drive,
+            false,
+            transaction,
+            drive_operations,
+            platform_version,
+        )?;
+
+        let query_result = drive.grove_get_path_query(
+            &path_query,
+            transaction,
+            QueryResultType::QueryPathKeyElementTrioResultType,
+            drive_operations,
+            &platform_version.drive,
+        );
+        let elements = match query_result {
+            Err(Error::GroveDB(grove_error))
+                if matches!(
+                    grove_error.as_ref(),
+                    grovedb::Error::PathKeyNotFound(_)
+                        | grovedb::Error::PathNotFound(_)
+                        | grovedb::Error::PathParentLayerNotFound(_)
+                ) =>
+            {
+                return Ok(Vec::new());
+            }
+            other => other?.0,
+        };
+
+        let index = self.find_best_index(platform_version)?;
+        elements
+            .to_path_key_elements()
+            .into_iter()
+            .map(|(path, key, _element)| {
+                synthesize_index_only_document(
+                    self.contract.id(),
+                    self.document_type,
+                    index,
+                    &path,
+                    &key,
+                )
+            })
+            .collect()
+    }
+}
+
+/// The index an executed-transition proof (waitForStateTransitionResult)
+/// runs against: the first `$ownerId`-bearing index that involves no
+/// `$createdAt` — the verifier cannot know the block timestamp the entry
+/// was keyed with, so a time-keyed entry cannot be located client-side.
+/// The parser guarantees an owner-bearing index exists; one avoiding
+/// `$createdAt` is a v1 proof-surface requirement.
+pub fn index_only_proof_index<'a>(document_type: &'a DocumentTypeRef) -> Result<&'a Index, Error> {
+    use dpp::document::property_names::{CREATED_AT, OWNER_ID};
+    document_type
+        .indexes()
+        .values()
+        .find(|index| {
+            let carries_owner = index.terminal.as_deref() == Some(OWNER_ID)
+                || index.properties.iter().any(|p| p.name == OWNER_ID);
+            let carries_created_at = index.terminal.as_deref() == Some(CREATED_AT)
+                || index.properties.iter().any(|p| p.name == CREATED_AT);
+            carries_owner && !carries_created_at
+        })
+        .ok_or(Error::Query(
+            crate::error::query::QuerySyntaxError::Unsupported(
+                "executed-transition proofs for an indexOnly type need an \
+                 $ownerId-bearing index that does not involve $createdAt"
+                    .to_string(),
+            ),
+        ))
+}
+
+/// The grove path and member key of the entry a transition's values
+/// produce under `index` — the from-values twin of the write path's
+/// document-based derivation, for provers and verifiers that hold a
+/// transition rather than a document.
+pub fn index_only_entry_path_and_key_from_values(
+    contract_id: Identifier,
+    document_type: DocumentTypeRef,
+    index: &Index,
+    data: &BTreeMap<String, Value>,
+    owner_id: Identifier,
+    platform_version: &PlatformVersion,
+) -> Result<(Vec<Vec<u8>>, Vec<u8>), Error> {
+    use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
+    use dpp::document::property_names::OWNER_ID;
+
+    let encoded_value_for = |property_name: &str| -> Result<Vec<u8>, Error> {
+        if property_name == OWNER_ID {
+            return Ok(owner_id.to_vec());
+        }
+        let value = data.get(property_name).ok_or(Error::Query(
+            crate::error::query::QuerySyntaxError::Unsupported(
+                "the transition's values do not cover the index's properties".to_string(),
+            ),
+        ))?;
+        document_type
+            .serialize_value_for_key(property_name, value, platform_version)
+            .map_err(|e| Error::Protocol(Box::new(e)))
+    };
+
+    let mut path: Vec<Vec<u8>> = Vec::with_capacity(5 + index.properties.len() * 2);
+    path.push(vec![crate::drive::RootTree::DataContractDocuments as u8]);
+    path.push(contract_id.to_vec());
+    path.push(vec![1]);
+    path.push(document_type.name().as_bytes().to_vec());
+    for property in index.properties.iter() {
+        path.push(property.name.as_bytes().to_vec());
+        path.push(encoded_value_for(&property.name)?);
+    }
+    path.push(vec![0]);
+
+    let terminal =
+        index
+            .terminal
+            .as_deref()
+            .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
+                "index_only_entry_path_and_key_from_values requires an indexOnly index",
+            )))?;
+    let member_key = encoded_value_for(terminal)?;
+
+    Ok((path, member_key))
+}
+
+/// The single-entry `PathQuery` an executed indexOnly create or delete is
+/// proven (and verified) against. Shared by `prove_state_transition` and
+/// `verify_state_transition_was_executed_with_proof` — one builder, both
+/// sides.
+pub fn index_only_transition_entry_path_query(
+    contract_id: Identifier,
+    document_type: DocumentTypeRef,
+    data: &BTreeMap<String, Value>,
+    owner_id: Identifier,
+    platform_version: &PlatformVersion,
+) -> Result<grovedb::PathQuery, Error> {
+    let index = index_only_proof_index(&document_type)?;
+    let (path, member_key) = index_only_entry_path_and_key_from_values(
+        contract_id,
+        document_type,
+        index,
+        data,
+        owner_id,
+        platform_version,
+    )?;
+    let mut query = grovedb::Query::new();
+    query.insert_key(member_key);
+    Ok(grovedb::PathQuery::new_unsized(path, query))
+}
+
+/// Synthesize the document a proved indexOnly entry represents.
+///
+/// `path` is the grove path of the entry's parent (ending with the `0`
+/// storage marker); `member_key` is the entry's key (the terminal
+/// property's encoded value).
+pub fn synthesize_index_only_document(
+    contract_id: Identifier,
+    document_type: DocumentTypeRef,
+    index: &Index,
+    path: &[Vec<u8>],
+    member_key: &[u8],
+) -> Result<Document, Error> {
+    use dpp::document::property_names::{CREATED_AT, OWNER_ID};
+
+    let corrupted =
+        |message: &'static str| Error::Drive(DriveError::CorruptedCodeExecution(message));
+
+    // The path must end [<prop1>, <val1>, …, <propK>, <valK>, [0]].
+    let expected_suffix_len = index.properties.len() * 2 + 1;
+    if path.len() < expected_suffix_len {
+        return Err(corrupted(
+            "indexOnly synthesis: proved path is shorter than the resolved index's shape",
+        ));
+    }
+    let suffix = &path[path.len() - expected_suffix_len..];
+    if suffix.last().map(|segment| segment.as_slice()) != Some(&[0u8][..]) {
+        return Err(corrupted(
+            "indexOnly synthesis: proved path does not end at the 0 storage marker",
+        ));
+    }
+
+    let mut properties: BTreeMap<String, Value> = BTreeMap::new();
+    let mut owner_id: Option<Identifier> = None;
+    let mut created_at: Option<u64> = None;
+
+    let mut assign = |property_name: &str, encoded: &[u8]| -> Result<(), Error> {
+        match property_name {
+            OWNER_ID => {
+                owner_id = Some(
+                    Identifier::from_bytes(encoded)
+                        .map_err(|_| corrupted("indexOnly synthesis: $ownerId is not 32 bytes"))?,
+                );
+            }
+            CREATED_AT => {
+                created_at = Some(
+                    dpp::data_contract::document_type::DocumentPropertyType::decode_date_timestamp(
+                        encoded,
+                    )
+                    .ok_or(corrupted(
+                        "indexOnly synthesis: $createdAt key bytes are not a timestamp",
+                    ))?,
+                );
+            }
+            name => {
+                let property = document_type
+                    .flattened_properties()
+                    .get(name)
+                    .ok_or(corrupted(
+                        "indexOnly synthesis: index names a property the document type lacks",
+                    ))?;
+                let value = property
+                    .property_type
+                    .decode_value_for_tree_keys(encoded)
+                    .map_err(|e| Error::Protocol(Box::new(e)))?;
+                properties.insert(name.to_string(), value);
+            }
+        }
+        Ok(())
+    };
+
+    for (position, index_property) in index.properties.iter().enumerate() {
+        let name_segment = &suffix[position * 2];
+        if name_segment.as_slice() != index_property.name.as_bytes() {
+            return Err(corrupted(
+                "indexOnly synthesis: proved path property name does not match the \
+                 resolved index — refusing to mislabel a value",
+            ));
+        }
+        assign(&index_property.name, &suffix[position * 2 + 1])?;
+    }
+
+    let terminal = index.terminal.as_deref().ok_or(corrupted(
+        "indexOnly synthesis requires an indexOnly index (terminal is always Some \
+         after parse normalization)",
+    ))?;
+    assign(terminal, member_key)?;
+
+    let owner_id = owner_id.ok_or(Error::Query(
+        crate::error::query::QuerySyntaxError::Unsupported(
+            "documents cannot be synthesized from an index that carries no $ownerId; \
+             query through an owner-bearing index"
+                .to_string(),
+        ),
+    ))?;
+
+    // Deterministic content-scoped id (see module docs).
+    let mut id_preimage: Vec<u8> = Vec::with_capacity(96);
+    id_preimage.extend_from_slice(contract_id.as_bytes());
+    id_preimage.extend_from_slice(owner_id.as_bytes());
+    id_preimage.extend_from_slice(document_type.name().as_bytes());
+    for (position, index_property) in index.properties.iter().enumerate() {
+        if index_property.name != OWNER_ID && index_property.name != CREATED_AT {
+            id_preimage.extend_from_slice(index_property.name.as_bytes());
+            id_preimage.extend_from_slice(&suffix[position * 2 + 1]);
+        }
+    }
+    if terminal != OWNER_ID && terminal != CREATED_AT {
+        id_preimage.extend_from_slice(terminal.as_bytes());
+        id_preimage.extend_from_slice(member_key);
+    }
+    let id = Identifier::new(hash_double(id_preimage));
+
+    Ok(DocumentV0 {
+        id,
+        owner_id,
+        properties,
+        created_at,
+        ..Default::default()
+    }
+    .into())
+}

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -21,12 +21,14 @@
 //! * `$ownerId` / `$createdAt` — from whichever position (prefix or
 //!   terminal) the index carries them.
 //!
-//! The synthesized `$id` is deterministic over the synthesized content:
-//! `hash_double(contract_id ‖ owner_id ‖ doctype ‖ (name ‖ key-bytes)*)`
-//! in property-name order. Nothing on chain is ever addressed by it — a
-//! query over a subset index yields a *projection*, and its id is scoped to
-//! that projection's content. Member keys are unique within any single
-//! query, so ids are unique within a result set.
+//! The synthesized `$id` is deterministic over the synthesized position:
+//! `hash_double("index_only_synthesized_id_v1" ‖ contract_id ‖ owner_id ‖
+//! frame(doctype) ‖ (frame(name) ‖ frame(key-bytes))*)` in index order —
+//! `frame(x) = u32_be(len(x)) ‖ x`, with every non-owner component
+//! (`$createdAt` included) participating, so distinct grove positions can
+//! never share an id. Nothing on chain is ever addressed by it — a query
+//! over a subset index yields a *projection*, and its id is scoped to that
+//! projection's content.
 //!
 //! Fail-closed: any arity or property-name mismatch between the trio and
 //! the index the query resolved is an error, never a partial document.
@@ -40,6 +42,7 @@ use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dpp::data_contract::document_type::{DocumentTypeRef, Index};
 use dpp::document::{Document, DocumentV0};
 use dpp::identifier::Identifier;
+use dpp::platform_value::btreemap_extensions::BTreeValueMapInsertionPathHelper;
 use dpp::platform_value::Value;
 use dpp::util::hash::hash_double;
 use dpp::version::PlatformVersion;
@@ -99,7 +102,7 @@ impl DriveDocumentQuery<'_> {
         transaction: grovedb::TransactionArg,
         drive_operations: &mut Vec<crate::fees::op::LowLevelDriveOperation>,
         platform_version: &PlatformVersion,
-    ) -> Result<Vec<Document>, Error> {
+    ) -> Result<(Vec<Document>, u16), Error> {
         use grovedb::query_result_type::QueryResultType;
 
         if self.start_at.is_some() {
@@ -126,7 +129,7 @@ impl DriveDocumentQuery<'_> {
             drive_operations,
             &platform_version.drive,
         );
-        let elements = match query_result {
+        let (elements, skipped) = match query_result {
             Err(Error::GroveDB(grove_error))
                 if matches!(
                     grove_error.as_ref(),
@@ -135,13 +138,13 @@ impl DriveDocumentQuery<'_> {
                         | grovedb::Error::PathParentLayerNotFound(_)
                 ) =>
             {
-                return Ok(Vec::new());
+                return Ok((Vec::new(), 0));
             }
-            other => other?.0,
+            other => other?,
         };
 
         let index = self.find_best_index(platform_version)?;
-        elements
+        let documents = elements
             .to_path_key_elements()
             .into_iter()
             .map(|(path, key, _element)| {
@@ -153,7 +156,8 @@ impl DriveDocumentQuery<'_> {
                     &key,
                 )
             })
-            .collect()
+            .collect::<Result<Vec<Document>, Error>>()?;
+        Ok((documents, skipped))
     }
 }
 
@@ -198,16 +202,25 @@ pub fn index_only_entry_path_and_key_from_values(
 ) -> Result<(Vec<Vec<u8>>, Vec<u8>), Error> {
     use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
     use dpp::document::property_names::OWNER_ID;
+    use dpp::platform_value::btreemap_extensions::BTreeValueMapPathHelper;
 
     let encoded_value_for = |property_name: &str| -> Result<Vec<u8>, Error> {
         if property_name == OWNER_ID {
             return Ok(owner_id.to_vec());
         }
-        let value = data.get(property_name).ok_or(Error::Query(
-            crate::error::query::QuerySyntaxError::Unsupported(
-                "the transition's values do not cover the index's properties".to_string(),
-            ),
-        ))?;
+        // Index property names are flattened dotted paths (`profile.targetId`)
+        // while transition data keeps the document's nested map shape — a
+        // plain top-level get would miss every nested indexed leaf the
+        // contract parser explicitly admits.
+        let value = data
+            .get_optional_at_path(property_name)
+            .ok()
+            .flatten()
+            .ok_or(Error::Query(
+                crate::error::query::QuerySyntaxError::Unsupported(
+                    "the transition's values do not cover the index's properties".to_string(),
+                ),
+            ))?;
         document_type
             .serialize_value_for_key(property_name, value, platform_version)
             .map_err(|e| Error::Protocol(Box::new(e)))
@@ -325,7 +338,13 @@ pub fn synthesize_index_only_document(
                     .property_type
                     .decode_value_for_tree_keys(encoded)
                     .map_err(|e| Error::Protocol(Box::new(e)))?;
-                properties.insert(name.to_string(), value);
+                // A flattened name like `profile.targetId` must come back
+                // as a nested `profile` map, not as a dotted top-level key
+                // — field access, schema serialization and index encoding
+                // all traverse the nested shape.
+                properties.insert_at_path(name, value).map_err(|_| {
+                    corrupted("indexOnly synthesis: could not rebuild the nested property path")
+                })?;
             }
         }
         Ok(())
@@ -356,20 +375,32 @@ pub fn synthesize_index_only_document(
         ),
     ))?;
 
-    // Deterministic content-scoped id (see module docs).
-    let mut id_preimage: Vec<u8> = Vec::with_capacity(96);
+    // Deterministic content-scoped id (see module docs). Every
+    // variable-length component is length-framed (`u32_be(len) ‖ bytes`)
+    // so distinct index positions can never concatenate to the same
+    // preimage, and every distinguishing component of the proved position
+    // — `$createdAt` included — participates: two rows differing only in
+    // their indexed creation time are different positions and must get
+    // different ids (verified results downstream are keyed by id, where a
+    // collision would silently drop a document).
+    let frame = |preimage: &mut Vec<u8>, bytes: &[u8]| {
+        preimage.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+        preimage.extend_from_slice(bytes);
+    };
+    let mut id_preimage: Vec<u8> = Vec::with_capacity(128);
+    id_preimage.extend_from_slice(b"index_only_synthesized_id_v1");
     id_preimage.extend_from_slice(contract_id.as_bytes());
     id_preimage.extend_from_slice(owner_id.as_bytes());
-    id_preimage.extend_from_slice(document_type.name().as_bytes());
+    frame(&mut id_preimage, document_type.name().as_bytes());
     for (position, index_property) in index.properties.iter().enumerate() {
-        if index_property.name != OWNER_ID && index_property.name != CREATED_AT {
-            id_preimage.extend_from_slice(index_property.name.as_bytes());
-            id_preimage.extend_from_slice(&suffix[position * 2 + 1]);
+        if index_property.name != OWNER_ID {
+            frame(&mut id_preimage, index_property.name.as_bytes());
+            frame(&mut id_preimage, &suffix[position * 2 + 1]);
         }
     }
-    if terminal != OWNER_ID && terminal != CREATED_AT {
-        id_preimage.extend_from_slice(terminal.as_bytes());
-        id_preimage.extend_from_slice(member_key);
+    if terminal != OWNER_ID {
+        frame(&mut id_preimage, terminal.as_bytes());
+        frame(&mut id_preimage, member_key);
     }
     let id = Identifier::new(hash_double(id_preimage));
 

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -1629,6 +1629,14 @@ impl<'a> DriveDocumentQuery<'a> {
                         .to_string(),
                 )));
             }
+            if self.document_type.index_only() && self.start_at.is_some() {
+                return Err(Error::Query(QuerySyntaxError::Unsupported(
+                    "startAt/startAfter is not yet supported for indexOnly document types: \
+                     the cursor would be resolved through the primary-key tree, which an \
+                     indexOnly type does not have"
+                        .to_string(),
+                )));
+            }
         }
         let drive_version = &platform_version.drive;
         // First we should get the overall document_type_path
@@ -1752,6 +1760,14 @@ impl<'a> DriveDocumentQuery<'a> {
                 return Err(Error::Query(QuerySyntaxError::Unsupported(
                     "indexOnly documents cannot be fetched by id: there is no primary-key \
                      tree; query through one of the type's indexes"
+                        .to_string(),
+                )));
+            }
+            if self.document_type.index_only() && self.start_at.is_some() {
+                return Err(Error::Query(QuerySyntaxError::Unsupported(
+                    "startAt/startAfter is not yet supported for indexOnly document types: \
+                     the cursor would be resolved through the primary-key tree, which an \
+                     indexOnly type does not have"
                         .to_string(),
                 )));
             }

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -285,7 +285,7 @@ pub mod drive_document_ranked_query;
 /// builder both the server's no-proof execution and the proof verifier
 /// call to turn one back into a `Document`.
 #[cfg(any(feature = "server", feature = "verify"))]
-pub mod index_only_synthesis;
+pub(crate) mod index_only_synthesis;
 
 /// Joint count-and-sum no-prove executor surface — backs the AVG
 /// no-prove path's unified single-walk dispatch. See its module

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -280,6 +280,13 @@ pub mod drive_document_having_query;
 #[cfg(any(feature = "server", feature = "verify"))]
 pub mod drive_document_ranked_query;
 
+/// Document synthesis for indexOnly queries: an indexOnly entry's proved
+/// `(path, key)` position IS the document, and this module is the single
+/// builder both the server's no-proof execution and the proof verifier
+/// call to turn one back into a `Document`.
+#[cfg(any(feature = "server", feature = "verify"))]
+pub mod index_only_synthesis;
+
 /// Joint count-and-sum no-prove executor surface — backs the AVG
 /// no-prove path's unified single-walk dispatch. See its module
 /// docstring for the perf / atomicity contract. Server-only because
@@ -1611,6 +1618,18 @@ impl<'a> DriveDocumentQuery<'a> {
         platform_version: &PlatformVersion,
     ) -> Result<PathQuery, Error> {
         self.validate_in_clause_shape(platform_version)?;
+        // indexOnly documents have no primary-key tree: nothing is ever
+        // addressed by document id, so a by-id query has no tree to land on.
+        {
+            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+            if self.document_type.index_only() && self.is_for_primary_key() {
+                return Err(Error::Query(QuerySyntaxError::Unsupported(
+                    "indexOnly documents cannot be fetched by id: there is no primary-key \
+                     tree; query through one of the type's indexes"
+                        .to_string(),
+                )));
+            }
+        }
         let drive_version = &platform_version.drive;
         // First we should get the overall document_type_path
         let document_type_path = self
@@ -1725,6 +1744,18 @@ impl<'a> DriveDocumentQuery<'a> {
         platform_version: &PlatformVersion,
     ) -> Result<PathQuery, Error> {
         self.validate_in_clause_shape(platform_version)?;
+        // indexOnly documents have no primary-key tree: nothing is ever
+        // addressed by document id, so a by-id query has no tree to land on.
+        {
+            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+            if self.document_type.index_only() && self.is_for_primary_key() {
+                return Err(Error::Query(QuerySyntaxError::Unsupported(
+                    "indexOnly documents cannot be fetched by id: there is no primary-key \
+                     tree; query through one of the type's indexes"
+                        .to_string(),
+                )));
+            }
+        }
         // First we should get the overall document_type_path
         let document_type_path = self
             .contract

--- a/packages/rs-drive/src/verify/document/verify_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/document/verify_proof/v0/mod.rs
@@ -35,6 +35,17 @@ impl DriveDocumentQuery<'_> {
         proof: &[u8],
         platform_version: &PlatformVersion,
     ) -> Result<(RootHash, Vec<Document>), Error> {
+        // indexOnly documents have no stored serialization — the entry's
+        // proved (path, key) position IS the document, so it is synthesized
+        // directly rather than round-tripping through serialized bytes
+        // (which a subset index's projection could not produce at all).
+        {
+            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+            if self.document_type.index_only() {
+                return self.verify_index_only_proof(proof, platform_version);
+            }
+        }
+
         self.verify_proof_keep_serialized(proof, platform_version)
             .map(|(root_hash, documents)| {
                 let documents = documents

--- a/packages/rs-drive/src/verify/document/verify_proof_keep_serialized/v0/mod.rs
+++ b/packages/rs-drive/src/verify/document/verify_proof_keep_serialized/v0/mod.rs
@@ -29,6 +29,20 @@ impl DriveDocumentQuery<'_> {
         proof: &[u8],
         platform_version: &PlatformVersion,
     ) -> Result<(RootHash, Vec<Vec<u8>>), Error> {
+        {
+            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+            if self.document_type.index_only() {
+                return Err(Error::Query(
+                    crate::error::query::QuerySyntaxError::Unsupported(
+                        "indexOnly documents have no stored serialization to keep; verify \
+                         with verify_proof, which synthesizes the documents from their \
+                         proved index positions"
+                            .to_string(),
+                    ),
+                ));
+            }
+        }
+
         let path_query = if let Some(start_at) = &self.start_at {
             let (_, start_document) =
                 self.verify_start_at_document_in_proof(proof, true, *start_at, platform_version)?;

--- a/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
@@ -276,20 +276,25 @@ impl Drive {
                                     }
                                 };
 
-                                // An indexOnly snapshot can never bind THIS
-                                // transition's execution: the row commitment
-                                // authenticates the tuple but carries neither
-                                // id, entropy nor nonce, so a second create
-                                // with identical owner/values (different
-                                // entropy) shares the proven entry while only
-                                // one of them executed — and a delete's
-                                // absence proof may describe state that was
-                                // already absent. The proof attests the
-                                // resulting STATE, not the execution.
-                                return Ok((
-                                    root_hash,
-                                    StateTransitionProofOutcome::AffectedState(result),
-                                ));
+                                // The classifier below is the single
+                                // authority on binding, and it returns false
+                                // for every indexOnly document transition: a
+                                // second create with identical owner/values
+                                // (different entropy) shares the proven entry
+                                // while only one of them executed, and a
+                                // delete's absence proof may describe state
+                                // that was already absent — the proof attests
+                                // the resulting STATE (`AffectedState`), not
+                                // the execution.
+                                let outcome = if Self::state_transition_proof_binds_execution(
+                                    state_transition,
+                                    known_contracts_provider_fn,
+                                )? {
+                                    StateTransitionProofOutcome::ExecutionProved(result)
+                                } else {
+                                    StateTransitionProofOutcome::AffectedState(result)
+                                };
+                                return Ok((root_hash, outcome));
                             }
                         }
 
@@ -2077,8 +2082,25 @@ impl Drive {
                 // consulted; classify fail-closed regardless.
                 None => false,
                 // Document proofs bind the exact document (or its absence
-                // after deletion), including contested status and history.
-                Some(BatchedTransitionRef::Document(_)) => true,
+                // after deletion), including contested status and history —
+                // EXCEPT indexOnly types: their snapshot authenticates the
+                // commitment-checked entry (or its absence), which carries
+                // neither id, entropy nor nonce and so cannot bind one
+                // specific transition's execution.
+                Some(BatchedTransitionRef::Document(document_transition)) => {
+                    use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+                    let data_contract_id = document_transition.data_contract_id();
+                    let contract = known_contracts_provider_fn(&data_contract_id)?.ok_or(
+                        Error::Proof(ProofError::UnknownContract(format!(
+                            "unknown contract with id {} in document verification",
+                            data_contract_id
+                        ))),
+                    )?;
+                    !contract
+                        .document_type_for_name(document_transition.document_type_name())
+                        .map_err(|e| Error::Proof(ProofError::UnknownContract(e.to_string())))?
+                        .index_only()
+                }
                 Some(BatchedTransitionRef::Token(token_transition)) => {
                     let data_contract_id = token_transition.data_contract_id();
                     let contract = known_contracts_provider_fn(&data_contract_id)?.ok_or(

--- a/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
@@ -202,12 +202,14 @@ impl Drive {
 
                                 let (root_hash, result) = match document_transition {
                                     DocumentTransition::Create(create_transition) => {
-                                        if entry_element.is_none() {
+                                        let Some(grovedb::Element::Item(payload, _)) =
+                                            entry_element
+                                        else {
                                             return Err(Error::Proof(ProofError::IncorrectProof(format!(
-                                                "proof did not contain the indexOnly entry expected to exist after create of {}",
+                                                "proof did not contain the indexOnly entry item expected to exist after create of {}",
                                                 create_transition.base().id()
                                             ))));
-                                        }
+                                        };
                                         let expected_document =
                                             Document::try_from_create_transition(
                                                 create_transition,
@@ -217,6 +219,31 @@ impl Drive {
                                                 &document_type,
                                                 platform_version,
                                             )?;
+                                        // Entry presence alone only proves that
+                                        // SOME row projects onto this position;
+                                        // the stored row commitment binds the
+                                        // entry to its document's full tuple,
+                                        // so a pre-existing row with the same
+                                        // projection but different values in
+                                        // other indexes cannot masquerade as
+                                        // this create. (`$createdAt`, when the
+                                        // type requires it, enters the
+                                        // commitment from the caller-supplied
+                                        // block info — the same execution-block
+                                        // assumption the expected document is
+                                        // built under.)
+                                        let expected_commitment =
+                                            crate::drive::document::index_only_row_commitment(
+                                                &expected_document,
+                                                document_type,
+                                                platform_version,
+                                            )?;
+                                        if payload != expected_commitment {
+                                            return Err(Error::Proof(ProofError::IncorrectProof(format!(
+                                                "the proved indexOnly entry's row commitment does not match the created document {}: the entry belongs to a different row",
+                                                create_transition.base().id()
+                                            ))));
+                                        }
                                         (
                                             root_hash,
                                             VerifiedDocuments(BTreeMap::from([(
@@ -249,17 +276,20 @@ impl Drive {
                                     }
                                 };
 
-                                // Same outcome wrapping the shared tail below
-                                // applies to every other arm.
-                                let outcome = if Self::state_transition_proof_binds_execution(
-                                    state_transition,
-                                    known_contracts_provider_fn,
-                                )? {
-                                    StateTransitionProofOutcome::ExecutionProved(result)
-                                } else {
-                                    StateTransitionProofOutcome::AffectedState(result)
-                                };
-                                return Ok((root_hash, outcome));
+                                // An indexOnly snapshot can never bind THIS
+                                // transition's execution: the row commitment
+                                // authenticates the tuple but carries neither
+                                // id, entropy nor nonce, so a second create
+                                // with identical owner/values (different
+                                // entropy) shares the proven entry while only
+                                // one of them executed — and a delete's
+                                // absence proof may describe state that was
+                                // already absent. The proof attests the
+                                // resulting STATE, not the execution.
+                                return Ok((
+                                    root_hash,
+                                    StateTransitionProofOutcome::AffectedState(result),
+                                ));
                             }
                         }
 

--- a/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
@@ -159,6 +159,110 @@ impl Drive {
                                 )))
                             })?;
 
+                        // indexOnly documents have no primary row: the executed
+                        // transition is verified against the single entry its
+                        // values produce under the proof index — rebuilt here
+                        // from the transition through the same builder the
+                        // prover used.
+                        {
+                            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+                            use dpp::state_transition::batch_transition::batched_transition::document_index_only_delete_transition::v0::v0_methods::DocumentIndexOnlyDeleteTransitionV0Methods;
+                            if document_type.index_only() {
+                                let values = match document_transition {
+                                    DocumentTransition::Create(create_transition) => {
+                                        create_transition.data().clone()
+                                    }
+                                    // The indexOnlyDelete kind always
+                                    // carries its values.
+                                    DocumentTransition::IndexOnlyDelete(delete_transition) => {
+                                        delete_transition.data().clone()
+                                    }
+                                    _ => {
+                                        return Err(Error::Proof(ProofError::IncorrectProof(
+                                            "indexOnly documents only support create and \
+                                             indexOnlyDelete"
+                                                .to_string(),
+                                        )));
+                                    }
+                                };
+                                let path_query = crate::query::index_only_synthesis::index_only_transition_entry_path_query(
+                                    contract.id(),
+                                    document_type,
+                                    &values,
+                                    documents_batch_transition.owner_id(),
+                                    platform_version,
+                                )?;
+                                let (root_hash, mut proved) = grovedb::GroveDb::verify_query(
+                                    proof,
+                                    &path_query,
+                                    &platform_version.drive.grove_version,
+                                )?;
+                                let entry_element =
+                                    proved.pop().and_then(|(_path, _key, element)| element);
+
+                                let (root_hash, result) = match document_transition {
+                                    DocumentTransition::Create(create_transition) => {
+                                        if entry_element.is_none() {
+                                            return Err(Error::Proof(ProofError::IncorrectProof(format!(
+                                                "proof did not contain the indexOnly entry expected to exist after create of {}",
+                                                create_transition.base().id()
+                                            ))));
+                                        }
+                                        let expected_document =
+                                            Document::try_from_create_transition(
+                                                create_transition,
+                                                documents_batch_transition.owner_id(),
+                                                block_info,
+                                                &contract,
+                                                &document_type,
+                                                platform_version,
+                                            )?;
+                                        (
+                                            root_hash,
+                                            VerifiedDocuments(BTreeMap::from([(
+                                                expected_document.id(),
+                                                Some(expected_document),
+                                            )])),
+                                        )
+                                    }
+                                    DocumentTransition::IndexOnlyDelete(delete_transition) => {
+                                        if entry_element.is_some() {
+                                            return Err(Error::Proof(ProofError::IncorrectProof(format!(
+                                                "proof still contained the indexOnly entry after delete of {}",
+                                                delete_transition.base().id()
+                                            ))));
+                                        }
+                                        (
+                                            root_hash,
+                                            VerifiedDocuments(BTreeMap::from([(
+                                                delete_transition.base().id(),
+                                                None,
+                                            )])),
+                                        )
+                                    }
+                                    _ => {
+                                        return Err(Error::Proof(ProofError::IncorrectProof(
+                                            "indexOnly documents only support create and \
+                                             indexOnlyDelete"
+                                                .to_string(),
+                                        )))
+                                    }
+                                };
+
+                                // Same outcome wrapping the shared tail below
+                                // applies to every other arm.
+                                let outcome = if Self::state_transition_proof_binds_execution(
+                                    state_transition,
+                                    known_contracts_provider_fn,
+                                )? {
+                                    StateTransitionProofOutcome::ExecutionProved(result)
+                                } else {
+                                    StateTransitionProofOutcome::AffectedState(result)
+                                };
+                                return Ok((root_hash, outcome));
+                            }
+                        }
+
                         let contested_status =
                             if let DocumentTransition::Create(create_transition) =
                                 document_transition
@@ -313,15 +417,14 @@ impl Drive {
                                 ))
                             }
                             DocumentTransition::IndexOnlyDelete(_) => {
-                                // An indexOnly document has no primary-storage
-                                // row, so the by-id single-document query this
-                                // verifier is built around cannot attest its
-                                // entries; indexOnly execution proofs verify
-                                // against the index entries themselves and are
-                                // not supported here yet.
+                                // Only reachable when the doctype is NOT
+                                // indexOnly (the indexOnly branch above
+                                // returns first): an indexOnlyDelete aimed at
+                                // a stored type can never have executed, so
+                                // there is nothing a proof could attest.
                                 Err(Error::Proof(ProofError::InvalidTransition(
-                                    "indexOnly delete-by-values execution proofs are not \
-                                     supported yet"
+                                    "an indexOnlyDelete cannot execute against a stored \
+                                     document type"
                                         .to_string(),
                                 )))
                             }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fourth PR of the **indexOnly document types** stack (rebased onto v4.2-dev after #4497, which superseded #4493 by modeling the indexOnly delete as its own transition kind): the read surface. The executed-transition prover/verifier here match `DocumentTransition::IndexOnlyDelete`, whose `data()` is non-optional — the values-missing error paths from the #4493-era draft are gone. An indexOnly entry's proved `(path, key)` position IS the document, so queries and proofs synthesize documents from index positions instead of dereferencing stored bodies.

## What was done?

**One builder, both sides** (`query/index_only_synthesis.rs`, compiled for server AND verify): `synthesize_index_only_document` turns a `(path, key)` trio back into a `Document` — prefix properties decoded from the value path segments via `decode_value_for_tree_keys` (the inverse of the write path's key encoding), the terminal property from the member key, `$ownerId`/`$createdAt` from wherever the index carries them. Arity and property-name mismatches against the resolved index fail closed. The synthesized `$id` is deterministic over the proved position: `hash_double("index_only_synthesized_id_v1" ‖ contract_id ‖ owner ‖ frame(doctype) ‖ (frame(name) ‖ frame(key-bytes))*)` with `frame(x) = u32_be(len(x)) ‖ x` and every non-owner component (`$createdAt` included) participating — length framing and full-position coverage make distinct grove positions collision-free by construction. A subset index yields a documented *projection* whose id is scoped to that projection.

**Server**: `query_documents_v0` branches for indexOnly — a trio-result grove read plus synthesis (`execute_index_only_documents_no_proof_internal`). **Verifier**: `verify_proof_v0` branches to `verify_index_only_proof`, synthesizing from the proved trios; `verify_proof_keep_serialized` errors with guidance (there is no stored serialization to keep — and a projection could not produce one). `FromProof for Documents` flows through `verify_proof` unchanged.

**Executed-transition proofs** (waitForStateTransitionResult): `prove_state_transition` and `verify_state_transition_was_executed_with_proof` gain indexOnly branches sharing `index_only_transition_entry_path_query` — a single-entry path query built from the transition's values under the **proof index** (the first `$ownerId`-bearing index not involving `$createdAt` — guaranteed to exist by the new admission rule). A create is proven by entry presence **with the Item payload matched against the transition-derived row commitment** (returning the expected document reconstructed from the transition), a delete by absence. Both outcomes are classified `AffectedState`, never `ExecutionProved`: the commitment carries neither id, entropy nor nonce, so no indexOnly snapshot can bind a *specific* transition's execution — the proof attests the resulting state. To keep the proof surface total, the dpp parser now requires every indexOnly type to keep at least one `$createdAt`-free index (the proof index); a fully time-keyed type would create and delete fine while every wait-for-transition proof failed, since a verifier cannot reproduce the block timestamp an entry was keyed with.

**Rejections with guidance**: by-`$id` queries (both path-query constructors — no primary tree exists) and `startAt`/`startAfter` (value-carrying cursors are a follow-up).

**Untouched by design**: ranked / count / range-aggregate queries — they never open value trees or primary storage, so the PV14 ranked surface serves indexOnly types as-is (pinned at the grove level by the storage PR's e2e tests).

## How Has This Been Tested?

- rs-drive e2e additions: query synthesis over the likes fixture (every (post, owner) pair recovered, prefix properties from the path), **proved/unproved parity** document-for-document, projection queries through `byLiker` (terminal recovered, absent property genuinely absent, proofs agree), by-id rejection.
- ABCI executed-proof roundtrip: prove + verify an executed like create (entry presence, expected document returned) and delete (entry absence).
- Full regression green: dpp, drive (all-features and verify-only), drive-abci, plus dash-sdk / wasm-sdk / proof-verifier / wasm-drive-verify compile checks.

## Breaking Changes

None on the wire; all read-path behavior is keyed off `indexOnly` types, which cannot exist below PV14.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**Stack**: #4491 → #4492 → #4493 → this → SDK/e2e.
**Known follow-ups**: startAt cursors; terminal-property where clauses ("did I like X" as a single existence query); serialized wire responses for projection queries (the proof path, which the evo SDK uses by default, is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added query support for index-only documents, including synthesized document results and processing fees.
  * Added proof verification for index-only document creation and deletion transitions.
  * Added support for verifying executed state-transition proofs for index-only documents.

* **Bug Fixes**
  * Index-only document types now require at least one index that does not use `$createdAt`.
  * Unsupported by-ID queries and serialization-preserving proof requests now return clear errors.
  * Improved validation prevents incomplete or inconsistent synthesized documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->