### PR TITLE
fix(sdk): separate the deletion-resolution doc from the Returns list

### DIFF
--- a/packages/rs-sdk/src/platform/documents/transitions/delete.rs
+++ b/packages/rs-sdk/src/platform/documents/transitions/delete.rs
@@ -165,6 +165,7 @@ impl DocumentDeleteTransitionBuilder {
     /// # Returns
     ///
     /// * `Result<StateTransition, Error>` - The signed state transition or an error
+    ///
     /// Resolve the document type and the document this delete will be
     /// built from, validating the builder's target. Runs BEFORE any nonce
     /// is reserved (an invalid builder must not advance the SDK's cached


### PR DESCRIPTION
v4.2-dev `Tests` went red at 4ca678f5 (Rust workspace / Clippy lints): 7x `doc list item without indentation` in `packages/rs-sdk/src/platform/documents/transitions/delete.rs:168-174`, introduced by #4495 — a new doc paragraph glued directly onto the `* Result<...>` list item. One blank `///` line ends the list. `cargo clippy -p dash-sdk --lib` clean after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the formatting of the `sign` method documentation for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->