### PR TITLE
feat(platform-wallet): external recipient support for asset-lock address funding

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
@@ -1122,6 +1122,121 @@ mod tests {
             );
         }
 
+        /// Consensus does not validate output OWNERSHIP: an
+        /// `AddressFundingFromAssetLock` may credit an address that has
+        /// no relationship whatsoever to the asset lock's one-time
+        /// credit-output key. This is what makes "Alice's Core funds pay
+        /// Bob's Platform address" possible without any protocol change.
+        ///
+        /// Shaped like `test_simple_asset_lock_funding_to_single_address`
+        /// but made explicit about the intent, and with balance
+        /// assertions that pin WHO ends up with WHAT:
+        /// - the unrelated third party's explicit output is credited to
+        ///   the exact requested amount, and
+        /// - the fee comes out of the remainder output, because
+        ///   `ReduceOutput(0)` resolves against the outputs map's
+        ///   lexicographic key order and the remainder address sorts
+        ///   first here.
+        ///
+        /// The wallet layer (`platform-wallet`) is where the
+        /// own-vs-external distinction lives, purely as a safety rail —
+        /// see `fund_from_asset_lock_external`. This test is the
+        /// standing evidence that the rail is a wallet policy and not a
+        /// protocol requirement.
+        #[tokio::test]
+        async fn test_asset_lock_funding_to_unrelated_third_party_address() {
+            let platform_version = PlatformVersion::latest();
+            let platform_config = PlatformConfig {
+                testing_configs: PlatformTestConfig {
+                    disable_instant_lock_signature_verification: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
+            let platform = TestPlatformBuilder::new()
+                .with_config(platform_config)
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let signer = TestAddressSigner::new();
+            let mut rng = StdRng::seed_from_u64(567);
+            let (asset_lock_proof, asset_lock_pk) = create_asset_lock_proof_with_key(&mut rng);
+
+            // `remainder` stands in for the sender's own change address;
+            // `third_party` is an address the sender does not control and
+            // that the protocol has never seen. Their hashes are chosen so
+            // that `remainder` sorts FIRST in the outputs `BTreeMap`
+            // (`PlatformAddress`'s derived `Ord`), which is what makes
+            // `ReduceOutput(0)` charge the fee to the change rather than to
+            // the payee.
+            let remainder = create_platform_address(0x0A);
+            let third_party = create_platform_address(0xBB);
+            assert!(
+                remainder < third_party,
+                "test setup: the remainder address must sort first"
+            );
+
+            let payment = dash_to_credits!(0.5);
+
+            // No inputs — the asset lock is the sole funding source, so
+            // there is no address whose ownership could be attested here
+            // even in principle.
+            let inputs = BTreeMap::new();
+            let mut outputs = BTreeMap::new();
+            outputs.insert(third_party, Some(payment));
+            outputs.insert(remainder, None);
+
+            let transition = create_signed_address_funding_from_asset_lock_transition(
+                asset_lock_proof,
+                &asset_lock_pk,
+                &signer,
+                inputs,
+                outputs,
+                vec![AddressFundsFeeStrategyStep::ReduceOutput(0)],
+            )
+            .await;
+
+            let result = transition.serialize_to_bytes().expect("should serialize");
+
+            let platform_state = platform.state.load();
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[result],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+            );
+
+            // The stranger got exactly what was asked for — untouched by
+            // the fee, because the fee strategy points at the remainder.
+            assert_eq!(
+                get_address_balance(&platform, third_party, &transaction),
+                payment,
+                "the unrelated third party must be credited the full explicit amount"
+            );
+            // And the sender's change absorbed the rest of the lock, minus
+            // the fee.
+            let change = get_address_balance(&platform, remainder, &transaction);
+            assert!(
+                change > 0,
+                "the remainder output must still hold the post-fee change"
+            );
+        }
+
         #[tokio::test]
         async fn test_asset_lock_funding_combined_with_existing_address_input() {
             let platform_version = PlatformVersion::latest();

--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
@@ -269,3 +269,307 @@ pub(super) unsafe fn decode_funding_addresses(
     }
     Ok(address_map)
 }
+
+/// Fund a THIRD PARTY's platform address from a Core L1 asset lock,
+/// with the caller's own address absorbing the remainder (change) and
+/// the fee.
+///
+/// Sister to [`platform_address_wallet_fund_from_asset_lock_signer`]:
+/// identical parameters, identical marshalling, identical orchestration.
+/// The only delta is the recipient pre-flight on the Rust side —
+/// explicit-amount (`has_balance == true`) entries may be ANY valid
+/// P2PKH address, while the single remainder (`has_balance == false`)
+/// entry must still belong to `platform_account_index`.
+///
+/// Callers that mean to fund only their own addresses should keep using
+/// the non-`external` entry point: there, a mistyped recipient is
+/// rejected before anything is broadcast, whereas here it is a valid
+/// (and irreversible) payment to a stranger.
+///
+/// `fee_strategy` is positional over the outputs map's LEXICOGRAPHIC
+/// order (`PlatformAddress`'s derived `Ord`: P2PKH before P2SH, then
+/// hash bytes), NOT over the order entries appear in `addresses` —
+/// `decode_funding_addresses` collects into a `BTreeMap`. Callers must
+/// compute `ReduceOutput(index)` against that ordering; the Swift SDK
+/// does so by sorting its recipient array into the same canonical order
+/// before marshalling.
+///
+/// # Safety
+/// - `signer_address_handle` / `core_signer_handle` — see
+///   [`platform_address_wallet_fund_from_asset_lock_signer`]. Same
+///   ownership and validity contract.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_external_signer(
+    handle: Handle,
+    amount_duffs: u64,
+    account_index: u32,
+    platform_account_index: u32,
+    addresses: *const FundingAddressEntryFFI,
+    addresses_count: usize,
+    fee_strategy: *const FeeStrategyStepFFI,
+    fee_strategy_count: usize,
+    signer_address_handle: *mut SignerHandle,
+    core_signer_handle: *mut MnemonicResolverHandle,
+    out_changeset: *mut PlatformAddressChangeSetFFI,
+) -> PlatformWalletFFIResult {
+    check_ptr!(out_changeset);
+    // Sentinel first — see `platform_address_wallet_fund_from_asset_lock_signer`.
+    *out_changeset = PlatformAddressChangeSetFFI::empty();
+    check_ptr!(addresses);
+    check_ptr!(signer_address_handle);
+    check_ptr!(core_signer_handle);
+
+    let address_map = match decode_funding_addresses(addresses, addresses_count) {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+
+    let fee = parse_fee_strategy(fee_strategy, fee_strategy_count);
+
+    let signer_addr = signer_address_handle as usize;
+    let core_signer_addr = core_signer_handle as usize;
+
+    let option = PLATFORM_ADDRESS_WALLET_STORAGE.with_item(handle, |wallet| {
+        let wallet_clone = wallet.clone();
+        let wallet_id = wallet.wallet_id();
+        let network = wallet.network();
+        block_on_worker(async move {
+            // SAFETY: see the fn-level safety doc — both handles are
+            // pinned alive for the duration of this FFI call.
+            let address_signer: &VTableSigner = unsafe { &*(signer_addr as *const VTableSigner) };
+            let asset_lock_signer = unsafe {
+                MnemonicResolverCoreSigner::new(
+                    core_signer_addr as *mut MnemonicResolverHandle,
+                    wallet_id,
+                    network,
+                )
+            };
+            wallet_clone
+                .fund_from_asset_lock_external(
+                    AssetLockFunding::FromWalletBalance {
+                        amount_duffs,
+                        account_index,
+                    },
+                    platform_account_index,
+                    address_map,
+                    fee,
+                    address_signer,
+                    &asset_lock_signer,
+                    None,
+                )
+                .await
+        })
+    });
+    let result = unwrap_option_or_return!(option);
+    let changeset = unwrap_result_or_return!(result);
+    *out_changeset = PlatformAddressChangeSetFFI::from(&changeset);
+    PlatformWalletFFIResult::ok()
+}
+
+/// Resume an external-recipient platform-address funding flow from an
+/// already-tracked asset lock by outpoint.
+///
+/// Sister to
+/// [`platform_address_wallet_fund_from_asset_lock_external_signer`]
+/// (same relaxed recipient rules) and to
+/// [`platform_address_wallet_resume_fund_from_asset_lock_signer`] (same
+/// resume-by-outpoint shape).
+///
+/// ## Why the recipients are a parameter and not recovered from state
+///
+/// The tracked asset lock records the L1 outpoint, its status and its
+/// proof — it does NOT record who the credits were destined for. Nothing
+/// on the Rust side ever learns the recipient set: it is chosen by the
+/// host at ST-submit time and, for a third-party payment, is not even
+/// derivable from the wallet's own key material. So a resume must be
+/// told the recipients again, exactly as the shielded resume entry point
+/// is (`platform_wallet_manager_shielded_resume_fund_from_asset_lock`).
+///
+/// The practical consequence is worth stating plainly: a resume with a
+/// DIFFERENT recipient set than the original attempt is accepted, and
+/// pays the new set. That is the correct behaviour for a flow whose
+/// first attempt never landed on Platform — the asset lock is a bearer
+/// input, not a commitment to a destination — but it does mean the host
+/// is responsible for round-tripping the intended recipient (which is
+/// what `PersistentAssetLock.recipientPlatformAddressHash` /
+/// `recipientIsExternal` exist for on the Swift side).
+///
+/// # Safety
+/// - `out_point` must be a valid, non-null pointer to an `OutPointFFI`
+///   (32-byte raw txid + u32 vout). The caller retains ownership.
+/// - `signer_address_handle` / `core_signer_handle` — see
+///   [`platform_address_wallet_fund_from_asset_lock_signer`].
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn platform_address_wallet_resume_fund_from_asset_lock_external_signer(
+    handle: Handle,
+    out_point: *const OutPointFFI,
+    platform_account_index: u32,
+    addresses: *const FundingAddressEntryFFI,
+    addresses_count: usize,
+    fee_strategy: *const FeeStrategyStepFFI,
+    fee_strategy_count: usize,
+    signer_address_handle: *mut SignerHandle,
+    core_signer_handle: *mut MnemonicResolverHandle,
+    out_changeset: *mut PlatformAddressChangeSetFFI,
+) -> PlatformWalletFFIResult {
+    check_ptr!(out_changeset);
+    // Sentinel first — see `platform_address_wallet_fund_from_asset_lock_signer`.
+    *out_changeset = PlatformAddressChangeSetFFI::empty();
+    check_ptr!(addresses);
+    check_ptr!(out_point);
+    check_ptr!(signer_address_handle);
+    check_ptr!(core_signer_handle);
+
+    let address_map = match decode_funding_addresses(addresses, addresses_count) {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+
+    let fee = parse_fee_strategy(fee_strategy, fee_strategy_count);
+
+    let out_point_ffi = *out_point;
+    let resume_outpoint = dashcore::OutPoint {
+        txid: dashcore::Txid::from_byte_array(out_point_ffi.txid),
+        vout: out_point_ffi.vout,
+    };
+
+    let signer_addr = signer_address_handle as usize;
+    let core_signer_addr = core_signer_handle as usize;
+
+    let option = PLATFORM_ADDRESS_WALLET_STORAGE.with_item(handle, |wallet| {
+        let wallet_clone = wallet.clone();
+        let wallet_id = wallet.wallet_id();
+        let network = wallet.network();
+        block_on_worker(async move {
+            // SAFETY: see the fn-level safety doc — both handles are
+            // pinned alive for the duration of this FFI call.
+            let address_signer: &VTableSigner = unsafe { &*(signer_addr as *const VTableSigner) };
+            let asset_lock_signer = unsafe {
+                MnemonicResolverCoreSigner::new(
+                    core_signer_addr as *mut MnemonicResolverHandle,
+                    wallet_id,
+                    network,
+                )
+            };
+            wallet_clone
+                .fund_from_asset_lock_external(
+                    AssetLockFunding::FromExistingAssetLock {
+                        out_point: resume_outpoint,
+                        consume_invitation_voucher: false,
+                    },
+                    platform_account_index,
+                    address_map,
+                    fee,
+                    address_signer,
+                    &asset_lock_signer,
+                    None,
+                )
+                .await
+        })
+    });
+    let result = unwrap_option_or_return!(option);
+    let changeset = unwrap_result_or_return!(result);
+    *out_changeset = PlatformAddressChangeSetFFI::from(&changeset);
+    PlatformWalletFFIResult::ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform_address_types::PlatformAddressFFI;
+
+    fn entry(address_type: u8, tag: u8, balance: Option<u64>) -> FundingAddressEntryFFI {
+        FundingAddressEntryFFI {
+            address: PlatformAddressFFI {
+                address_type,
+                hash: [tag; 20],
+            },
+            has_balance: balance.is_some(),
+            balance: balance.unwrap_or(0),
+        }
+    }
+
+    /// Pins the contract the SDKs' fee-strategy computation depends on:
+    /// `ReduceOutput(index)` is resolved by consensus against the
+    /// outputs `BTreeMap`'s key order, and `decode_funding_addresses`
+    /// builds that map. So when the caller hands us a canonically
+    /// sorted array (P2PKH before P2SH, then hash bytes ascending — the
+    /// derived `Ord` on `PlatformAddress`), array position and
+    /// consensus output index are the SAME number.
+    ///
+    /// The hazard this guards: a caller that computes the remainder
+    /// index from its own arbitrary array order silently re-targets the
+    /// fee onto a different output whenever the remainder is not first
+    /// lexicographically. With a third-party recipient in the set, that
+    /// means the payee's explicit amount pays the fee instead of the
+    /// sender's change.
+    #[test]
+    fn decoded_map_order_matches_canonically_sorted_input() {
+        // Alice (0x0A) is the remainder; Bob (0xBB) and Carol (0xCC)
+        // take explicit amounts. Alice sorts FIRST, so the remainder
+        // index is 0 even though a caller listing "payees first" would
+        // have naively computed 2.
+        let canonical = [
+            entry(0, 0x0A, None),
+            entry(0, 0xBB, Some(500)),
+            entry(0, 0xCC, Some(700)),
+        ];
+
+        let map = unsafe { decode_funding_addresses(canonical.as_ptr(), canonical.len()) }
+            .expect("valid entries decode");
+
+        let decoded_order: Vec<PlatformAddress> = map.keys().copied().collect();
+        let input_order: Vec<PlatformAddress> = canonical
+            .iter()
+            .map(|e| PlatformAddress::try_from(e.address).expect("valid address"))
+            .collect();
+        assert_eq!(
+            decoded_order, input_order,
+            "a canonically sorted input array must survive the BTreeMap round trip in order"
+        );
+
+        let remainder_index = canonical
+            .iter()
+            .position(|e| !e.has_balance)
+            .expect("exactly one remainder");
+        assert_eq!(remainder_index, 0);
+        assert_eq!(
+            map.get(&decoded_order[remainder_index]),
+            Some(&None),
+            "ReduceOutput(remainder_index) must land on the None (remainder) output"
+        );
+    }
+
+    /// The inverse arrangement: the remainder sorts LAST. Pins that the
+    /// index tracks lexicographic position rather than being pinned to
+    /// 0 or to the caller's listing order.
+    #[test]
+    fn remainder_index_tracks_lexicographic_position() {
+        let canonical = [
+            entry(0, 0x0A, Some(500)),
+            entry(0, 0xBB, Some(700)),
+            entry(0, 0xCC, None),
+        ];
+
+        let map = unsafe { decode_funding_addresses(canonical.as_ptr(), canonical.len()) }
+            .expect("valid entries decode");
+        let decoded_order: Vec<PlatformAddress> = map.keys().copied().collect();
+
+        let remainder_index = canonical
+            .iter()
+            .position(|e| !e.has_balance)
+            .expect("exactly one remainder");
+        assert_eq!(remainder_index, 2);
+        assert_eq!(map.get(&decoded_order[remainder_index]), Some(&None));
+    }
+
+    #[test]
+    fn rejects_duplicate_recipients() {
+        let entries = [entry(0, 0x0A, Some(500)), entry(0, 0x0A, None)];
+        let err = unsafe { decode_funding_addresses(entries.as_ptr(), entries.len()) }
+            .expect_err("duplicates must be rejected");
+        assert_eq!(err.code, PlatformWalletFFIResultCode::ErrorInvalidParameter);
+    }
+}

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
@@ -149,9 +149,125 @@ impl PlatformAddressWallet {
         S: Signer<PlatformAddress> + Send + Sync,
         AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
     {
+        self.fund_from_asset_lock_inner(
+            funding,
+            platform_account_index,
+            addresses,
+            fee_strategy,
+            address_signer,
+            asset_lock_signer,
+            settings,
+            RecipientOwnership::AllOwned,
+        )
+        .await
+    }
+
+    /// Fund a THIRD PARTY's platform address from a Core L1 asset
+    /// lock, with the sender's own address absorbing the remainder
+    /// (change) and the fee.
+    ///
+    /// Sibling to [`PlatformAddressWallet::fund_from_asset_lock`]:
+    /// identical pipeline, identical arguments, identical bookkeeping —
+    /// the ONLY delta is the recipient pre-flight.
+    ///
+    /// | | `fund_from_asset_lock` | `fund_from_asset_lock_external` |
+    /// |---|---|---|
+    /// | explicit-amount outputs (`Some(credits)`) | must belong to `platform_account_index` | **any valid P2PKH address** |
+    /// | remainder output (`None`) | must belong to `platform_account_index` | must belong to `platform_account_index` |
+    /// | address type | P2PKH only | P2PKH only |
+    ///
+    /// Why this is a separate entry point rather than a relaxation of
+    /// the existing one: for every current caller, a typo'd recipient
+    /// address is caught today by the membership check. Relaxing that
+    /// check in place would silently convert "typo'd address → typed
+    /// error before anything is broadcast" into "typo'd address →
+    /// asset-lock credits irrecoverably delivered to a stranger". Opting
+    /// in by function name keeps that failure mode confined to callers
+    /// that actually mean to pay someone else.
+    ///
+    /// Why the remainder must still be owned: the asset lock is
+    /// consumed in full, so the `None` bucket receives everything left
+    /// after the explicit outputs and fees — i.e. the change. Sending
+    /// change to a stranger is never the intent, and a caller bug that
+    /// mixed up which entry was the remainder would leak the entire
+    /// lock value rather than the intended payment. Consensus does not
+    /// care (it never validates output ownership — see
+    /// `test_external_recipient_asset_lock_funding_is_consensus_valid`
+    /// in rs-drive-abci), so this is purely a wallet-level safety rail.
+    ///
+    /// Reconciliation needs no special casing: the third party's output
+    /// simply does not resolve to a wallet-owned slot, which
+    /// `reconcile_address_infos_with_persistence` already treats as a
+    /// normal outcome (it warns and still reports `persisted = true`),
+    /// while the sender's remainder output resolves and is credited as
+    /// usual.
+    ///
+    /// See [`PlatformAddressWallet::fund_from_asset_lock`] for the
+    /// argument-by-argument reference, the latency budget and the
+    /// cancellation contract — all of which apply verbatim.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn fund_from_asset_lock_external<S, AS>(
+        &self,
+        funding: AssetLockFunding,
+        platform_account_index: u32,
+        addresses: BTreeMap<PlatformAddress, Option<Credits>>,
+        fee_strategy: AddressFundsFeeStrategy,
+        address_signer: &S,
+        asset_lock_signer: &AS,
+        settings: Option<PutSettings>,
+    ) -> Result<PlatformAddressChangeSet, PlatformWalletError>
+    where
+        S: Signer<PlatformAddress> + Send + Sync,
+        AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
+    {
+        self.fund_from_asset_lock_inner(
+            funding,
+            platform_account_index,
+            addresses,
+            fee_strategy,
+            address_signer,
+            asset_lock_signer,
+            settings,
+            RecipientOwnership::ExternalExplicitOutputs,
+        )
+        .await
+    }
+
+    /// Shared body behind [`PlatformAddressWallet::fund_from_asset_lock`]
+    /// and [`PlatformAddressWallet::fund_from_asset_lock_external`].
+    ///
+    /// `ownership` is the single point of divergence between the two
+    /// public entry points; everything from Step 2 onward is identical,
+    /// because nothing downstream of the pre-flight is
+    /// ownership-sensitive (the proof carries every output regardless of
+    /// who owns it, and reconciliation resolves whichever subset happens
+    /// to be ours).
+    ///
+    /// There is deliberately no separate `resume_*` variant at this
+    /// layer: resuming is expressed as
+    /// `AssetLockFunding::FromExistingAssetLock`, a value of the
+    /// `funding` parameter, so both public entry points already cover
+    /// fresh-build and resume. (The FFI layer does expose distinct
+    /// resume symbols, because a C ABI cannot take a Rust enum.)
+    #[allow(clippy::too_many_arguments)]
+    async fn fund_from_asset_lock_inner<S, AS>(
+        &self,
+        funding: AssetLockFunding,
+        platform_account_index: u32,
+        addresses: BTreeMap<PlatformAddress, Option<Credits>>,
+        fee_strategy: AddressFundsFeeStrategy,
+        address_signer: &S,
+        asset_lock_signer: &AS,
+        settings: Option<PutSettings>,
+        ownership: RecipientOwnership,
+    ) -> Result<PlatformAddressChangeSet, PlatformWalletError>
+    where
+        S: Signer<PlatformAddress> + Send + Sync,
+        AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
+    {
         // Step 1: pre-flight. Failing fast here avoids broadcasting
         // an unfundable asset-lock tx.
-        validate_recipient_addresses(self, platform_account_index, &addresses).await?;
+        validate_recipient_addresses(self, platform_account_index, &addresses, ownership).await?;
 
         // Step 2: resolve funding. `AssetLockAddressTopUp` selects the
         // BIP44 funding family for the Core asset-lock tx. The
@@ -390,28 +506,51 @@ impl PlatformAddressWallet {
     }
 }
 
+/// Which recipient outputs must belong to the sender's own managed
+/// platform account.
+///
+/// This is the sole behavioural difference between
+/// [`PlatformAddressWallet::fund_from_asset_lock`] and
+/// [`PlatformAddressWallet::fund_from_asset_lock_external`]. Consensus
+/// itself never validates output ownership, so both modes produce
+/// equally valid state transitions — the distinction exists purely to
+/// keep an accidental third-party payment from being indistinguishable
+/// from a deliberate one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RecipientOwnership {
+    /// Every recipient — explicit-amount outputs and the remainder
+    /// alike — must be a member of the platform-payment account. This
+    /// is the legacy "fund my own addresses" behaviour.
+    AllOwned,
+    /// Explicit-amount (`Some(credits)`) outputs may be any valid P2PKH
+    /// address, including addresses this wallet knows nothing about.
+    /// The single remainder (`None`) output must still be owned,
+    /// because it is the change.
+    ExternalExplicitOutputs,
+}
+
 /// Pre-flight check for the recipient address map:
 /// - Non-empty
 /// - Exactly one `None`-amount entry (the remainder recipient)
-/// - All addresses are P2PKH and belong to the specified platform-payment account
+/// - All addresses are P2PKH
+/// - Ownership per `ownership` (see [`RecipientOwnership`])
+///
+/// Resolves the managed account once and delegates the actual rules to
+/// the pure [`validate_recipient_map`], which is where the unit tests
+/// live (no wallet construction needed to exercise the rules).
 async fn validate_recipient_addresses(
     wallet: &PlatformAddressWallet,
     platform_account_index: u32,
     addresses: &BTreeMap<PlatformAddress, Option<Credits>>,
+    ownership: RecipientOwnership,
 ) -> Result<(), PlatformWalletError> {
-    if addresses.is_empty() {
-        return Err(PlatformWalletError::AddressOperation(
-            "fund_from_asset_lock requires at least one recipient address".to_string(),
-        ));
-    }
-
-    let none_count = addresses.values().filter(|v| v.is_none()).count();
-    if none_count != 1 {
-        return Err(PlatformWalletError::AddressOperation(format!(
-            "Exactly one address must have None balance (the funding recipient), found {}",
-            none_count
-        )));
-    }
+    // Shape checks before the lock. `validate_recipient_map` re-runs
+    // them (it is self-contained so the tests can call it directly);
+    // running them here too is what preserves the pre-existing error
+    // precedence — a malformed recipient map is rejected with its own
+    // typed error even when the wallet handle or the account is gone,
+    // rather than being masked by `WalletNotFound` / `AddressSync`.
+    validate_recipient_shape(addresses)?;
 
     let wm = wallet.wallet_manager.read().await;
     let info = wm.get_wallet_info(&wallet.wallet_id).ok_or_else(|| {
@@ -429,18 +568,98 @@ async fn validate_recipient_addresses(
                 platform_account_index
             ))
         })?;
+
+    validate_recipient_map(addresses, ownership, platform_account_index, |p2pkh| {
+        account.contains_platform_address(p2pkh)
+    })
+}
+
+/// Ownership-independent half of the pre-flight: cardinality and
+/// address-type rules that hold for every funding mode.
+///
+/// P2SH stays rejected for ALL recipients, including pure third-party
+/// payees under [`RecipientOwnership::ExternalExplicitOutputs`].
+/// Relaxing that for recipient-only outputs is a deliberate follow-up:
+/// the FFI's `TryFrom<PlatformAddressFFI> for PlatformAddress` rejects
+/// the P2SH discriminant outright, so lifting the restriction here
+/// alone would not actually make P2SH reachable from the SDKs.
+fn validate_recipient_shape(
+    addresses: &BTreeMap<PlatformAddress, Option<Credits>>,
+) -> Result<(), PlatformWalletError> {
+    if addresses.is_empty() {
+        return Err(PlatformWalletError::AddressOperation(
+            "fund_from_asset_lock requires at least one recipient address".to_string(),
+        ));
+    }
+
+    let none_count = addresses.values().filter(|v| v.is_none()).count();
+    if none_count != 1 {
+        return Err(PlatformWalletError::AddressOperation(format!(
+            "Exactly one address must have None balance (the funding recipient), found {}",
+            none_count
+        )));
+    }
+
     for addr in addresses.keys() {
+        if !matches!(addr, PlatformAddress::P2pkh(_)) {
+            return Err(PlatformWalletError::AddressOperation(
+                "Only P2PKH addresses are supported".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Pure recipient-map pre-flight, generic over the ownership oracle so
+/// it can be unit-tested without standing up a `PlatformAddressWallet`.
+///
+/// `is_owned` answers "is this address a member of
+/// `platform_account_index`?"; in production it is
+/// `ManagedPlatformAccount::contains_platform_address`.
+fn validate_recipient_map<F>(
+    addresses: &BTreeMap<PlatformAddress, Option<Credits>>,
+    ownership: RecipientOwnership,
+    platform_account_index: u32,
+    is_owned: F,
+) -> Result<(), PlatformWalletError>
+where
+    F: Fn(&PlatformP2PKHAddress) -> bool,
+{
+    validate_recipient_shape(addresses)?;
+
+    for (addr, amount) in addresses {
         let PlatformAddress::P2pkh(hash) = addr else {
+            // Unreachable: `validate_recipient_shape` already rejected
+            // every non-P2PKH address above. Kept as a total match
+            // rather than an `unwrap` so a future third variant is a
+            // compile-time prompt, not a panic.
             return Err(PlatformWalletError::AddressOperation(
                 "Only P2PKH addresses are supported".to_string(),
             ));
         };
         let p2pkh = PlatformP2PKHAddress::new(*hash);
-        if !account.contains_platform_address(&p2pkh) {
-            return Err(PlatformWalletError::AddressNotFound(format!(
-                "Address {} does not belong to platform account index {}",
-                p2pkh, platform_account_index
-            )));
+
+        // `None` == the remainder/change bucket. It must be ours in
+        // BOTH modes: the asset lock is consumed in full, so this
+        // output receives everything left over after the explicit
+        // outputs and the fee.
+        let is_remainder = amount.is_none();
+        let must_be_owned = is_remainder || ownership == RecipientOwnership::AllOwned;
+        if must_be_owned && !is_owned(&p2pkh) {
+            return Err(PlatformWalletError::AddressNotFound(if is_remainder {
+                format!(
+                    "Remainder (change) address {} does not belong to platform account index {}; \
+                     the remainder output absorbs the asset lock's leftover value and must be \
+                     owned by the sender",
+                    p2pkh, platform_account_index
+                )
+            } else {
+                format!(
+                    "Address {} does not belong to platform account index {}",
+                    p2pkh, platform_account_index
+                )
+            }));
         }
     }
     Ok(())
@@ -505,6 +724,251 @@ mod tests {
             balance: 1_000,
             nonce: 0,
         }
+    }
+
+    /// Ownership oracle standing in for
+    /// `ManagedPlatformAccount::contains_platform_address`: the byte
+    /// tags in `owned` are the addresses the sender's account holds.
+    fn owned(tags: &[u8]) -> impl Fn(&PlatformP2PKHAddress) -> bool + '_ {
+        move |addr: &PlatformP2PKHAddress| {
+            tags.iter()
+                .any(|t| PlatformP2PKHAddress::new([*t; 20]) == *addr)
+        }
+    }
+
+    fn check(
+        addresses: &BTreeMap<PlatformAddress, Option<Credits>>,
+        ownership: RecipientOwnership,
+        owned_tags: &[u8],
+    ) -> Result<(), PlatformWalletError> {
+        validate_recipient_map(addresses, ownership, 0, owned(owned_tags))
+    }
+
+    /// Legacy behaviour is untouched: an explicit-amount output the
+    /// sender does not own is still rejected before anything is
+    /// broadcast. This is the safety property that motivated adding a
+    /// second entry point rather than relaxing this one.
+    #[test]
+    fn all_owned_rejects_external_explicit_recipient() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xBB), Some(500)); // Bob — not ours
+        addresses.insert(p2pkh(0xAA), None); // our change
+        let err = check(&addresses, RecipientOwnership::AllOwned, &[0xAA])
+            .expect_err("legacy mode must reject a third-party recipient");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("does not belong to platform account index"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn all_owned_accepts_fully_owned_recipient_set() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xAA), Some(500));
+        addresses.insert(p2pkh(0xAB), None);
+        check(&addresses, RecipientOwnership::AllOwned, &[0xAA, 0xAB])
+            .expect("fully-owned set must pass in legacy mode");
+    }
+
+    /// The feature: Alice pays Bob an exact amount and keeps the
+    /// remainder on an address of her own.
+    #[test]
+    fn external_accepts_external_explicit_with_owned_remainder() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xBB), Some(500)); // Bob — external
+        addresses.insert(p2pkh(0xAA), None); // Alice's change
+        check(
+            &addresses,
+            RecipientOwnership::ExternalExplicitOutputs,
+            &[0xAA],
+        )
+        .expect("external explicit recipient with owned remainder must pass");
+    }
+
+    /// Multiple third-party payees in a single asset lock are fine —
+    /// consensus places no cap on output count beyond the versioned
+    /// maximum, and none of them need to be ours.
+    #[test]
+    fn external_accepts_several_external_explicit_recipients() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xBB), Some(500));
+        addresses.insert(p2pkh(0xCC), Some(700));
+        addresses.insert(p2pkh(0xAA), None);
+        check(
+            &addresses,
+            RecipientOwnership::ExternalExplicitOutputs,
+            &[0xAA],
+        )
+        .expect("multiple external recipients must pass");
+    }
+
+    /// The one ownership rule the external variant keeps: change comes
+    /// home. A caller bug that put the third party in the remainder
+    /// slot would hand them the WHOLE lock value, not the intended
+    /// payment, so this stays a hard error.
+    #[test]
+    fn external_rejects_external_remainder() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xAA), Some(500)); // ours, explicit
+        addresses.insert(p2pkh(0xBB), None); // Bob would get the change
+        let err = check(
+            &addresses,
+            RecipientOwnership::ExternalExplicitOutputs,
+            &[0xAA],
+        )
+        .expect_err("an unowned remainder must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            matches!(err, PlatformWalletError::AddressNotFound(_)),
+            "expected AddressNotFound, got: {msg}"
+        );
+        assert!(
+            msg.contains("Remainder (change) address"),
+            "the error must name the remainder output: {msg}"
+        );
+    }
+
+    /// A recipient set with no owned address at all still fails on the
+    /// remainder rule — there is no path to "send everything away".
+    #[test]
+    fn external_rejects_when_nothing_is_owned() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xBB), Some(500));
+        addresses.insert(p2pkh(0xCC), None);
+        check(&addresses, RecipientOwnership::ExternalExplicitOutputs, &[])
+            .expect_err("a wholly-external recipient set must be rejected");
+    }
+
+    #[test]
+    fn rejects_p2sh_recipient_in_both_modes() {
+        // P2SH explicit output, owned remainder. Rejected even in the
+        // external mode, where ownership would otherwise not matter —
+        // the address-type restriction is orthogonal to ownership and
+        // relaxing it is a separate follow-up.
+        let mut addresses = BTreeMap::new();
+        addresses.insert(PlatformAddress::P2sh([0xBB; 20]), Some(500));
+        addresses.insert(p2pkh(0xAA), None);
+        for ownership in [
+            RecipientOwnership::AllOwned,
+            RecipientOwnership::ExternalExplicitOutputs,
+        ] {
+            let err = check(&addresses, ownership, &[0xAA])
+                .expect_err("P2SH recipients must be rejected in every mode");
+            assert!(
+                format!("{err}").contains("Only P2PKH addresses are supported"),
+                "{ownership:?}: unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_zero_remainders() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xAA), Some(500));
+        addresses.insert(p2pkh(0xBB), Some(700));
+        for ownership in [
+            RecipientOwnership::AllOwned,
+            RecipientOwnership::ExternalExplicitOutputs,
+        ] {
+            let err = check(&addresses, ownership, &[0xAA, 0xBB])
+                .expect_err("a recipient set with no remainder must be rejected");
+            assert!(
+                format!("{err}").contains("found 0"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_two_remainders() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xAA), None);
+        addresses.insert(p2pkh(0xBB), None);
+        for ownership in [
+            RecipientOwnership::AllOwned,
+            RecipientOwnership::ExternalExplicitOutputs,
+        ] {
+            let err = check(&addresses, ownership, &[0xAA, 0xBB])
+                .expect_err("two remainders must be rejected");
+            assert!(
+                format!("{err}").contains("found 2"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_empty_recipient_map() {
+        let addresses = BTreeMap::new();
+        for ownership in [
+            RecipientOwnership::AllOwned,
+            RecipientOwnership::ExternalExplicitOutputs,
+        ] {
+            let err = check(&addresses, ownership, &[])
+                .expect_err("an empty recipient map must be rejected");
+            assert!(
+                format!("{err}").contains("at least one recipient address"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    /// The FFI marshals recipients into a flat array and names the
+    /// fee-paying output POSITIONALLY (`ReduceOutput(index)`), while
+    /// consensus resolves that index against the outputs map's
+    /// lexicographic key order (`PlatformAddress`'s derived `Ord`:
+    /// P2PKH before P2SH, then hash bytes). This test pins the ordering
+    /// the SDK callers rely on when they compute the remainder index:
+    /// sorting the recipients the same way the `BTreeMap` does makes
+    /// array position and consensus index the same number, INCLUDING
+    /// when the remainder is not the first recipient the caller listed.
+    #[test]
+    fn remainder_index_matches_btreemap_position() {
+        // Caller-supplied order: Bob (explicit) first, Alice's change
+        // second — and Alice's hash sorts BEFORE Bob's, so the naive
+        // "position in the caller's array" answer (1) is wrong and the
+        // lexicographic answer (0) is right.
+        let alice = p2pkh(0x0A);
+        let bob = p2pkh(0xBB);
+        let carol = p2pkh(0xCC);
+
+        let mut addresses = BTreeMap::new();
+        addresses.insert(bob, Some(500));
+        addresses.insert(carol, Some(700));
+        addresses.insert(alice, None);
+
+        let keys: Vec<PlatformAddress> = addresses.keys().copied().collect();
+        assert_eq!(
+            keys,
+            vec![alice, bob, carol],
+            "BTreeMap must order by PlatformAddress's derived Ord"
+        );
+
+        let remainder_index = addresses
+            .iter()
+            .position(|(_, amount)| amount.is_none())
+            .expect("exactly one remainder");
+        assert_eq!(
+            remainder_index, 0,
+            "the remainder index is its lexicographic position, not its position in the \
+             caller's list"
+        );
+        assert_eq!(keys[remainder_index], alice);
+
+        // And the inverse hazard: a remainder that is LAST
+        // lexicographically but first in the caller's list.
+        let mut addresses = BTreeMap::new();
+        addresses.insert(carol, None);
+        addresses.insert(alice, Some(500));
+        addresses.insert(bob, Some(700));
+        let keys: Vec<PlatformAddress> = addresses.keys().copied().collect();
+        let remainder_index = addresses
+            .iter()
+            .position(|(_, amount)| amount.is_none())
+            .expect("exactly one remainder");
+        assert_eq!(remainder_index, 2);
+        assert_eq!(keys[remainder_index], carol);
     }
 
     #[test]

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
@@ -2314,6 +2314,65 @@ mod tests {
         assert!(outcome.entries.is_empty());
     }
 
+    /// External-recipient asset-lock funding (Alice pays Bob): the
+    /// proof carries BOTH Bob's third-party output and Alice's own
+    /// remainder/change output. Reconciliation must credit Alice's
+    /// address and quietly ignore Bob's — the partial resolve is the
+    /// normal, expected outcome, not an error.
+    ///
+    /// This is the provider-level half of the guarantee that
+    /// `fund_from_asset_lock_external` needs no persistence changes:
+    /// `resolved > 0`, so
+    /// `reconcile_address_infos_with_persistence` takes its normal
+    /// apply-and-persist path (and therefore reports `persisted =
+    /// true`, which is what gates `consume_asset_lock`), while the
+    /// stranger's address never enters the committed seed.
+    #[test]
+    fn commit_reconciliation_mixed_own_and_external_recipients() {
+        use dash_sdk::query_types::AddressInfo;
+
+        // Alice's change address, tracked by the provider.
+        let alice = p2pkh(0x11);
+        let mut provider = provider_with_one_funded_address(alice, funds(700, 3));
+
+        let alice_addr = PlatformAddress::P2pkh([0x11; 20]);
+        // Bob: a third party. Not in the provider bijection, not in the
+        // live pool — the wallet has never seen this address.
+        let bob_addr = PlatformAddress::P2pkh([0xBB; 20]);
+
+        let mut address_infos = AddressInfos::new();
+        address_infos.insert(
+            alice_addr,
+            Some(AddressInfo {
+                address: alice_addr,
+                nonce: 3,
+                balance: 5_000,
+            }),
+        );
+        address_infos.insert(
+            bob_addr,
+            Some(AddressInfo {
+                address: bob_addr,
+                nonce: 0,
+                balance: 9_000,
+            }),
+        );
+
+        let outcome = provider.commit_reconciliation(&WALLET, &address_infos, &BTreeMap::new(), 77);
+
+        assert_eq!(
+            outcome.resolved, 1,
+            "exactly the sender-owned remainder output must resolve"
+        );
+        assert_eq!(outcome.entries.len(), 1);
+        assert_eq!(outcome.entries[0].address, alice);
+        assert_eq!(outcome.entries[0].funds, funds_at(5_000, 3, 77));
+
+        let seed: Vec<_> = provider.current_balances().collect();
+        assert_eq!(seed.len(), 1, "the third party must not enter the seed");
+        assert_eq!(seed[0].2, funds_at(5_000, 3, 77));
+    }
+
     /// Height authority: an absolute pinned at a LATER height is
     /// authoritative even when it revises the balance DOWNWARD — this is
     /// the ADDR-09 healing property. A poisoned legacy row (e.g. a

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentAssetLock.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentAssetLock.swift
@@ -38,9 +38,10 @@ import SwiftData
 /// - **Platform address** (`fundingTypeRaw == 4` —
 ///   AssetLockAddressTopUp):
 ///   `recipientPlatformAddressHash` + `recipientPlatformAddressType`
-///   identify the destination. Set by Swift on the controller's
-///   `.completed` phase because the recipient is picked at
-///   ST-submit time on the host side; Rust never sees it.
+///   identify the destination, and `recipientIsExternal` says whether
+///   it belongs to this wallet or to a third party. Set by Swift on
+///   the controller's `.completed` phase because the recipient is
+///   picked at ST-submit time on the host side; Rust never sees it.
 ///
 /// - **Shielded address** (`fundingTypeRaw == 5` —
 ///   AssetLockShieldedAddressTopUp, not yet wired): will add a
@@ -157,6 +158,39 @@ public final class PersistentAssetLock {
     /// without joining against `PersistentPlatformAddress`. `nil`
     /// whenever `recipientPlatformAddressHash` is `nil`.
     public var recipientPlatformAddressType: UInt8?
+
+    /// Whether `recipientPlatformAddressHash` is a THIRD PARTY's
+    /// address (`true`) or one of this wallet's own addresses
+    /// (`false`) — the own/external discriminator for the funding
+    /// type 4 field-family.
+    ///
+    /// Without it, a populated recipient hash is ambiguous. Consumers
+    /// read that hash as "this lock topped up an address of mine" —
+    /// `PlatformAddressActivityStore.matchesOwnAssetLockTopUp` in
+    /// dashwallet-ios does exactly that — so an outgoing payment to
+    /// someone else would be rendered as an incoming credit to the
+    /// user. `true` marks the row as an outgoing send whose recipient
+    /// hash names a stranger and therefore will NEVER have a matching
+    /// `PersistentPlatformAddress` row.
+    ///
+    /// Written by the caller that picked the recipient, alongside the
+    /// hash and type: `false` for `fundFromAssetLock`, `true` for
+    /// `fundFromAssetLockExternal`.
+    ///
+    /// `nil` for:
+    /// - Identity-funding asset locks (no platform-address recipient).
+    /// - Address-funding locks that haven't completed yet.
+    /// - Pre-this-commit address-funding locks that completed before
+    ///   the field existed. Treat `nil` alongside a populated
+    ///   `recipientPlatformAddressHash` as "own" — that was the only
+    ///   flow those rows could have come from.
+    ///
+    /// Default `nil` on the column makes SwiftData's lightweight
+    /// migration safe for rows that pre-date this field; adding an
+    /// optional property to an existing `@Model` needs no new
+    /// `MigrationStage`, and the model LIST is unchanged, so
+    /// `DashMigrationPlan` is untouched.
+    public var recipientIsExternal: Bool?
 
     /// Record timestamps.
     public var createdAt: Date

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
@@ -623,12 +623,20 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
 
     // MARK: - Fund from Core asset lock
 
-    /// Recipient entry for `fundFromAssetLock(...)`.
+    /// Recipient entry for `fundFromAssetLock(...)` and
+    /// `fundFromAssetLockExternal(...)`.
     ///
     /// Exactly one entry per call must have `credits = nil` — that
     /// address receives the remainder after explicit outputs and fees
     /// (the asset lock is consumed in full, so a remainder bucket is
     /// mandatory).
+    ///
+    /// There is deliberately no `isExternal` flag here: whether a
+    /// recipient may be a third party is decided by WHICH entry point
+    /// you call, not per row. The same convention as the shielded
+    /// funding surface, and it keeps "am I allowed to pay a stranger?"
+    /// a single, auditable decision at the call site rather than a
+    /// property buried in one element of an array.
     public struct FundFromAssetLockRecipient: Sendable {
         /// Must be `0` (P2PKH). Funding recipients flow through the same
         /// P2PKH-only Rust `TryFrom<PlatformAddressFFI>` as transfer
@@ -666,10 +674,14 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
     ///   - platformAccountIndex: Platform-payment account containing
     ///     `recipients`. Used for the membership pre-flight on the Rust
     ///     side and the post-success balance write.
-    ///   - recipients: Destination addresses. Exactly one must carry
+    ///   - recipients: Destination addresses, ALL of which must belong
+    ///     to `platformAccountIndex`. Exactly one must carry
     ///     `credits = nil` (remainder recipient). The Rust side
     ///     enforces both invariants and returns a typed error if
-    ///     either is violated.
+    ///     either is violated. To pay an address this wallet does not
+    ///     own, use [`fundFromAssetLockExternal`] instead — this entry
+    ///     point deliberately keeps rejecting unknown addresses so a
+    ///     typo cannot become an irreversible payment to a stranger.
     ///   - signer: `KeychainSigner` used for any input-witness
     ///     signatures on the address-funding transition. The same
     ///     wallet's `MnemonicResolver` (constructed internally) signs
@@ -685,7 +697,7 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
         recipients: [FundFromAssetLockRecipient],
         signer: KeychainSigner
     ) async throws -> [UpdatedBalance] {
-        try fundFromAssetLockPreflight(recipients: recipients)
+        try Self.fundFromAssetLockPreflight(recipients: recipients)
         let handle = self.handle
         let signerHandle = signer.handle
         let recipientRows = recipients
@@ -699,26 +711,7 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
 
         return try await Task.detached(priority: .userInitiated) {
             () -> [UpdatedBalance] in
-            let ffiAddresses = recipientRows.map { r -> FundingAddressEntryFFI in
-                FundingAddressEntryFFI(
-                    address: PlatformAddressFFI(
-                        address_type: r.addressType,
-                        hash: Self.hashTuple(from: r.hash)
-                    ),
-                    has_balance: r.credits != nil,
-                    balance: r.credits ?? 0
-                )
-            }
-            // Take the fee out of the remainder output. Today the
-            // `None` recipient is structurally the same as the
-            // "change" output on a transfer — it absorbs whatever's
-            // left after explicit outputs + fees.
-            let remainderIndex = UInt16(
-                ffiAddresses.firstIndex(where: { !$0.has_balance }) ?? 0
-            )
-            let feeRows: [FeeStrategyStepFFI] = [
-                FeeStrategyStepFFI(step_type: 1, index: remainderIndex)  // 1 = ReduceOutput
-            ]
+            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
             var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
             let result = withExtendedLifetime((signer, coreSigner)) {
                 ffiAddresses.withUnsafeBufferPointer { addrBp in
@@ -778,7 +771,7 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
                 "outPointTxid must be exactly 32 bytes (was \(outPointTxid.count))"
             )
         }
-        try fundFromAssetLockPreflight(recipients: recipients)
+        try Self.fundFromAssetLockPreflight(recipients: recipients)
         let handle = self.handle
         let signerHandle = signer.handle
         let recipientRows = recipients
@@ -786,37 +779,11 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
 
         return try await Task.detached(priority: .userInitiated) {
             () -> [UpdatedBalance] in
-            var txidTuple: (
-                UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-                UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-                UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-                UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
-            ) = (
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            var outPoint = OutPointFFI(
+                txid: Self.txidTuple(from: outPointTxid),
+                vout: outPointVout
             )
-            outPointTxid.withUnsafeBytes { src in
-                Swift.withUnsafeMutableBytes(of: &txidTuple) { dst in
-                    dst.copyMemory(from: src)
-                }
-            }
-            var outPoint = OutPointFFI(txid: txidTuple, vout: outPointVout)
-            let ffiAddresses = recipientRows.map { r -> FundingAddressEntryFFI in
-                FundingAddressEntryFFI(
-                    address: PlatformAddressFFI(
-                        address_type: r.addressType,
-                        hash: Self.hashTuple(from: r.hash)
-                    ),
-                    has_balance: r.credits != nil,
-                    balance: r.credits ?? 0
-                )
-            }
-            let remainderIndex = UInt16(
-                ffiAddresses.firstIndex(where: { !$0.has_balance }) ?? 0
-            )
-            let feeRows: [FeeStrategyStepFFI] = [
-                FeeStrategyStepFFI(step_type: 1, index: remainderIndex)  // 1 = ReduceOutput
-            ]
+            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
             var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
             let result = withExtendedLifetime((signer, coreSigner)) {
                 ffiAddresses.withUnsafeBufferPointer { addrBp in
@@ -843,11 +810,291 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
         }.value
     }
 
+    // MARK: - Fund an external recipient from a Core asset lock
+
+    /// Pay a THIRD PARTY's platform address from a Core L1 asset lock,
+    /// keeping the remainder (change) on one of this wallet's own
+    /// addresses.
+    ///
+    /// Sibling to [`fundFromAssetLock`]: same orchestration, same
+    /// parameters, same return value. The only delta is on the Rust
+    /// side's recipient pre-flight — explicit-amount recipients may be
+    /// ANY valid P2PKH platform address, not just members of
+    /// `platformAccountIndex`.
+    ///
+    /// Externality is a property of WHICH function you call, not a flag
+    /// on `FundFromAssetLockRecipient` — the same shape the shielded
+    /// funding surface uses. Keep using [`fundFromAssetLock`] for
+    /// self-funding: there a mistyped address is rejected before
+    /// anything is broadcast, while here it is a valid and irreversible
+    /// payment to a stranger.
+    ///
+    /// - Parameters:
+    ///   - amountDuffs: Amount to lock in Core duffs.
+    ///   - fundingAccountIndex: standard-family source index — see
+    ///     [`fundFromAssetLock`].
+    ///   - platformAccountIndex: Platform-payment account that owns the
+    ///     REMAINDER recipient. Explicit-amount recipients are not
+    ///     required to belong to it.
+    ///   - recipients: Exactly one entry must carry `credits = nil` (the
+    ///     remainder, which must be an address of this wallet); at least
+    ///     one entry must carry an explicit amount, otherwise there is
+    ///     no external payment to make and [`fundFromAssetLock`] is the
+    ///     right call.
+    ///   - signer: `KeychainSigner` — see [`fundFromAssetLock`].
+    ///
+    /// Returns `[UpdatedBalance]` for the recipients that resolved to
+    /// this wallet — in practice just the remainder/change address. The
+    /// third party's output is proven and credited on Platform but has
+    /// no local row, so it does not appear here; query its balance to
+    /// observe it.
+    @discardableResult
+    public func fundFromAssetLockExternal(
+        amountDuffs: UInt64,
+        fundingAccountIndex: UInt32,
+        platformAccountIndex: UInt32,
+        recipients: [FundFromAssetLockRecipient],
+        signer: KeychainSigner
+    ) async throws -> [UpdatedBalance] {
+        try Self.fundFromAssetLockExternalPreflight(recipients: recipients)
+        let handle = self.handle
+        let signerHandle = signer.handle
+        let recipientRows = recipients
+        // Constructed on the calling actor so it lives for the entire
+        // detached Task — see `fundFromAssetLock` for why `_ = signer`
+        // is not a substitute.
+        let coreSigner = MnemonicResolver()
+
+        return try await Task.detached(priority: .userInitiated) {
+            () -> [UpdatedBalance] in
+            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
+            var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
+            let result = withExtendedLifetime((signer, coreSigner)) {
+                ffiAddresses.withUnsafeBufferPointer { addrBp in
+                    feeRows.withUnsafeBufferPointer { feeBp in
+                        platform_address_wallet_fund_from_asset_lock_external_signer(
+                            handle,
+                            amountDuffs,
+                            fundingAccountIndex,
+                            platformAccountIndex,
+                            addrBp.baseAddress,
+                            UInt(addrBp.count),
+                            feeBp.baseAddress,
+                            UInt(feeBp.count),
+                            signerHandle,
+                            coreSigner.handle,
+                            &changeset
+                        )
+                    }
+                }
+            }
+            try result.check()
+
+            defer { platform_address_wallet_free_changeset(&changeset) }
+            return Self.decodeChangeset(&changeset)
+        }.value
+    }
+
+    /// Resume a stuck external-recipient funding flow from an
+    /// already-tracked asset lock by outpoint.
+    ///
+    /// Sibling to [`resumeFundFromAssetLock`] (same resume-by-outpoint
+    /// shape) and to [`fundFromAssetLockExternal`] (same relaxed
+    /// recipient rules).
+    ///
+    /// The recipients are a PARAMETER, not something recovered from the
+    /// tracked lock: Rust never learns the destination of an
+    /// address-funding asset lock — it only tracks the L1 outpoint, its
+    /// status and its proof. The host is responsible for round-tripping
+    /// the intended recipient, which is what
+    /// `PersistentAssetLock.recipientPlatformAddressHash` /
+    /// `.recipientIsExternal` record. Resuming with a different
+    /// recipient set pays the new set; the asset lock is a bearer input,
+    /// not a commitment to a destination.
+    ///
+    /// - Parameters:
+    ///   - outPointTxid: 32-byte raw txid (little-endian wire order) —
+    ///     see [`resumeFundFromAssetLock`].
+    ///   - outPointVout: Funding output index.
+    @discardableResult
+    public func resumeFundFromAssetLockExternal(
+        outPointTxid: Data,
+        outPointVout: UInt32,
+        platformAccountIndex: UInt32,
+        recipients: [FundFromAssetLockRecipient],
+        signer: KeychainSigner
+    ) async throws -> [UpdatedBalance] {
+        guard outPointTxid.count == 32 else {
+            throw PlatformWalletError.invalidParameter(
+                "outPointTxid must be exactly 32 bytes (was \(outPointTxid.count))"
+            )
+        }
+        try Self.fundFromAssetLockExternalPreflight(recipients: recipients)
+        let handle = self.handle
+        let signerHandle = signer.handle
+        let recipientRows = recipients
+        let coreSigner = MnemonicResolver()
+
+        return try await Task.detached(priority: .userInitiated) {
+            () -> [UpdatedBalance] in
+            var outPoint = OutPointFFI(
+                txid: Self.txidTuple(from: outPointTxid),
+                vout: outPointVout
+            )
+            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
+            var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
+            let result = withExtendedLifetime((signer, coreSigner)) {
+                ffiAddresses.withUnsafeBufferPointer { addrBp in
+                    feeRows.withUnsafeBufferPointer { feeBp in
+                        platform_address_wallet_resume_fund_from_asset_lock_external_signer(
+                            handle,
+                            &outPoint,
+                            platformAccountIndex,
+                            addrBp.baseAddress,
+                            UInt(addrBp.count),
+                            feeBp.baseAddress,
+                            UInt(feeBp.count),
+                            signerHandle,
+                            coreSigner.handle,
+                            &changeset
+                        )
+                    }
+                }
+            }
+            try result.check()
+
+            defer { platform_address_wallet_free_changeset(&changeset) }
+            return Self.decodeChangeset(&changeset)
+        }.value
+    }
+
+    /// Recipients in the order the Rust side will see them.
+    ///
+    /// `decode_funding_addresses` collects the FFI array into a
+    /// `BTreeMap<PlatformAddress, Option<Credits>>`, and consensus
+    /// resolves `ReduceOutput(index)` positionally against THAT map's key
+    /// order — never against the order the caller happened to list its
+    /// recipients in. `PlatformAddress`'s derived `Ord` orders by variant
+    /// first (P2PKH before P2SH) and then by the 20-byte hash, so
+    /// reproducing it here is a two-key sort.
+    ///
+    /// Sorting before marshalling makes array position and consensus
+    /// output index the same number, which is what lets
+    /// [`remainderStepIndex`] name the remainder output correctly. The
+    /// recipient SET is unaffected — a `BTreeMap` does not care what
+    /// order it was filled in.
+    static func canonicallyOrderedRecipients(
+        _ recipients: [FundFromAssetLockRecipient]
+    ) -> [FundFromAssetLockRecipient] {
+        recipients.sorted { lhs, rhs in
+            if lhs.addressType != rhs.addressType {
+                return lhs.addressType < rhs.addressType
+            }
+            return lhs.hash.lexicographicallyPrecedes(rhs.hash)
+        }
+    }
+
+    /// Position of the remainder (`credits == nil`) recipient within a
+    /// [`canonicallyOrderedRecipients`] list — i.e. the index consensus
+    /// will resolve `ReduceOutput` against.
+    ///
+    /// Callers never supply this index themselves. A positional index
+    /// over a lexicographically-ordered map is a live hazard: adding one
+    /// recipient can shift which output pays the fee, and with a
+    /// third-party payee in the set that means the payee's explicit
+    /// amount silently absorbs the fee instead of the sender's change.
+    /// Computing it here from the canonical order is what prevents that.
+    static func remainderStepIndex(
+        in ordered: [FundFromAssetLockRecipient]
+    ) -> UInt16 {
+        UInt16(ordered.firstIndex(where: { $0.credits == nil }) ?? 0)
+    }
+
+    /// Marshal recipients into the FFI address array plus the matching
+    /// fee strategy.
+    ///
+    /// The fee comes out of the remainder output: the `nil`-credits
+    /// recipient is structurally the "change" output — it absorbs
+    /// whatever is left after the explicit outputs and fees.
+    static func marshalFundingRequest(
+        _ recipients: [FundFromAssetLockRecipient]
+    ) -> (addresses: [FundingAddressEntryFFI], feeStrategy: [FeeStrategyStepFFI]) {
+        let ordered = canonicallyOrderedRecipients(recipients)
+        let addresses = ordered.map { r -> FundingAddressEntryFFI in
+            FundingAddressEntryFFI(
+                address: PlatformAddressFFI(
+                    address_type: r.addressType,
+                    hash: Self.hashTuple(from: r.hash)
+                ),
+                has_balance: r.credits != nil,
+                balance: r.credits ?? 0
+            )
+        }
+        let feeStrategy = [
+            FeeStrategyStepFFI(step_type: 1, index: remainderStepIndex(in: ordered))  // 1 = ReduceOutput
+        ]
+        return (addresses, feeStrategy)
+    }
+
+    /// Copy a 32-byte txid `Data` into the C tuple `OutPointFFI` wants.
+    private static func txidTuple(
+        from data: Data
+    ) -> (
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+    ) {
+        var tuple: (
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+        ) = (
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        )
+        data.withUnsafeBytes { src in
+            Swift.withUnsafeMutableBytes(of: &tuple) { dst in
+                dst.copyMemory(from: src)
+            }
+        }
+        return tuple
+    }
+
+    /// Pre-flight for the external-recipient entry points.
+    ///
+    /// Sibling to [`fundFromAssetLockPreflight`]: every rule there still
+    /// applies verbatim — exactly one remainder, P2PKH only (address
+    /// type `0`), 20-byte hashes. Third-party explicit-amount
+    /// recipients were already permitted by those rules, because
+    /// ownership is not something Swift can check: only the Rust side
+    /// knows which addresses belong to `platformAccountIndex`, and it
+    /// enforces the remaining rule (the remainder must be ours) in
+    /// `fund_from_asset_lock_external`.
+    ///
+    /// The one rule this ADDS: at least one explicit-amount recipient.
+    /// A call with nothing but a remainder makes no external payment at
+    /// all, so it is a caller mistake — [`fundFromAssetLock`] is the
+    /// entry point for pure self-funding, and it validates the
+    /// destination properly.
+    static func fundFromAssetLockExternalPreflight(
+        recipients: [FundFromAssetLockRecipient]
+    ) throws {
+        try Self.fundFromAssetLockPreflight(recipients: recipients)
+        guard recipients.contains(where: { $0.credits != nil }) else {
+            throw PlatformWalletError.invalidParameter(
+                "fundFromAssetLockExternal requires at least one explicit-amount recipient; "
+                    + "a remainder-only request funds nothing externally — use fundFromAssetLock"
+            )
+        }
+    }
+
     /// Validate the recipient list before the FFI sees it. The Rust
     /// side enforces the same invariants — we duplicate them here so
     /// the user gets a synchronous error before paying for the Task
     /// detach + handle marshaling.
-    private func fundFromAssetLockPreflight(
+    static func fundFromAssetLockPreflight(
         recipients: [FundFromAssetLockRecipient]
     ) throws {
         guard !recipients.isEmpty else {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/FundFromAssetLockPlatformAddressView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/FundFromAssetLockPlatformAddressView.swift
@@ -759,6 +759,13 @@ struct FundFromAssetLockPlatformAddressView: View {
         guard let lock = target else { return }
         lock.recipientPlatformAddressHash = recipientHash
         lock.recipientPlatformAddressType = recipientType
+        // This screen only ever funds one of the wallet's OWN platform
+        // addresses (`fundFromAssetLock`), so the recipient hash names
+        // an address that has a `PersistentPlatformAddress` row. Stamp
+        // the discriminator explicitly rather than leaving it `nil`, so
+        // consumers never have to fall back on the legacy
+        // "populated hash implies own" reading.
+        lock.recipientIsExternal = false
         do {
             try modelContext.save()
         } catch {

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Platform/CoreToPlatformIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Platform/CoreToPlatformIntegrationTests.swift
@@ -44,6 +44,140 @@ final class CoreToPlatformIntegrationTests: IntegrationTestCase {
         XCTAssertGreaterThan(try addressWallet.totalCredits(), 0)
     }
 
+    /// Alice's Core funds pay BOB's Platform address.
+    ///
+    /// The end-to-end shape of `fundFromAssetLockExternal`: two
+    /// unrelated wallets, Alice builds the Core asset lock, Bob is
+    /// credited an exact explicit amount, and Alice's own change
+    /// address absorbs the remainder and the fee.
+    ///
+    /// What this pins beyond "it doesn't error":
+    /// - Bob really is credited on Platform, observed from BOB's wallet
+    ///   after a platform-address sync — not inferred from Alice's
+    ///   changeset.
+    /// - Alice's returned changeset carries ONLY her change address.
+    ///   Bob's output is proven and credited, but it resolves to no
+    ///   wallet-owned slot on Alice's side, so reconciliation skips it
+    ///   (the `outcome.resolved == 0` / partial-resolve path). A row for
+    ///   Bob appearing here would mean the wallet had mistaken a
+    ///   third-party payee for one of its own addresses.
+    /// - Alice's change row is persisted, which is what gates
+    ///   `consume_asset_lock` on the Rust side.
+    func testFundExternalRecipientFromCoreAssetLock() async throws {
+        try await env.walletManager.startSpv(config: env.spvConfig)
+        let alice = try await env.makeTestWallet(name: "c2p-external-alice")
+        let bob = try await env.makeTestWallet(name: "c2p-external-bob")
+
+        let coreAddress = try alice.getCoreWallet().nextReceiveAddress()
+        _ = try await env.fund(address: coreAddress, dash: fundingDash)
+        try await alice.waitForSpendable(exactly: fundingDuffs, timeout: 90)
+
+        let aliceChange = try await firstPlatformAddress(
+            walletId: alice.getPlatformWallet().walletId
+        )
+        let bobRecipient = try await firstPlatformAddress(
+            walletId: bob.getPlatformWallet().walletId
+        )
+        XCTAssertNotEqual(
+            aliceChange.hash, bobRecipient.hash,
+            "test setup: the payee must not be one of Alice's own addresses"
+        )
+
+        let signer = KeychainSigner(
+            modelContainer: env.modelContainer,
+            network: .regtest
+        )
+        let aliceAddresses = try alice.getPlatformWallet().platformAddressWallet()
+        let bobAddresses = try bob.getPlatformWallet().platformAddressWallet()
+
+        XCTAssertEqual(
+            try bobAddresses.totalCredits(), 0,
+            "test setup: Bob starts with no platform credits"
+        )
+
+        // 0.1 DASH locked; 0.02 DASH of credits paid to Bob. The rest
+        // (minus the ST fee) comes back to Alice's change address.
+        let assetLockDuffs: UInt64 = 10_000_000
+        // 2_000_000_000 credits == 2_000_000 duffs == 0.02 DASH
+        // (`CREDITS_PER_DUFF` is 1000), comfortably above the
+        // versioned `min_output_amount` of 500_000 credits.
+        let payment: UInt64 = 2_000_000_000
+
+        let updated = try await aliceAddresses.fundFromAssetLockExternal(
+            amountDuffs: assetLockDuffs,
+            fundingAccountIndex: 0,
+            platformAccountIndex: 0,
+            recipients: [
+                .init(
+                    addressType: bobRecipient.type,
+                    hash: bobRecipient.hash,
+                    credits: payment
+                ),
+                .init(addressType: aliceChange.type, hash: aliceChange.hash, credits: nil),
+            ],
+            signer: signer
+        )
+
+        // Only Alice's change output resolves to a wallet-owned slot.
+        XCTAssertEqual(
+            updated.count, 1,
+            "the third party's output must not produce a local balance row"
+        )
+        XCTAssertEqual(updated.first?.hash, aliceChange.hash)
+        XCTAssertGreaterThan(updated.first?.balance ?? 0, 0)
+        XCTAssertFalse(
+            updated.contains(where: { $0.hash == bobRecipient.hash }),
+            "Alice's changeset must never carry Bob's address"
+        )
+
+        // Bob is credited on Platform — observed from Bob's own wallet.
+        try await env.walletManager.syncPlatformAddressNow()
+        try await Wait.until(
+            "Bob's platform address reflects the external funding",
+            timeout: 60,
+            pollInterval: 0.5
+        ) {
+            try bobAddresses.totalCredits() == payment
+        }
+        XCTAssertEqual(
+            try bobAddresses.addressesWithBalances()
+                .first(where: { $0.hash == bobRecipient.hash })?.balance,
+            payment,
+            "Bob must be credited exactly the explicit amount — the fee comes out of "
+                + "Alice's remainder, not out of the payee's output"
+        )
+
+        // Alice's change row reached disk (this is what gates
+        // `consume_asset_lock`), and no row was written for Bob under
+        // Alice's wallet id.
+        let container = env.modelContainer
+        let aliceWalletId = alice.getPlatformWallet().walletId
+        let aliceHash = aliceChange.hash
+        let bobHash = bobRecipient.hash
+        try await Wait.until(
+            "Alice's change address row carries the reconciled balance",
+            timeout: 30,
+            pollInterval: 0.1
+        ) {
+            try await MainActor.run {
+                let ctx = ModelContext(container)
+                let rows = try ctx.fetch(
+                    FetchDescriptor<PersistentPlatformAddress>(
+                        predicate: #Predicate<PersistentPlatformAddress> {
+                            $0.walletId == aliceWalletId
+                        }
+                    )
+                )
+                XCTAssertFalse(
+                    rows.contains(where: { $0.addressHash == bobHash }),
+                    "Bob's address must never be persisted under Alice's wallet"
+                )
+                return rows.first(where: { $0.addressHash == aliceHash })
+                    .map { $0.balance > 0 } ?? false
+            }
+        }
+    }
+
     /// Lowest-index platform address for `walletId`, polled because the
     /// emit lands on the persister's background context.
     private func firstPlatformAddress(

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/FundFromAssetLockRecipientTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/FundFromAssetLockRecipientTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+
+@testable import SwiftDashSDK
+
+/// Pins the two host-side decisions in the asset-lock funding surface:
+/// which recipient pays the fee, and which recipient lists are legal.
+///
+/// The fee-strategy step (`ReduceOutput(index)`) is POSITIONAL, and
+/// consensus resolves that position against the transition's outputs
+/// map — a Rust `BTreeMap<PlatformAddress, Option<Credits>>` keyed by
+/// `PlatformAddress`'s derived `Ord` (P2PKH before P2SH, then hash
+/// bytes ascending). The caller's array order has no bearing on it.
+/// `ManagedPlatformAddressWallet` therefore sorts recipients into that
+/// canonical order before marshalling, so array position and consensus
+/// output index are the same number.
+///
+/// The hazard being guarded: computing the index from an arbitrary
+/// caller-supplied order silently re-targets the fee whenever the
+/// remainder is not first lexicographically. With a third-party payee
+/// in the set — the whole point of `fundFromAssetLockExternal` — that
+/// means the payee's explicit amount absorbs the fee instead of the
+/// sender's change.
+final class FundFromAssetLockRecipientTests: XCTestCase {
+    private typealias Recipient = ManagedPlatformAddressWallet.FundFromAssetLockRecipient
+
+    private func recipient(_ tag: UInt8, credits: UInt64?, type: UInt8 = 0) -> Recipient {
+        Recipient(
+            addressType: type,
+            hash: Data(repeating: tag, count: 20),
+            credits: credits
+        )
+    }
+
+    // MARK: - Canonical ordering / fee targeting
+
+    func testRemainderIndexIsLexicographicNotCallerOrder() {
+        // Caller lists payees first; Alice's change sorts FIRST.
+        let alice = recipient(0x0A, credits: nil)
+        let bob = recipient(0xBB, credits: 500)
+        let carol = recipient(0xCC, credits: 700)
+
+        let ordered = ManagedPlatformAddressWallet.canonicallyOrderedRecipients([bob, carol, alice])
+        XCTAssertEqual(ordered.map(\.hash), [alice.hash, bob.hash, carol.hash])
+
+        let index = ManagedPlatformAddressWallet.remainderStepIndex(in: ordered)
+        XCTAssertEqual(
+            index, 0,
+            "the remainder's lexicographic position is 0, even though the caller listed it last"
+        )
+        XCTAssertNil(ordered[Int(index)].credits)
+    }
+
+    func testRemainderIndexWhenRemainderSortsLast() {
+        // The inverse arrangement: caller lists the remainder first, but
+        // it sorts last. A naive "position in the caller's array" answer
+        // would be 0 and would charge the fee to Alice's payee output.
+        let alice = recipient(0x0A, credits: 500)
+        let bob = recipient(0xBB, credits: 700)
+        let carol = recipient(0xCC, credits: nil)
+
+        let ordered = ManagedPlatformAddressWallet.canonicallyOrderedRecipients([carol, alice, bob])
+        let index = ManagedPlatformAddressWallet.remainderStepIndex(in: ordered)
+        XCTAssertEqual(index, 2)
+        XCTAssertNil(ordered[Int(index)].credits)
+    }
+
+    func testMarshalledFeeStrategyTargetsTheRemainderOutput() {
+        let alice = recipient(0x0A, credits: nil)
+        let bob = recipient(0xBB, credits: 500)
+        let carol = recipient(0xCC, credits: 700)
+
+        let request = ManagedPlatformAddressWallet.marshalFundingRequest([bob, carol, alice])
+
+        XCTAssertEqual(request.feeStrategy.count, 1)
+        XCTAssertEqual(request.feeStrategy[0].step_type, 1, "1 = ReduceOutput")
+
+        let index = Int(request.feeStrategy[0].index)
+        XCTAssertFalse(
+            request.addresses[index].has_balance,
+            "ReduceOutput must name the remainder output, not an explicit-amount payee"
+        )
+        // And the marshalled array is in the canonical order the Rust
+        // BTreeMap will reproduce, which is what makes the index valid.
+        let hashes = request.addresses.map { entry in
+            withUnsafeBytes(of: entry.address.hash) { Data($0) }
+        }
+        XCTAssertEqual(hashes, [alice.hash, bob.hash, carol.hash])
+    }
+
+    func testCanonicalOrderPutsP2PKHBeforeP2SH() {
+        // `PlatformAddress` is a Rust enum: the variant discriminant
+        // orders before the payload. (P2SH is rejected downstream, but
+        // the ordering rule is part of the contract being mirrored.)
+        let p2sh = recipient(0x01, credits: 500, type: 1)
+        let p2pkh = recipient(0xFF, credits: nil, type: 0)
+
+        let ordered = ManagedPlatformAddressWallet.canonicallyOrderedRecipients([p2sh, p2pkh])
+        XCTAssertEqual(ordered.map(\.addressType), [0, 1])
+    }
+
+    // MARK: - Preflight
+
+    func testExternalPreflightAcceptsThirdPartyPayeeWithOwnRemainder() throws {
+        try ManagedPlatformAddressWallet.fundFromAssetLockExternalPreflight(
+            recipients: [recipient(0xBB, credits: 500), recipient(0x0A, credits: nil)]
+        )
+    }
+
+    func testExternalPreflightRejectsRemainderOnlyRequest() {
+        // Nothing is being paid externally — that is a call-site mistake,
+        // and `fundFromAssetLock` validates the destination properly.
+        XCTAssertThrowsError(
+            try ManagedPlatformAddressWallet.fundFromAssetLockExternalPreflight(
+                recipients: [recipient(0x0A, credits: nil)]
+            )
+        )
+    }
+
+    func testPreflightsRejectP2SHAndBadHashLengths() {
+        let p2shSet = [recipient(0xBB, credits: 500, type: 1), recipient(0x0A, credits: nil)]
+        XCTAssertThrowsError(
+            try ManagedPlatformAddressWallet.fundFromAssetLockPreflight(recipients: p2shSet)
+        )
+        XCTAssertThrowsError(
+            try ManagedPlatformAddressWallet.fundFromAssetLockExternalPreflight(recipients: p2shSet)
+        )
+
+        let shortHash = [
+            Recipient(addressType: 0, hash: Data(repeating: 0xBB, count: 19), credits: 500),
+            recipient(0x0A, credits: nil),
+        ]
+        XCTAssertThrowsError(
+            try ManagedPlatformAddressWallet.fundFromAssetLockPreflight(recipients: shortHash)
+        )
+        XCTAssertThrowsError(
+            try ManagedPlatformAddressWallet.fundFromAssetLockExternalPreflight(
+                recipients: shortHash)
+        )
+    }
+
+    func testPreflightsRejectWrongRemainderCardinality() {
+        for recipients in [
+            [Recipient](),
+            [recipient(0x0A, credits: 500), recipient(0xBB, credits: 700)],
+            [recipient(0x0A, credits: nil), recipient(0xBB, credits: nil)],
+        ] {
+            XCTAssertThrowsError(
+                try ManagedPlatformAddressWallet.fundFromAssetLockPreflight(recipients: recipients)
+            )
+            XCTAssertThrowsError(
+                try ManagedPlatformAddressWallet.fundFromAssetLockExternalPreflight(
+                    recipients: recipients)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Today a Core-chain asset lock can only fund Platform addresses that belong to the sender's own managed wallet account. This adds the ability to fund an **external third party's** Platform address (Alice pays Bob) from a Core asset lock, with the sender's own change address absorbing the remainder and the fee.

The capability already exists at the protocol layer — the only blocker was a wallet-side pre-flight.

**No consensus / rs-dpp / rs-drive-abci production changes are needed.** Consensus never validates output ownership: `AddressFundingFromAssetLockTransition` treats its outputs map as opaque destinations, and the pre-existing `test_simple_asset_lock_funding_to_single_address` already funds arbitrary unrelated addresses. This PR adds a drive-abci test that documents that property explicitly rather than changing any validator.

**rs-sdk needs no changes either.** `packages/rs-sdk/src/platform/transition/top_up_address.rs` is ownership-agnostic — it only does set-equality checks between the requested recipients and the proof-attested `AddressInfos`, which holds identically whether an output is ours or a stranger's.

## What was done?

### `packages/rs-platform-wallet`

- New `PlatformAddressWallet::fund_from_asset_lock_external`, a sibling of `fund_from_asset_lock`. Same signature, same pipeline — both now delegate to a shared `fund_from_asset_lock_inner` whose single point of divergence is a `RecipientOwnership` mode.
  - Explicit-amount (`Some(credits)`) outputs may be **any** valid P2PKH platform address.
  - The single remainder (`None`) output **must still be owned** by `platform_account_index`.
  - P2SH stays rejected for every recipient.
- The existing `fund_from_asset_lock` is deliberately **not** relaxed. For every current caller a mistyped recipient is caught today by the membership check; relaxing it in place would silently convert "typo'd address → typed error before anything is broadcast" into "typo'd address → asset-lock credits irrecoverably delivered to a stranger". Opting in by function name confines that failure mode to callers that mean to pay someone else.
- **Why the remainder must remain sender-owned:** the asset lock is consumed in full, so the `None` bucket receives everything left after the explicit outputs and the fee — i.e. the change. Sending change to a stranger is never the intent, and a caller bug that mixed up which entry was the remainder would leak the *entire lock value* rather than the intended payment. Consensus does not care; this is purely a wallet-level safety rail, and the new drive-abci test is the standing evidence of that distinction.
- The pre-flight is factored into a pure, wallet-free `validate_recipient_map` generic over an ownership oracle, so the rules are unit-testable without constructing a `PlatformAddressWallet`. Shape checks (`validate_recipient_shape`) are shared by both modes.
- **No resume variant at this layer.** Resuming is expressed as `AssetLockFunding::FromExistingAssetLock`, a *value* of the `funding` parameter, so both public entry points already cover fresh-build and resume. (The FFI does expose distinct resume symbols, because a C ABI cannot take a Rust enum.)

### Reconciliation / persistence: no changes needed

`reconcile_address_infos_with_persistence` (`packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs:382-392`) already tolerates third-party recipients: it handles `outcome.resolved == 0` with a warning whose text literally reads *"Expected when every address belongs to a third party"*, and still returns `persisted = true` so `consume_asset_lock` fires correctly. `validate_address_infos_complete` is proof-level and ownership-agnostic, so the third party's output is still proven.

The **mixed** own+external case (the one this feature actually produces) is now pinned by a new provider test: only the sender's remainder output resolves and enters the committed seed, `resolved > 0` so the normal apply-and-persist path runs, and the stranger's address never reaches disk.

### `packages/rs-platform-wallet-ffi`

- `platform_address_wallet_fund_from_asset_lock_external_signer`
- `platform_address_wallet_resume_fund_from_asset_lock_external_signer`

Both reuse `FundingAddressEntryFFI`, `decode_funding_addresses` and the existing fee-strategy parsing verbatim. The existing symbols' ABI is untouched; the P2SH rejection in `TryFrom<PlatformAddressFFI> for PlatformAddress` is unchanged. `src/platform_addresses/mod.rs` already glob-re-exports the module, so no wiring change was needed, and cbindgen picks the new symbols up automatically (verified in the generated header).

Resume takes the recipients as **caller-supplied parameters** rather than recovering them from persisted state, matching the shielded resume entry point: Rust never learns the destination of an address-funding asset lock — only the outpoint, its status and its proof. The consequence is documented on the function: resuming with a different recipient set pays the new set, because the asset lock is a bearer input, not a commitment to a destination.

### `packages/swift-sdk`

- `fundFromAssetLockExternal(...)` / `resumeFundFromAssetLockExternal(...)` as siblings of the existing pair.
- `FundFromAssetLockRecipient` is reused unchanged — **no `isExternal` flag**. Externality is a property of which function you call, matching the shielded side, which keeps "am I allowed to pay a stranger?" a single auditable decision at the call site.
- `fundFromAssetLockExternalPreflight` keeps every rule of the base preflight (exactly one remainder, P2PKH only, 20-byte hashes) and adds one: at least one explicit-amount recipient, since a remainder-only request pays nobody externally and `fundFromAssetLock` is the right entry point for pure self-funding.
- **Fee-strategy index fix (see "Breaking Changes" — behavioural, not API).** The `ReduceOutput(remainderIndex)` step is still computed Swift-side from the recipient array (callers never pass positional indices), but it is now computed over the **canonical order** rather than the caller's array order, and marshalling emits the array in that same order. Consensus resolves `ReduceOutput(i)` against the outputs `BTreeMap`'s lexicographic key order (`PlatformAddress`'s derived `Ord`: P2PKH before P2SH, then hash bytes) — so the previous "position in the caller's array" computation named the wrong output whenever the remainder was not first lexicographically. Sorting before marshalling makes array position and consensus index the same number by construction. The logic is centralised in `canonicallyOrderedRecipients` / `remainderStepIndex` / `marshalFundingRequest` and shared by all four entry points.
- `PersistentAssetLock` gains `recipientIsExternal: Bool?` in the funding-type-4 field family, following the file's "one typed field-family per funding type" convention and doc style. Consumers currently read a populated recipient hash as "this was my own top-up" (dashwallet-ios `PlatformAddressActivityStore.matchesOwnAssetLockTopUp`), so without a discriminator an external send would be misclassified as an incoming own credit. **No migration is required:** adding an optional property to an existing `@Model` is handled by SwiftData lightweight migration, the model *list* is unchanged, and `DashMigrationPlan` is therefore untouched — the same rationale already documented on `recipientPlatformAddressHash`.
- `SwiftExampleApp`'s own-funding screen now stamps `recipientIsExternal = false` alongside the hash it already wrote, so in-repo rows are never ambiguous.

## How Has This Been Tested?

**Executed, all passing:**

| Suite | Result |
|---|---|
| `cargo test -p platform-wallet --lib` | **770 passed, 0 failed** (includes 11 new recipient-validation tests + the new mixed own/external provider test) |
| `cargo test -p platform-wallet-ffi --lib` | **297 passed, 0 failed** (includes 3 new FFI ordering/decoding tests) |
| `cargo test -p drive-abci address_funding_from_asset_lock` | **112 passed, 0 failed** (includes the new `test_asset_lock_funding_to_unrelated_third_party_address`) |
| `swift test --filter FundFromAssetLockRecipientTests` (macOS slice) | **8 passed, 0 failed** |
| `cargo check` / `cargo clippy` on `platform-wallet` + `platform-wallet-ffi` (`--tests`) | clean — zero warnings from either crate |
| `cargo fmt` | applied |
| `swift build --target SwiftDashSDK` + `swift build --build-tests` | clean; the integration target compiles under its `-warnings-as-errors` setting |

New test coverage:

1. **Recipient validation unit tests** (`fund_from_asset_lock.rs`) — there were previously none for `validate_recipient_addresses`. Covers: all-owned (legacy fn still rejects an external explicit recipient), external explicit + owned remainder (accepted), several external recipients (accepted), external remainder (rejected, with the remainder-specific message), nothing owned (rejected), P2SH in both modes, zero remainders, two remainders, empty map, and the BTreeMap remainder-index mapping.
2. **Mixed own+external reconciliation** (`provider.rs`) — patterned on the existing `commit_reconciliation_pool_fallback_skips_untracked_account`.
3. **drive-abci consensus test** — clones the shape of `test_simple_asset_lock_funding_to_single_address` with an explicit-amount unrelated recipient plus a remainder output, and asserts the third party is credited *exactly* the requested amount while the sender's change absorbs the fee.
4. **Fee-strategy remainder-index tests** — in Rust (`platform-wallet` map ordering, `platform-wallet-ffi` decode round-trip) and in Swift (`FundFromAssetLockRecipientTests`), each pinning that the index tracks lexicographic position when the remainder is *not* first in the caller's list, and its mirror image.

**Authored but NOT executed:**

- `CoreToPlatformIntegrationTests.testFundExternalRecipientFromCoreAssetLock` — the Alice-Core → Bob-Platform end-to-end test. It follows the file's existing conventions and **compiles cleanly**, but requires a running local dashmate devnet (`RUN_INTEGRATION_TESTS=1`), which is not available in the authoring environment. It asserts Bob's credited balance from *Bob's own wallet* after a platform-address sync, that Alice's returned changeset carries only her change address, and that no `PersistentPlatformAddress` row for Bob is written under Alice's wallet id.
- `SwiftExampleApp` was not built. The `DashSDKFFI.xcframework` was built for the **macOS slice only** (enough to compile and test the Swift package); the iOS-simulator slice needed by the example app was not produced. The example-app change is a single property assignment and was syntax-checked with `swiftc -parse`, nothing more.
- Kotlin/JNI (`packages/rs-unified-sdk-jni`) was intentionally not extended with the new entry points — see Deferred below.

## Breaking Changes

None to any public API or FFI ABI. Existing Rust, FFI and Swift entry points keep their exact signatures.

One **behavioural** change worth calling out: on the Swift side, `fundFromAssetLock` / `resumeFundFromAssetLock` now target the fee at the true remainder output. Previously, a multi-recipient call whose remainder was not first lexicographically charged the fee to a different output. Because every recipient in that flow belonged to the caller, the old behaviour only misallocated the fee among the user's own addresses — no funds were ever at risk — but it had to be corrected before a third-party payee could be in the set.

Deliberately deferred:

- **P2SH recipients.** Relaxing the P2PKH-only restriction for pure-recipient outputs is a separate follow-up. It is not just a wallet-side rule: `TryFrom<PlatformAddressFFI> for PlatformAddress` rejects the P2SH discriminant outright, so lifting it in the wallet alone would not make P2SH reachable from the SDKs.
- **Kotlin/JNI bridge** for the new entry points, mirroring the existing `platform_address_wallet_fund_from_asset_lock_signer` binding.
- **A companion `dashwallet-ios` PR will follow** that persists the recipient (hash, type and the new `recipientIsExternal` discriminator) and adds the `.coreToPlatform` send route. This PR only adds the model field; it does not change persistence behaviour.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fund third-party platform addresses directly from Core asset locks.
  * Resume existing asset-lock funding while sending specified amounts to external recipients.
  * Automatically return change and cover fees using the wallet’s own address.
  * Added recipient tracking for external asset-lock payments.
* **Bug Fixes**
  * Improved recipient ordering and fee handling for consistent funding results.
  * Prevented third-party addresses from being incorrectly recorded as wallet-owned balances.
* **Tests**
  * Added coverage for external recipients, validation, change handling, and cross-wallet funding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->