### PR TITLE
feat(drive): indexOnly terminal-property where clauses and keyset pagination

### DIFF
--- a/book/src/drive/index-only-document-types.md
+++ b/book/src/drive/index-only-document-types.md
@@ -122,9 +122,18 @@ from the transition. The outcome is always `AffectedState`, never
 `ExecutionProved`: the commitment carries neither id, entropy nor nonce,
 so a snapshot cannot bind one specific transition's execution.
 
-Not yet supported on the read surface: by-`$id` fetches (no primary tree —
-rejected with guidance), `startAt` cursors, and where clauses on the
-terminal property; ranked / count / range-aggregate queries work unchanged
+Where clauses on the **terminal property** lower directly onto the entry
+level's member keys once every prefix property carries an equality clause:
+an equality answers "did I like X" in one query, and a range ordered by
+the terminal (`terminal > <last seen>`, with a limit) walks the entries
+page by page — **keyset pagination**, the indexOnly replacement for
+id-shaped `startAt` cursors, which cannot address a position whose
+synthesized id is a one-way hash. Both shapes prove and verify through
+the same shared path-query builder.
+
+Not supported on the read surface: by-`$id` fetches (no primary tree —
+rejected with guidance) and `startAt` cursors (rejected with the keyset
+guidance above); ranked / count / range-aggregate queries work unchanged
 since they never open value trees.
 
 ## What it costs and what it saves

--- a/book/src/drive/index-only-document-types.md
+++ b/book/src/drive/index-only-document-types.md
@@ -128,8 +128,12 @@ an equality answers "did I like X" in one query, and a range ordered by
 the terminal (`terminal > <last seen>`, with a limit) walks the entries
 page by page — **keyset pagination**, the indexOnly replacement for
 id-shaped `startAt` cursors, which cannot address a position whose
-synthesized id is a one-way hash. Both shapes prove and verify through
-the same shared path-query builder.
+synthesized id is a one-way hash. Mixed shapes are served through a
+**prefix pivot**: one range or `in` clause may sit on a prefix property
+instead of the terminal (`hashtag == h AND postId > p AND $ownerId ==
+me`), with everything above the pivot equality-bound, everything below
+it unconstrained, and the terminal clause an equality. All shapes prove
+and verify through the same shared path-query builder.
 
 Not supported on the read surface: by-`$id` fetches (no primary tree —
 rejected with guidance) and `startAt` cursors (rejected with the keyset

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
@@ -374,6 +374,67 @@ fn accepts_created_at_in_prefix_when_required() {
         .expect("$createdAt in an index prefix should be accepted when required");
 }
 
+/// The unified matcher: terminals participate as an index's deepest
+/// matchable component, with generic (non-terminal) matches keeping
+/// absolute precedence and difference-scored best-match inside each
+/// class.
+#[test]
+fn terminal_aware_matching_prefers_generic_and_scores_candidates() {
+    use crate::data_contract::document_type::methods::DocumentTypeV0Methods;
+
+    let document_type_ref =
+        &parse_with(likes_schema(), PlatformVersion::latest(), false).expect("likes schema parses");
+
+    // A pure-property cover exists (`byPost` = [postId] → $ownerId used
+    // generically): it must win over `byLiker`'s terminal cover of the
+    // same field, and report the terminal unused.
+    let (index, difference, terminal_used) = document_type_ref
+        .index_for_types_matching_including_terminal(
+            &["postId"],
+            None,
+            &[],
+            |_| true,
+            PlatformVersion::latest(),
+        )
+        .expect("matcher runs")
+        .expect("an index matches");
+    assert_eq!(index.name, "byPost");
+    assert_eq!((difference, terminal_used), (0, false));
+
+    // No pure-property cover for {$ownerId, postId}: `byLiker`
+    // ([$ownerId] → postId) covers it exactly through its terminal
+    // (difference 0) and must beat `byHashtagPost`'s costlier terminal
+    // cover (hashtag unused, difference 1).
+    let (index, difference, terminal_used) = document_type_ref
+        .index_for_types_matching_including_terminal(
+            &["$ownerId", "postId"],
+            None,
+            &[],
+            |_| true,
+            PlatformVersion::latest(),
+        )
+        .expect("matcher runs")
+        .expect("an index matches");
+    assert_eq!(index.name, "byLiker");
+    assert_eq!((difference, terminal_used), (0, true));
+
+    // The full tuple {hashtag, postId, $ownerId} is only coverable with
+    // `byHashtagPost`'s terminal; an unused terminal never costs score,
+    // so the exact cover reports difference 0.
+    let (index, difference, terminal_used) = document_type_ref
+        .index_for_types_matching_including_terminal(
+            &["hashtag", "postId", "$ownerId"],
+            None,
+            &[],
+            |_| true,
+            PlatformVersion::latest(),
+        )
+        .expect("matcher runs")
+        .expect("an index matches");
+    assert_eq!(index.name, "byHashtagPost");
+    assert_eq!((difference, terminal_used), (0, true));
+}
+
 #[test]
 fn rejects_when_every_index_involves_created_at() {
     // Executed-transition proofs locate an entry from the transition's

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -731,17 +731,22 @@ impl Index {
         Self::matches_over_components(&self.properties, index_names, in_field_name, order_by)
     }
 
-    /// [`Self::matches`] over an index's full component list, terminal
-    /// included: the terminal (an indexOnly index's member-key property)
-    /// participates in field coverage, the `in`-position rule and the
-    /// order-by suffix exactly as if it were the index's deepest property.
+    /// [`Self::matches`] with the index's terminal (an indexOnly index's
+    /// member-key property) as a matchable component. The terminal is the
+    /// entry level itself — ALWAYS the index's deepest component — so it
+    /// never participates in the prefix's order-by reduction: a
+    /// constrained terminal leaves prefix ordering intact (each fully
+    /// determined path holds at most one entry per member key), a
+    /// terminal named in `order_by` must be its LAST (deepest) entry, and
+    /// a terminal `in` field trivially satisfies the deepest-position
+    /// rule. The prefix properties then match through the exact
+    /// [`Self::matches`] algorithm.
     ///
     /// Returns `(difference, terminal_used)` — the difference counts
-    /// unused PREFIX properties only (an unused terminal costs nothing:
-    /// it is the entry level itself, always reachable), so scores stay
-    /// comparable with [`Self::matches`] and an index is never penalized
-    /// for merely having a terminal. On an index without a terminal this
-    /// is exactly [`Self::matches`] with `terminal_used = false`.
+    /// unused PREFIX properties only (an unused terminal costs nothing),
+    /// so scores stay comparable with [`Self::matches`]. On an index
+    /// without a terminal this is exactly [`Self::matches`] with
+    /// `terminal_used = false`.
     pub fn matches_including_terminal(
         &self,
         index_names: &[&str],
@@ -754,26 +759,32 @@ impl Index {
                 .map(|difference| (difference, false));
         };
 
-        // One extended component list, one matching algorithm. The parser
-        // rejects a terminal repeating an index property, so the synthetic
-        // component cannot shadow a prefix property.
-        let mut components = Vec::with_capacity(self.properties.len() + 1);
-        components.extend(self.properties.iter().cloned());
-        components.push(IndexProperty {
-            name: terminal.to_string(),
-            ascending: true,
-        });
-
-        let difference =
-            Self::matches_over_components(&components, index_names, in_field_name, order_by)?;
         let terminal_used = index_names.contains(&terminal);
-        // An unused terminal was counted as an unused component by the
-        // shared algorithm; take it back out of the score.
-        let difference = if terminal_used {
-            difference
-        } else {
-            difference.saturating_sub(1)
+        let prefix_fields: Vec<&str> = index_names
+            .iter()
+            .copied()
+            .filter(|field| *field != terminal)
+            .collect();
+        let prefix_order_by: &[&str] = match order_by.iter().position(|field| *field == terminal) {
+            // Ordering by the terminal is ordering the deepest level —
+            // admissible only as the ordering's last entry.
+            Some(position) if position + 1 == order_by.len() => &order_by[..position],
+            Some(_) => return None,
+            None => order_by,
         };
+        let prefix_in_field = match in_field_name {
+            // An `in` on the terminal sits at the deepest position by
+            // construction; the prefix keeps no `in` constraint.
+            Some(field) if field == terminal => None,
+            other => other,
+        };
+
+        let difference = Self::matches_over_components(
+            &self.properties,
+            &prefix_fields,
+            prefix_in_field,
+            prefix_order_by,
+        )?;
         Some((difference, terminal_used))
     }
 

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -728,13 +728,68 @@ impl Index {
         in_field_name: Option<&str>,
         order_by: &[&str],
     ) -> Option<u16> {
+        Self::matches_over_components(&self.properties, index_names, in_field_name, order_by)
+    }
+
+    /// [`Self::matches`] over an index's full component list, terminal
+    /// included: the terminal (an indexOnly index's member-key property)
+    /// participates in field coverage, the `in`-position rule and the
+    /// order-by suffix exactly as if it were the index's deepest property.
+    ///
+    /// Returns `(difference, terminal_used)` — the difference counts
+    /// unused PREFIX properties only (an unused terminal costs nothing:
+    /// it is the entry level itself, always reachable), so scores stay
+    /// comparable with [`Self::matches`] and an index is never penalized
+    /// for merely having a terminal. On an index without a terminal this
+    /// is exactly [`Self::matches`] with `terminal_used = false`.
+    pub fn matches_including_terminal(
+        &self,
+        index_names: &[&str],
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+    ) -> Option<(u16, bool)> {
+        let Some(terminal) = self.terminal.as_deref() else {
+            return self
+                .matches(index_names, in_field_name, order_by)
+                .map(|difference| (difference, false));
+        };
+
+        // One extended component list, one matching algorithm. The parser
+        // rejects a terminal repeating an index property, so the synthetic
+        // component cannot shadow a prefix property.
+        let mut components = Vec::with_capacity(self.properties.len() + 1);
+        components.extend(self.properties.iter().cloned());
+        components.push(IndexProperty {
+            name: terminal.to_string(),
+            ascending: true,
+        });
+
+        let difference =
+            Self::matches_over_components(&components, index_names, in_field_name, order_by)?;
+        let terminal_used = index_names.contains(&terminal);
+        // An unused terminal was counted as an unused component by the
+        // shared algorithm; take it back out of the score.
+        let difference = if terminal_used {
+            difference
+        } else {
+            difference.saturating_sub(1)
+        };
+        Some((difference, terminal_used))
+    }
+
+    fn matches_over_components(
+        properties: &[IndexProperty],
+        index_names: &[&str],
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+    ) -> Option<u16> {
         // Here we are trying to figure out if the Index matches the order by
         // To do so we take the index and go backwards as we need the order by clauses to be
         // continuous, but they do not need to be at the end.
-        let mut reduced_properties = self.properties.as_slice();
+        let mut reduced_properties = properties;
         // let mut should_ignore: Vec<String> = order_by.iter().map(|&str| str.to_string()).collect();
         if !order_by.is_empty() {
-            for _ in 0..self.properties.len() {
+            for _ in 0..properties.len() {
                 if reduced_properties.len() < order_by.len() {
                     return None;
                 }
@@ -755,23 +810,23 @@ impl Index {
             }
         }
 
-        let last_property = self.properties.last()?;
+        let last_property = properties.last()?;
 
         // the in field can only be on the last or before last property
         if let Some(in_field_name) = in_field_name {
             if last_property.name.as_str() != in_field_name {
                 // it can also be on the before last
-                if self.properties.len() == 1 {
+                if properties.len() == 1 {
                     return None;
                 }
-                let before_last_property = self.properties.get(self.properties.len() - 2)?;
+                let before_last_property = properties.get(properties.len() - 2)?;
                 if before_last_property.name.as_str() != in_field_name {
                     return None;
                 }
             }
         }
 
-        let mut d = self.properties.len();
+        let mut d = properties.len();
 
         for search_name in index_names.iter() {
             if !reduced_properties

--- a/packages/rs-dpp/src/data_contract/document_type/methods/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/methods/mod.rs
@@ -130,6 +130,44 @@ pub trait DocumentTypeV0Methods: DocumentTypeV0Getters + DocumentTypeV0MethodsVe
         }
     }
 
+    /// [`Self::index_for_types_matching`] with terminals (an indexOnly
+    /// index's member-key property) as matchable deepest components. The
+    /// returned bool says whether the winning index consumed its terminal;
+    /// generic (non-terminal) matches always take precedence, so on any
+    /// document type without terminals this is exactly
+    /// [`Self::index_for_types_matching`]. Shares the `index_for_types`
+    /// feature-version gate: terminal participation only changes outcomes
+    /// on indexOnly document types, which cannot exist below protocol
+    /// version 14.
+    fn index_for_types_matching_including_terminal(
+        &self,
+        index_names: &[&str],
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+        filter: impl Fn(&Index) -> bool,
+        platform_version: &PlatformVersion,
+    ) -> Result<Option<(&Index, u16, bool)>, ProtocolError> {
+        match platform_version
+            .dpp
+            .contract_versions
+            .document_type_versions
+            .methods
+            .index_for_types
+        {
+            0 => Ok(self.index_for_types_matching_including_terminal_v0(
+                index_names,
+                in_field_name,
+                order_by,
+                filter,
+            )),
+            version => Err(ProtocolError::UnknownVersionMismatch {
+                method: "index_for_types_matching_including_terminal".to_string(),
+                known_versions: vec![0],
+                received: version,
+            }),
+        }
+    }
+
     fn serialize_value_for_key(
         &self,
         key: &str,

--- a/packages/rs-dpp/src/data_contract/document_type/methods/versioned_methods.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/methods/versioned_methods.rs
@@ -416,6 +416,55 @@ pub trait DocumentTypeV0MethodsVersioned: DocumentTypeV0Getters + DocumentTypeBa
     /// the winner among equally-good candidates is decided by the index map's
     /// name ordering, and a post-check can only reject the winner — never
     /// promote the index that was actually required.
+    /// [`Self::index_for_types_matching_v0`] with the terminal (an
+    /// indexOnly index's member-key property) participating as the
+    /// index's deepest matchable component. Generic matches keep absolute
+    /// precedence: a candidate that covers the query WITHOUT its terminal
+    /// always beats every terminal-using candidate, regardless of score —
+    /// the terminal route is a stand-in for "no ordinary index serves
+    /// this", never a competitor to one that does. Within each class the
+    /// difference scoring (and its index-map-order tie-break) is exactly
+    /// the generic matcher's.
+    fn index_for_types_matching_including_terminal_v0(
+        &self,
+        index_names: &[&str],
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+        filter: impl Fn(&Index) -> bool,
+    ) -> Option<(&Index, u16, bool)> {
+        let mut best_generic: Option<(&Index, u16)> = None;
+        let mut best_generic_difference = u16::MAX;
+        let mut best_terminal: Option<(&Index, u16)> = None;
+        let mut best_terminal_difference = u16::MAX;
+        for (_, index) in self.indexes().iter() {
+            if !filter(index) {
+                continue;
+            }
+            let Some((difference, terminal_used)) =
+                index.matches_including_terminal(index_names, in_field_name, order_by)
+            else {
+                continue;
+            };
+            if terminal_used {
+                if difference < best_terminal_difference {
+                    best_terminal_difference = difference;
+                    best_terminal = Some((index, difference));
+                }
+            } else {
+                if difference == 0 {
+                    return Some((index, 0, false));
+                }
+                if difference < best_generic_difference {
+                    best_generic_difference = difference;
+                    best_generic = Some((index, difference));
+                }
+            }
+        }
+        best_generic
+            .map(|(index, difference)| (index, difference, false))
+            .or(best_terminal.map(|(index, difference)| (index, difference, true)))
+    }
+
     fn index_for_types_matching_v0(
         &self,
         index_names: &[&str],

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -932,6 +932,57 @@ fn should_refuse_by_id_queries() {
     );
 }
 
+/// Clause-field classification is the modeled answer to "where may a
+/// clause sit": roles are derived once against the doctype, and a field
+/// can hold several at once (`postId` is a prefix property of two yappr
+/// indexes AND `byLiker`'s terminal).
+#[test]
+fn should_classify_clause_fields_against_the_doctype() {
+    use crate::query::{InternalClauses, WhereClause, WhereOperator};
+    use dpp::platform_value::Value;
+
+    let (_drive, contract) = setup_likes();
+    let document_type = contract
+        .document_type_for_name(DOCTYPE)
+        .expect("like doctype exists");
+
+    // Dual role: prefix property of byHashtagPost/byPost, terminal of byLiker.
+    let post_id_roles = InternalClauses::classify_field(document_type, "postId");
+    assert!(post_id_roles.index_property && post_id_roles.terminal);
+    assert!(!post_id_roles.primary_key && !post_id_roles.unindexed());
+
+    // Terminal-only ($ownerId is byHashtagPost/byPost's terminal and
+    // byLiker's prefix property — also dual on this fixture), and a
+    // genuinely unindexed field.
+    let owner_roles = InternalClauses::classify_field(document_type, "$ownerId");
+    assert!(owner_roles.index_property && owner_roles.terminal);
+    let id_roles = InternalClauses::classify_field(document_type, "$id");
+    assert!(id_roles.primary_key && !id_roles.index_property && !id_roles.terminal);
+    assert!(InternalClauses::classify_field(document_type, "nope").unindexed());
+
+    // classify_fields covers every clause field exactly once.
+    let clauses = InternalClauses::extract_from_clauses(
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::GreaterThan,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        platform_version(),
+    )
+    .expect("clauses extract");
+    let classified = clauses.classify_fields(document_type);
+    assert_eq!(classified.len(), 2);
+    assert!(classified["hashtag"].index_property && !classified["hashtag"].terminal);
+    assert!(classified["$ownerId"].terminal);
+}
+
 /// A cursor (`startAt`/`startAfter`) would be resolved through the
 /// primary-key tree an indexOnly type does not have — the path
 /// constructors must refuse it with the typed `Unsupported` error before

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -646,6 +646,259 @@ fn should_synthesize_query_documents_with_proof_parity() {
     assert_grovedb_is_consistent(&drive);
 }
 
+/// "Did I like X" as a single query: equality on the terminal property
+/// through `byLiker` ([$ownerId] → postId) — the prefix equality fixes the
+/// path, the terminal equality selects one member key. Proved and
+/// unproved paths agree.
+#[test]
+fn should_serve_terminal_equality_did_i_like_queries() {
+    use crate::query::{WhereClause, WhereOperator};
+    use dpp::document::DocumentV0Getters;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    for (post, owner, seed) in [
+        (POST_A, OWNER_1, 1u64),
+        (POST_A, OWNER_2, 2),
+        (POST_B, OWNER_3, 3),
+    ] {
+        let like = build_like(&contract, "dash", post, owner, seed);
+        insert_like(&drive, &contract, &like, true).expect("insert like");
+    }
+
+    let did_owner_1_like_post_a = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(OWNER_1),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(POST_A),
+            },
+        ],
+        Some(1),
+    );
+    let outcome = drive
+        .query_documents(did_owner_1_like_post_a.clone(), None, false, None, None)
+        .expect("terminal-equality query executes");
+    let documents = outcome.documents();
+    assert_eq!(documents.len(), 1, "OWNER_1 liked POST_A");
+    assert_eq!(documents[0].owner_id().to_buffer(), OWNER_1);
+
+    // Proof parity for the existence answer.
+    let (proof, _) = did_owner_1_like_post_a
+        .clone()
+        .execute_with_proof(&drive, None, None, platform_version())
+        .expect("terminal-equality proof generation");
+    let (_root, verified) = did_owner_1_like_post_a
+        .verify_proof(proof.as_slice(), platform_version())
+        .expect("terminal-equality proof verification");
+    assert_eq!(verified.len(), 1);
+    assert_eq!(verified[0].id(), documents[0].id());
+
+    // And the negative answer: OWNER_1 never liked POST_B.
+    let did_owner_1_like_post_b = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(OWNER_1),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(POST_B),
+            },
+        ],
+        Some(1),
+    );
+    let outcome = drive
+        .query_documents(did_owner_1_like_post_b.clone(), None, false, None, None)
+        .expect("negative terminal-equality query executes");
+    assert_eq!(outcome.documents().len(), 0, "no such like");
+    let (proof, _) = did_owner_1_like_post_b
+        .clone()
+        .execute_with_proof(&drive, None, None, platform_version())
+        .expect("absence proof generation");
+    let (_root, verified) = did_owner_1_like_post_b
+        .verify_proof(proof.as_slice(), platform_version())
+        .expect("absence proof verification");
+    assert!(verified.is_empty(), "absence must verify as absence");
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// Keyset pagination through a range clause on the terminal: with the
+/// prefix fully determined, `terminal > <last seen>` ordered by the
+/// terminal walks the member keys page by page — the indexOnly
+/// replacement for id-shaped startAt cursors. Every page agrees with its
+/// proof.
+#[test]
+fn should_serve_terminal_range_keyset_pagination() {
+    use crate::query::{OrderClause, WhereClause, WhereOperator};
+    use dpp::document::DocumentV0Getters;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    for (owner, seed) in [(OWNER_1, 1u64), (OWNER_2, 2), (OWNER_3, 3)] {
+        let like = build_like(&contract, "dash", POST_A, owner, seed);
+        insert_like(&drive, &contract, &like, true).expect("insert like");
+    }
+
+    let page_query = |after: Option<[u8; 32]>| {
+        let mut clauses = vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(POST_A),
+            },
+        ];
+        if let Some(after) = after {
+            clauses.push(WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::GreaterThan,
+                value: Value::Identifier(after),
+            });
+        }
+        let mut query = likes_query(&contract, clauses, Some(1));
+        query.order_by.insert(
+            "$ownerId".to_string(),
+            OrderClause {
+                field: "$ownerId".to_string(),
+                ascending: true,
+            },
+        );
+        query
+    };
+
+    // Walk the three likes one page at a time, keyed by the last owner.
+    let mut cursor: Option<[u8; 32]> = None;
+    let mut walked: Vec<[u8; 32]> = vec![];
+    loop {
+        let query = page_query(cursor);
+        let outcome = drive
+            .query_documents(query.clone(), None, false, None, None)
+            .expect("keyset page executes");
+        let documents = outcome.documents();
+        if documents.is_empty() {
+            break;
+        }
+        assert_eq!(documents.len(), 1, "limit 1 per page");
+        let owner = documents[0].owner_id().to_buffer();
+
+        // The page's proof verifies to the same document.
+        let (proof, _) = query
+            .clone()
+            .execute_with_proof(&drive, None, None, platform_version())
+            .expect("page proof generation");
+        let (_root, verified) = query
+            .verify_proof(proof.as_slice(), platform_version())
+            .expect("page proof verification");
+        assert_eq!(verified.len(), 1);
+        assert_eq!(verified[0].id(), documents[0].id());
+
+        walked.push(owner);
+        cursor = Some(owner);
+    }
+    assert_eq!(
+        walked,
+        vec![OWNER_1, OWNER_2, OWNER_3],
+        "keyset pagination must walk every entry exactly once, in key order"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// A terminal clause whose index prefix is not fully determined is
+/// refused with the shape requirement — never a wrong-answer scan.
+#[test]
+fn should_refuse_terminal_clause_without_full_prefix_equalities() {
+    use crate::error::query::QuerySyntaxError;
+    use crate::query::{WhereClause, WhereOperator};
+    use assert_matches::assert_matches;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    // hashtag is a property of byHashtagPost, $ownerId its terminal — but
+    // the prefix also needs postId, which carries no equality here.
+    let query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(1),
+    );
+    let error = drive
+        .query_documents(query, None, false, None, None)
+        .expect_err("an underdetermined terminal clause must be refused");
+    assert_matches!(
+        &error,
+        crate::error::Error::Query(QuerySyntaxError::Unsupported(message))
+            if message.contains("equality clauses"),
+        "unexpected error: {error}"
+    );
+}
+
+/// A range on the terminal requires an orderBy on it, mirroring the
+/// stored-document rule.
+#[test]
+fn should_require_order_by_for_terminal_range() {
+    use crate::error::query::QuerySyntaxError;
+    use crate::query::{WhereClause, WhereOperator};
+    use assert_matches::assert_matches;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    let query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(POST_A),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::GreaterThan,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(1),
+    );
+    let error = drive
+        .query_documents(query, None, false, None, None)
+        .expect_err("a terminal range without orderBy must be refused");
+    assert_matches!(
+        &error,
+        crate::error::Error::Query(QuerySyntaxError::MissingOrderByForRange(_)),
+        "unexpected error: {error}"
+    );
+}
+
 /// By-id fetches have no tree to land on and are refused with guidance.
 #[test]
 fn should_refuse_by_id_queries() {

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -782,9 +782,12 @@ fn should_serve_terminal_range_keyset_pagination() {
     };
 
     // Walk the three likes one page at a time, keyed by the last owner.
+    // Bounded at four iterations (three pages + the terminating empty
+    // one) so a non-progress regression fails the walked assertion
+    // instead of hanging the suite.
     let mut cursor: Option<[u8; 32]> = None;
     let mut walked: Vec<[u8; 32]> = vec![];
-    loop {
+    for _ in 0..=3 {
         let query = page_query(cursor);
         let outcome = drive
             .query_documents(query.clone(), None, false, None, None)
@@ -957,7 +960,7 @@ fn should_refuse_cursor_queries() {
     assert_matches!(
         &error,
         crate::error::Error::Query(QuerySyntaxError::Unsupported(message))
-            if message.contains("startAt/startAfter is not yet supported"),
+            if message.contains("paginate with a range clause on the terminal property"),
         "unexpected error: {error}"
     );
 }

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -822,6 +822,306 @@ fn should_serve_terminal_range_keyset_pagination() {
     assert_grovedb_is_consistent(&drive);
 }
 
+/// Mixed shape: a range on a PREFIX property (the pivot) with a terminal
+/// equality — `hashtag == h AND postId > p AND $ownerId == me`. The path
+/// stops at the pivot, the range selects its values, and the terminal
+/// equality runs beneath each of them. Proved and unproved paths agree.
+#[test]
+fn should_serve_prefix_pivot_with_terminal_equality() {
+    use crate::query::{OrderClause, WhereClause, WhereOperator};
+    use dpp::document::DocumentV0Getters;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    for (post, owner, seed) in [
+        (POST_A, OWNER_1, 1u64),
+        (POST_B, OWNER_1, 2),
+        (POST_B, OWNER_2, 3),
+    ] {
+        let like = build_like(&contract, "dash", post, owner, seed);
+        insert_like(&drive, &contract, &like, true).expect("insert like");
+    }
+
+    let mut query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::GreaterThan,
+                value: Value::Identifier(POST_A),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(10),
+    );
+    query.order_by.insert(
+        "postId".to_string(),
+        OrderClause {
+            field: "postId".to_string(),
+            ascending: true,
+        },
+    );
+
+    let outcome = drive
+        .query_documents(query.clone(), None, false, None, None)
+        .expect("pivot query executes");
+    let documents = outcome.documents();
+    assert_eq!(documents.len(), 1, "only OWNER_1's like beyond POST_A");
+    assert_eq!(documents[0].owner_id().to_buffer(), OWNER_1);
+    assert_eq!(
+        documents[0]
+            .properties()
+            .get("postId")
+            .expect("postId recovered")
+            .to_identifier_bytes()
+            .expect("identifier"),
+        POST_B.to_vec()
+    );
+
+    let (proof, _) = query
+        .clone()
+        .execute_with_proof(&drive, None, None, platform_version())
+        .expect("pivot proof generation");
+    let (_root, verified) = query
+        .verify_proof(proof.as_slice(), platform_version())
+        .expect("pivot proof verification");
+    assert_eq!(verified.len(), 1);
+    assert_eq!(verified[0].id(), documents[0].id());
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// A pivot on the FIRST property with the one below it unconstrained:
+/// `hashtag >= h AND $ownerId == me` walks every post under each matched
+/// hashtag through an insert-all level before the terminal equality.
+#[test]
+fn should_serve_first_property_pivot_with_unconstrained_below() {
+    use crate::query::{OrderClause, WhereClause, WhereOperator};
+    use dpp::document::DocumentV0Getters;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    for (post, owner, seed) in [
+        (POST_A, OWNER_1, 1u64),
+        (POST_B, OWNER_1, 2),
+        (POST_B, OWNER_2, 3),
+    ] {
+        let like = build_like(&contract, "dash", post, owner, seed);
+        insert_like(&drive, &contract, &like, true).expect("insert like");
+    }
+
+    let mut query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::GreaterThanOrEquals,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(10),
+    );
+    query.order_by.insert(
+        "hashtag".to_string(),
+        OrderClause {
+            field: "hashtag".to_string(),
+            ascending: true,
+        },
+    );
+
+    let outcome = drive
+        .query_documents(query.clone(), None, false, None, None)
+        .expect("first-property pivot query executes");
+    let documents = outcome.documents();
+    assert_eq!(documents.len(), 2, "both of OWNER_1's likes");
+    let mut posts: Vec<Vec<u8>> = documents
+        .iter()
+        .map(|document| {
+            assert_eq!(document.owner_id().to_buffer(), OWNER_1);
+            document
+                .properties()
+                .get("postId")
+                .expect("postId recovered")
+                .to_identifier_bytes()
+                .expect("identifier")
+        })
+        .collect();
+    posts.sort();
+    assert_eq!(posts, vec![POST_A.to_vec(), POST_B.to_vec()]);
+
+    let (proof, _) = query
+        .clone()
+        .execute_with_proof(&drive, None, None, platform_version())
+        .expect("first-property pivot proof generation");
+    let (_root, verified) = query
+        .verify_proof(proof.as_slice(), platform_version())
+        .expect("first-property pivot proof verification");
+    let mut verified_ids: Vec<_> = verified.iter().map(|d| d.id()).collect();
+    let mut queried_ids: Vec<_> = documents.iter().map(|d| d.id()).collect();
+    verified_ids.sort();
+    queried_ids.sort();
+    assert_eq!(verified_ids, queried_ids);
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// A pivot demands a terminal EQUALITY — two simultaneous non-equality
+/// levels have no single pagination order.
+#[test]
+fn should_refuse_pivot_with_terminal_range() {
+    use crate::error::query::QuerySyntaxError;
+    use crate::query::{OrderClause, WhereClause, WhereOperator};
+    use assert_matches::assert_matches;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    let mut query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::In,
+                value: Value::Array(vec![Value::Identifier(POST_A), Value::Identifier(POST_B)]),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::GreaterThan,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(10),
+    );
+    for field in ["postId", "$ownerId"] {
+        query.order_by.insert(
+            field.to_string(),
+            OrderClause {
+                field: field.to_string(),
+                ascending: true,
+            },
+        );
+    }
+    let error = drive
+        .query_documents(query, None, false, None, None)
+        .expect_err("a pivot with a terminal range must be refused");
+    assert_matches!(
+        &error,
+        crate::error::Error::Query(QuerySyntaxError::Unsupported(message))
+            if message.contains("EQUALITY clause on the terminal"),
+        "unexpected error: {error}"
+    );
+}
+
+/// An equality BELOW the pivot is not yet supported and must be refused
+/// rather than silently scanned.
+#[test]
+fn should_refuse_equality_below_pivot() {
+    use crate::error::query::QuerySyntaxError;
+    use crate::query::{OrderClause, WhereClause, WhereOperator};
+    use assert_matches::assert_matches;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    let mut query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::GreaterThan,
+                value: Value::Text("c".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(POST_A),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(10),
+    );
+    for field in ["hashtag", "postId"] {
+        query.order_by.insert(
+            field.to_string(),
+            OrderClause {
+                field: field.to_string(),
+                ascending: true,
+            },
+        );
+    }
+    let error = drive
+        .query_documents(query, None, false, None, None)
+        .expect_err("an equality below the pivot must be refused");
+    assert_matches!(
+        &error,
+        crate::error::Error::Query(QuerySyntaxError::Unsupported(message))
+            if message.contains("BELOW a pivot"),
+        "unexpected error: {error}"
+    );
+}
+
+/// A pivot range without an orderBy on it is refused, mirroring the
+/// stored-document rule.
+#[test]
+fn should_require_order_by_for_pivot_range() {
+    use crate::error::query::QuerySyntaxError;
+    use crate::query::{WhereClause, WhereOperator};
+    use assert_matches::assert_matches;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    let query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::GreaterThan,
+                value: Value::Identifier(POST_A),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(10),
+    );
+    let error = drive
+        .query_documents(query, None, false, None, None)
+        .expect_err("a pivot range without orderBy must be refused");
+    assert_matches!(
+        &error,
+        crate::error::Error::Query(QuerySyntaxError::MissingOrderByForRange(_)),
+        "unexpected error: {error}"
+    );
+}
+
 /// A terminal clause whose index prefix is not fully determined is
 /// refused with the shape requirement — never a wrong-answer scan.
 #[test]

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -88,6 +88,15 @@ impl DriveDocumentQuery<'_> {
                 })
         };
 
+        // Shapes the terminal route can never serve opt out up front, so
+        // their generic-route miss errors propagate untouched: a resolved
+        // time range needs a bucketed index (which an indexOnly type
+        // cannot even declare), and the multi-`In` machinery has its own
+        // error surface.
+        if !self.resolved_time_ranges.is_empty() || self.internal_clauses.in_clauses.len() > 1 {
+            return Ok(None);
+        }
+
         let mut candidate_seen = false;
         for index in self.document_type.indexes().values() {
             let Some(terminal) = index.terminal.as_deref() else {
@@ -257,37 +266,18 @@ impl DriveDocumentQuery<'_> {
     /// by synthesis (which must decode trios against the same index the
     /// path query was built from) and by the route dispatch in the path
     /// constructors.
-    /// Whether a `find_best_index` error means "no generic index matches
-    /// this query" — the only failures the terminal route may stand in
-    /// for. Structural preflight errors (resolved-source shape, version
-    /// dispatch, multiple resolved time ranges) must propagate unchanged,
-    /// and a query carrying a resolved time range can never be served by
-    /// a terminal route (an indexOnly type cannot even declare a bucketed
-    /// index, so the preflight refusal is the true answer).
-    fn generic_route_missed(&self, error: &Error) -> bool {
-        self.resolved_time_ranges.is_empty()
-            && matches!(
-                error,
-                Error::Query(
-                    crate::error::query::QuerySyntaxError::WhereClauseOnNonIndexedProperty(_)
-                        | crate::error::query::QuerySyntaxError::QueryTooFarFromIndex(_)
-                )
-            )
-    }
-
     pub(crate) fn index_only_query_index(
         &self,
         platform_version: &PlatformVersion,
     ) -> Result<&Index, Error> {
-        match self.find_best_index(platform_version) {
-            Ok(index) => Ok(index),
-            Err(generic_error) if self.generic_route_missed(&generic_error) => {
+        match self.select_best_index(platform_version)? {
+            crate::query::BestIndexOutcome::Matched(index) => Ok(index),
+            crate::query::BestIndexOutcome::NoIndexMatches(no_index_error) => {
                 match self.index_only_terminal_clause_selection()? {
                     Some((index, _)) => Ok(index),
-                    None => Err(generic_error),
+                    None => Err(no_index_error),
                 }
             }
-            Err(other) => Err(other),
         }
     }
 
@@ -301,9 +291,9 @@ impl DriveDocumentQuery<'_> {
         document_type_path: &[Vec<u8>],
         platform_version: &PlatformVersion,
     ) -> Result<Option<grovedb::PathQuery>, Error> {
-        match self.find_best_index(platform_version) {
-            Ok(_) => Ok(None),
-            Err(generic_error) if self.generic_route_missed(&generic_error) => {
+        match self.select_best_index(platform_version)? {
+            crate::query::BestIndexOutcome::Matched(_) => Ok(None),
+            crate::query::BestIndexOutcome::NoIndexMatches(no_index_error) => {
                 match self.index_only_terminal_clause_selection()? {
                     Some((index, terminal_clause)) => self
                         .index_only_terminal_path_query(
@@ -313,10 +303,9 @@ impl DriveDocumentQuery<'_> {
                             platform_version,
                         )
                         .map(Some),
-                    None => Err(generic_error),
+                    None => Err(no_index_error),
                 }
             }
-            Err(other) => Err(other),
         }
     }
 

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -49,6 +49,22 @@ use dpp::version::PlatformVersion;
 use grovedb::GroveDb;
 use std::collections::BTreeMap;
 
+/// A resolved indexOnly terminal route: the matcher's winning index, the
+/// clause on its terminal, and — for mixed shapes — the *prefix pivot*: a
+/// range or `in` clause sitting on one of the index's prefix properties
+/// (by position), with every property above it equality-bound and every
+/// property below it unconstrained.
+pub(crate) struct IndexOnlyTerminalRoute<'a> {
+    /// The index the entries are addressed through.
+    pub index: &'a Index,
+    /// The clause on the index's terminal property; `None` only for the
+    /// first keyset page (order-by on the terminal, no cursor clause yet).
+    pub terminal_clause: Option<&'a crate::query::WhereClause>,
+    /// `(position, clause)` of a range / `in` clause on a prefix
+    /// property. When present the terminal clause is always an equality.
+    pub prefix_pivot: Option<(usize, &'a crate::query::WhereClause)>,
+}
+
 impl DriveDocumentQuery<'_> {
     /// The terminal-clause route for indexOnly queries.
     ///
@@ -68,19 +84,26 @@ impl DriveDocumentQuery<'_> {
     /// nothing outside the index (a range or `in` on the terminal
     /// requires ordering by it, mirroring the stored-document rule).
     ///
+    /// Mixed shapes are served through a *prefix pivot*: one range or
+    /// `in` clause may sit on a prefix property instead of the terminal
+    /// (`hashtag == h AND postId > p AND $ownerId == me`), provided every
+    /// property above the pivot is equality-bound, properties below it
+    /// are unconstrained, the terminal clause is an equality, and the
+    /// pivot is ordered by (`MissingOrderByForRange` otherwise).
+    ///
     /// Returns `Ok(None)` when the matcher finds no terminal-using index
     /// (the generic route's miss error stands), `Ok(Some(..))` with the
-    /// selected index and the terminal clause — `None` for the first
-    /// keyset page, which has no cursor clause yet and scans the member
-    /// keys in `orderBy` order — and a targeted error when a terminal
-    /// index matched but the clause shape does not hold.
+    /// resolved route — `terminal_clause: None` only for the first keyset
+    /// page, which has no cursor clause yet and scans the member keys in
+    /// `orderBy` order — and a targeted error when a terminal index
+    /// matched but the clause shape does not hold.
     ///
     /// [`index_for_types_matching_including_terminal`]:
     /// dpp::data_contract::document_type::methods::DocumentTypeV0Methods::index_for_types_matching_including_terminal
     pub(crate) fn index_only_terminal_clause_selection(
         &self,
         platform_version: &PlatformVersion,
-    ) -> Result<Option<(&Index, Option<&crate::query::WhereClause>)>, Error> {
+    ) -> Result<Option<IndexOnlyTerminalRoute<'_>>, Error> {
         use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
 
         // Shapes the terminal route can never serve opt out up front, so
@@ -178,80 +201,160 @@ impl DriveDocumentQuery<'_> {
                     .find(|in_clause| in_clause.field == terminal)
             });
 
-        let shape_error = || {
+        let shape_error = |message: &str| {
             Error::Query(crate::error::query::QuerySyntaxError::Unsupported(
-                "a clause on an indexOnly terminal property requires equality clauses \
-                 on ALL of that index's properties (the path to the entries must be \
-                 fully determined), with no other clauses and orderBy limited to the \
-                 index"
-                    .to_string(),
+                message.to_string(),
             ))
         };
 
-        // Every prefix property must carry an equality clause: the path
-        // down to the entry level must be fully determined.
-        if !index.properties.iter().all(|property| {
-            self.internal_clauses
-                .equal_clauses
-                .contains_key(property.name.as_str())
-        }) {
-            return Err(shape_error());
-        }
-
-        // No clause may be left over, and any range / `in` clause must BE
-        // the terminal clause. (Field coverage is the matcher's job; the
-        // PLACEMENT of non-equality clauses is the shape rule here.)
-        if let Some(range_clause) = &self.internal_clauses.range_clause {
-            if range_clause.field != terminal {
-                return Err(shape_error());
-            }
-        }
-        if !self
+        // The one non-equality, non-terminal clause — the prefix pivot
+        // candidate. (Field coverage is the matcher's job; PLACEMENT of
+        // non-equality clauses is the shape rule here.)
+        let position_of = |field: &str| -> Option<usize> {
+            index
+                .properties
+                .iter()
+                .position(|property| property.name == field)
+        };
+        let mut prefix_pivot: Option<(usize, &crate::query::WhereClause)> = None;
+        for clause in self
             .internal_clauses
-            .in_clauses
+            .range_clause
             .iter()
-            .all(|in_clause| in_clause.field == terminal)
+            .chain(self.internal_clauses.in_clauses.iter())
         {
-            return Err(shape_error());
-        }
-
-        if let Some(terminal_clause) = terminal_clause {
-            if terminal_clause.operator.is_range() && !self.order_by.contains_key(terminal) {
-                return Err(Error::Query(
-                    crate::error::query::QuerySyntaxError::MissingOrderByForRange(
-                        "a range or `in` clause on an indexOnly terminal property \
-                         requires an orderBy on that property",
-                    ),
+            if clause.field == terminal {
+                continue;
+            }
+            let Some(position) = position_of(&clause.field) else {
+                // Not on the terminal, not on a prefix property — the
+                // matcher could not have covered it. Unreachable.
+                return Err(Error::Drive(DriveError::CorruptedCodeExecution(
+                    "a matched terminal route cannot carry a clause outside the index",
+                )));
+            };
+            if prefix_pivot.is_some() {
+                return Err(shape_error(
+                    "an indexOnly terminal query supports at most one range or `in` \
+                     clause on a prefix property (the pivot)",
                 ));
             }
+            prefix_pivot = Some((position, clause));
         }
 
-        Ok(Some((index, terminal_clause)))
+        match prefix_pivot {
+            None => {
+                // Fully determined prefix: every prefix property must
+                // carry an equality clause — the path down to the entry
+                // level admits no gaps.
+                if !index.properties.iter().all(|property| {
+                    self.internal_clauses
+                        .equal_clauses
+                        .contains_key(property.name.as_str())
+                }) {
+                    return Err(shape_error(
+                        "a clause on an indexOnly terminal property requires equality \
+                         clauses on ALL of that index's properties (the path to the \
+                         entries must be fully determined), with no other clauses and \
+                         orderBy limited to the index",
+                    ));
+                }
+                if let Some(terminal_clause) = terminal_clause {
+                    if terminal_clause.operator.is_range() && !self.order_by.contains_key(terminal)
+                    {
+                        return Err(Error::Query(
+                            crate::error::query::QuerySyntaxError::MissingOrderByForRange(
+                                "a range or `in` clause on an indexOnly terminal property \
+                                 requires an orderBy on that property",
+                            ),
+                        ));
+                    }
+                }
+            }
+            Some((pivot_position, pivot_clause)) => {
+                // Mixed shape: everything above the pivot equality-bound,
+                // everything below it unconstrained, terminal clause an
+                // equality, pivot ordered by.
+                let terminal_is_equality =
+                    self.internal_clauses.equal_clauses.contains_key(terminal);
+                if !terminal_is_equality {
+                    return Err(shape_error(
+                        "a range or `in` clause on an indexOnly prefix property requires \
+                         an EQUALITY clause on the terminal: two simultaneous non-equality \
+                         levels have no single pagination order",
+                    ));
+                }
+                for (position, property) in index.properties.iter().enumerate() {
+                    let has_equality = self
+                        .internal_clauses
+                        .equal_clauses
+                        .contains_key(property.name.as_str());
+                    if position < pivot_position && !has_equality {
+                        return Err(shape_error(
+                            "every prefix property ABOVE a pivot range/`in` clause must \
+                             carry an equality clause",
+                        ));
+                    }
+                    if position > pivot_position && has_equality {
+                        return Err(shape_error(
+                            "prefix properties BELOW a pivot range/`in` clause must be \
+                             unconstrained: an equality below the pivot is not yet \
+                             supported",
+                        ));
+                    }
+                }
+                if !self.order_by.contains_key(pivot_clause.field.as_str()) {
+                    return Err(Error::Query(
+                        crate::error::query::QuerySyntaxError::MissingOrderByForRange(
+                            "a range or `in` clause on an indexOnly prefix property \
+                             requires an orderBy on that property",
+                        ),
+                    ));
+                }
+            }
+        }
+
+        Ok(Some(IndexOnlyTerminalRoute {
+            index,
+            terminal_clause,
+            prefix_pivot,
+        }))
     }
 
-    /// Build the path query for a terminal-clause indexOnly query: the
-    /// fully determined prefix path down to the `0` entry level, with the
-    /// terminal clause lowered over the member keys. One builder for the
-    /// server's execution, the prover and the verifier.
+    /// Build the path query for a terminal-clause indexOnly query. One
+    /// builder for the server's execution, the prover and the verifier.
+    ///
+    /// Without a pivot: the fully determined prefix path down to the `0`
+    /// entry level, with the terminal clause lowered over the member
+    /// keys. With a prefix pivot: the path stops at the pivot property,
+    /// the pivot clause ranges over its values, and a subquery chain
+    /// walks each selected value through the unconstrained properties
+    /// below it (`insert_all` per level) down to `0`, where the terminal
+    /// equality selects the member key.
     pub(crate) fn index_only_terminal_path_query(
         &self,
         document_type_path: Vec<Vec<u8>>,
-        index: &Index,
-        terminal_clause: Option<&crate::query::WhereClause>,
+        route: &IndexOnlyTerminalRoute<'_>,
         platform_version: &PlatformVersion,
     ) -> Result<grovedb::PathQuery, Error> {
         use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
 
-        let terminal_direction = |field: &str| {
+        let IndexOnlyTerminalRoute {
+            index,
+            terminal_clause,
+            prefix_pivot,
+        } = route;
+
+        let direction_for = |field: &str, fallback: bool| {
             self.order_by
                 .get(field)
                 .map(|order_clause| order_clause.ascending)
-                .unwrap_or(true)
+                .unwrap_or(fallback)
         };
-        let final_query = match terminal_clause {
+        let terminal_query = match terminal_clause {
             Some(terminal_clause) => {
                 let left_to_right = if terminal_clause.operator.is_range() {
-                    terminal_direction(terminal_clause.field.as_str())
+                    direction_for(terminal_clause.field.as_str(), true)
                 } else {
                     true
                 };
@@ -270,20 +373,76 @@ impl DriveDocumentQuery<'_> {
                         "terminal-route selection guarantees an indexOnly index",
                     ),
                 ))?;
-                let mut query = grovedb::Query::new_with_direction(terminal_direction(terminal));
+                let mut query = grovedb::Query::new_with_direction(direction_for(terminal, true));
                 query.insert_all();
                 query
             }
         };
 
         let mut path = document_type_path;
-        for property in index.properties.iter() {
+        let (final_query, path_property_count) = match prefix_pivot {
+            None => {
+                // Fully determined prefix: the path descends every
+                // property's value; the terminal query runs at `0`.
+                (terminal_query, index.properties.len())
+            }
+            Some((pivot_position, pivot_clause)) => {
+                // The pivot clause ranges over its property's values;
+                // below it, one `insert_all` level per unconstrained
+                // property, then `0` and the terminal equality. Built
+                // innermost-out.
+                let mut chain = terminal_query;
+                let mut chain_is_terminal = true;
+                for position in ((pivot_position + 1)..index.properties.len()).rev() {
+                    let property = &index.properties[position];
+                    let mut values_query = grovedb::Query::new_with_direction(direction_for(
+                        &property.name,
+                        property.ascending,
+                    ));
+                    values_query.insert_all();
+                    if chain_is_terminal {
+                        values_query.set_subquery_key(vec![0]);
+                    } else {
+                        values_query.set_subquery_key(
+                            index.properties[position + 1].name.as_bytes().to_vec(),
+                        );
+                    }
+                    values_query.set_subquery(chain);
+                    chain = values_query;
+                    chain_is_terminal = false;
+                }
+
+                let mut pivot_query = pivot_clause.to_path_query(
+                    self.document_type,
+                    &None,
+                    direction_for(pivot_clause.field.as_str(), true),
+                    platform_version,
+                )?;
+                if chain_is_terminal {
+                    // The pivot is the last property: `0` sits directly
+                    // under each of its values.
+                    pivot_query.set_subquery_key(vec![0]);
+                } else {
+                    pivot_query.set_subquery_key(
+                        index.properties[pivot_position + 1]
+                            .name
+                            .as_bytes()
+                            .to_vec(),
+                    );
+                }
+                pivot_query.set_subquery(chain);
+                (pivot_query, *pivot_position)
+            }
+        };
+
+        for property in index.properties.iter().take(path_property_count) {
             let where_clause = self
                 .internal_clauses
                 .equal_clauses
                 .get(property.name.as_str())
                 .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
-                    "terminal-route selection guarantees an equality per prefix property",
+                    "terminal-route selection guarantees an equality per determined prefix \
+                     property",
                 )))?;
             path.push(property.name.as_bytes().to_vec());
             path.push(self.document_type.serialize_value_for_key(
@@ -292,7 +451,12 @@ impl DriveDocumentQuery<'_> {
                 platform_version,
             )?);
         }
-        path.push(vec![0]);
+        match prefix_pivot {
+            None => path.push(vec![0]),
+            Some((pivot_position, _)) => {
+                path.push(index.properties[*pivot_position].name.as_bytes().to_vec())
+            }
+        }
 
         Ok(grovedb::PathQuery::new(
             path,
@@ -313,7 +477,7 @@ impl DriveDocumentQuery<'_> {
             crate::query::BestIndexOutcome::Matched(index) => Ok(index),
             crate::query::BestIndexOutcome::NoIndexMatches(no_index_error) => {
                 match self.index_only_terminal_clause_selection(platform_version)? {
-                    Some((index, _)) => Ok(index),
+                    Some(route) => Ok(route.index),
                     None => Err(no_index_error),
                 }
             }
@@ -334,11 +498,10 @@ impl DriveDocumentQuery<'_> {
             crate::query::BestIndexOutcome::Matched(_) => Ok(None),
             crate::query::BestIndexOutcome::NoIndexMatches(no_index_error) => {
                 match self.index_only_terminal_clause_selection(platform_version)? {
-                    Some((index, terminal_clause)) => self
+                    Some(route) => self
                         .index_only_terminal_path_query(
                             document_type_path.to_vec(),
-                            index,
-                            terminal_clause,
+                            &route,
                             platform_version,
                         )
                         .map(Some),

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -56,37 +56,32 @@ impl DriveDocumentQuery<'_> {
     /// value, so a clause on the terminal lowers directly onto the final
     /// key level — the shape behind both "did I like X" (equality on the
     /// terminal) and keyset pagination (range on the terminal after the
-    /// last seen value, with a limit). The shape requirement: every one of
-    /// the index's prefix properties carries an equality clause (the path
-    /// down to the `0` level must be fully determined), the terminal
-    /// carries the one remaining clause, and `orderBy` names nothing
-    /// outside the index (a range or `in` on the terminal requires
-    /// ordering by it, mirroring the stored-document rule).
+    /// last seen value, with a limit). Index selection is the SAME dpp
+    /// matcher the generic route uses
+    /// ([`index_for_types_matching_including_terminal`]), with terminals
+    /// as matchable deepest components and difference-scored best-match
+    /// semantics — generic matches keep absolute precedence inside the
+    /// matcher itself. What remains here is clause-shape validation on
+    /// the matcher's winner: every prefix property must carry an equality
+    /// clause (the path down to the `0` level must be fully determined),
+    /// the terminal carries the one remaining clause, and `orderBy` names
+    /// nothing outside the index (a range or `in` on the terminal
+    /// requires ordering by it, mirroring the stored-document rule).
     ///
-    /// Returns `Ok(None)` when no index's terminal is named by any clause
-    /// or orderBy (the generic index route owns the query), `Ok(Some(..))`
-    /// with the selected index and the terminal clause — `None` for the
-    /// first keyset page, which has no cursor clause yet and scans the
-    /// member keys in `orderBy` order — and a targeted error when a
-    /// terminal was named but no index satisfies the shape.
+    /// Returns `Ok(None)` when the matcher finds no terminal-using index
+    /// (the generic route's miss error stands), `Ok(Some(..))` with the
+    /// selected index and the terminal clause — `None` for the first
+    /// keyset page, which has no cursor clause yet and scans the member
+    /// keys in `orderBy` order — and a targeted error when a terminal
+    /// index matched but the clause shape does not hold.
+    ///
+    /// [`index_for_types_matching_including_terminal`]:
+    /// dpp::data_contract::document_type::methods::DocumentTypeV0Methods::index_for_types_matching_including_terminal
     pub(crate) fn index_only_terminal_clause_selection(
         &self,
+        platform_version: &PlatformVersion,
     ) -> Result<Option<(&Index, Option<&crate::query::WhereClause>)>, Error> {
-        let terminal_clause_for = |terminal: &str| -> Option<&crate::query::WhereClause> {
-            self.internal_clauses
-                .equal_clauses
-                .get(terminal)
-                .or(match &self.internal_clauses.range_clause {
-                    Some(range_clause) if range_clause.field == terminal => Some(range_clause),
-                    _ => None,
-                })
-                .or_else(|| {
-                    self.internal_clauses
-                        .in_clauses
-                        .iter()
-                        .find(|in_clause| in_clause.field == terminal)
-                })
-        };
+        use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
 
         // Shapes the terminal route can never serve opt out up front, so
         // their generic-route miss errors propagate untouched: a resolved
@@ -97,97 +92,127 @@ impl DriveDocumentQuery<'_> {
             return Ok(None);
         }
 
-        let mut candidate_seen = false;
-        for index in self.document_type.indexes().values() {
-            let Some(terminal) = index.terminal.as_deref() else {
-                continue;
-            };
-            let terminal_clause = terminal_clause_for(terminal);
-            // The index is only a terminal-route candidate when the query
-            // actually names its terminal — through a clause, or through
-            // an orderBy alone (the first keyset page: full prefix
-            // equalities, ordered member-key scan, no cursor clause yet).
-            if terminal_clause.is_none() && !self.order_by.contains_key(terminal) {
-                continue;
-            }
-            candidate_seen = true;
+        // The same field assembly the generic matcher receives.
+        let mut fields = self
+            .internal_clauses
+            .equal_clauses
+            .keys()
+            .map(|field| field.as_str())
+            .collect::<Vec<&str>>();
+        if let Some(range_clause) = &self.internal_clauses.range_clause {
+            fields.push(range_clause.field.as_str());
+        }
+        let in_field = self
+            .internal_clauses
+            .in_clauses
+            .first()
+            .map(|in_clause| in_clause.field.as_str());
+        if let Some(in_field) = in_field {
+            fields.push(in_field);
+        }
+        let order_by_keys: Vec<&str> = self
+            .order_by
+            .keys()
+            .map(|key: &String| {
+                let field = key.as_str();
+                if !fields.contains(&field) {
+                    fields.push(field);
+                }
+                field
+            })
+            .collect();
 
-            // Every prefix property must carry an equality clause: the
-            // path down to the entry level must be fully determined.
-            if !index.properties.iter().all(|property| {
+        let Some((index, _difference, terminal_used)) = self
+            .document_type
+            .index_for_types_matching_including_terminal(
+                fields.as_slice(),
+                in_field,
+                order_by_keys.as_slice(),
+                |_| true,
+                platform_version,
+            )
+            .map_err(|e| Error::Protocol(Box::new(e)))?
+        else {
+            return Ok(None);
+        };
+        if !terminal_used {
+            // A generic cover exists after all — the generic route owns
+            // it (unreachable when this runs after a generic miss, since
+            // both share one matching algorithm).
+            return Ok(None);
+        }
+
+        let terminal =
+            index
+                .terminal
+                .as_deref()
+                .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
+                    "a terminal-using match implies an indexOnly index",
+                )))?;
+        let terminal_clause = self
+            .internal_clauses
+            .equal_clauses
+            .get(terminal)
+            .or(match &self.internal_clauses.range_clause {
+                Some(range_clause) if range_clause.field == terminal => Some(range_clause),
+                _ => None,
+            })
+            .or_else(|| {
                 self.internal_clauses
-                    .equal_clauses
-                    .contains_key(property.name.as_str())
-            }) {
-                continue;
-            }
+                    .in_clauses
+                    .iter()
+                    .find(|in_clause| in_clause.field == terminal)
+            });
 
-            // No clause may be left over: equalities must all sit on the
-            // index's properties (or be the terminal equality), and any
-            // range / `in` clause must BE the terminal clause.
-            let within_index = |field: &str| {
-                field == terminal
-                    || index
-                        .properties
-                        .iter()
-                        .any(|property| property.name == field)
-            };
-            if !self
-                .internal_clauses
+        let shape_error = || {
+            Error::Query(crate::error::query::QuerySyntaxError::Unsupported(
+                "a clause on an indexOnly terminal property requires equality clauses \
+                 on ALL of that index's properties (the path to the entries must be \
+                 fully determined), with no other clauses and orderBy limited to the \
+                 index"
+                    .to_string(),
+            ))
+        };
+
+        // Every prefix property must carry an equality clause: the path
+        // down to the entry level must be fully determined.
+        if !index.properties.iter().all(|property| {
+            self.internal_clauses
                 .equal_clauses
-                .keys()
-                .all(|field| within_index(field))
-            {
-                continue;
-            }
-            if let Some(range_clause) = &self.internal_clauses.range_clause {
-                if range_clause.field != terminal {
-                    continue;
-                }
-            }
-            if !self
-                .internal_clauses
-                .in_clauses
-                .iter()
-                .all(|in_clause| in_clause.field == terminal)
-                || self.internal_clauses.in_clauses.len() > 1
-            {
-                continue;
-            }
-
-            // orderBy must stay within the index; ordering a fully
-            // determined prefix is a no-op, so only the terminal's
-            // direction matters — and a range or `in` terminal clause
-            // requires it, same as the stored-document rule.
-            if !self.order_by.keys().all(|field| within_index(field)) {
-                continue;
-            }
-            if let Some(terminal_clause) = terminal_clause {
-                if terminal_clause.operator.is_range() && !self.order_by.contains_key(terminal) {
-                    return Err(Error::Query(
-                        crate::error::query::QuerySyntaxError::MissingOrderByForRange(
-                            "a range or `in` clause on an indexOnly terminal property \
-                             requires an orderBy on that property",
-                        ),
-                    ));
-                }
-            }
-
-            return Ok(Some((index, terminal_clause)));
+                .contains_key(property.name.as_str())
+        }) {
+            return Err(shape_error());
         }
 
-        if candidate_seen {
-            return Err(Error::Query(
-                crate::error::query::QuerySyntaxError::Unsupported(
-                    "a clause on an indexOnly terminal property requires equality clauses \
-                     on ALL of that index's properties (the path to the entries must be \
-                     fully determined), with no other clauses and orderBy limited to the \
-                     index"
-                        .to_string(),
-                ),
-            ));
+        // No clause may be left over, and any range / `in` clause must BE
+        // the terminal clause. (Field coverage is the matcher's job; the
+        // PLACEMENT of non-equality clauses is the shape rule here.)
+        if let Some(range_clause) = &self.internal_clauses.range_clause {
+            if range_clause.field != terminal {
+                return Err(shape_error());
+            }
         }
-        Ok(None)
+        if !self
+            .internal_clauses
+            .in_clauses
+            .iter()
+            .all(|in_clause| in_clause.field == terminal)
+        {
+            return Err(shape_error());
+        }
+
+        if let Some(terminal_clause) = terminal_clause {
+            if terminal_clause.operator.is_range() && !self.order_by.contains_key(terminal) {
+                return Err(Error::Query(
+                    crate::error::query::QuerySyntaxError::MissingOrderByForRange(
+                        "a range or `in` clause on an indexOnly terminal property \
+                         requires an orderBy on that property",
+                    ),
+                ));
+            }
+        }
+
+        Ok(Some((index, terminal_clause)))
     }
 
     /// Build the path query for a terminal-clause indexOnly query: the
@@ -273,7 +298,7 @@ impl DriveDocumentQuery<'_> {
         match self.select_best_index(platform_version)? {
             crate::query::BestIndexOutcome::Matched(index) => Ok(index),
             crate::query::BestIndexOutcome::NoIndexMatches(no_index_error) => {
-                match self.index_only_terminal_clause_selection()? {
+                match self.index_only_terminal_clause_selection(platform_version)? {
                     Some((index, _)) => Ok(index),
                     None => Err(no_index_error),
                 }
@@ -294,7 +319,7 @@ impl DriveDocumentQuery<'_> {
         match self.select_best_index(platform_version)? {
             crate::query::BestIndexOutcome::Matched(_) => Ok(None),
             crate::query::BestIndexOutcome::NoIndexMatches(no_index_error) => {
-                match self.index_only_terminal_clause_selection()? {
+                match self.index_only_terminal_clause_selection(platform_version)? {
                     Some((index, terminal_clause)) => self
                         .index_only_terminal_path_query(
                             document_type_path.to_vec(),

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -50,6 +50,252 @@ use grovedb::GroveDb;
 use std::collections::BTreeMap;
 
 impl DriveDocumentQuery<'_> {
+    /// The terminal-clause route for indexOnly queries.
+    ///
+    /// An indexOnly entry's member key IS the terminal property's encoded
+    /// value, so a clause on the terminal lowers directly onto the final
+    /// key level — the shape behind both "did I like X" (equality on the
+    /// terminal) and keyset pagination (range on the terminal after the
+    /// last seen value, with a limit). The shape requirement: every one of
+    /// the index's prefix properties carries an equality clause (the path
+    /// down to the `0` level must be fully determined), the terminal
+    /// carries the one remaining clause, and `orderBy` names nothing
+    /// outside the index (a range or `in` on the terminal requires
+    /// ordering by it, mirroring the stored-document rule).
+    ///
+    /// Returns `Ok(None)` when no index's terminal is named by any clause
+    /// or orderBy (the generic index route owns the query), `Ok(Some(..))`
+    /// with the selected index and the terminal clause — `None` for the
+    /// first keyset page, which has no cursor clause yet and scans the
+    /// member keys in `orderBy` order — and a targeted error when a
+    /// terminal was named but no index satisfies the shape.
+    pub(crate) fn index_only_terminal_clause_selection(
+        &self,
+    ) -> Result<Option<(&Index, Option<&crate::query::WhereClause>)>, Error> {
+        let terminal_clause_for = |terminal: &str| -> Option<&crate::query::WhereClause> {
+            self.internal_clauses
+                .equal_clauses
+                .get(terminal)
+                .or(match &self.internal_clauses.range_clause {
+                    Some(range_clause) if range_clause.field == terminal => Some(range_clause),
+                    _ => None,
+                })
+                .or_else(|| {
+                    self.internal_clauses
+                        .in_clauses
+                        .iter()
+                        .find(|in_clause| in_clause.field == terminal)
+                })
+        };
+
+        let mut candidate_seen = false;
+        for index in self.document_type.indexes().values() {
+            let Some(terminal) = index.terminal.as_deref() else {
+                continue;
+            };
+            let terminal_clause = terminal_clause_for(terminal);
+            // The index is only a terminal-route candidate when the query
+            // actually names its terminal — through a clause, or through
+            // an orderBy alone (the first keyset page: full prefix
+            // equalities, ordered member-key scan, no cursor clause yet).
+            if terminal_clause.is_none() && !self.order_by.contains_key(terminal) {
+                continue;
+            }
+            candidate_seen = true;
+
+            // Every prefix property must carry an equality clause: the
+            // path down to the entry level must be fully determined.
+            if !index.properties.iter().all(|property| {
+                self.internal_clauses
+                    .equal_clauses
+                    .contains_key(property.name.as_str())
+            }) {
+                continue;
+            }
+
+            // No clause may be left over: equalities must all sit on the
+            // index's properties (or be the terminal equality), and any
+            // range / `in` clause must BE the terminal clause.
+            let within_index = |field: &str| {
+                field == terminal
+                    || index
+                        .properties
+                        .iter()
+                        .any(|property| property.name == field)
+            };
+            if !self
+                .internal_clauses
+                .equal_clauses
+                .keys()
+                .all(|field| within_index(field))
+            {
+                continue;
+            }
+            if let Some(range_clause) = &self.internal_clauses.range_clause {
+                if range_clause.field != terminal {
+                    continue;
+                }
+            }
+            if !self
+                .internal_clauses
+                .in_clauses
+                .iter()
+                .all(|in_clause| in_clause.field == terminal)
+                || self.internal_clauses.in_clauses.len() > 1
+            {
+                continue;
+            }
+
+            // orderBy must stay within the index; ordering a fully
+            // determined prefix is a no-op, so only the terminal's
+            // direction matters — and a range or `in` terminal clause
+            // requires it, same as the stored-document rule.
+            if !self.order_by.keys().all(|field| within_index(field)) {
+                continue;
+            }
+            if let Some(terminal_clause) = terminal_clause {
+                if terminal_clause.operator.is_range() && !self.order_by.contains_key(terminal) {
+                    return Err(Error::Query(
+                        crate::error::query::QuerySyntaxError::MissingOrderByForRange(
+                            "a range or `in` clause on an indexOnly terminal property \
+                             requires an orderBy on that property",
+                        ),
+                    ));
+                }
+            }
+
+            return Ok(Some((index, terminal_clause)));
+        }
+
+        if candidate_seen {
+            return Err(Error::Query(
+                crate::error::query::QuerySyntaxError::Unsupported(
+                    "a clause on an indexOnly terminal property requires equality clauses \
+                     on ALL of that index's properties (the path to the entries must be \
+                     fully determined), with no other clauses and orderBy limited to the \
+                     index"
+                        .to_string(),
+                ),
+            ));
+        }
+        Ok(None)
+    }
+
+    /// Build the path query for a terminal-clause indexOnly query: the
+    /// fully determined prefix path down to the `0` entry level, with the
+    /// terminal clause lowered over the member keys. One builder for the
+    /// server's execution, the prover and the verifier.
+    pub(crate) fn index_only_terminal_path_query(
+        &self,
+        document_type_path: Vec<Vec<u8>>,
+        index: &Index,
+        terminal_clause: Option<&crate::query::WhereClause>,
+        platform_version: &PlatformVersion,
+    ) -> Result<grovedb::PathQuery, Error> {
+        use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
+
+        let terminal_direction = |field: &str| {
+            self.order_by
+                .get(field)
+                .map(|order_clause| order_clause.ascending)
+                .unwrap_or(true)
+        };
+        let final_query = match terminal_clause {
+            Some(terminal_clause) => {
+                let left_to_right = if terminal_clause.operator.is_range() {
+                    terminal_direction(terminal_clause.field.as_str())
+                } else {
+                    true
+                };
+                terminal_clause.to_path_query(
+                    self.document_type,
+                    &None,
+                    left_to_right,
+                    platform_version,
+                )?
+            }
+            // First keyset page: no cursor clause yet — every member key
+            // in the terminal's orderBy direction.
+            None => {
+                let terminal = index.terminal.as_deref().ok_or(Error::Drive(
+                    DriveError::CorruptedCodeExecution(
+                        "terminal-route selection guarantees an indexOnly index",
+                    ),
+                ))?;
+                let mut query = grovedb::Query::new_with_direction(terminal_direction(terminal));
+                query.insert_all();
+                query
+            }
+        };
+
+        let mut path = document_type_path;
+        for property in index.properties.iter() {
+            let where_clause = self
+                .internal_clauses
+                .equal_clauses
+                .get(property.name.as_str())
+                .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
+                    "terminal-route selection guarantees an equality per prefix property",
+                )))?;
+            path.push(property.name.as_bytes().to_vec());
+            path.push(self.document_type.serialize_value_for_key(
+                &property.name,
+                &where_clause.value,
+                platform_version,
+            )?);
+        }
+        path.push(vec![0]);
+
+        Ok(grovedb::PathQuery::new(
+            path,
+            grovedb::SizedQuery::new(final_query, self.limit, self.offset),
+        ))
+    }
+
+    /// The index an indexOnly query resolves to — the generic matcher
+    /// when it can serve the query, else the terminal-clause route. Used
+    /// by synthesis (which must decode trios against the same index the
+    /// path query was built from) and by the route dispatch in the path
+    /// constructors.
+    pub(crate) fn index_only_query_index(
+        &self,
+        platform_version: &PlatformVersion,
+    ) -> Result<&Index, Error> {
+        match self.find_best_index(platform_version) {
+            Ok(index) => Ok(index),
+            Err(generic_error) => match self.index_only_terminal_clause_selection()? {
+                Some((index, _)) => Ok(index),
+                None => Err(generic_error),
+            },
+        }
+    }
+
+    /// Route an indexOnly query: `Ok(Some(..))` with the terminal-route
+    /// path query when the generic index matcher cannot serve the query
+    /// but a terminal clause can, `Ok(None)` when the generic route owns
+    /// it. Shared by both path constructors so server, prover and
+    /// verifier build the same query.
+    pub(crate) fn index_only_route(
+        &self,
+        document_type_path: &[Vec<u8>],
+        platform_version: &PlatformVersion,
+    ) -> Result<Option<grovedb::PathQuery>, Error> {
+        match self.find_best_index(platform_version) {
+            Ok(_) => Ok(None),
+            Err(generic_error) => match self.index_only_terminal_clause_selection()? {
+                Some((index, terminal_clause)) => self
+                    .index_only_terminal_path_query(
+                        document_type_path.to_vec(),
+                        index,
+                        terminal_clause,
+                        platform_version,
+                    )
+                    .map(Some),
+                None => Err(generic_error),
+            },
+        }
+    }
+
     /// Verify a proof for an indexOnly query, synthesizing the documents
     /// from the proved `(path, key)` positions. The mirror of the server's
     /// no-proof synthesis path — both call the one builder below.
@@ -71,7 +317,7 @@ impl DriveDocumentQuery<'_> {
         let (root_hash, proved_key_values) =
             GroveDb::verify_query(proof, &path_query, &platform_version.drive.grove_version)?;
 
-        let index = self.find_best_index(platform_version)?;
+        let index = self.index_only_query_index(platform_version)?;
         let documents = proved_key_values
             .into_iter()
             .filter_map(|(path, key, element)| element.map(|_| (path, key)))
@@ -143,7 +389,7 @@ impl DriveDocumentQuery<'_> {
             other => other?,
         };
 
-        let index = self.find_best_index(platform_version)?;
+        let index = self.index_only_query_index(platform_version)?;
         let documents = elements
             .to_path_key_elements()
             .into_iter()

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -92,6 +92,20 @@ impl DriveDocumentQuery<'_> {
             return Ok(None);
         }
 
+        // Classified once against the doctype: unless some clause or
+        // order-by field actually holds the TERMINAL role, this query has
+        // nothing for the terminal route and the generic miss stands —
+        // the modeled form of "a clause may sit on a terminal, not only
+        // on an index prefix property".
+        let clause_roles = self.internal_clauses.classify_fields(self.document_type);
+        let names_a_terminal = clause_roles.values().any(|roles| roles.terminal)
+            || self.order_by.keys().any(|field| {
+                crate::query::InternalClauses::classify_field(self.document_type, field).terminal
+            });
+        if !names_a_terminal {
+            return Ok(None);
+        }
+
         // The same field assembly the generic matcher receives.
         let mut fields = self
             .internal_clauses

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -257,16 +257,37 @@ impl DriveDocumentQuery<'_> {
     /// by synthesis (which must decode trios against the same index the
     /// path query was built from) and by the route dispatch in the path
     /// constructors.
+    /// Whether a `find_best_index` error means "no generic index matches
+    /// this query" — the only failures the terminal route may stand in
+    /// for. Structural preflight errors (resolved-source shape, version
+    /// dispatch, multiple resolved time ranges) must propagate unchanged,
+    /// and a query carrying a resolved time range can never be served by
+    /// a terminal route (an indexOnly type cannot even declare a bucketed
+    /// index, so the preflight refusal is the true answer).
+    fn generic_route_missed(&self, error: &Error) -> bool {
+        self.resolved_time_ranges.is_empty()
+            && matches!(
+                error,
+                Error::Query(
+                    crate::error::query::QuerySyntaxError::WhereClauseOnNonIndexedProperty(_)
+                        | crate::error::query::QuerySyntaxError::QueryTooFarFromIndex(_)
+                )
+            )
+    }
+
     pub(crate) fn index_only_query_index(
         &self,
         platform_version: &PlatformVersion,
     ) -> Result<&Index, Error> {
         match self.find_best_index(platform_version) {
             Ok(index) => Ok(index),
-            Err(generic_error) => match self.index_only_terminal_clause_selection()? {
-                Some((index, _)) => Ok(index),
-                None => Err(generic_error),
-            },
+            Err(generic_error) if self.generic_route_missed(&generic_error) => {
+                match self.index_only_terminal_clause_selection()? {
+                    Some((index, _)) => Ok(index),
+                    None => Err(generic_error),
+                }
+            }
+            Err(other) => Err(other),
         }
     }
 
@@ -282,17 +303,20 @@ impl DriveDocumentQuery<'_> {
     ) -> Result<Option<grovedb::PathQuery>, Error> {
         match self.find_best_index(platform_version) {
             Ok(_) => Ok(None),
-            Err(generic_error) => match self.index_only_terminal_clause_selection()? {
-                Some((index, terminal_clause)) => self
-                    .index_only_terminal_path_query(
-                        document_type_path.to_vec(),
-                        index,
-                        terminal_clause,
-                        platform_version,
-                    )
-                    .map(Some),
-                None => Err(generic_error),
-            },
+            Err(generic_error) if self.generic_route_missed(&generic_error) => {
+                match self.index_only_terminal_clause_selection()? {
+                    Some((index, terminal_clause)) => self
+                        .index_only_terminal_path_query(
+                            document_type_path.to_vec(),
+                            index,
+                            terminal_clause,
+                            platform_version,
+                        )
+                        .map(Some),
+                    None => Err(generic_error),
+                }
+            }
+            Err(other) => Err(other),
         }
     }
 
@@ -307,7 +331,9 @@ impl DriveDocumentQuery<'_> {
         if self.start_at.is_some() {
             return Err(Error::Query(
                 crate::error::query::QuerySyntaxError::Unsupported(
-                    "startAt/startAfter is not yet supported for indexOnly document types"
+                    "startAt/startAfter cannot address an indexOnly position (the synthesized \
+                     document id is a one-way hash of it); paginate with a range clause on \
+                     the terminal property ordered by the terminal, with a limit"
                         .to_string(),
                 ),
             ));
@@ -354,7 +380,9 @@ impl DriveDocumentQuery<'_> {
         if self.start_at.is_some() {
             return Err(Error::Query(
                 crate::error::query::QuerySyntaxError::Unsupported(
-                    "startAt/startAfter is not yet supported for indexOnly document types"
+                    "startAt/startAfter cannot address an indexOnly position (the synthesized \
+                     document id is a one-way hash of it); paginate with a range clause on \
+                     the terminal property ordered by the terminal, with a limit"
                         .to_string(),
                 ),
             ));

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -336,10 +336,41 @@ pub struct InternalClauses {
     /// path-query lowering (protocol version 14 is the first to accept
     /// multiple in clauses, on consecutive index properties).
     pub in_clauses: Vec<WhereClause>,
-    /// Range clause
+    /// Range clause.
+    ///
+    /// On an indexOnly document type this may sit on an index's TERMINAL
+    /// (member-key) property, not only on an index prefix property — see
+    /// [`InternalClauses::classify_fields`] for the modeled roles instead
+    /// of assuming property placement.
     pub range_clause: Option<WhereClause>,
     /// Equal clause
     pub equal_clauses: BTreeMap<String, WhereClause>,
+}
+
+/// How one where-clause (or order-by) field relates to a document type's
+/// indexes — classified ONCE against the doctype instead of re-derived by
+/// every consumer. Roles are not exclusive: on the yappr fixture `postId`
+/// is a prefix property of `byHashtagPost`/`byPost` AND the terminal of
+/// `byLiker`.
+#[cfg(any(feature = "server", feature = "verify"))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ClauseFieldRoles {
+    /// The field is `$id`.
+    pub primary_key: bool,
+    /// The field is a prefix property of at least one index.
+    pub index_property: bool,
+    /// The field is the terminal (member-key property) of at least one
+    /// index — only ever true on indexOnly document types.
+    pub terminal: bool,
+}
+
+#[cfg(any(feature = "server", feature = "verify"))]
+impl ClauseFieldRoles {
+    /// The field appears in no index at all (and is not the primary key)
+    /// — a clause on it can never be served.
+    pub fn unindexed(&self) -> bool {
+        !self.primary_key && !self.index_property && !self.terminal
+    }
 }
 
 /// The outcome of generic index selection
@@ -358,6 +389,64 @@ pub(crate) enum BestIndexOutcome<'a> {
 }
 
 impl InternalClauses {
+    /// Classify one field's index roles against `document_type`. The
+    /// single derivation site for "is this a prefix property, a terminal,
+    /// or `$id`" — consumers must branch on this instead of assuming a
+    /// clause sits on an index prefix property (on indexOnly types it may
+    /// sit on a terminal).
+    #[cfg(any(feature = "server", feature = "verify"))]
+    pub fn classify_field(document_type: DocumentTypeRef, field: &str) -> ClauseFieldRoles {
+        let mut roles = ClauseFieldRoles {
+            primary_key: field == "$id",
+            ..Default::default()
+        };
+        for index in document_type.indexes().values() {
+            if index
+                .properties
+                .iter()
+                .any(|property| property.name == field)
+            {
+                roles.index_property = true;
+            }
+            if index.terminal.as_deref() == Some(field) {
+                roles.terminal = true;
+            }
+            if roles.index_property && roles.terminal {
+                break;
+            }
+        }
+        roles
+    }
+
+    /// [`Self::classify_field`] over every field these clauses name —
+    /// classification happens once, at the seam between clause extraction
+    /// and routing, instead of being re-derived downstream.
+    #[cfg(any(feature = "server", feature = "verify"))]
+    pub fn classify_fields(
+        &self,
+        document_type: DocumentTypeRef,
+    ) -> BTreeMap<String, ClauseFieldRoles> {
+        let mut classified = BTreeMap::new();
+        let mut add = |field: &str| {
+            classified
+                .entry(field.to_string())
+                .or_insert_with(|| Self::classify_field(document_type, field));
+        };
+        if self.primary_key_equal_clause.is_some() || self.primary_key_in_clause.is_some() {
+            add("$id");
+        }
+        for field in self.equal_clauses.keys() {
+            add(field);
+        }
+        if let Some(range_clause) = &self.range_clause {
+            add(&range_clause.field);
+        }
+        for in_clause in &self.in_clauses {
+            add(&in_clause.field);
+        }
+        classified
+    }
+
     #[cfg(any(feature = "server", feature = "verify"))]
     /// Returns true if the clause is a valid format.
     pub fn verify(&self) -> bool {

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -342,6 +342,21 @@ pub struct InternalClauses {
     pub equal_clauses: BTreeMap<String, WhereClause>,
 }
 
+/// The outcome of generic index selection
+/// ([`DriveDocumentQuery::select_best_index`]): a match, or the fact that
+/// no index serves the query — carried as a value, not an error, so a
+/// route that may legitimately stand in for a miss (the indexOnly
+/// terminal route) never has to reconstruct that fact from error
+/// variants. Structural failures never appear here; they stay `Err`.
+#[cfg(any(feature = "server", feature = "verify"))]
+pub(crate) enum BestIndexOutcome<'a> {
+    /// An index serves the query.
+    Matched(&'a Index),
+    /// No index matches; carries the error [`DriveDocumentQuery::find_best_index`]
+    /// reports for this query.
+    NoIndexMatches(Error),
+}
+
 impl InternalClauses {
     #[cfg(any(feature = "server", feature = "verify"))]
     /// Returns true if the clause is a valid format.
@@ -2014,6 +2029,24 @@ impl<'a> DriveDocumentQuery<'a> {
     /// mismatch would produce a validly-proven wrong answer. The rule applies
     /// on both routes, including the multiple-`In` selection.
     pub fn find_best_index(&self, platform_version: &PlatformVersion) -> Result<&Index, Error> {
+        match self.select_best_index(platform_version)? {
+            BestIndexOutcome::Matched(index) => Ok(index),
+            BestIndexOutcome::NoIndexMatches(no_index_error) => Err(no_index_error),
+        }
+    }
+
+    /// Generic index selection with "no index matches" separated from the
+    /// structural failures, in the type instead of in error variants:
+    /// `Err` is a structural problem with the query itself (preflight,
+    /// resolved-source shape, version dispatch) and always propagates,
+    /// while `NoIndexMatches` carries the would-be [`Self::find_best_index`]
+    /// error as a value — a routing fact the indexOnly terminal route is
+    /// allowed to stand in for. [`Self::find_best_index`] collapses both
+    /// non-matches back into `Err` for every ordinary caller.
+    pub(crate) fn select_best_index(
+        &self,
+        platform_version: &PlatformVersion,
+    ) -> Result<BestIndexOutcome<'_>, Error> {
         // A transform's source must be its index's first property, so one
         // index buckets exactly one field and no index can carry two resolved
         // equalities. Serving such a query would need a join across two
@@ -2033,7 +2066,12 @@ impl<'a> DriveDocumentQuery<'a> {
         self.validate_resolved_source_shape()?;
 
         if self.internal_clauses.in_clauses.len() > 1 {
-            return Ok(self.find_best_index_for_multiple_in_clauses()?.0);
+            // The multi-`In` machinery keeps its own error surface; its
+            // shapes are never terminal-routable, so there is nothing to
+            // classify as a plain miss.
+            return Ok(BestIndexOutcome::Matched(
+                self.find_best_index_for_multiple_in_clauses()?.0,
+            ));
         }
 
         let equal_fields = self
@@ -2073,61 +2111,67 @@ impl<'a> DriveDocumentQuery<'a> {
             })
             .collect();
 
-        let (index, difference) = self
-            .document_type
-            .index_for_types_matching(
-                fields.as_slice(),
-                in_field,
-                order_by_keys.as_slice(),
-                |index| index_admissible_for_resolved_time_range(index, &self.resolved_time_ranges),
-                platform_version,
-            )?
-            .ok_or_else(|| match self.resolved_time_ranges.first() {
-                // A time-range query is only servable by the index that
-                // buckets the field with the resolved grid, so "no index"
-                // here is a narrower fact than the generic case: some index
-                // buckets the field (the clause could not have been resolved
-                // otherwise), but none with that grid also covers the rest
-                // of the query.
-                Some(resolved) => {
-                    Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(format!(
-                        "a time-range query on \"{}\" requires an index that buckets it with \
+        let Some((index, difference)) = self.document_type.index_for_types_matching(
+            fields.as_slice(),
+            in_field,
+            order_by_keys.as_slice(),
+            |index| index_admissible_for_resolved_time_range(index, &self.resolved_time_ranges),
+            platform_version,
+        )?
+        else {
+            return Ok(BestIndexOutcome::NoIndexMatches(
+                match self.resolved_time_ranges.first() {
+                    // A time-range query is only servable by the index that
+                    // buckets the field with the resolved grid, so "no index"
+                    // here is a narrower fact than the generic case: some index
+                    // buckets the field (the clause could not have been resolved
+                    // otherwise), but none with that grid also covers the rest
+                    // of the query.
+                    Some(resolved) => {
+                        Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(format!(
+                            "a time-range query on \"{}\" requires an index that buckets it with \
                          the resolved grid AND covers the query's other where and order-by \
                          fields; valid indexes are: {:?}",
-                        resolved.field(),
-                        self.document_type.indexes()
-                    )))
-                }
-                None => {
-                    // A raw query never binds to a bucketed index; when one
-                    // exists, say so — the caller may be holding a
-                    // time-range proof on a surface that cannot supply
-                    // resolution provenance (e.g. the standalone wasm
-                    // verifiers), where this refusal is otherwise opaque.
-                    let has_bucketed_index = self
-                        .document_type
-                        .indexes()
-                        .values()
-                        .any(|index| index.time_range.is_some());
-                    if has_bucketed_index {
-                        Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(format!(
+                            resolved.field(),
+                            self.document_type.indexes()
+                        )))
+                    }
+                    None => {
+                        // A raw query never binds to a bucketed index; when one
+                        // exists, say so — the caller may be holding a
+                        // time-range proof on a surface that cannot supply
+                        // resolution provenance (e.g. the standalone wasm
+                        // verifiers), where this refusal is otherwise opaque.
+                        let has_bucketed_index = self
+                            .document_type
+                            .indexes()
+                            .values()
+                            .any(|index| index.time_range.is_some());
+                        if has_bucketed_index {
+                            Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(
+                                format!(
                             "query must be for valid indexes, valid indexes are: {:?}; note: \
                              this document type's time-range (timeRange) indexes only serve \
                              IN_TIME_RANGE selections carrying their resolution — a raw clause \
                              on the bucketed field never binds to them",
                             self.document_type.indexes()
-                        )))
-                    } else {
-                        Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(format!(
-                            "query must be for valid indexes, valid indexes are: {:?}",
-                            self.document_type.indexes()
-                        )))
+                        ),
+                            ))
+                        } else {
+                            Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(
+                                format!(
+                                    "query must be for valid indexes, valid indexes are: {:?}",
+                                    self.document_type.indexes()
+                                ),
+                            ))
+                        }
                     }
-                }
-            })?;
+                },
+            ));
+        };
         if difference > defaults::MAX_INDEX_DIFFERENCE {
-            return Err(Error::Query(QuerySyntaxError::QueryTooFarFromIndex(
-                "query must better match an existing index",
+            return Ok(BestIndexOutcome::NoIndexMatches(Error::Query(
+                QuerySyntaxError::QueryTooFarFromIndex("query must better match an existing index"),
             )));
         }
 
@@ -2137,7 +2181,7 @@ impl<'a> DriveDocumentQuery<'a> {
         // index bucketing exactly the resolved field, so guarding by
         // provenance there is equivalent to guarding by the selected index's
         // transform here.
-        Ok(index)
+        Ok(BestIndexOutcome::Matched(index))
     }
 
     /// The residual source-shape contract for a query carrying a

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -1631,9 +1631,11 @@ impl<'a> DriveDocumentQuery<'a> {
             }
             if self.document_type.index_only() && self.start_at.is_some() {
                 return Err(Error::Query(QuerySyntaxError::Unsupported(
-                    "startAt/startAfter is not yet supported for indexOnly document types: \
-                     the cursor would be resolved through the primary-key tree, which an \
-                     indexOnly type does not have"
+                    "startAt/startAfter cursors cannot address an indexOnly position (the \
+                     synthesized document id is a one-way hash of it); paginate with a \
+                     range clause on the terminal property instead — equality clauses on \
+                     the index's properties, `terminal > <last seen value>` ordered by the \
+                     terminal, and a limit"
                         .to_string(),
                 )));
             }
@@ -1646,6 +1648,21 @@ impl<'a> DriveDocumentQuery<'a> {
             .into_iter()
             .map(|a| a.to_vec())
             .collect::<Vec<Vec<u8>>>();
+
+        // indexOnly terminal-clause route: a clause on an index's terminal
+        // lowers onto the entry level's member keys when the generic
+        // matcher cannot serve the query. Shared with the verifier-side
+        // constructor below so prover and verifier build the same query.
+        {
+            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+            if self.document_type.index_only() {
+                if let Some(path_query) =
+                    self.index_only_route(&document_type_path, platform_version)?
+                {
+                    return Ok(path_query);
+                }
+            }
+        }
 
         let (starts_at_document, start_at_path_query) = match &self.start_at {
             None => Ok((None, None)),
@@ -1765,9 +1782,11 @@ impl<'a> DriveDocumentQuery<'a> {
             }
             if self.document_type.index_only() && self.start_at.is_some() {
                 return Err(Error::Query(QuerySyntaxError::Unsupported(
-                    "startAt/startAfter is not yet supported for indexOnly document types: \
-                     the cursor would be resolved through the primary-key tree, which an \
-                     indexOnly type does not have"
+                    "startAt/startAfter cursors cannot address an indexOnly position (the \
+                     synthesized document id is a one-way hash of it); paginate with a \
+                     range clause on the terminal property instead — equality clauses on \
+                     the index's properties, `terminal > <last seen value>` ordered by the \
+                     terminal, and a limit"
                         .to_string(),
                 )));
             }
@@ -1779,6 +1798,21 @@ impl<'a> DriveDocumentQuery<'a> {
             .into_iter()
             .map(|a| a.to_vec())
             .collect::<Vec<Vec<u8>>>();
+
+        // indexOnly terminal-clause route — the verifier-side mirror of
+        // the dispatch in `construct_path_query_operations`, so both
+        // sides build the same query.
+        {
+            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+            if self.document_type.index_only() {
+                if let Some(path_query) =
+                    self.index_only_route(&document_type_path, platform_version)?
+                {
+                    return Ok(path_query);
+                }
+            }
+        }
+
         let starts_at_document = starts_at_document
             .map(|starts_at_document| (starts_at_document, self.start_at_included));
         if self.is_for_primary_key() {

--- a/packages/rs-sdk/src/platform/documents/transitions/delete.rs
+++ b/packages/rs-sdk/src/platform/documents/transitions/delete.rs
@@ -153,18 +153,6 @@ impl DocumentDeleteTransitionBuilder {
         self
     }
 
-    /// Signs the document delete transition
-    ///
-    /// # Arguments
-    ///
-    /// * `sdk` - The SDK instance
-    /// * `identity_public_key` - The public key of the identity
-    /// * `signer` - The signer instance
-    /// * `platform_version` - The platform version
-    ///
-    /// # Returns
-    ///
-    /// * `Result<StateTransition, Error>` - The signed state transition or an error
     /// Resolve the document type and the document this delete will be
     /// built from, validating the builder's target. Runs BEFORE any nonce
     /// is reserved (an invalid builder must not advance the SDK's cached
@@ -238,6 +226,18 @@ impl DocumentDeleteTransitionBuilder {
         Ok((document_type, document))
     }
 
+    /// Signs the document delete transition
+    ///
+    /// # Arguments
+    ///
+    /// * `sdk` - The SDK instance
+    /// * `identity_public_key` - The public key of the identity
+    /// * `signer` - The signer instance
+    /// * `platform_version` - The platform version
+    ///
+    /// # Returns
+    ///
+    /// * `Result<StateTransition, Error>` - The signed state transition or an error
     pub async fn sign(
         &self,
         sdk: &Sdk,


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to the indexOnly document types stack (#4491–#4495, all merged): the two read-surface gaps #4494 shipped as rejections-with-guidance — where clauses on the **terminal property** and pagination.

## What was done?

**Terminal-property where clauses.** An indexOnly entry's member key IS the terminal property's encoded value, so a clause on the terminal lowers directly onto the entry level's member keys — no new storage shape, just routing. The shape requirement: every one of the index's prefix properties carries an equality clause (the path down to the `0` entry level must be fully determined), the terminal carries the one remaining clause (equality, range, or `in`), and `orderBy` names nothing outside the index. With that:

- `WHERE $ownerId == me AND postId == X` through `byLiker` ([$ownerId] → postId) answers **"did I like X"** in a single provable query — including the negative answer as an absence proof.
- `WHERE hashtag == h AND postId == p AND $ownerId > lastSeen ORDER BY $ownerId LIMIT n` walks the entries page by page — **keyset pagination**.

**Keyset pagination instead of startAt cursors.** An id-shaped `startAt` cursor fundamentally cannot address an indexOnly position: the synthesized document id is a one-way hash of the position, and a value-carrying cursor format would be a wire change across dapi-grpc, drive-abci and the SDKs. Keyset pagination through terminal range clauses is strictly more expressive, needs no wire changes, and every page proves and verifies. The first page (orderBy on the terminal, no cursor clause yet) is served as an ordered member-key scan; the `startAt` rejections now point at the keyset recipe instead of "not yet supported".

**Routing discipline.** The terminal route engages only when the generic index matcher cannot serve the query, so every previously-working shape keeps its route (e.g. `postId == X` still enumerates through `byPost`). One selection + one path-query builder are shared by the server's execution, the prover and the verifier — so both sides build the same query by construction — and synthesis resolves trios against the same index the route selected. Underdetermined prefixes and terminal ranges without `orderBy` are refused with targeted guidance, never a wrong-answer scan.

## How Has This Been Tested?

Four new e2e tests in the shared yappr-likes suite, all with proved/unproved parity:
- `should_serve_terminal_equality_did_i_like_queries` — positive and negative existence answers, absence verified as absence
- `should_serve_terminal_range_keyset_pagination` — walks three entries page by page (limit 1), each page's proof verifying to the same document, terminating cleanly
- `should_refuse_terminal_clause_without_full_prefix_equalities` — typed `Unsupported` with the shape requirement
- `should_require_order_by_for_terminal_range` — typed `MissingOrderByForRange`

Full drive query suite (699 tests) and the drive-abci indexOnly pipeline suite green; verify-only feature build clean; `cargo check --workspace --all-targets` clean.

## Breaking Changes

None — the new shapes were previously rejected, and every previously-served query keeps its route (the terminal route only engages where the generic matcher errors).

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

Remaining indexOnly follow-ups (tracked, not in this PR): platform-test-suite functional spec, refersTo property-agreement binding, sum axes via SumItem, timeRange buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added equality and range queries on terminal properties when preceding index fields use equality filters.
  - Added keyset pagination for terminal range queries using terminal-property values.
  - Continued support for ranked, count, and range-aggregate queries on index-only document types.

- **Bug Fixes**
  - Improved validation and clarified errors for unsupported cursors, missing ordering, and incomplete index prefixes.

- **Documentation**
  - Updated guidance for supported and unsupported index-only read patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->