### PR TITLE
feat(sdk): indexOnly delete-by-values through the SDKs; book chapter

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -68,6 +68,7 @@
 - [Average Index Examples](drive/average-index-examples.md)
 - [Document Ranked Trees](drive/document-ranked-trees.md)
 - [Ranked Index Examples](drive/ranked-index-examples.md)
+- [Index-Only Document Types](drive/index-only-document-types.md)
 
 # Testing
 

--- a/book/src/drive/index-only-document-types.md
+++ b/book/src/drive/index-only-document-types.md
@@ -1,0 +1,140 @@
+# Index-Only Document Types
+
+> **Status:** implemented and gated at protocol version 14 (meta-schema v3 /
+> parser generation 3). The storage layout is pinned end-to-end against a real
+> grovedb by
+> [`index_only_e2e_tests`](https://github.com/dashpay/platform/blob/v4.2-dev/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs),
+> which runs against the yappr-likes fixture at
+> [`packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json`](https://github.com/dashpay/platform/blob/v4.2-dev/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json).
+> The full ABCI pipeline (transitions, validation, executed-transition
+> proofs) is exercised by the `index_only` test modules in rs-drive-abci's
+> batch tests.
+
+## The problem
+
+A minimal social interaction — a like — is fully expressed by *where it
+sits*: which post, which hashtag, which identity. Storing it as an ordinary
+document costs a serialized body in primary storage (~90–150 bytes plus
+element flags and tree-node overhead), a primary-tree insertion, and a
+~70–90-byte reference per index, for a fact whose entire content is its
+index position.
+
+An **index-only document type** (`indexOnly: true` on the doc-type schema)
+stores nothing in primary storage. The index entries ARE the rows:
+
+```text
+[DataContractDocuments, contract_id, 1, <doctype>,
+   <prop 1>, <val 1>, …, <prop K>, <val K>, 0, <terminal value>]
+      → Item(<row commitment>, flags)
+```
+
+The **terminal** — a per-index keyword defaulting to `$ownerId`, or any
+refersTo-typed identifier property (identity, contract, token, permanent
+document) — is the member key, sitting exactly where a normal non-unique
+index keys by document id; the element is an `Item` instead of a
+`Reference` because there is nothing to point at. The `0` storage marker,
+value-tree types, and the count/ranked tree derivation are byte-identical
+to the ordinary non-unique layout, which is what lets the protocol v14
+ranked machinery (see [Document Ranked Trees](./document-ranked-trees.md))
+serve index-only types unchanged: "the five most-liked posts in `#dash`"
+is an O(log n + k) read with an O(log n + k) proof, and Items count in
+count/ranked trees exactly as References do.
+
+**Governing principle: only what is in the indexes exists and is
+recoverable.** Prefix property values live in the path, the terminal id in
+the member key, `$ownerId` and `$createdAt` wherever an index carries them.
+There is no document beyond that.
+
+## The row commitment
+
+Each entry's 32-byte payload is
+`hash_double(owner ‖ (name ‖ length ‖ raw index bytes)* ‖ [$createdAt])`
+over ALL of the document's properties in sorted-name order
+(`index_only_row_commitment`). It binds the independently stored index
+projections of one document back into one logical row: a delete recomputes
+the commitment from its submitted values, and every probed entry must
+carry it. A values tuple spliced from two different creates — even two
+creates by the same owner — fails the comparison on whichever entry
+belongs to the other row. Entry existence alone cannot make that
+distinction; the commitment is what does.
+
+## Constraint matrix (parse-time, `apply_index_only`)
+
+The on-disk layout depends on every one of these, so they run regardless
+of `full_validation` — the same untrusted-boundary rule the doctype
+aggregate keywords follow:
+
+| Constraint | Why |
+|---|---|
+| every property in `required`; every ancestor of an indexed dotted path required | the index path is the storage; no null layout exists |
+| every property appears in ≥ 1 index (prefix or terminal) | an unindexed property would be silently dropped |
+| **every index embeds `$ownerId`** (prefix or terminal) | entries are self-authorizing: a delete computed with owner = signer can only ever address the signer's own entries |
+| terminal is `$ownerId` or a single-id refersTo property | the member key must alone be a referable entity id (`identityPublicKey` is compound and rejected) |
+| indexed `$createdAt` requires `$createdAt` in `required` | creation only assigns timestamps for required system times |
+| `documentsMutable: false`, no transfers/trading/history/transient | no stored row, no revision |
+| non-unique, non-contested, `nullSearchable` default, no `timeRange`, count axes only | v1 scope; sum axes and buckets are follow-ups |
+
+`indexOnly` and the index set (terminals included) are immutable across
+contract updates — a later-added index could never be backfilled.
+
+## Lifecycle
+
+- **Create** reuses `DocumentCreateTransitionV0` unchanged. State
+  validation probes every index's entry: ANY existing entry is a duplicate
+  (`DuplicateUniqueIndexError`), which is also what makes a shorter index a
+  uniqueness constraint over its value projection plus owner — for likes,
+  the `[postId]` index is the one-like-per-(post, owner) rule. `refersTo`
+  validation runs unchanged (it reads transition values, not storage), so a
+  like on a nonexistent post is rejected.
+- **Delete** is its own transition kind,
+  `DocumentIndexOnlyDeleteTransition { base, data }` (`$action:
+  "indexOnlyDelete"`), carrying the full value tuple (`$createdAt` under
+  its system key exactly when the type requires it). Delete-by-id and
+  delete-by-values are different operations — different payload,
+  authorization model and validation pipeline — so the factory picks the
+  KIND from the doctype's storage mode. Validation and the storage layer
+  both require every entry to exist AND match the row commitment. A by-id
+  delete on an index-only type (and an indexOnlyDelete on a stored type)
+  is rejected by the structure gates; below PV14 the kind is rejected at
+  basic structure, keeping check_tx behavior aligned with pre-4.2
+  software.
+- **Replace / transfer / purchase / price** are structurally impossible.
+
+## Reads
+
+An entry's proved `(path, key)` position IS the document, so queries and
+proofs **synthesize** documents through one shared builder
+(`query/index_only_synthesis.rs`, compiled for server and verify): prefix
+properties decoded from the path via `decode_value_for_tree_keys` (the
+inverse of the write path's key encoding), the terminal from the member
+key. A query through a subset index yields a documented *projection*. The
+synthesized `$id` is deterministic over the proved position (a
+domain-separated, length-framed hash covering every non-owner component,
+`$createdAt` included) — nothing on chain is ever addressed by it.
+
+Executed-transition proofs (waitForStateTransitionResult) prove a create
+by the presence of the entry its values produce under the **proof index**
+(the first `$ownerId`-bearing index not involving `$createdAt` — contract
+admission guarantees one exists) and a delete by its absence, with the
+proved entry's payload checked against the transition-derived row
+commitment; prover and verifier build the same single-entry path query
+from the transition. The outcome is always `AffectedState`, never
+`ExecutionProved`: the commitment carries neither id, entropy nor nonce,
+so a snapshot cannot bind one specific transition's execution.
+
+Not yet supported on the read surface: by-`$id` fetches (no primary tree —
+rejected with guidance), `startAt` cursors, and where clauses on the
+terminal property; ranked / count / range-aggregate queries work unchanged
+since they never open value trees.
+
+## What it costs and what it saves
+
+Registration skips the `[0]` primary-key tree. Each document is exactly
+one `[…values, 0, terminal] → Item(32-byte commitment)` per index — no
+primary row, no references — cutting storage well past half against a
+minimal stored document, with deletion refunds flowing from each entry's
+own element flags (the index walkers pass flags for
+immutable-yet-deletable index-only types specifically). Estimation pads
+the dry-run item above the real payload so estimated fees keep
+upper-bounding applied fees across the indexed-tree layers' documented
+under-count.

--- a/packages/js-evo-sdk/src/documents/facade.ts
+++ b/packages/js-evo-sdk/src/documents/facade.ts
@@ -50,7 +50,13 @@ export class DocumentsFacade {
     return w.getDocumentWithProofInfo(contractId, type, documentId);
   }
 
-  async create(options: wasm.DocumentCreateOptions): Promise<void> {
+  /**
+   * Creates a document and resolves to the confirmed Document as Platform
+   * committed it, consensus-populated system fields included — keep this
+   * instance when you later intend to delete an indexOnly document whose
+   * type requires `$createdAt`.
+   */
+  async create(options: wasm.DocumentCreateOptions): Promise<wasm.Document> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.documentCreate(options);
   }

--- a/packages/rs-sdk/src/platform/documents/transitions/delete.rs
+++ b/packages/rs-sdk/src/platform/documents/transitions/delete.rs
@@ -23,6 +23,11 @@ pub struct DocumentDeleteTransitionBuilder {
     pub document_type_name: String,
     pub document_id: Identifier,
     pub owner_id: Identifier,
+    /// The full document, when the builder was constructed from one.
+    /// Required for indexOnly document types: their delete transition
+    /// carries the document's values (there is no stored row to fetch
+    /// them from), so an id-only builder cannot delete them.
+    pub document: Option<Document>,
     pub token_payment_info: Option<TokenPaymentInfo>,
     pub settings: Option<PutSettings>,
     pub user_fee_increase: Option<UserFeeIncrease>,
@@ -53,6 +58,7 @@ impl DocumentDeleteTransitionBuilder {
             document_type_name,
             document_id,
             owner_id,
+            document: None,
             token_payment_info: None,
             settings: None,
             user_fee_increase: None,
@@ -77,12 +83,15 @@ impl DocumentDeleteTransitionBuilder {
         document: &Document,
     ) -> Self {
         use dpp::document::DocumentV0Getters;
-        Self::new(
+        let mut builder = Self::new(
             data_contract,
             document_type_name,
             document.id(),
             document.owner_id(),
-        )
+        );
+        // Keep the full document: an indexOnly delete carries its values.
+        builder.document = Some(document.clone());
+        builder
     }
 
     /// Adds token payment info to the document delete transition
@@ -177,24 +186,44 @@ impl DocumentDeleteTransitionBuilder {
             .document_type_for_name(&self.document_type_name)
             .map_err(|e| Error::Protocol(e.into()))?;
 
-        // Create a minimal document for deletion
-        let document = Document::V0(dpp::document::DocumentV0 {
-            contract_version: None,
-            id: self.document_id,
-            owner_id: self.owner_id,
-            properties: Default::default(),
-            revision: Some(INITIAL_REVISION),
-            created_at: None,
-            updated_at: None,
-            transferred_at: None,
-            created_at_block_height: None,
-            updated_at_block_height: None,
-            transferred_at_block_height: None,
-            created_at_core_block_height: None,
-            updated_at_core_block_height: None,
-            transferred_at_core_block_height: None,
-            creator_id: None,
-        });
+        // indexOnly deletes carry the document's values — an id-only
+        // builder has nothing to carry, so demand the full document.
+        {
+            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+            if document_type.index_only() && self.document.is_none() {
+                return Err(Error::Generic(
+                    "deleting an indexOnly document requires the full document (its values \
+                     are what identify the entries): construct the builder with \
+                     DocumentDeleteTransitionBuilder::from_document"
+                        .to_string(),
+                ));
+            }
+        }
+
+        // The stored full document when we have one (mandatory for
+        // indexOnly types); otherwise a minimal id-only document, which is
+        // all a stored-document (V0) delete needs.
+        let document = if let Some(document) = &self.document {
+            document.clone()
+        } else {
+            Document::V0(dpp::document::DocumentV0 {
+                contract_version: None,
+                id: self.document_id,
+                owner_id: self.owner_id,
+                properties: Default::default(),
+                revision: Some(INITIAL_REVISION),
+                created_at: None,
+                updated_at: None,
+                transferred_at: None,
+                created_at_block_height: None,
+                updated_at_block_height: None,
+                transferred_at_block_height: None,
+                created_at_core_block_height: None,
+                updated_at_core_block_height: None,
+                transferred_at_core_block_height: None,
+                creator_id: None,
+            })
+        };
 
         let state_transition = BatchTransition::new_document_deletion_transition_from_document(
             document,

--- a/packages/rs-sdk/src/platform/documents/transitions/delete.rs
+++ b/packages/rs-sdk/src/platform/documents/transitions/delete.rs
@@ -165,6 +165,79 @@ impl DocumentDeleteTransitionBuilder {
     /// # Returns
     ///
     /// * `Result<StateTransition, Error>` - The signed state transition or an error
+    /// Resolve the document type and the document this delete will be
+    /// built from, validating the builder's target. Runs BEFORE any nonce
+    /// is reserved (an invalid builder must not advance the SDK's cached
+    /// nonce — enough poisoned increments would push the next valid
+    /// transition beyond the protocol's missing-revision window):
+    /// an id-only builder is refused for indexOnly types, and a stored
+    /// full document must agree with the builder's public id/owner fields.
+    fn resolve_document_for_deletion(
+        &self,
+    ) -> Result<
+        (
+            dpp::data_contract::document_type::DocumentTypeRef<'_>,
+            Document,
+        ),
+        Error,
+    > {
+        use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+        use dpp::document::DocumentV0Getters;
+
+        let document_type = self
+            .data_contract
+            .document_type_for_name(&self.document_type_name)
+            .map_err(|e| Error::Protocol(e.into()))?;
+
+        if let Some(document) = &self.document {
+            // The id/owner fields stay public alongside the stored
+            // document; refuse a contradictory target instead of
+            // reserving a nonce for one identity while signing a
+            // transition derived from another.
+            if document.id() != self.document_id || document.owner_id() != self.owner_id {
+                return Err(Error::Generic(
+                    "the builder's document_id/owner_id do not match the stored document: \
+                     the transition is derived from the document, so a mismatched target \
+                     would sign for a different identity or document than the fields claim"
+                        .to_string(),
+                ));
+            }
+            return Ok((document_type, document.clone()));
+        }
+
+        // indexOnly deletes carry the document's values — an id-only
+        // builder has nothing to carry, so demand the full document.
+        if document_type.index_only() {
+            return Err(Error::Generic(
+                "deleting an indexOnly document requires the full document (its values \
+                 are what identify the entries): construct the builder with \
+                 DocumentDeleteTransitionBuilder::from_document"
+                    .to_string(),
+            ));
+        }
+
+        // A minimal id-only document is all a stored-document (by-id)
+        // delete needs.
+        let document = Document::V0(dpp::document::DocumentV0 {
+            contract_version: None,
+            id: self.document_id,
+            owner_id: self.owner_id,
+            properties: Default::default(),
+            revision: Some(INITIAL_REVISION),
+            created_at: None,
+            updated_at: None,
+            transferred_at: None,
+            created_at_block_height: None,
+            updated_at_block_height: None,
+            transferred_at_block_height: None,
+            created_at_core_block_height: None,
+            updated_at_core_block_height: None,
+            transferred_at_core_block_height: None,
+            creator_id: None,
+        });
+        Ok((document_type, document))
+    }
+
     pub async fn sign(
         &self,
         sdk: &Sdk,
@@ -172,6 +245,12 @@ impl DocumentDeleteTransitionBuilder {
         signer: &impl Signer<IdentityPublicKey>,
         platform_version: &PlatformVersion,
     ) -> Result<StateTransition, Error> {
+        // Validate the target FIRST: the nonce fetch below bumps the
+        // SDK's cached contract nonce, and no transition is broadcast on
+        // an error path, so a rejection after it would leak an increment
+        // per failed call.
+        let (document_type, document) = self.resolve_document_for_deletion()?;
+
         let identity_contract_nonce = sdk
             .get_identity_contract_nonce(
                 self.owner_id,
@@ -180,50 +259,6 @@ impl DocumentDeleteTransitionBuilder {
                 self.settings,
             )
             .await?;
-
-        let document_type = self
-            .data_contract
-            .document_type_for_name(&self.document_type_name)
-            .map_err(|e| Error::Protocol(e.into()))?;
-
-        // indexOnly deletes carry the document's values — an id-only
-        // builder has nothing to carry, so demand the full document.
-        {
-            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
-            if document_type.index_only() && self.document.is_none() {
-                return Err(Error::Generic(
-                    "deleting an indexOnly document requires the full document (its values \
-                     are what identify the entries): construct the builder with \
-                     DocumentDeleteTransitionBuilder::from_document"
-                        .to_string(),
-                ));
-            }
-        }
-
-        // The stored full document when we have one (mandatory for
-        // indexOnly types); otherwise a minimal id-only document, which is
-        // all a stored-document (V0) delete needs.
-        let document = if let Some(document) = &self.document {
-            document.clone()
-        } else {
-            Document::V0(dpp::document::DocumentV0 {
-                contract_version: None,
-                id: self.document_id,
-                owner_id: self.owner_id,
-                properties: Default::default(),
-                revision: Some(INITIAL_REVISION),
-                created_at: None,
-                updated_at: None,
-                transferred_at: None,
-                created_at_block_height: None,
-                updated_at_block_height: None,
-                transferred_at_block_height: None,
-                created_at_core_block_height: None,
-                updated_at_core_block_height: None,
-                transferred_at_core_block_height: None,
-                creator_id: None,
-            })
-        };
 
         let state_transition = BatchTransition::new_document_deletion_transition_from_document(
             document,
@@ -314,5 +349,121 @@ impl Sdk {
                 Default::default(),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::document::{DocumentV0Getters, DocumentV0Setters};
+    use dpp::platform_value::Value;
+    use dpp::tests::json_document::json_document_to_contract;
+
+    const YAPPR_LIKES_CONTRACT: &str =
+        "../rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json";
+
+    fn likes_contract() -> Arc<DataContract> {
+        Arc::new(
+            json_document_to_contract(YAPPR_LIKES_CONTRACT, true, PlatformVersion::latest())
+                .expect("expected to parse the yappr-likes contract"),
+        )
+    }
+
+    fn like_document(contract: &DataContract) -> Document {
+        use dpp::data_contract::document_type::random_document::CreateRandomDocument;
+        let like_type = contract
+            .document_type_for_name("like")
+            .expect("like doctype exists");
+        let mut document = like_type
+            .random_document(Some(1337), PlatformVersion::latest())
+            .expect("expected a random like");
+        document.set("hashtag", "dash".into());
+        document.set(
+            "postId",
+            Value::Identifier(Identifier::new([0xe3; 32]).to_buffer()),
+        );
+        document
+    }
+
+    /// The refusal must come out of the pure resolution step — before
+    /// `sign()` ever reaches the nonce cache, so a rejected call cannot
+    /// advance the cached contract nonce.
+    #[test]
+    fn should_refuse_an_id_only_delete_of_an_index_only_type_before_any_nonce_work() {
+        let contract = likes_contract();
+        let builder = DocumentDeleteTransitionBuilder::new(
+            Arc::clone(&contract),
+            "like".to_string(),
+            Identifier::new([1u8; 32]),
+            Identifier::new([2u8; 32]),
+        );
+        let error = builder
+            .resolve_document_for_deletion()
+            .expect_err("an id-only builder must be refused for an indexOnly type");
+        assert!(
+            error.to_string().contains("requires the full document"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// A stored full document must agree with the builder's public
+    /// id/owner fields — a contradictory target must not resolve.
+    #[test]
+    fn should_refuse_a_document_target_that_contradicts_the_builder_fields() {
+        let contract = likes_contract();
+        let like = like_document(&contract);
+        let mut builder = DocumentDeleteTransitionBuilder::from_document(
+            Arc::clone(&contract),
+            "like".to_string(),
+            &like,
+        );
+        builder.document_id = Identifier::new([9u8; 32]);
+        let error = builder
+            .resolve_document_for_deletion()
+            .expect_err("a mismatched target must be refused");
+        assert!(
+            error.to_string().contains("do not match"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// `from_document` keeps the full value tuple: the resolved document
+    /// is the one the batch factory derives the indexOnlyDelete kind's
+    /// payload from.
+    #[test]
+    fn should_keep_the_full_document_for_index_only_deletes() {
+        let contract = likes_contract();
+        let like = like_document(&contract);
+        let builder = DocumentDeleteTransitionBuilder::from_document(
+            Arc::clone(&contract),
+            "like".to_string(),
+            &like,
+        );
+        let (document_type, resolved) = builder
+            .resolve_document_for_deletion()
+            .expect("a full-document builder must resolve");
+        use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
+        assert_eq!(document_type.name(), "like");
+        assert_eq!(resolved.properties(), like.properties());
+        assert_eq!(resolved.id(), like.id());
+        assert_eq!(resolved.owner_id(), like.owner_id());
+    }
+
+    /// Stored doctypes keep the id-only path: the resolved document is the
+    /// minimal by-id shell.
+    #[test]
+    fn should_resolve_a_minimal_document_for_stored_type_id_only_deletes() {
+        let contract = likes_contract();
+        let builder = DocumentDeleteTransitionBuilder::new(
+            Arc::clone(&contract),
+            "post".to_string(),
+            Identifier::new([1u8; 32]),
+            Identifier::new([2u8; 32]),
+        );
+        let (_, resolved) = builder
+            .resolve_document_for_deletion()
+            .expect("an id-only builder must resolve for a stored type");
+        assert!(resolved.properties().is_empty());
+        assert_eq!(resolved.id(), Identifier::new([1u8; 32]));
     }
 }

--- a/packages/wasm-sdk/src/state_transitions/document.rs
+++ b/packages/wasm-sdk/src/state_transitions/document.rs
@@ -149,12 +149,18 @@ impl WasmSdk {
     /// 4. Broadcasts and waits for confirmation
     ///
     /// @param options - Creation options including document, identity key, and signer
-    /// @returns Promise that resolves when the document is created
+    /// @returns Promise resolving to the confirmed Document as Platform
+    ///          committed it — consensus-populated system fields
+    ///          (`$createdAt` and friends) included. Keep THIS instance
+    ///          when you later intend to delete an indexOnly document
+    ///          whose type requires `$createdAt`: the delete carries the
+    ///          document's values, and the pre-broadcast wrapper never
+    ///          learns the block timestamp Platform assigned.
     #[wasm_bindgen(js_name = "documentCreate")]
     pub async fn document_create(
         &self,
         options: DocumentCreateOptionsJs,
-    ) -> Result<(), WasmSdkError> {
+    ) -> Result<DocumentWasm, WasmSdkError> {
         // Extract document from options
         let document_wasm = DocumentWasm::try_from_options(&options, "document")?;
         let document: Document = document_wasm.clone().into();
@@ -195,8 +201,10 @@ impl WasmSdk {
             try_from_options_optional::<PutSettingsInput>(&options, "settings")?.map(Into::into);
         let token_payment_info = try_from_options_optional_token_payment_info(&options)?;
 
-        // Use PutDocument trait for creation
-        document
+        // Use PutDocument trait for creation, keeping the confirmed
+        // document Platform returns — it carries the consensus-assigned
+        // system fields the caller's pre-broadcast wrapper lacks.
+        let confirmed_document = document
             .put_to_platform_and_wait_for_response(
                 self.inner_sdk(),
                 document_type,
@@ -208,7 +216,12 @@ impl WasmSdk {
             )
             .await?;
 
-        Ok(())
+        Ok(DocumentWasm::new(
+            confirmed_document,
+            contract_id,
+            document_type_name,
+            Some(entropy_array),
+        ))
     }
 }
 

--- a/packages/wasm-sdk/src/state_transitions/document.rs
+++ b/packages/wasm-sdk/src/state_transitions/document.rs
@@ -404,12 +404,16 @@ impl WasmSdk {
             return Err(WasmSdkError::invalid_argument("document is required"));
         }
 
-        // Check if it's a Document instance or a plain object with fields
-        let (document_id, owner_id, contract_id, document_type_name): (
+        // Check if it's a Document instance or a plain object with fields.
+        // The full document is kept when provided — indexOnly document
+        // types can ONLY be deleted from their values, so the id-only
+        // plain-object form does not work for them.
+        let (document_id, owner_id, contract_id, document_type_name, full_document): (
             Identifier,
             Identifier,
             Identifier,
             String,
+            Option<Document>,
         ) = if get_class_type(&document_js).ok().as_deref() == Some("Document") {
             // It's a Document instance - extract fields from it
             let doc: DocumentWasm = document_js
@@ -421,6 +425,7 @@ impl WasmSdk {
                 doc_inner.owner_id(),
                 doc.data_contract_id().into(),
                 doc.document_type_name(),
+                Some(doc_inner),
             )
         } else {
             // It's a plain object - extract individual fields
@@ -431,6 +436,7 @@ impl WasmSdk {
                 try_from_options_with(&document_js, "documentTypeName", |v| {
                     try_to_string(v, "documentTypeName")
                 })?,
+                None,
             )
         };
 
@@ -449,13 +455,23 @@ impl WasmSdk {
             try_from_options_optional::<PutSettingsInput>(&options, "settings")?.map(Into::into);
         let token_payment_info = try_from_options_optional_token_payment_info(&options)?;
 
-        // Build and execute delete transition using DocumentDeleteTransitionBuilder
-        let builder = DocumentDeleteTransitionBuilder::new(
-            Arc::new(data_contract),
-            document_type_name,
-            document_id,
-            owner_id,
-        );
+        // Build and execute delete transition using DocumentDeleteTransitionBuilder.
+        // A provided Document instance goes through from_document so its
+        // values ride along (required for indexOnly document types).
+        let builder = if let Some(full_document) = &full_document {
+            DocumentDeleteTransitionBuilder::from_document(
+                Arc::new(data_contract),
+                document_type_name,
+                full_document,
+            )
+        } else {
+            DocumentDeleteTransitionBuilder::new(
+                Arc::new(data_contract),
+                document_type_name,
+                document_id,
+                owner_id,
+            )
+        };
 
         let builder = if let Some(token_payment_info) = token_payment_info {
             builder.with_token_payment_info(token_payment_info)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fifth and final PR of the **indexOnly document types** stack (rebased onto v4.2-dev after #4497 and #4494 merged): the client surface and long-term documentation.

## What was done?

- **rs-sdk**: `DocumentDeleteTransitionBuilder` now keeps the full document when constructed via `from_document` (previously it discarded everything but the ids), and `sign()` refuses an id-only builder for an indexOnly type with guidance — the delete transition carries the document's values, and the batch factory selects the `DocumentIndexOnlyDeleteTransition` KIND from the doctype's storage mode (#4497's design — delete-by-values is its own operation, not a version of the delete).
- **wasm-sdk / js-evo-sdk**: `documentDelete` routes a provided `Document` instance through `from_document` so its values ride along; the id-only plain-object form keeps working for stored document types. Queries and proofs need no client changes — `FromProof for Documents` flows through the synthesis path from #4494.
- **Book**: new chapter `book/src/drive/index-only-document-types.md` covering the layout, the row commitment, the constraint matrix, the lifecycle, the synthesis read surface, and the cost story; registered in SUMMARY and cross-linked with the ranked-trees chapter.

## How Has This Been Tested?

dash-sdk and wasm-sdk compile checks; the underlying flows are covered by the storage/ABCI/read-surface suites in the earlier PRs of the stack (including the SDK-equivalent executed-proof roundtrips).

**Deferred with rationale**: a platform-test-suite functional spec requires the legacy js-dash-sdk's delete factory to build the indexOnlyDelete kind first — the evo (wasm-sdk) flow is the covered path; tracked as a follow-up alongside startAt cursors, terminal-property where clauses, and the sum-axis/timeRange extensions.

## Breaking Changes

None — client-side plumbing only.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**Stack**: #4491 (schema) → #4492 (storage) → #4493 (transitions/ABCI) → #4494 (queries/proofs) → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for index-only document types, including their lifecycle, constraints, reads, proofs, and storage benefits.
  * Added support for creating and deleting index-only documents while preserving the document data required for deletion.
  * Document creation now returns the confirmed document, including system-generated fields such as creation time.

* **Documentation**
  * Added index-only document types to the Drive documentation contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->