### PR TITLE
feat(platform-wallet): external recipient support for asset-lock address funding

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
@@ -1122,6 +1122,121 @@ mod tests {
             );
         }
 
+        /// Consensus does not validate output OWNERSHIP: an
+        /// `AddressFundingFromAssetLock` may credit an address that has
+        /// no relationship whatsoever to the asset lock's one-time
+        /// credit-output key. This is what makes "Alice's Core funds pay
+        /// Bob's Platform address" possible without any protocol change.
+        ///
+        /// Shaped like `test_simple_asset_lock_funding_to_single_address`
+        /// but made explicit about the intent, and with balance
+        /// assertions that pin WHO ends up with WHAT:
+        /// - the unrelated third party's explicit output is credited to
+        ///   the exact requested amount, and
+        /// - the fee comes out of the remainder output, because
+        ///   `ReduceOutput(0)` resolves against the outputs map's
+        ///   lexicographic key order and the remainder address sorts
+        ///   first here.
+        ///
+        /// The wallet layer (`platform-wallet`) is where the
+        /// own-vs-external distinction lives, purely as a safety rail —
+        /// see `fund_from_asset_lock_external`. This test is the
+        /// standing evidence that the rail is a wallet policy and not a
+        /// protocol requirement.
+        #[tokio::test]
+        async fn test_asset_lock_funding_to_unrelated_third_party_address() {
+            let platform_version = PlatformVersion::latest();
+            let platform_config = PlatformConfig {
+                testing_configs: PlatformTestConfig {
+                    disable_instant_lock_signature_verification: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
+            let platform = TestPlatformBuilder::new()
+                .with_config(platform_config)
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let signer = TestAddressSigner::new();
+            let mut rng = StdRng::seed_from_u64(567);
+            let (asset_lock_proof, asset_lock_pk) = create_asset_lock_proof_with_key(&mut rng);
+
+            // `remainder` stands in for the sender's own change address;
+            // `third_party` is an address the sender does not control and
+            // that the protocol has never seen. Their hashes are chosen so
+            // that `remainder` sorts FIRST in the outputs `BTreeMap`
+            // (`PlatformAddress`'s derived `Ord`), which is what makes
+            // `ReduceOutput(0)` charge the fee to the change rather than to
+            // the payee.
+            let remainder = create_platform_address(0x0A);
+            let third_party = create_platform_address(0xBB);
+            assert!(
+                remainder < third_party,
+                "test setup: the remainder address must sort first"
+            );
+
+            let payment = dash_to_credits!(0.5);
+
+            // No inputs — the asset lock is the sole funding source, so
+            // there is no address whose ownership could be attested here
+            // even in principle.
+            let inputs = BTreeMap::new();
+            let mut outputs = BTreeMap::new();
+            outputs.insert(third_party, Some(payment));
+            outputs.insert(remainder, None);
+
+            let transition = create_signed_address_funding_from_asset_lock_transition(
+                asset_lock_proof,
+                &asset_lock_pk,
+                &signer,
+                inputs,
+                outputs,
+                vec![AddressFundsFeeStrategyStep::ReduceOutput(0)],
+            )
+            .await;
+
+            let result = transition.serialize_to_bytes().expect("should serialize");
+
+            let platform_state = platform.state.load();
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[result],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+            );
+
+            // The stranger got exactly what was asked for — untouched by
+            // the fee, because the fee strategy points at the remainder.
+            assert_eq!(
+                get_address_balance(&platform, third_party, &transaction),
+                payment,
+                "the unrelated third party must be credited the full explicit amount"
+            );
+            // And the sender's change absorbed the rest of the lock, minus
+            // the fee.
+            let change = get_address_balance(&platform, remainder, &transaction);
+            assert!(
+                change > 0,
+                "the remainder output must still hold the post-fee change"
+            );
+        }
+
         #[tokio::test]
         async fn test_asset_lock_funding_combined_with_existing_address_input() {
             let platform_version = PlatformVersion::latest();

--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
@@ -41,6 +41,22 @@ use crate::{unwrap_option_or_return, unwrap_result_or_return};
 /// `platform_account_index` selects which platform-payment account the
 /// recipient addresses belong to.
 ///
+/// ## `fee_strategy` / `fee_strategy_count` are IGNORED
+///
+/// Retained for ABI compatibility only; pass `NULL` / `0`. The fee
+/// strategy for this transition is derived inside `platform-wallet`
+/// (`remainder_fee_strategy`) from the recipient map itself.
+///
+/// `ReduceOutput(i)` is positional and consensus resolves `i` against
+/// the outputs `BTreeMap`'s LEXICOGRAPHIC key order
+/// (`PlatformAddress`'s derived `Ord`: P2PKH before P2SH, then hash
+/// bytes) — never the order entries appear in `addresses`. A caller
+/// holding a flat array cannot compute that index without
+/// reimplementing a consensus ordering rule, and every binding that
+/// tried silently mis-targeted the fee whenever the remainder was not
+/// also first lexicographically. So the index is no longer the
+/// caller's to supply.
+///
 /// # Safety
 /// - `signer_address_handle` must be a valid, non-destroyed
 ///   `*mut SignerHandle` produced by `dash_sdk_signer_create_with_ctx`.
@@ -58,8 +74,8 @@ pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_signer(
     platform_account_index: u32,
     addresses: *const FundingAddressEntryFFI,
     addresses_count: usize,
-    fee_strategy: *const FeeStrategyStepFFI,
-    fee_strategy_count: usize,
+    _fee_strategy: *const FeeStrategyStepFFI,
+    _fee_strategy_count: usize,
     signer_address_handle: *mut SignerHandle,
     core_signer_handle: *mut MnemonicResolverHandle,
     out_changeset: *mut PlatformAddressChangeSetFFI,
@@ -77,8 +93,6 @@ pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_signer(
         Ok(m) => m,
         Err(e) => return e,
     };
-
-    let fee = parse_fee_strategy(fee_strategy, fee_strategy_count);
 
     // Round-trip both handles through `usize` so the spawned future's
     // capture is `Send + 'static` (raw pointers are `!Send`).
@@ -111,7 +125,6 @@ pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_signer(
                     },
                     platform_account_index,
                     address_map,
-                    fee,
                     address_signer,
                     &asset_lock_signer,
                     None,
@@ -137,6 +150,22 @@ pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_signer(
 /// but the address-funding ST never completed, and the user wants
 /// to consume the lock from the "Unused Asset Locks" picker.
 ///
+/// ## `fee_strategy` / `fee_strategy_count` are IGNORED
+///
+/// Retained for ABI compatibility only; pass `NULL` / `0`. The fee
+/// strategy for this transition is derived inside `platform-wallet`
+/// (`remainder_fee_strategy`) from the recipient map itself.
+///
+/// `ReduceOutput(i)` is positional and consensus resolves `i` against
+/// the outputs `BTreeMap`'s LEXICOGRAPHIC key order
+/// (`PlatformAddress`'s derived `Ord`: P2PKH before P2SH, then hash
+/// bytes) — never the order entries appear in `addresses`. A caller
+/// holding a flat array cannot compute that index without
+/// reimplementing a consensus ordering rule, and every binding that
+/// tried silently mis-targeted the fee whenever the remainder was not
+/// also first lexicographically. So the index is no longer the
+/// caller's to supply.
+///
 /// # Safety
 /// - `out_point` must be a valid, non-null pointer to an
 ///   `OutPointFFI` (32-byte raw txid + u32 vout). The caller retains
@@ -151,8 +180,8 @@ pub unsafe extern "C" fn platform_address_wallet_resume_fund_from_asset_lock_sig
     platform_account_index: u32,
     addresses: *const FundingAddressEntryFFI,
     addresses_count: usize,
-    fee_strategy: *const FeeStrategyStepFFI,
-    fee_strategy_count: usize,
+    _fee_strategy: *const FeeStrategyStepFFI,
+    _fee_strategy_count: usize,
     signer_address_handle: *mut SignerHandle,
     core_signer_handle: *mut MnemonicResolverHandle,
     out_changeset: *mut PlatformAddressChangeSetFFI,
@@ -171,8 +200,6 @@ pub unsafe extern "C" fn platform_address_wallet_resume_fund_from_asset_lock_sig
         Ok(m) => m,
         Err(e) => return e,
     };
-
-    let fee = parse_fee_strategy(fee_strategy, fee_strategy_count);
 
     let out_point_ffi = *out_point;
     let resume_outpoint = dashcore::OutPoint {
@@ -206,7 +233,6 @@ pub unsafe extern "C" fn platform_address_wallet_resume_fund_from_asset_lock_sig
                     },
                     platform_account_index,
                     address_map,
-                    fee,
                     address_signer,
                     &asset_lock_signer,
                     None,
@@ -286,13 +312,21 @@ pub(super) unsafe fn decode_funding_addresses(
 /// rejected before anything is broadcast, whereas here it is a valid
 /// (and irreversible) payment to a stranger.
 ///
-/// `fee_strategy` is positional over the outputs map's LEXICOGRAPHIC
-/// order (`PlatformAddress`'s derived `Ord`: P2PKH before P2SH, then
-/// hash bytes), NOT over the order entries appear in `addresses` —
-/// `decode_funding_addresses` collects into a `BTreeMap`. Callers must
-/// compute `ReduceOutput(index)` against that ordering; the Swift SDK
-/// does so by sorting its recipient array into the same canonical order
-/// before marshalling.
+/// ## `fee_strategy` / `fee_strategy_count` are IGNORED
+///
+/// Retained for ABI compatibility only; pass `NULL` / `0`. The fee
+/// strategy for this transition is derived inside `platform-wallet`
+/// (`remainder_fee_strategy`) from the recipient map itself.
+///
+/// `ReduceOutput(i)` is positional and consensus resolves `i` against
+/// the outputs `BTreeMap`'s LEXICOGRAPHIC key order
+/// (`PlatformAddress`'s derived `Ord`: P2PKH before P2SH, then hash
+/// bytes) — never the order entries appear in `addresses`. A caller
+/// holding a flat array cannot compute that index without
+/// reimplementing a consensus ordering rule, and every binding that
+/// tried silently mis-targeted the fee whenever the remainder was not
+/// also first lexicographically. So the index is no longer the
+/// caller's to supply.
 ///
 /// # Safety
 /// - `signer_address_handle` / `core_signer_handle` — see
@@ -307,8 +341,8 @@ pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_external_s
     platform_account_index: u32,
     addresses: *const FundingAddressEntryFFI,
     addresses_count: usize,
-    fee_strategy: *const FeeStrategyStepFFI,
-    fee_strategy_count: usize,
+    _fee_strategy: *const FeeStrategyStepFFI,
+    _fee_strategy_count: usize,
     signer_address_handle: *mut SignerHandle,
     core_signer_handle: *mut MnemonicResolverHandle,
     out_changeset: *mut PlatformAddressChangeSetFFI,
@@ -324,8 +358,6 @@ pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_external_s
         Ok(m) => m,
         Err(e) => return e,
     };
-
-    let fee = parse_fee_strategy(fee_strategy, fee_strategy_count);
 
     let signer_addr = signer_address_handle as usize;
     let core_signer_addr = core_signer_handle as usize;
@@ -353,7 +385,6 @@ pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_external_s
                     },
                     platform_account_index,
                     address_map,
-                    fee,
                     address_signer,
                     &asset_lock_signer,
                     None,
@@ -395,6 +426,22 @@ pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_external_s
 /// what `PersistentAssetLock.recipientPlatformAddressHash` /
 /// `recipientIsExternal` exist for on the Swift side).
 ///
+/// ## `fee_strategy` / `fee_strategy_count` are IGNORED
+///
+/// Retained for ABI compatibility only; pass `NULL` / `0`. The fee
+/// strategy for this transition is derived inside `platform-wallet`
+/// (`remainder_fee_strategy`) from the recipient map itself.
+///
+/// `ReduceOutput(i)` is positional and consensus resolves `i` against
+/// the outputs `BTreeMap`'s LEXICOGRAPHIC key order
+/// (`PlatformAddress`'s derived `Ord`: P2PKH before P2SH, then hash
+/// bytes) — never the order entries appear in `addresses`. A caller
+/// holding a flat array cannot compute that index without
+/// reimplementing a consensus ordering rule, and every binding that
+/// tried silently mis-targeted the fee whenever the remainder was not
+/// also first lexicographically. So the index is no longer the
+/// caller's to supply.
+///
 /// # Safety
 /// - `out_point` must be a valid, non-null pointer to an `OutPointFFI`
 ///   (32-byte raw txid + u32 vout). The caller retains ownership.
@@ -408,8 +455,8 @@ pub unsafe extern "C" fn platform_address_wallet_resume_fund_from_asset_lock_ext
     platform_account_index: u32,
     addresses: *const FundingAddressEntryFFI,
     addresses_count: usize,
-    fee_strategy: *const FeeStrategyStepFFI,
-    fee_strategy_count: usize,
+    _fee_strategy: *const FeeStrategyStepFFI,
+    _fee_strategy_count: usize,
     signer_address_handle: *mut SignerHandle,
     core_signer_handle: *mut MnemonicResolverHandle,
     out_changeset: *mut PlatformAddressChangeSetFFI,
@@ -426,8 +473,6 @@ pub unsafe extern "C" fn platform_address_wallet_resume_fund_from_asset_lock_ext
         Ok(m) => m,
         Err(e) => return e,
     };
-
-    let fee = parse_fee_strategy(fee_strategy, fee_strategy_count);
 
     let out_point_ffi = *out_point;
     let resume_outpoint = dashcore::OutPoint {
@@ -461,7 +506,6 @@ pub unsafe extern "C" fn platform_address_wallet_resume_fund_from_asset_lock_ext
                     },
                     platform_account_index,
                     address_map,
-                    fee,
                     address_signer,
                     &asset_lock_signer,
                     None,
@@ -491,78 +535,47 @@ mod tests {
         }
     }
 
-    /// Pins the contract the SDKs' fee-strategy computation depends on:
-    /// `ReduceOutput(index)` is resolved by consensus against the
-    /// outputs `BTreeMap`'s key order, and `decode_funding_addresses`
-    /// builds that map. So when the caller hands us a canonically
-    /// sorted array (P2PKH before P2SH, then hash bytes ascending — the
-    /// derived `Ord` on `PlatformAddress`), array position and
-    /// consensus output index are the SAME number.
-    ///
-    /// The hazard this guards: a caller that computes the remainder
-    /// index from its own arbitrary array order silently re-targets the
-    /// fee onto a different output whenever the remainder is not first
-    /// lexicographically. With a third-party recipient in the set, that
-    /// means the payee's explicit amount pays the fee instead of the
-    /// sender's change.
+    /// `decode_funding_addresses` is a pure marshalling step: the array
+    /// becomes a set, and the caller's listing order carries no meaning
+    /// downstream. Pinned because it is what lets every binding hand us
+    /// recipients in whatever order it has them — the fee-paying
+    /// output's consensus index is derived in `platform-wallet` from
+    /// the resulting map, not from array position.
     #[test]
-    fn decoded_map_order_matches_canonically_sorted_input() {
-        // Alice (0x0A) is the remainder; Bob (0xBB) and Carol (0xCC)
-        // take explicit amounts. Alice sorts FIRST, so the remainder
-        // index is 0 even though a caller listing "payees first" would
-        // have naively computed 2.
-        let canonical = [
-            entry(0, 0x0A, None),
+    fn decoding_is_order_insensitive() {
+        let listed_payees_first = [
             entry(0, 0xBB, Some(500)),
             entry(0, 0xCC, Some(700)),
+            entry(0, 0x0A, None),
+        ];
+        let listed_remainder_first = [
+            entry(0, 0x0A, None),
+            entry(0, 0xCC, Some(700)),
+            entry(0, 0xBB, Some(500)),
         ];
 
-        let map = unsafe { decode_funding_addresses(canonical.as_ptr(), canonical.len()) }
-            .expect("valid entries decode");
+        let a = unsafe {
+            decode_funding_addresses(listed_payees_first.as_ptr(), listed_payees_first.len())
+        }
+        .expect("valid entries decode");
+        let b = unsafe {
+            decode_funding_addresses(
+                listed_remainder_first.as_ptr(),
+                listed_remainder_first.len(),
+            )
+        }
+        .expect("valid entries decode");
 
-        let decoded_order: Vec<PlatformAddress> = map.keys().copied().collect();
-        let input_order: Vec<PlatformAddress> = canonical
-            .iter()
-            .map(|e| PlatformAddress::try_from(e.address).expect("valid address"))
-            .collect();
+        assert_eq!(a, b, "the decoded map must not depend on array order");
         assert_eq!(
-            decoded_order, input_order,
-            "a canonically sorted input array must survive the BTreeMap round trip in order"
+            a.keys().copied().collect::<Vec<_>>(),
+            vec![
+                PlatformAddress::P2pkh([0x0A; 20]),
+                PlatformAddress::P2pkh([0xBB; 20]),
+                PlatformAddress::P2pkh([0xCC; 20]),
+            ],
+            "keys land in PlatformAddress's derived Ord regardless of input order"
         );
-
-        let remainder_index = canonical
-            .iter()
-            .position(|e| !e.has_balance)
-            .expect("exactly one remainder");
-        assert_eq!(remainder_index, 0);
-        assert_eq!(
-            map.get(&decoded_order[remainder_index]),
-            Some(&None),
-            "ReduceOutput(remainder_index) must land on the None (remainder) output"
-        );
-    }
-
-    /// The inverse arrangement: the remainder sorts LAST. Pins that the
-    /// index tracks lexicographic position rather than being pinned to
-    /// 0 or to the caller's listing order.
-    #[test]
-    fn remainder_index_tracks_lexicographic_position() {
-        let canonical = [
-            entry(0, 0x0A, Some(500)),
-            entry(0, 0xBB, Some(700)),
-            entry(0, 0xCC, None),
-        ];
-
-        let map = unsafe { decode_funding_addresses(canonical.as_ptr(), canonical.len()) }
-            .expect("valid entries decode");
-        let decoded_order: Vec<PlatformAddress> = map.keys().copied().collect();
-
-        let remainder_index = canonical
-            .iter()
-            .position(|e| !e.has_balance)
-            .expect("exactly one remainder");
-        assert_eq!(remainder_index, 2);
-        assert_eq!(map.get(&decoded_order[remainder_index]), Some(&None));
     }
 
     #[test]
@@ -570,6 +583,14 @@ mod tests {
         let entries = [entry(0, 0x0A, Some(500)), entry(0, 0x0A, None)];
         let err = unsafe { decode_funding_addresses(entries.as_ptr(), entries.len()) }
             .expect_err("duplicates must be rejected");
+        assert_eq!(err.code, PlatformWalletFFIResultCode::ErrorInvalidParameter);
+    }
+
+    #[test]
+    fn rejects_unknown_address_type() {
+        let entries = [entry(9, 0x0A, None)];
+        let err = unsafe { decode_funding_addresses(entries.as_ptr(), entries.len()) }
+            .expect_err("an unknown address-type discriminant must be rejected");
         assert_eq!(err.code, PlatformWalletFFIResultCode::ErrorInvalidParameter);
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
@@ -125,6 +125,10 @@ pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_signer(
                     },
                     platform_account_index,
                     address_map,
+                    // Vestigial: the Rust method retains this argument
+                    // for source compatibility and ignores it, deriving
+                    // the remainder strategy from `address_map`.
+                    Vec::new(),
                     address_signer,
                     &asset_lock_signer,
                     None,
@@ -233,6 +237,8 @@ pub unsafe extern "C" fn platform_address_wallet_resume_fund_from_asset_lock_sig
                     },
                     platform_account_index,
                     address_map,
+                    // Vestigial: see the sibling call site above.
+                    Vec::new(),
                     address_signer,
                     &asset_lock_signer,
                     None,
@@ -329,9 +335,36 @@ pub(super) unsafe fn decode_funding_addresses(
 /// caller's to supply.
 ///
 /// # Safety
-/// - `signer_address_handle` / `core_signer_handle` — see
-///   [`platform_address_wallet_fund_from_asset_lock_signer`]. Same
-///   ownership and validity contract.
+/// - `addresses` must be non-null. When `addresses_count > 0` it must
+///   point to `addresses_count` consecutive, properly aligned and
+///   initialized `FundingAddressEntryFFI` values inside a single
+///   allocation, and stay readable and unmutated for the whole call.
+///   `addresses_count` must not exceed `isize::MAX` bytes' worth of
+///   entries. A `0` count is short-circuited before any dereference, so
+///   a dangling non-null sentinel is sound in that case only.
+/// - `fee_strategy` / `fee_strategy_count` are never read (see above),
+///   so they carry no validity obligation at all — any value, including
+///   a dangling or misaligned pointer, is sound. Pass `NULL` / `0`.
+/// - `out_changeset` must be non-null, properly aligned and valid for
+///   writes of one `PlatformAddressChangeSetFFI`. It is overwritten
+///   unconditionally (with an empty sentinel first, then the result),
+///   so it need not be initialized on entry, but any changeset already
+///   stored there is leaked rather than freed — pass a fresh slot.
+///   Ownership of the written changeset transfers to the caller, which
+///   must release it with `platform_address_wallet_free_changeset`.
+/// - `signer_address_handle` must be a valid, non-destroyed
+///   `*mut SignerHandle` produced by `dash_sdk_signer_create_with_ctx`.
+/// - `core_signer_handle` must be a valid, non-destroyed
+///   `*mut MnemonicResolverHandle` produced by
+///   [`crate::dash_sdk_mnemonic_resolver_create`].
+/// - The caller retains ownership of both handles, and both must stay
+///   alive — and must not be destroyed, moved or otherwise mutated from
+///   another thread — until this call returns. The call blocks on a
+///   worker until the flow completes, so "until this returns" spans the
+///   entire build/broadcast/submit pipeline, not just the marshalling.
+/// - `handle` must be a live `PlatformAddressWallet` handle; a stale or
+///   already-destroyed one is rejected by the handle table rather than
+///   dereferenced.
 #[no_mangle]
 #[allow(clippy::too_many_arguments)]
 pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_external_signer(
@@ -443,10 +476,41 @@ pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_external_s
 /// caller's to supply.
 ///
 /// # Safety
-/// - `out_point` must be a valid, non-null pointer to an `OutPointFFI`
-///   (32-byte raw txid + u32 vout). The caller retains ownership.
-/// - `signer_address_handle` / `core_signer_handle` — see
-///   [`platform_address_wallet_fund_from_asset_lock_signer`].
+/// - `out_point` must be non-null, properly aligned, and point to one
+///   fully initialized `OutPointFFI` (32-byte raw txid + `u32` vout)
+///   that stays readable until this call returns. It is read once, by
+///   value, before the worker is spawned; the caller retains ownership
+///   and may free it once the call returns.
+/// - `addresses` must be non-null. When `addresses_count > 0` it must
+///   point to `addresses_count` consecutive, properly aligned and
+///   initialized `FundingAddressEntryFFI` values inside a single
+///   allocation, and stay readable and unmutated for the whole call.
+///   `addresses_count` must not exceed `isize::MAX` bytes' worth of
+///   entries. A `0` count is short-circuited before any dereference, so
+///   a dangling non-null sentinel is sound in that case only.
+/// - `fee_strategy` / `fee_strategy_count` are never read (see above),
+///   so they carry no validity obligation at all — any value, including
+///   a dangling or misaligned pointer, is sound. Pass `NULL` / `0`.
+/// - `out_changeset` must be non-null, properly aligned and valid for
+///   writes of one `PlatformAddressChangeSetFFI`. It is overwritten
+///   unconditionally (with an empty sentinel first, then the result),
+///   so it need not be initialized on entry, but any changeset already
+///   stored there is leaked rather than freed — pass a fresh slot.
+///   Ownership of the written changeset transfers to the caller, which
+///   must release it with `platform_address_wallet_free_changeset`.
+/// - `signer_address_handle` must be a valid, non-destroyed
+///   `*mut SignerHandle` produced by `dash_sdk_signer_create_with_ctx`.
+/// - `core_signer_handle` must be a valid, non-destroyed
+///   `*mut MnemonicResolverHandle` produced by
+///   [`crate::dash_sdk_mnemonic_resolver_create`].
+/// - The caller retains ownership of both handles, and both must stay
+///   alive — and must not be destroyed, moved or otherwise mutated from
+///   another thread — until this call returns. The call blocks on a
+///   worker until the flow completes, so "until this returns" spans the
+///   entire build/broadcast/submit pipeline, not just the marshalling.
+/// - `handle` must be a live `PlatformAddressWallet` handle; a stale or
+///   already-destroyed one is rejected by the handle table rather than
+///   dereferenced.
 #[no_mangle]
 #[allow(clippy::too_many_arguments)]
 pub unsafe extern "C" fn platform_address_wallet_resume_fund_from_asset_lock_external_signer(

--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_asset_lock.rs
@@ -269,3 +269,307 @@ pub(super) unsafe fn decode_funding_addresses(
     }
     Ok(address_map)
 }
+
+/// Fund a THIRD PARTY's platform address from a Core L1 asset lock,
+/// with the caller's own address absorbing the remainder (change) and
+/// the fee.
+///
+/// Sister to [`platform_address_wallet_fund_from_asset_lock_signer`]:
+/// identical parameters, identical marshalling, identical orchestration.
+/// The only delta is the recipient pre-flight on the Rust side —
+/// explicit-amount (`has_balance == true`) entries may be ANY valid
+/// P2PKH address, while the single remainder (`has_balance == false`)
+/// entry must still belong to `platform_account_index`.
+///
+/// Callers that mean to fund only their own addresses should keep using
+/// the non-`external` entry point: there, a mistyped recipient is
+/// rejected before anything is broadcast, whereas here it is a valid
+/// (and irreversible) payment to a stranger.
+///
+/// `fee_strategy` is positional over the outputs map's LEXICOGRAPHIC
+/// order (`PlatformAddress`'s derived `Ord`: P2PKH before P2SH, then
+/// hash bytes), NOT over the order entries appear in `addresses` —
+/// `decode_funding_addresses` collects into a `BTreeMap`. Callers must
+/// compute `ReduceOutput(index)` against that ordering; the Swift SDK
+/// does so by sorting its recipient array into the same canonical order
+/// before marshalling.
+///
+/// # Safety
+/// - `signer_address_handle` / `core_signer_handle` — see
+///   [`platform_address_wallet_fund_from_asset_lock_signer`]. Same
+///   ownership and validity contract.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn platform_address_wallet_fund_from_asset_lock_external_signer(
+    handle: Handle,
+    amount_duffs: u64,
+    account_index: u32,
+    platform_account_index: u32,
+    addresses: *const FundingAddressEntryFFI,
+    addresses_count: usize,
+    fee_strategy: *const FeeStrategyStepFFI,
+    fee_strategy_count: usize,
+    signer_address_handle: *mut SignerHandle,
+    core_signer_handle: *mut MnemonicResolverHandle,
+    out_changeset: *mut PlatformAddressChangeSetFFI,
+) -> PlatformWalletFFIResult {
+    check_ptr!(out_changeset);
+    // Sentinel first — see `platform_address_wallet_fund_from_asset_lock_signer`.
+    *out_changeset = PlatformAddressChangeSetFFI::empty();
+    check_ptr!(addresses);
+    check_ptr!(signer_address_handle);
+    check_ptr!(core_signer_handle);
+
+    let address_map = match decode_funding_addresses(addresses, addresses_count) {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+
+    let fee = parse_fee_strategy(fee_strategy, fee_strategy_count);
+
+    let signer_addr = signer_address_handle as usize;
+    let core_signer_addr = core_signer_handle as usize;
+
+    let option = PLATFORM_ADDRESS_WALLET_STORAGE.with_item(handle, |wallet| {
+        let wallet_clone = wallet.clone();
+        let wallet_id = wallet.wallet_id();
+        let network = wallet.network();
+        block_on_worker(async move {
+            // SAFETY: see the fn-level safety doc — both handles are
+            // pinned alive for the duration of this FFI call.
+            let address_signer: &VTableSigner = unsafe { &*(signer_addr as *const VTableSigner) };
+            let asset_lock_signer = unsafe {
+                MnemonicResolverCoreSigner::new(
+                    core_signer_addr as *mut MnemonicResolverHandle,
+                    wallet_id,
+                    network,
+                )
+            };
+            wallet_clone
+                .fund_from_asset_lock_external(
+                    AssetLockFunding::FromWalletBalance {
+                        amount_duffs,
+                        account_index,
+                    },
+                    platform_account_index,
+                    address_map,
+                    fee,
+                    address_signer,
+                    &asset_lock_signer,
+                    None,
+                )
+                .await
+        })
+    });
+    let result = unwrap_option_or_return!(option);
+    let changeset = unwrap_result_or_return!(result);
+    *out_changeset = PlatformAddressChangeSetFFI::from(&changeset);
+    PlatformWalletFFIResult::ok()
+}
+
+/// Resume an external-recipient platform-address funding flow from an
+/// already-tracked asset lock by outpoint.
+///
+/// Sister to
+/// [`platform_address_wallet_fund_from_asset_lock_external_signer`]
+/// (same relaxed recipient rules) and to
+/// [`platform_address_wallet_resume_fund_from_asset_lock_signer`] (same
+/// resume-by-outpoint shape).
+///
+/// ## Why the recipients are a parameter and not recovered from state
+///
+/// The tracked asset lock records the L1 outpoint, its status and its
+/// proof — it does NOT record who the credits were destined for. Nothing
+/// on the Rust side ever learns the recipient set: it is chosen by the
+/// host at ST-submit time and, for a third-party payment, is not even
+/// derivable from the wallet's own key material. So a resume must be
+/// told the recipients again, exactly as the shielded resume entry point
+/// is (`platform_wallet_manager_shielded_resume_fund_from_asset_lock`).
+///
+/// The practical consequence is worth stating plainly: a resume with a
+/// DIFFERENT recipient set than the original attempt is accepted, and
+/// pays the new set. That is the correct behaviour for a flow whose
+/// first attempt never landed on Platform — the asset lock is a bearer
+/// input, not a commitment to a destination — but it does mean the host
+/// is responsible for round-tripping the intended recipient (which is
+/// what `PersistentAssetLock.recipientPlatformAddressHash` /
+/// `recipientIsExternal` exist for on the Swift side).
+///
+/// # Safety
+/// - `out_point` must be a valid, non-null pointer to an `OutPointFFI`
+///   (32-byte raw txid + u32 vout). The caller retains ownership.
+/// - `signer_address_handle` / `core_signer_handle` — see
+///   [`platform_address_wallet_fund_from_asset_lock_signer`].
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn platform_address_wallet_resume_fund_from_asset_lock_external_signer(
+    handle: Handle,
+    out_point: *const OutPointFFI,
+    platform_account_index: u32,
+    addresses: *const FundingAddressEntryFFI,
+    addresses_count: usize,
+    fee_strategy: *const FeeStrategyStepFFI,
+    fee_strategy_count: usize,
+    signer_address_handle: *mut SignerHandle,
+    core_signer_handle: *mut MnemonicResolverHandle,
+    out_changeset: *mut PlatformAddressChangeSetFFI,
+) -> PlatformWalletFFIResult {
+    check_ptr!(out_changeset);
+    // Sentinel first — see `platform_address_wallet_fund_from_asset_lock_signer`.
+    *out_changeset = PlatformAddressChangeSetFFI::empty();
+    check_ptr!(addresses);
+    check_ptr!(out_point);
+    check_ptr!(signer_address_handle);
+    check_ptr!(core_signer_handle);
+
+    let address_map = match decode_funding_addresses(addresses, addresses_count) {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+
+    let fee = parse_fee_strategy(fee_strategy, fee_strategy_count);
+
+    let out_point_ffi = *out_point;
+    let resume_outpoint = dashcore::OutPoint {
+        txid: dashcore::Txid::from_byte_array(out_point_ffi.txid),
+        vout: out_point_ffi.vout,
+    };
+
+    let signer_addr = signer_address_handle as usize;
+    let core_signer_addr = core_signer_handle as usize;
+
+    let option = PLATFORM_ADDRESS_WALLET_STORAGE.with_item(handle, |wallet| {
+        let wallet_clone = wallet.clone();
+        let wallet_id = wallet.wallet_id();
+        let network = wallet.network();
+        block_on_worker(async move {
+            // SAFETY: see the fn-level safety doc — both handles are
+            // pinned alive for the duration of this FFI call.
+            let address_signer: &VTableSigner = unsafe { &*(signer_addr as *const VTableSigner) };
+            let asset_lock_signer = unsafe {
+                MnemonicResolverCoreSigner::new(
+                    core_signer_addr as *mut MnemonicResolverHandle,
+                    wallet_id,
+                    network,
+                )
+            };
+            wallet_clone
+                .fund_from_asset_lock_external(
+                    AssetLockFunding::FromExistingAssetLock {
+                        out_point: resume_outpoint,
+                        consume_invitation_voucher: false,
+                    },
+                    platform_account_index,
+                    address_map,
+                    fee,
+                    address_signer,
+                    &asset_lock_signer,
+                    None,
+                )
+                .await
+        })
+    });
+    let result = unwrap_option_or_return!(option);
+    let changeset = unwrap_result_or_return!(result);
+    *out_changeset = PlatformAddressChangeSetFFI::from(&changeset);
+    PlatformWalletFFIResult::ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform_address_types::PlatformAddressFFI;
+
+    fn entry(address_type: u8, tag: u8, balance: Option<u64>) -> FundingAddressEntryFFI {
+        FundingAddressEntryFFI {
+            address: PlatformAddressFFI {
+                address_type,
+                hash: [tag; 20],
+            },
+            has_balance: balance.is_some(),
+            balance: balance.unwrap_or(0),
+        }
+    }
+
+    /// Pins the contract the SDKs' fee-strategy computation depends on:
+    /// `ReduceOutput(index)` is resolved by consensus against the
+    /// outputs `BTreeMap`'s key order, and `decode_funding_addresses`
+    /// builds that map. So when the caller hands us a canonically
+    /// sorted array (P2PKH before P2SH, then hash bytes ascending — the
+    /// derived `Ord` on `PlatformAddress`), array position and
+    /// consensus output index are the SAME number.
+    ///
+    /// The hazard this guards: a caller that computes the remainder
+    /// index from its own arbitrary array order silently re-targets the
+    /// fee onto a different output whenever the remainder is not first
+    /// lexicographically. With a third-party recipient in the set, that
+    /// means the payee's explicit amount pays the fee instead of the
+    /// sender's change.
+    #[test]
+    fn decoded_map_order_matches_canonically_sorted_input() {
+        // Alice (0x0A) is the remainder; Bob (0xBB) and Carol (0xCC)
+        // take explicit amounts. Alice sorts FIRST, so the remainder
+        // index is 0 even though a caller listing "payees first" would
+        // have naively computed 2.
+        let canonical = [
+            entry(0, 0x0A, None),
+            entry(0, 0xBB, Some(500)),
+            entry(0, 0xCC, Some(700)),
+        ];
+
+        let map = unsafe { decode_funding_addresses(canonical.as_ptr(), canonical.len()) }
+            .expect("valid entries decode");
+
+        let decoded_order: Vec<PlatformAddress> = map.keys().copied().collect();
+        let input_order: Vec<PlatformAddress> = canonical
+            .iter()
+            .map(|e| PlatformAddress::try_from(e.address).expect("valid address"))
+            .collect();
+        assert_eq!(
+            decoded_order, input_order,
+            "a canonically sorted input array must survive the BTreeMap round trip in order"
+        );
+
+        let remainder_index = canonical
+            .iter()
+            .position(|e| !e.has_balance)
+            .expect("exactly one remainder");
+        assert_eq!(remainder_index, 0);
+        assert_eq!(
+            map.get(&decoded_order[remainder_index]),
+            Some(&None),
+            "ReduceOutput(remainder_index) must land on the None (remainder) output"
+        );
+    }
+
+    /// The inverse arrangement: the remainder sorts LAST. Pins that the
+    /// index tracks lexicographic position rather than being pinned to
+    /// 0 or to the caller's listing order.
+    #[test]
+    fn remainder_index_tracks_lexicographic_position() {
+        let canonical = [
+            entry(0, 0x0A, Some(500)),
+            entry(0, 0xBB, Some(700)),
+            entry(0, 0xCC, None),
+        ];
+
+        let map = unsafe { decode_funding_addresses(canonical.as_ptr(), canonical.len()) }
+            .expect("valid entries decode");
+        let decoded_order: Vec<PlatformAddress> = map.keys().copied().collect();
+
+        let remainder_index = canonical
+            .iter()
+            .position(|e| !e.has_balance)
+            .expect("exactly one remainder");
+        assert_eq!(remainder_index, 2);
+        assert_eq!(map.get(&decoded_order[remainder_index]), Some(&None));
+    }
+
+    #[test]
+    fn rejects_duplicate_recipients() {
+        let entries = [entry(0, 0x0A, Some(500)), entry(0, 0x0A, None)];
+        let err = unsafe { decode_funding_addresses(entries.as_ptr(), entries.len()) }
+            .expect_err("duplicates must be rejected");
+        assert_eq!(err.code, PlatformWalletFFIResultCode::ErrorInvalidParameter);
+    }
+}

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
@@ -149,9 +149,125 @@ impl PlatformAddressWallet {
         S: Signer<PlatformAddress> + Send + Sync,
         AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
     {
+        self.fund_from_asset_lock_inner(
+            funding,
+            platform_account_index,
+            addresses,
+            fee_strategy,
+            address_signer,
+            asset_lock_signer,
+            settings,
+            RecipientOwnership::AllOwned,
+        )
+        .await
+    }
+
+    /// Fund a THIRD PARTY's platform address from a Core L1 asset
+    /// lock, with the sender's own address absorbing the remainder
+    /// (change) and the fee.
+    ///
+    /// Sibling to [`PlatformAddressWallet::fund_from_asset_lock`]:
+    /// identical pipeline, identical arguments, identical bookkeeping —
+    /// the ONLY delta is the recipient pre-flight.
+    ///
+    /// | | `fund_from_asset_lock` | `fund_from_asset_lock_external` |
+    /// |---|---|---|
+    /// | explicit-amount outputs (`Some(credits)`) | must belong to `platform_account_index` | **any valid P2PKH address** |
+    /// | remainder output (`None`) | must belong to `platform_account_index` | must belong to `platform_account_index` |
+    /// | address type | P2PKH only | P2PKH only |
+    ///
+    /// Why this is a separate entry point rather than a relaxation of
+    /// the existing one: for every current caller, a typo'd recipient
+    /// address is caught today by the membership check. Relaxing that
+    /// check in place would silently convert "typo'd address → typed
+    /// error before anything is broadcast" into "typo'd address →
+    /// asset-lock credits irrecoverably delivered to a stranger". Opting
+    /// in by function name keeps that failure mode confined to callers
+    /// that actually mean to pay someone else.
+    ///
+    /// Why the remainder must still be owned: the asset lock is
+    /// consumed in full, so the `None` bucket receives everything left
+    /// after the explicit outputs and fees — i.e. the change. Sending
+    /// change to a stranger is never the intent, and a caller bug that
+    /// mixed up which entry was the remainder would leak the entire
+    /// lock value rather than the intended payment. Consensus does not
+    /// care (it never validates output ownership — see
+    /// `test_external_recipient_asset_lock_funding_is_consensus_valid`
+    /// in rs-drive-abci), so this is purely a wallet-level safety rail.
+    ///
+    /// Reconciliation needs no special casing: the third party's output
+    /// simply does not resolve to a wallet-owned slot, which
+    /// `reconcile_address_infos_with_persistence` already treats as a
+    /// normal outcome (it warns and still reports `persisted = true`),
+    /// while the sender's remainder output resolves and is credited as
+    /// usual.
+    ///
+    /// See [`PlatformAddressWallet::fund_from_asset_lock`] for the
+    /// argument-by-argument reference, the latency budget and the
+    /// cancellation contract — all of which apply verbatim.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn fund_from_asset_lock_external<S, AS>(
+        &self,
+        funding: AssetLockFunding,
+        platform_account_index: u32,
+        addresses: BTreeMap<PlatformAddress, Option<Credits>>,
+        fee_strategy: AddressFundsFeeStrategy,
+        address_signer: &S,
+        asset_lock_signer: &AS,
+        settings: Option<PutSettings>,
+    ) -> Result<PlatformAddressChangeSet, PlatformWalletError>
+    where
+        S: Signer<PlatformAddress> + Send + Sync,
+        AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
+    {
+        self.fund_from_asset_lock_inner(
+            funding,
+            platform_account_index,
+            addresses,
+            fee_strategy,
+            address_signer,
+            asset_lock_signer,
+            settings,
+            RecipientOwnership::ExternalExplicitOutputs,
+        )
+        .await
+    }
+
+    /// Shared body behind [`PlatformAddressWallet::fund_from_asset_lock`]
+    /// and [`PlatformAddressWallet::fund_from_asset_lock_external`].
+    ///
+    /// `ownership` is the single point of divergence between the two
+    /// public entry points; everything from Step 2 onward is identical,
+    /// because nothing downstream of the pre-flight is
+    /// ownership-sensitive (the proof carries every output regardless of
+    /// who owns it, and reconciliation resolves whichever subset happens
+    /// to be ours).
+    ///
+    /// There is deliberately no separate `resume_*` variant at this
+    /// layer: resuming is expressed as
+    /// `AssetLockFunding::FromExistingAssetLock`, a value of the
+    /// `funding` parameter, so both public entry points already cover
+    /// fresh-build and resume. (The FFI layer does expose distinct
+    /// resume symbols, because a C ABI cannot take a Rust enum.)
+    #[allow(clippy::too_many_arguments)]
+    async fn fund_from_asset_lock_inner<S, AS>(
+        &self,
+        funding: AssetLockFunding,
+        platform_account_index: u32,
+        addresses: BTreeMap<PlatformAddress, Option<Credits>>,
+        fee_strategy: AddressFundsFeeStrategy,
+        address_signer: &S,
+        asset_lock_signer: &AS,
+        settings: Option<PutSettings>,
+        ownership: RecipientOwnership,
+    ) -> Result<PlatformAddressChangeSet, PlatformWalletError>
+    where
+        S: Signer<PlatformAddress> + Send + Sync,
+        AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
+    {
         // Step 1: pre-flight. Failing fast here avoids broadcasting
         // an unfundable asset-lock tx.
-        validate_recipient_addresses(self, platform_account_index, &addresses).await?;
+        validate_recipient_addresses(self, platform_account_index, &addresses, ownership).await?;
 
         // Step 2: resolve funding. `AssetLockAddressTopUp` selects the
         // BIP44 funding family for the Core asset-lock tx. The
@@ -390,28 +506,51 @@ impl PlatformAddressWallet {
     }
 }
 
+/// Which recipient outputs must belong to the sender's own managed
+/// platform account.
+///
+/// This is the sole behavioural difference between
+/// [`PlatformAddressWallet::fund_from_asset_lock`] and
+/// [`PlatformAddressWallet::fund_from_asset_lock_external`]. Consensus
+/// itself never validates output ownership, so both modes produce
+/// equally valid state transitions — the distinction exists purely to
+/// keep an accidental third-party payment from being indistinguishable
+/// from a deliberate one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RecipientOwnership {
+    /// Every recipient — explicit-amount outputs and the remainder
+    /// alike — must be a member of the platform-payment account. This
+    /// is the legacy "fund my own addresses" behaviour.
+    AllOwned,
+    /// Explicit-amount (`Some(credits)`) outputs may be any valid P2PKH
+    /// address, including addresses this wallet knows nothing about.
+    /// The single remainder (`None`) output must still be owned,
+    /// because it is the change.
+    ExternalExplicitOutputs,
+}
+
 /// Pre-flight check for the recipient address map:
 /// - Non-empty
 /// - Exactly one `None`-amount entry (the remainder recipient)
-/// - All addresses are P2PKH and belong to the specified platform-payment account
+/// - All addresses are P2PKH
+/// - Ownership per `ownership` (see [`RecipientOwnership`])
+///
+/// Resolves the managed account once and delegates the actual rules to
+/// the pure [`validate_recipient_map`], which is where the unit tests
+/// live (no wallet construction needed to exercise the rules).
 async fn validate_recipient_addresses(
     wallet: &PlatformAddressWallet,
     platform_account_index: u32,
     addresses: &BTreeMap<PlatformAddress, Option<Credits>>,
+    ownership: RecipientOwnership,
 ) -> Result<(), PlatformWalletError> {
-    if addresses.is_empty() {
-        return Err(PlatformWalletError::AddressOperation(
-            "fund_from_asset_lock requires at least one recipient address".to_string(),
-        ));
-    }
-
-    let none_count = addresses.values().filter(|v| v.is_none()).count();
-    if none_count != 1 {
-        return Err(PlatformWalletError::AddressOperation(format!(
-            "Exactly one address must have None balance (the funding recipient), found {}",
-            none_count
-        )));
-    }
+    // Shape checks before the lock. `validate_recipient_map` re-runs
+    // them (it is self-contained so the tests can call it directly);
+    // running them here too is what preserves the pre-existing error
+    // precedence — a malformed recipient map is rejected with its own
+    // typed error even when the wallet handle or the account is gone,
+    // rather than being masked by `WalletNotFound` / `AddressSync`.
+    validate_recipient_shape(addresses)?;
 
     let wm = wallet.wallet_manager.read().await;
     let info = wm.get_wallet_info(&wallet.wallet_id).ok_or_else(|| {
@@ -429,18 +568,98 @@ async fn validate_recipient_addresses(
                 platform_account_index
             ))
         })?;
+
+    validate_recipient_map(addresses, ownership, platform_account_index, |p2pkh| {
+        account.contains_platform_address(p2pkh)
+    })
+}
+
+/// Ownership-independent half of the pre-flight: cardinality and
+/// address-type rules that hold for every funding mode.
+///
+/// P2SH stays rejected for ALL recipients, including pure third-party
+/// payees under [`RecipientOwnership::ExternalExplicitOutputs`].
+/// Relaxing that for recipient-only outputs is a deliberate follow-up:
+/// the FFI's `TryFrom<PlatformAddressFFI> for PlatformAddress` rejects
+/// the P2SH discriminant outright, so lifting the restriction here
+/// alone would not actually make P2SH reachable from the SDKs.
+fn validate_recipient_shape(
+    addresses: &BTreeMap<PlatformAddress, Option<Credits>>,
+) -> Result<(), PlatformWalletError> {
+    if addresses.is_empty() {
+        return Err(PlatformWalletError::AddressOperation(
+            "fund_from_asset_lock requires at least one recipient address".to_string(),
+        ));
+    }
+
+    let none_count = addresses.values().filter(|v| v.is_none()).count();
+    if none_count != 1 {
+        return Err(PlatformWalletError::AddressOperation(format!(
+            "Exactly one address must have None balance (the funding recipient), found {}",
+            none_count
+        )));
+    }
+
     for addr in addresses.keys() {
+        if !matches!(addr, PlatformAddress::P2pkh(_)) {
+            return Err(PlatformWalletError::AddressOperation(
+                "Only P2PKH addresses are supported".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Pure recipient-map pre-flight, generic over the ownership oracle so
+/// it can be unit-tested without standing up a `PlatformAddressWallet`.
+///
+/// `is_owned` answers "is this address a member of
+/// `platform_account_index`?"; in production it is
+/// `ManagedPlatformAccount::contains_platform_address`.
+fn validate_recipient_map<F>(
+    addresses: &BTreeMap<PlatformAddress, Option<Credits>>,
+    ownership: RecipientOwnership,
+    platform_account_index: u32,
+    is_owned: F,
+) -> Result<(), PlatformWalletError>
+where
+    F: Fn(&PlatformP2PKHAddress) -> bool,
+{
+    validate_recipient_shape(addresses)?;
+
+    for (addr, amount) in addresses {
         let PlatformAddress::P2pkh(hash) = addr else {
+            // Unreachable: `validate_recipient_shape` already rejected
+            // every non-P2PKH address above. Kept as a total match
+            // rather than an `unwrap` so a future third variant is a
+            // compile-time prompt, not a panic.
             return Err(PlatformWalletError::AddressOperation(
                 "Only P2PKH addresses are supported".to_string(),
             ));
         };
         let p2pkh = PlatformP2PKHAddress::new(*hash);
-        if !account.contains_platform_address(&p2pkh) {
-            return Err(PlatformWalletError::AddressNotFound(format!(
-                "Address {} does not belong to platform account index {}",
-                p2pkh, platform_account_index
-            )));
+
+        // `None` == the remainder/change bucket. It must be ours in
+        // BOTH modes: the asset lock is consumed in full, so this
+        // output receives everything left over after the explicit
+        // outputs and the fee.
+        let is_remainder = amount.is_none();
+        let must_be_owned = is_remainder || ownership == RecipientOwnership::AllOwned;
+        if must_be_owned && !is_owned(&p2pkh) {
+            return Err(PlatformWalletError::AddressNotFound(if is_remainder {
+                format!(
+                    "Remainder (change) address {} does not belong to platform account index {}; \
+                     the remainder output absorbs the asset lock's leftover value and must be \
+                     owned by the sender",
+                    p2pkh, platform_account_index
+                )
+            } else {
+                format!(
+                    "Address {} does not belong to platform account index {}",
+                    p2pkh, platform_account_index
+                )
+            }));
         }
     }
     Ok(())
@@ -505,6 +724,251 @@ mod tests {
             balance: 1_000,
             nonce: 0,
         }
+    }
+
+    /// Ownership oracle standing in for
+    /// `ManagedPlatformAccount::contains_platform_address`: the byte
+    /// tags in `owned` are the addresses the sender's account holds.
+    fn owned(tags: &[u8]) -> impl Fn(&PlatformP2PKHAddress) -> bool + '_ {
+        move |addr: &PlatformP2PKHAddress| {
+            tags.iter()
+                .any(|t| PlatformP2PKHAddress::new([*t; 20]) == *addr)
+        }
+    }
+
+    fn check(
+        addresses: &BTreeMap<PlatformAddress, Option<Credits>>,
+        ownership: RecipientOwnership,
+        owned_tags: &[u8],
+    ) -> Result<(), PlatformWalletError> {
+        validate_recipient_map(addresses, ownership, 0, owned(owned_tags))
+    }
+
+    /// Legacy behaviour is untouched: an explicit-amount output the
+    /// sender does not own is still rejected before anything is
+    /// broadcast. This is the safety property that motivated adding a
+    /// second entry point rather than relaxing this one.
+    #[test]
+    fn all_owned_rejects_external_explicit_recipient() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xBB), Some(500)); // Bob — not ours
+        addresses.insert(p2pkh(0xAA), None); // our change
+        let err = check(&addresses, RecipientOwnership::AllOwned, &[0xAA])
+            .expect_err("legacy mode must reject a third-party recipient");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("does not belong to platform account index"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn all_owned_accepts_fully_owned_recipient_set() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xAA), Some(500));
+        addresses.insert(p2pkh(0xAB), None);
+        check(&addresses, RecipientOwnership::AllOwned, &[0xAA, 0xAB])
+            .expect("fully-owned set must pass in legacy mode");
+    }
+
+    /// The feature: Alice pays Bob an exact amount and keeps the
+    /// remainder on an address of her own.
+    #[test]
+    fn external_accepts_external_explicit_with_owned_remainder() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xBB), Some(500)); // Bob — external
+        addresses.insert(p2pkh(0xAA), None); // Alice's change
+        check(
+            &addresses,
+            RecipientOwnership::ExternalExplicitOutputs,
+            &[0xAA],
+        )
+        .expect("external explicit recipient with owned remainder must pass");
+    }
+
+    /// Multiple third-party payees in a single asset lock are fine —
+    /// consensus places no cap on output count beyond the versioned
+    /// maximum, and none of them need to be ours.
+    #[test]
+    fn external_accepts_several_external_explicit_recipients() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xBB), Some(500));
+        addresses.insert(p2pkh(0xCC), Some(700));
+        addresses.insert(p2pkh(0xAA), None);
+        check(
+            &addresses,
+            RecipientOwnership::ExternalExplicitOutputs,
+            &[0xAA],
+        )
+        .expect("multiple external recipients must pass");
+    }
+
+    /// The one ownership rule the external variant keeps: change comes
+    /// home. A caller bug that put the third party in the remainder
+    /// slot would hand them the WHOLE lock value, not the intended
+    /// payment, so this stays a hard error.
+    #[test]
+    fn external_rejects_external_remainder() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xAA), Some(500)); // ours, explicit
+        addresses.insert(p2pkh(0xBB), None); // Bob would get the change
+        let err = check(
+            &addresses,
+            RecipientOwnership::ExternalExplicitOutputs,
+            &[0xAA],
+        )
+        .expect_err("an unowned remainder must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            matches!(err, PlatformWalletError::AddressNotFound(_)),
+            "expected AddressNotFound, got: {msg}"
+        );
+        assert!(
+            msg.contains("Remainder (change) address"),
+            "the error must name the remainder output: {msg}"
+        );
+    }
+
+    /// A recipient set with no owned address at all still fails on the
+    /// remainder rule — there is no path to "send everything away".
+    #[test]
+    fn external_rejects_when_nothing_is_owned() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xBB), Some(500));
+        addresses.insert(p2pkh(0xCC), None);
+        check(&addresses, RecipientOwnership::ExternalExplicitOutputs, &[])
+            .expect_err("a wholly-external recipient set must be rejected");
+    }
+
+    #[test]
+    fn rejects_p2sh_recipient_in_both_modes() {
+        // P2SH explicit output, owned remainder. Rejected even in the
+        // external mode, where ownership would otherwise not matter —
+        // the address-type restriction is orthogonal to ownership and
+        // relaxing it is a separate follow-up.
+        let mut addresses = BTreeMap::new();
+        addresses.insert(PlatformAddress::P2sh([0xBB; 20]), Some(500));
+        addresses.insert(p2pkh(0xAA), None);
+        for ownership in [
+            RecipientOwnership::AllOwned,
+            RecipientOwnership::ExternalExplicitOutputs,
+        ] {
+            let err = check(&addresses, ownership, &[0xAA])
+                .expect_err("P2SH recipients must be rejected in every mode");
+            assert!(
+                format!("{err}").contains("Only P2PKH addresses are supported"),
+                "{ownership:?}: unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_zero_remainders() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xAA), Some(500));
+        addresses.insert(p2pkh(0xBB), Some(700));
+        for ownership in [
+            RecipientOwnership::AllOwned,
+            RecipientOwnership::ExternalExplicitOutputs,
+        ] {
+            let err = check(&addresses, ownership, &[0xAA, 0xBB])
+                .expect_err("a recipient set with no remainder must be rejected");
+            assert!(
+                format!("{err}").contains("found 0"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_two_remainders() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xAA), None);
+        addresses.insert(p2pkh(0xBB), None);
+        for ownership in [
+            RecipientOwnership::AllOwned,
+            RecipientOwnership::ExternalExplicitOutputs,
+        ] {
+            let err = check(&addresses, ownership, &[0xAA, 0xBB])
+                .expect_err("two remainders must be rejected");
+            assert!(
+                format!("{err}").contains("found 2"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_empty_recipient_map() {
+        let addresses = BTreeMap::new();
+        for ownership in [
+            RecipientOwnership::AllOwned,
+            RecipientOwnership::ExternalExplicitOutputs,
+        ] {
+            let err = check(&addresses, ownership, &[])
+                .expect_err("an empty recipient map must be rejected");
+            assert!(
+                format!("{err}").contains("at least one recipient address"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    /// The FFI marshals recipients into a flat array and names the
+    /// fee-paying output POSITIONALLY (`ReduceOutput(index)`), while
+    /// consensus resolves that index against the outputs map's
+    /// lexicographic key order (`PlatformAddress`'s derived `Ord`:
+    /// P2PKH before P2SH, then hash bytes). This test pins the ordering
+    /// the SDK callers rely on when they compute the remainder index:
+    /// sorting the recipients the same way the `BTreeMap` does makes
+    /// array position and consensus index the same number, INCLUDING
+    /// when the remainder is not the first recipient the caller listed.
+    #[test]
+    fn remainder_index_matches_btreemap_position() {
+        // Caller-supplied order: Bob (explicit) first, Alice's change
+        // second — and Alice's hash sorts BEFORE Bob's, so the naive
+        // "position in the caller's array" answer (1) is wrong and the
+        // lexicographic answer (0) is right.
+        let alice = p2pkh(0x0A);
+        let bob = p2pkh(0xBB);
+        let carol = p2pkh(0xCC);
+
+        let mut addresses = BTreeMap::new();
+        addresses.insert(bob, Some(500));
+        addresses.insert(carol, Some(700));
+        addresses.insert(alice, None);
+
+        let keys: Vec<PlatformAddress> = addresses.keys().copied().collect();
+        assert_eq!(
+            keys,
+            vec![alice, bob, carol],
+            "BTreeMap must order by PlatformAddress's derived Ord"
+        );
+
+        let remainder_index = addresses
+            .iter()
+            .position(|(_, amount)| amount.is_none())
+            .expect("exactly one remainder");
+        assert_eq!(
+            remainder_index, 0,
+            "the remainder index is its lexicographic position, not its position in the \
+             caller's list"
+        );
+        assert_eq!(keys[remainder_index], alice);
+
+        // And the inverse hazard: a remainder that is LAST
+        // lexicographically but first in the caller's list.
+        let mut addresses = BTreeMap::new();
+        addresses.insert(carol, None);
+        addresses.insert(alice, Some(500));
+        addresses.insert(bob, Some(700));
+        let keys: Vec<PlatformAddress> = addresses.keys().copied().collect();
+        let remainder_index = addresses
+            .iter()
+            .position(|(_, amount)| amount.is_none())
+            .expect("exactly one remainder");
+        assert_eq!(remainder_index, 2);
+        assert_eq!(keys[remainder_index], carol);
     }
 
     #[test]

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
@@ -34,6 +34,7 @@ use crate::{error::is_instant_lock_proof_invalid, PlatformAddressChangeSet, Plat
 use dash_sdk::platform::transition::put_settings::PutSettings;
 use dash_sdk::platform::transition::top_up_address::TopUpAddress;
 use dash_sdk::query_types::AddressInfos;
+use dpp::address_funds::fee_strategy::AddressFundsFeeStrategyStep;
 use dpp::address_funds::{AddressFundsFeeStrategy, PlatformAddress};
 use dpp::fee::Credits;
 use dpp::identity::signer::Signer;
@@ -67,8 +68,12 @@ impl PlatformAddressWallet {
     ///   amount in credits. Exactly one entry must be `None` — the
     ///   remainder-after-fees-and-explicit-outputs recipient (the lock
     ///   is consumed in full, so a remainder bucket is mandatory).
-    /// * `fee_strategy` — Per-step fee-deduction strategy applied to
-    ///   the address-funding transition.
+    ///
+    ///   The fee strategy is NOT a parameter: it is derived from this
+    ///   map by [`remainder_fee_strategy`], because the only address
+    ///   that can legitimately absorb the fee is the remainder output
+    ///   and its consensus index is a property of this map's ordering,
+    ///   not of any caller's list order.
     /// * `address_signer` — Signs per-input `AddressWitness` for any
     ///   additional inputs from existing platform addresses (today
     ///   none — combining external inputs with an asset-lock proof is
@@ -140,7 +145,6 @@ impl PlatformAddressWallet {
         funding: AssetLockFunding,
         platform_account_index: u32,
         addresses: BTreeMap<PlatformAddress, Option<Credits>>,
-        fee_strategy: AddressFundsFeeStrategy,
         address_signer: &S,
         asset_lock_signer: &AS,
         settings: Option<PutSettings>,
@@ -153,7 +157,6 @@ impl PlatformAddressWallet {
             funding,
             platform_account_index,
             addresses,
-            fee_strategy,
             address_signer,
             asset_lock_signer,
             settings,
@@ -211,7 +214,6 @@ impl PlatformAddressWallet {
         funding: AssetLockFunding,
         platform_account_index: u32,
         addresses: BTreeMap<PlatformAddress, Option<Credits>>,
-        fee_strategy: AddressFundsFeeStrategy,
         address_signer: &S,
         asset_lock_signer: &AS,
         settings: Option<PutSettings>,
@@ -224,7 +226,6 @@ impl PlatformAddressWallet {
             funding,
             platform_account_index,
             addresses,
-            fee_strategy,
             address_signer,
             asset_lock_signer,
             settings,
@@ -255,7 +256,6 @@ impl PlatformAddressWallet {
         funding: AssetLockFunding,
         platform_account_index: u32,
         addresses: BTreeMap<PlatformAddress, Option<Credits>>,
-        fee_strategy: AddressFundsFeeStrategy,
         address_signer: &S,
         asset_lock_signer: &AS,
         settings: Option<PutSettings>,
@@ -268,6 +268,12 @@ impl PlatformAddressWallet {
         // Step 1: pre-flight. Failing fast here avoids broadcasting
         // an unfundable asset-lock tx.
         validate_recipient_addresses(self, platform_account_index, &addresses, ownership).await?;
+
+        // Step 1b: derive the fee strategy from the recipient map. This
+        // is deliberately NOT a caller-supplied value — see
+        // `remainder_fee_strategy` for why a positional index cannot be
+        // computed correctly outside this layer.
+        let fee_strategy = remainder_fee_strategy(&addresses)?;
 
         // Step 2: resolve funding. `AssetLockAddressTopUp` selects the
         // BIP44 funding family for the Core asset-lock tx. The
@@ -527,6 +533,75 @@ pub(super) enum RecipientOwnership {
     /// The single remainder (`None`) output must still be owned,
     /// because it is the change.
     ExternalExplicitOutputs,
+}
+
+/// Derive the fee strategy for an `AddressFundingFromAssetLock`
+/// transition from the recipient map itself.
+///
+/// ## Why this cannot be a caller-supplied value
+///
+/// `AddressFundsFeeStrategyStep::ReduceOutput(i)` is POSITIONAL, and
+/// consensus resolves `i` against the transition's `outputs`
+/// `BTreeMap<PlatformAddress, Option<Credits>>` — i.e. against
+/// `PlatformAddress`'s derived `Ord` (P2PKH before P2SH, then the
+/// 20-byte hash ascending). See
+/// `deduct_fee_from_outputs_or_remaining_balance_of_inputs_v0`, which
+/// snapshots `outputs.keys()` before mutating, and
+/// `AddressFundingFromAssetLockTransitionActionV0::resolved_outputs`,
+/// which preserves those keys verbatim.
+///
+/// A caller holding a flat array therefore cannot name the fee-paying
+/// output without reproducing `PlatformAddress`'s `Ord` exactly. Every
+/// binding that tried to do so from array position (the Swift SDK, the
+/// JNI `decode_funding_recipients`) got it wrong whenever the remainder
+/// was not also first lexicographically — silently charging the fee to
+/// an explicit-amount payee instead of the sender's change. With a
+/// third-party payee in the set that is a real misallocation, not a
+/// wash. Deriving it here, from the same map that becomes the outputs
+/// map, is the only place the answer is knowable without duplicating a
+/// consensus rule.
+///
+/// ## Why the remainder is always the right target
+///
+/// This flow never builds address inputs (`top_up_with_signers` passes
+/// `BTreeMap::new()` for them), so `DeductFromInput(_)` has nothing to
+/// resolve against and would leave the fee uncovered. Among the
+/// outputs, the explicit-amount entries are exact amounts the caller
+/// asked to deliver; only the `None` entry is a residual bucket
+/// (`total_available - Σ explicit`), so it is the one output that can
+/// absorb a fee without shortchanging a payee.
+///
+/// The `None` entry is unique — [`validate_recipient_shape`] rejects
+/// any other cardinality — so the returned strategy is a single step.
+fn remainder_fee_strategy(
+    addresses: &BTreeMap<PlatformAddress, Option<Credits>>,
+) -> Result<AddressFundsFeeStrategy, PlatformWalletError> {
+    let index = addresses
+        .values()
+        .position(|amount| amount.is_none())
+        .ok_or_else(|| {
+            // Unreachable in the orchestrated flow: `validate_recipient_shape`
+            // runs first and requires exactly one `None`. Kept as a typed
+            // error rather than an `expect` so a future caller that skips
+            // the pre-flight gets a diagnosable failure instead of a panic
+            // across the FFI boundary.
+            PlatformWalletError::AddressOperation(
+                "fund_from_asset_lock requires exactly one remainder (None-amount) recipient to                  absorb the fee, found none"
+                    .to_string(),
+            )
+        })?;
+
+    // `ReduceOutput` carries a u16. Guard the narrowing so a
+    // pathological recipient count cannot wrap the index onto a
+    // different — and possibly third-party — output.
+    let index: u16 = index.try_into().map_err(|_| {
+        PlatformWalletError::AddressOperation(format!(
+            "Too many funding recipients: remainder index {} exceeds u16::MAX",
+            index
+        ))
+    })?;
+
+    Ok(vec![AddressFundsFeeStrategyStep::ReduceOutput(index)])
 }
 
 /// Pre-flight check for the recipient address map:
@@ -914,25 +989,27 @@ mod tests {
         }
     }
 
-    /// The FFI marshals recipients into a flat array and names the
-    /// fee-paying output POSITIONALLY (`ReduceOutput(index)`), while
-    /// consensus resolves that index against the outputs map's
-    /// lexicographic key order (`PlatformAddress`'s derived `Ord`:
-    /// P2PKH before P2SH, then hash bytes). This test pins the ordering
-    /// the SDK callers rely on when they compute the remainder index:
-    /// sorting the recipients the same way the `BTreeMap` does makes
-    /// array position and consensus index the same number, INCLUDING
-    /// when the remainder is not the first recipient the caller listed.
+    /// The consensus contract this whole flow hangs on:
+    /// `ReduceOutput(i)` is resolved by consensus against the outputs
+    /// `BTreeMap`'s key order (`PlatformAddress`'s derived `Ord`), and
+    /// `remainder_fee_strategy` must name the `None` output's position
+    /// in exactly that order.
+    ///
+    /// Both arrangements are pinned, because the hazard is asymmetric:
+    /// a caller computing the index from its own array order happens to
+    /// be right whenever the remainder is also first lexicographically,
+    /// and silently wrong otherwise. The second case below is the one
+    /// that used to misfire — with a third-party payee in the set it
+    /// charges the fee to the payee's explicit amount instead of the
+    /// sender's change.
     #[test]
-    fn remainder_index_matches_btreemap_position() {
-        // Caller-supplied order: Bob (explicit) first, Alice's change
-        // second — and Alice's hash sorts BEFORE Bob's, so the naive
-        // "position in the caller's array" answer (1) is wrong and the
-        // lexicographic answer (0) is right.
+    fn remainder_fee_strategy_targets_the_remainder_output() {
         let alice = p2pkh(0x0A);
         let bob = p2pkh(0xBB);
         let carol = p2pkh(0xCC);
 
+        // Case 1: the remainder sorts FIRST. Caller-supplied insertion
+        // order deliberately lists it LAST.
         let mut addresses = BTreeMap::new();
         addresses.insert(bob, Some(500));
         addresses.insert(carol, Some(700));
@@ -945,30 +1022,80 @@ mod tests {
             "BTreeMap must order by PlatformAddress's derived Ord"
         );
 
-        let remainder_index = addresses
-            .iter()
-            .position(|(_, amount)| amount.is_none())
-            .expect("exactly one remainder");
-        assert_eq!(
-            remainder_index, 0,
-            "the remainder index is its lexicographic position, not its position in the \
-             caller's list"
-        );
-        assert_eq!(keys[remainder_index], alice);
+        let strategy = remainder_fee_strategy(&addresses).expect("one remainder");
+        assert_eq!(strategy, vec![AddressFundsFeeStrategyStep::ReduceOutput(0)]);
 
-        // And the inverse hazard: a remainder that is LAST
-        // lexicographically but first in the caller's list.
+        // Case 2: the remainder sorts LAST while the caller listed it
+        // FIRST — the arrangement a naive array-position index gets
+        // wrong (it would answer 0 and charge the fee to Alice's payee
+        // output).
         let mut addresses = BTreeMap::new();
         addresses.insert(carol, None);
         addresses.insert(alice, Some(500));
         addresses.insert(bob, Some(700));
+
+        let strategy = remainder_fee_strategy(&addresses).expect("one remainder");
+        assert_eq!(strategy, vec![AddressFundsFeeStrategyStep::ReduceOutput(2)]);
+
+        // Resolve the emitted index the way consensus does and confirm
+        // it lands on the `None` bucket, not on a payee.
         let keys: Vec<PlatformAddress> = addresses.keys().copied().collect();
-        let remainder_index = addresses
-            .iter()
-            .position(|(_, amount)| amount.is_none())
-            .expect("exactly one remainder");
-        assert_eq!(remainder_index, 2);
-        assert_eq!(keys[remainder_index], carol);
+        let AddressFundsFeeStrategyStep::ReduceOutput(index) = strategy[0] else {
+            panic!("expected a ReduceOutput step");
+        };
+        assert_eq!(keys[index as usize], carol);
+        assert_eq!(addresses[&keys[index as usize]], None);
+    }
+
+    /// The remainder sitting in the MIDDLE of the lexicographic order —
+    /// an index that is neither 0 nor `len - 1`, so it cannot be
+    /// produced by an off-by-one or a "first"/"last" shortcut.
+    #[test]
+    fn remainder_fee_strategy_handles_a_middle_remainder() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0xCC), Some(700));
+        addresses.insert(p2pkh(0x0A), Some(500));
+        addresses.insert(p2pkh(0xBB), None);
+        addresses.insert(p2pkh(0xDD), Some(900));
+
+        let strategy = remainder_fee_strategy(&addresses).expect("one remainder");
+        assert_eq!(strategy, vec![AddressFundsFeeStrategyStep::ReduceOutput(1)]);
+
+        let keys: Vec<PlatformAddress> = addresses.keys().copied().collect();
+        assert_eq!(addresses[&keys[1]], None);
+    }
+
+    /// P2SH sorts after every P2PKH (variant discriminant first), which
+    /// is part of the ordering contract even though the pre-flight
+    /// rejects P2SH recipients today. Pinned directly on the ordering
+    /// helper so the rule survives any future relaxation of the
+    /// address-type restriction.
+    #[test]
+    fn remainder_fee_strategy_orders_p2pkh_before_p2sh() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(PlatformAddress::P2sh([0x01; 20]), Some(500));
+        addresses.insert(p2pkh(0xFF), None);
+
+        let keys: Vec<PlatformAddress> = addresses.keys().copied().collect();
+        assert_eq!(keys, vec![p2pkh(0xFF), PlatformAddress::P2sh([0x01; 20])]);
+
+        let strategy = remainder_fee_strategy(&addresses).expect("one remainder");
+        assert_eq!(strategy, vec![AddressFundsFeeStrategyStep::ReduceOutput(0)]);
+    }
+
+    /// No remainder at all is a typed error, never a panic and never a
+    /// silent `ReduceOutput(0)` aimed at whichever payee sorts first.
+    #[test]
+    fn remainder_fee_strategy_rejects_a_map_with_no_remainder() {
+        let mut addresses = BTreeMap::new();
+        addresses.insert(p2pkh(0x0A), Some(500));
+        addresses.insert(p2pkh(0xBB), Some(700));
+
+        let err = remainder_fee_strategy(&addresses).expect_err("no remainder must be rejected");
+        assert!(
+            format!("{err}").contains("exactly one remainder"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
@@ -68,12 +68,24 @@ impl PlatformAddressWallet {
     ///   amount in credits. Exactly one entry must be `None` — the
     ///   remainder-after-fees-and-explicit-outputs recipient (the lock
     ///   is consumed in full, so a remainder bucket is mandatory).
+    /// * `_fee_strategy` — **IGNORED.** Retained so the pre-derivation
+    ///   signature still compiles for out-of-tree callers; pass
+    ///   whatever you passed before (`vec![]` is fine). The strategy
+    ///   actually used is derived from `addresses` by
+    ///   [`remainder_fee_strategy`], because the only address that can
+    ///   legitimately absorb the fee is the remainder output and its
+    ///   consensus index is a property of that map's ordering, not of
+    ///   any caller's list order. Every binding that computed the index
+    ///   from its own list order silently mis-targeted the fee whenever
+    ///   the remainder was not also first lexicographically, so the
+    ///   index is no longer the caller's to supply. This mirrors the C
+    ///   ABI, where `fee_strategy` / `fee_strategy_count` are likewise
+    ///   still accepted and ignored.
     ///
-    ///   The fee strategy is NOT a parameter: it is derived from this
-    ///   map by [`remainder_fee_strategy`], because the only address
-    ///   that can legitimately absorb the fee is the remainder output
-    ///   and its consensus index is a property of this map's ordering,
-    ///   not of any caller's list order.
+    ///   [`PlatformAddressWallet::fund_from_asset_lock_external`] has no
+    ///   such compatibility obligation (it is new in this release) and
+    ///   therefore omits the argument rather than carrying the vestige
+    ///   forward.
     /// * `address_signer` — Signs per-input `AddressWitness` for any
     ///   additional inputs from existing platform addresses (today
     ///   none — combining external inputs with an asset-lock proof is
@@ -145,6 +157,7 @@ impl PlatformAddressWallet {
         funding: AssetLockFunding,
         platform_account_index: u32,
         addresses: BTreeMap<PlatformAddress, Option<Credits>>,
+        _fee_strategy: AddressFundsFeeStrategy,
         address_signer: &S,
         asset_lock_signer: &AS,
         settings: Option<PutSettings>,
@@ -170,8 +183,11 @@ impl PlatformAddressWallet {
     /// (change) and the fee.
     ///
     /// Sibling to [`PlatformAddressWallet::fund_from_asset_lock`]:
-    /// identical pipeline, identical arguments, identical bookkeeping —
-    /// the ONLY delta is the recipient pre-flight.
+    /// identical pipeline, identical bookkeeping — the ONLY behavioural
+    /// delta is the recipient pre-flight. The one signature difference
+    /// is that this entry point omits the vestigial `_fee_strategy`
+    /// argument: it is new here, so it has no source-compatibility debt
+    /// to carry (see that method's `_fee_strategy` note).
     ///
     /// | | `fund_from_asset_lock` | `fund_from_asset_lock_external` |
     /// |---|---|---|
@@ -586,7 +602,7 @@ fn remainder_fee_strategy(
             // the pre-flight gets a diagnosable failure instead of a panic
             // across the FFI boundary.
             PlatformWalletError::AddressOperation(
-                "fund_from_asset_lock requires exactly one remainder (None-amount) recipient to                  absorb the fee, found none"
+                "fund_from_asset_lock requires exactly one remainder (None-amount) recipient to absorb the fee, found none"
                     .to_string(),
             )
         })?;

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
@@ -2314,6 +2314,65 @@ mod tests {
         assert!(outcome.entries.is_empty());
     }
 
+    /// External-recipient asset-lock funding (Alice pays Bob): the
+    /// proof carries BOTH Bob's third-party output and Alice's own
+    /// remainder/change output. Reconciliation must credit Alice's
+    /// address and quietly ignore Bob's — the partial resolve is the
+    /// normal, expected outcome, not an error.
+    ///
+    /// This is the provider-level half of the guarantee that
+    /// `fund_from_asset_lock_external` needs no persistence changes:
+    /// `resolved > 0`, so
+    /// `reconcile_address_infos_with_persistence` takes its normal
+    /// apply-and-persist path (and therefore reports `persisted =
+    /// true`, which is what gates `consume_asset_lock`), while the
+    /// stranger's address never enters the committed seed.
+    #[test]
+    fn commit_reconciliation_mixed_own_and_external_recipients() {
+        use dash_sdk::query_types::AddressInfo;
+
+        // Alice's change address, tracked by the provider.
+        let alice = p2pkh(0x11);
+        let mut provider = provider_with_one_funded_address(alice, funds(700, 3));
+
+        let alice_addr = PlatformAddress::P2pkh([0x11; 20]);
+        // Bob: a third party. Not in the provider bijection, not in the
+        // live pool — the wallet has never seen this address.
+        let bob_addr = PlatformAddress::P2pkh([0xBB; 20]);
+
+        let mut address_infos = AddressInfos::new();
+        address_infos.insert(
+            alice_addr,
+            Some(AddressInfo {
+                address: alice_addr,
+                nonce: 3,
+                balance: 5_000,
+            }),
+        );
+        address_infos.insert(
+            bob_addr,
+            Some(AddressInfo {
+                address: bob_addr,
+                nonce: 0,
+                balance: 9_000,
+            }),
+        );
+
+        let outcome = provider.commit_reconciliation(&WALLET, &address_infos, &BTreeMap::new(), 77);
+
+        assert_eq!(
+            outcome.resolved, 1,
+            "exactly the sender-owned remainder output must resolve"
+        );
+        assert_eq!(outcome.entries.len(), 1);
+        assert_eq!(outcome.entries[0].address, alice);
+        assert_eq!(outcome.entries[0].funds, funds_at(5_000, 3, 77));
+
+        let seed: Vec<_> = provider.current_balances().collect();
+        assert_eq!(seed.len(), 1, "the third party must not enter the seed");
+        assert_eq!(seed[0].2, funds_at(5_000, 3, 77));
+    }
+
     /// Height authority: an absolute pinned at a LATER height is
     /// authoritative even when it revises the balance DOWNWARD — this is
     /// the ADDR-09 healing property. A poisoned legacy row (e.g. a

--- a/packages/rs-unified-sdk-jni/src/wallet_manager.rs
+++ b/packages/rs-unified-sdk-jni/src/wallet_manager.rs
@@ -1696,22 +1696,25 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_WalletManagerNative_w
 
 // ── Asset-lock funding of Platform addresses ──────────────────────────
 
-/// Decode the recipient BLOB into `FundingAddressEntryFFI` rows and derive
-/// the `ReduceOutput` fee step (at the first `hasBalance = false` remainder
-/// recipient, mirroring `ManagedPlatformAddressWallet.fundFromAssetLock`).
+/// Decode the recipient BLOB into `FundingAddressEntryFFI` rows.
 ///
 /// BLOB layout (big-endian): `u32 rowCount` then per row
 /// `u8 addressType, u8[20] hash, u8 hasBalance (0/1), u64 balance`.
 ///
-/// Returns `(entries, feeRows)` or throws + returns `None` on a malformed
-/// blob / missing remainder recipient.
+/// This used to also derive the `ReduceOutput` fee step from the row's
+/// position in the blob. That was WRONG: consensus resolves
+/// `ReduceOutput(i)` against the outputs `BTreeMap`'s lexicographic key
+/// order, not the caller's list order, so the fee landed on a payee's
+/// explicit output whenever the remainder recipient was not also first
+/// lexicographically. The index is now derived inside `platform-wallet`
+/// from the recipient map itself (`remainder_fee_strategy`), and the
+/// FFI's `fee_strategy` parameters are ignored.
+///
+/// Returns the entries, or throws + returns `None` on a malformed blob.
 fn decode_funding_recipients(
     env: &mut JNIEnv,
     arr: &JByteArray,
-) -> Option<(
-    Vec<platform_wallet_ffi::FundingAddressEntryFFI>,
-    Vec<platform_wallet_ffi::FeeStrategyStepFFI>,
-)> {
+) -> Option<Vec<platform_wallet_ffi::FundingAddressEntryFFI>> {
     let bytes = match env.convert_byte_array(arr) {
         Ok(b) => b,
         Err(_) => {
@@ -1746,7 +1749,6 @@ fn decode_funding_recipients(
         return None;
     }
     let mut entries = Vec::with_capacity(count);
-    let mut remainder_index: Option<u16> = None;
     for i in 0..count {
         let Some(type_byte) = read(&mut cursor, 1) else {
             throw_sdk_exception(
@@ -1783,9 +1785,6 @@ fn decode_funding_recipients(
         let mut hash = [0u8; 20];
         hash.copy_from_slice(&hash_bytes);
         let has_balance = has_balance_byte[0] != 0;
-        if !has_balance && remainder_index.is_none() {
-            remainder_index = Some(i as u16);
-        }
         let balance = u64::from_be_bytes(balance_bytes.as_slice().try_into().ok()?);
         // The Kotlin encoder writes this field from a signed long; a set
         // sign bit means a negative amount crossed the boundary — reject
@@ -1807,15 +1806,10 @@ fn decode_funding_recipients(
             balance,
         });
     }
-    // Exactly one remainder recipient must be present (the fee-absorbing
-    // output). The Rust FFI enforces this too, but we need its index for
-    // the ReduceOutput fee step.
-    let remainder = remainder_index.unwrap_or(0);
-    let fee_rows = vec![platform_wallet_ffi::FeeStrategyStepFFI {
-        step_type: 1, // 1 = ReduceOutput
-        index: remainder,
-    }];
-    Some((entries, fee_rows))
+    // The "exactly one remainder recipient" rule is enforced by
+    // `platform-wallet`'s pre-flight, which returns a typed error before
+    // anything is broadcast.
+    Some(entries)
 }
 
 /// Decode the credit-outputs BLOB for a wallet-signed platform-address
@@ -1984,7 +1978,7 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_WalletManagerNative_w
             return ptr::null_mut();
         }
 
-        let Some((entries, fee_rows)) = decode_funding_recipients(env, &recipients_blob) else {
+        let Some(entries) = decode_funding_recipients(env, &recipients_blob) else {
             return ptr::null_mut();
         };
 
@@ -2012,8 +2006,9 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_WalletManagerNative_w
                 platform_account_index as u32,
                 entries.as_ptr(),
                 entries.len(),
-                fee_rows.as_ptr(),
-                fee_rows.len(),
+                // The fee strategy is derived Rust-side; these are ignored.
+                ptr::null(),
+                0,
                 signer_handle as *mut rs_sdk_ffi::SignerHandle,
                 core_signer_handle as *mut rs_sdk_ffi::MnemonicResolverHandle,
                 &mut changeset as *mut platform_wallet_ffi::PlatformAddressChangeSetFFI,
@@ -2096,7 +2091,7 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_WalletManagerNative_w
             vout: out_point_vout as u32,
         };
 
-        let Some((entries, fee_rows)) = decode_funding_recipients(env, &recipients_blob) else {
+        let Some(entries) = decode_funding_recipients(env, &recipients_blob) else {
             return ptr::null_mut();
         };
 
@@ -2122,8 +2117,9 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_WalletManagerNative_w
                 platform_account_index as u32,
                 entries.as_ptr(),
                 entries.len(),
-                fee_rows.as_ptr(),
-                fee_rows.len(),
+                // The fee strategy is derived Rust-side; these are ignored.
+                ptr::null(),
+                0,
                 signer_handle as *mut rs_sdk_ffi::SignerHandle,
                 core_signer_handle as *mut rs_sdk_ffi::MnemonicResolverHandle,
                 &mut changeset as *mut platform_wallet_ffi::PlatformAddressChangeSetFFI,

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/DashModelContainer.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/DashModelContainer.swift
@@ -3,9 +3,16 @@ import SwiftData
 
 /// Factory for creating SwiftData model containers for Dash Platform persistence
 public enum DashModelContainer {
-    /// The exact model set shipped as schema V1. Keep frozen: staged
-    /// migration identifies an existing store by this schema checksum.
-    fileprivate static var v1ModelTypes: [any PersistentModel.Type] {
+    /// Every registered schema version's model list, parameterised on the
+    /// one model whose shape differs between versions.
+    ///
+    /// Ordering is load-bearing only in the sense that it must not need to
+    /// change: keeping `assetLock` in the slot the live `PersistentAssetLock`
+    /// occupied means a frozen version's list is positionally identical to
+    /// what that version shipped.
+    private static func allModelTypes(
+        assetLock: any PersistentModel.Type
+    ) -> [any PersistentModel.Type] {
         [
             PersistentIdentity.self,
             PersistentDPNSName.self,
@@ -38,20 +45,38 @@ public enum DashModelContainer {
             PersistentShieldedSyncState.self,
             PersistentShieldedActivity.self,
             PersistentShieldedViewingKey.self,
-            PersistentAssetLock.self,
+            assetLock,
             PersistentInvitation.self,
             PersistentMasternode.self
         ]
     }
 
-    /// All persistent model types in the current Dash SDK schema.
-    public static var modelTypes: [any PersistentModel.Type] {
+    /// The exact model set registered as schema V1. Keep frozen: staged
+    /// migration identifies an existing store by this schema's checksum, so
+    /// this list may only reference models whose shape is frozen (see
+    /// `DashSchemaFrozenModels.swift`).
+    fileprivate static var v1ModelTypes: [any PersistentModel.Type] {
+        allModelTypes(assetLock: DashSchemaV1.PersistentAssetLock.self)
+    }
+
+    /// The exact model set registered as schema V2 — V1 plus
+    /// `PersistentTrackedMasternode`. Frozen for the same reason as
+    /// `v1ModelTypes`.
+    fileprivate static var v2ModelTypes: [any PersistentModel.Type] {
         v1ModelTypes + [PersistentTrackedMasternode.self]
+    }
+
+    /// All persistent model types in the current Dash SDK schema (V3).
+    /// Unlike `v1ModelTypes` / `v2ModelTypes` this list tracks the LIVE
+    /// models, so it moves whenever a model gains a property — which is
+    /// exactly why the released versions above must not.
+    public static var modelTypes: [any PersistentModel.Type] {
+        allModelTypes(assetLock: PersistentAssetLock.self) + [PersistentTrackedMasternode.self]
     }
 
     /// Create the schema for all Dash Platform models
     public static var schema: Schema {
-        Schema(versionedSchema: DashSchemaV2.self)
+        Schema(versionedSchema: DashSchemaV3.self)
     }
 
     /// Create a persistent model container for storing data
@@ -99,12 +124,13 @@ public enum DashModelContainer {
 /// SwiftData migration plan for Dash Platform model updates
 public enum DashMigrationPlan: SchemaMigrationPlan {
     public static var schemas: [any VersionedSchema.Type] {
-        [DashSchemaV1.self, DashSchemaV2.self]
+        [DashSchemaV1.self, DashSchemaV2.self, DashSchemaV3.self]
     }
 
     public static var stages: [MigrationStage] {
         [
-            .lightweight(fromVersion: DashSchemaV1.self, toVersion: DashSchemaV2.self)
+            .lightweight(fromVersion: DashSchemaV1.self, toVersion: DashSchemaV2.self),
+            .lightweight(fromVersion: DashSchemaV2.self, toVersion: DashSchemaV3.self)
         ]
     }
 }
@@ -247,6 +273,27 @@ public enum DashSchemaV1: VersionedSchema {
 public enum DashSchemaV2: VersionedSchema {
     public static var versionIdentifier: Schema.Version {
         Schema.Version(2, 0, 0)
+    }
+
+    public static var models: [any PersistentModel.Type] {
+        DashModelContainer.v2ModelTypes
+    }
+}
+
+/// Version 3 adds `recipientIsExternal` to `PersistentAssetLock` — an
+/// optional column on an existing entity, so a lightweight migration
+/// preserves every existing row and backfills `NULL`.
+///
+/// This is the first version to be registered alongside a genuinely frozen
+/// copy of the model it changes (`DashSchemaV1.PersistentAssetLock`). Without
+/// that copy, adding the property would have mutated V1's and V2's checksums
+/// in place and a store written by the V2 binary would have matched no
+/// registered schema, failing to open with Cocoa error 134504 rather than
+/// migrating. Follow the same pattern for the next property added to any
+/// model: freeze the old shape, add a version, add a stage.
+public enum DashSchemaV3: VersionedSchema {
+    public static var versionIdentifier: Schema.Version {
+        Schema.Version(3, 0, 0)
     }
 
     public static var models: [any PersistentModel.Type] {

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/DashSchemaFrozenModels.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/DashSchemaFrozenModels.swift
@@ -1,0 +1,102 @@
+import Foundation
+import SwiftData
+
+// MARK: - Frozen model definitions for already-released schema versions
+//
+// A `VersionedSchema` identifies a store by the CHECKSUM of the entities it
+// declares, not by the identity of the Swift type list. So a registered
+// schema version may only ever reference model types whose *shape* is frozen
+// at the moment that version shipped. Pointing `DashSchemaVN.models` at a
+// live `@Model` type means the next property added to that type silently
+// mutates version N's checksum in place: a store written by the previously
+// released binary then matches no schema in `DashMigrationPlan.schemas`, and
+// `ModelContainer(for:migrationPlan:configurations:)` fails to open it with
+// Cocoa error 134504 ("Cannot use staged migration with an unknown model
+// version") instead of migrating it.
+//
+// This file holds the frozen copies. A frozen copy must be a *nested* type,
+// because SwiftData derives the entity name from the unqualified type name —
+// `DashSchemaV1.PersistentAssetLock` and the top-level `PersistentAssetLock`
+// are two distinct Swift types that both describe the entity named
+// "PersistentAssetLock", which is exactly what lets a migration stage map one
+// onto the other. (`DashModelMigrationTests` asserts that entity naming, so a
+// future SwiftData change to the derivation would fail loudly rather than
+// silently renaming an entity.)
+//
+// ## Scope of the freeze
+//
+// Only `PersistentAssetLock` is frozen today, because it is the only model
+// this file's callers have changed since V2 shipped. Every other model in
+// `DashSchemaV1` / `DashSchemaV2` is still referenced live and therefore
+// still carries the same latent defect. Freezing them is a mechanical but
+// wide change (34 models) and is deliberately left out of the change that
+// introduced this file; when the next model gains a property, freeze that
+// one here too and add the matching stage.
+//
+// V1's own checksum has already drifted from what actually shipped as V1
+// (see the `DashSchemaV1` doc comment: several models were changed in place
+// while V1 was the only registered version, and dev stores at V1 are
+// knowingly expected to fail open and be rebuilt). The frozen copy below is
+// therefore the shape as of the V2 release, shared by V1 and V2 — which is
+// what makes V1 -> V2 continue to be "add `PersistentTrackedMasternode`"
+// and nothing else, exactly as before.
+
+extension DashSchemaV1 {
+    /// `PersistentAssetLock` frozen at the shape it had when schema V2
+    /// shipped — i.e. everything the live model has today EXCEPT
+    /// `recipientIsExternal`, which is what V3 adds.
+    ///
+    /// Referenced by both `DashSchemaV1.models` and `DashSchemaV2.models`.
+    /// Do not add properties here and do not "fix" its doc comments to
+    /// match the live model: every attribute, its optionality, its default
+    /// value, the `@Attribute(.unique)` marker and the `#Index` are all
+    /// inputs to the V2 checksum, and changing any of them re-breaks the
+    /// V2 stores this type exists to keep openable. Doc comments are not
+    /// inputs to the checksum, but keeping them minimal here keeps the
+    /// live model the single place worth reading.
+    ///
+    /// See the live ``SwiftDashSDK/PersistentAssetLock`` for what each
+    /// column means.
+    @Model
+    final class PersistentAssetLock {
+        #Index<PersistentAssetLock>([\.walletId])
+
+        @Attribute(.unique) var outPointHex: String
+        var walletId: Data
+        var transactionBytes: Data
+        var fundingTypeRaw: Int
+        var identityIndexRaw: Int32
+        var accountIndexRaw: Int32 = 0
+        var amountDuffs: Int64
+        var statusRaw: Int
+        var proofBytes: Data?
+        var recipientPlatformAddressHash: Data?
+        var recipientPlatformAddressType: UInt8?
+        var createdAt: Date
+        var updatedAt: Date
+
+        init(
+            outPointHex: String,
+            walletId: Data,
+            transactionBytes: Data,
+            fundingTypeRaw: Int,
+            identityIndexRaw: Int32,
+            accountIndexRaw: Int32 = 0,
+            amountDuffs: Int64,
+            statusRaw: Int,
+            proofBytes: Data? = nil
+        ) {
+            self.outPointHex = outPointHex
+            self.walletId = walletId
+            self.transactionBytes = transactionBytes
+            self.fundingTypeRaw = fundingTypeRaw
+            self.identityIndexRaw = identityIndexRaw
+            self.accountIndexRaw = accountIndexRaw
+            self.amountDuffs = amountDuffs
+            self.statusRaw = statusRaw
+            self.proofBytes = proofBytes
+            self.createdAt = Date()
+            self.updatedAt = Date()
+        }
+    }
+}

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentAssetLock.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentAssetLock.swift
@@ -38,9 +38,10 @@ import SwiftData
 /// - **Platform address** (`fundingTypeRaw == 4` —
 ///   AssetLockAddressTopUp):
 ///   `recipientPlatformAddressHash` + `recipientPlatformAddressType`
-///   identify the destination. Set by Swift on the controller's
-///   `.completed` phase because the recipient is picked at
-///   ST-submit time on the host side; Rust never sees it.
+///   identify the destination, and `recipientIsExternal` says whether
+///   it belongs to this wallet or to a third party. Set by Swift on
+///   the controller's `.completed` phase because the recipient is
+///   picked at ST-submit time on the host side; Rust never sees it.
 ///
 /// - **Shielded address** (`fundingTypeRaw == 5` —
 ///   AssetLockShieldedAddressTopUp, not yet wired): will add a
@@ -157,6 +158,39 @@ public final class PersistentAssetLock {
     /// without joining against `PersistentPlatformAddress`. `nil`
     /// whenever `recipientPlatformAddressHash` is `nil`.
     public var recipientPlatformAddressType: UInt8?
+
+    /// Whether `recipientPlatformAddressHash` is a THIRD PARTY's
+    /// address (`true`) or one of this wallet's own addresses
+    /// (`false`) — the own/external discriminator for the funding
+    /// type 4 field-family.
+    ///
+    /// Without it, a populated recipient hash is ambiguous. Consumers
+    /// read that hash as "this lock topped up an address of mine" —
+    /// `PlatformAddressActivityStore.matchesOwnAssetLockTopUp` in
+    /// dashwallet-ios does exactly that — so an outgoing payment to
+    /// someone else would be rendered as an incoming credit to the
+    /// user. `true` marks the row as an outgoing send whose recipient
+    /// hash names a stranger and therefore will NEVER have a matching
+    /// `PersistentPlatformAddress` row.
+    ///
+    /// Written by the caller that picked the recipient, alongside the
+    /// hash and type: `false` for `fundFromAssetLock`, `true` for
+    /// `fundFromAssetLockExternal`.
+    ///
+    /// `nil` for:
+    /// - Identity-funding asset locks (no platform-address recipient).
+    /// - Address-funding locks that haven't completed yet.
+    /// - Pre-this-commit address-funding locks that completed before
+    ///   the field existed. Treat `nil` alongside a populated
+    ///   `recipientPlatformAddressHash` as "own" — that was the only
+    ///   flow those rows could have come from.
+    ///
+    /// Default `nil` on the column makes SwiftData's lightweight
+    /// migration safe for rows that pre-date this field; adding an
+    /// optional property to an existing `@Model` needs no new
+    /// `MigrationStage`, and the model LIST is unchanged, so
+    /// `DashMigrationPlan` is untouched.
+    public var recipientIsExternal: Bool?
 
     /// Record timestamps.
     public var createdAt: Date

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentAssetLock.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentAssetLock.swift
@@ -185,11 +185,25 @@ public final class PersistentAssetLock {
     ///   `recipientPlatformAddressHash` as "own" — that was the only
     ///   flow those rows could have come from.
     ///
-    /// Default `nil` on the column makes SwiftData's lightweight
-    /// migration safe for rows that pre-date this field; adding an
-    /// optional property to an existing `@Model` needs no new
-    /// `MigrationStage`, and the model LIST is unchanged, so
-    /// `DashMigrationPlan` is untouched.
+    /// ## Migration
+    ///
+    /// Adding this property is a lightweight-migratable change (a new
+    /// optional column backfilled `NULL`), but it is NOT a free one: a
+    /// `VersionedSchema` identifies a store by the CHECKSUM of the
+    /// entities it declares, so adding a property to the live model
+    /// mutates the checksum of every registered schema version that
+    /// references it. The model LIST being unchanged is irrelevant.
+    ///
+    /// Left unaddressed, a store written by the V2 binary would match no
+    /// schema in `DashMigrationPlan.schemas` and
+    /// `ModelContainer(for:migrationPlan:configurations:)` would fail to
+    /// open it with Cocoa error 134504 ("Cannot use staged migration with
+    /// an unknown model version"). So V1 and V2 now reference a frozen
+    /// copy of this model (`DashSchemaV1.PersistentAssetLock`, in
+    /// `DashSchemaFrozenModels.swift`), this property is what schema
+    /// `DashSchemaV3` adds, and a lightweight V2 -> V3 stage carries
+    /// existing stores across. Do the same for the next property added
+    /// here.
     public var recipientIsExternal: Bool?
 
     /// Record timestamps.

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
@@ -623,12 +623,20 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
 
     // MARK: - Fund from Core asset lock
 
-    /// Recipient entry for `fundFromAssetLock(...)`.
+    /// Recipient entry for `fundFromAssetLock(...)` and
+    /// `fundFromAssetLockExternal(...)`.
     ///
     /// Exactly one entry per call must have `credits = nil` — that
     /// address receives the remainder after explicit outputs and fees
     /// (the asset lock is consumed in full, so a remainder bucket is
     /// mandatory).
+    ///
+    /// There is deliberately no `isExternal` flag here: whether a
+    /// recipient may be a third party is decided by WHICH entry point
+    /// you call, not per row. The same convention as the shielded
+    /// funding surface, and it keeps "am I allowed to pay a stranger?"
+    /// a single, auditable decision at the call site rather than a
+    /// property buried in one element of an array.
     public struct FundFromAssetLockRecipient: Sendable {
         /// Must be `0` (P2PKH). Funding recipients flow through the same
         /// P2PKH-only Rust `TryFrom<PlatformAddressFFI>` as transfer
@@ -666,10 +674,14 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
     ///   - platformAccountIndex: Platform-payment account containing
     ///     `recipients`. Used for the membership pre-flight on the Rust
     ///     side and the post-success balance write.
-    ///   - recipients: Destination addresses. Exactly one must carry
+    ///   - recipients: Destination addresses, ALL of which must belong
+    ///     to `platformAccountIndex`. Exactly one must carry
     ///     `credits = nil` (remainder recipient). The Rust side
     ///     enforces both invariants and returns a typed error if
-    ///     either is violated.
+    ///     either is violated. To pay an address this wallet does not
+    ///     own, use [`fundFromAssetLockExternal`] instead — this entry
+    ///     point deliberately keeps rejecting unknown addresses so a
+    ///     typo cannot become an irreversible payment to a stranger.
     ///   - signer: `KeychainSigner` used for any input-witness
     ///     signatures on the address-funding transition. The same
     ///     wallet's `MnemonicResolver` (constructed internally) signs
@@ -685,7 +697,7 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
         recipients: [FundFromAssetLockRecipient],
         signer: KeychainSigner
     ) async throws -> [UpdatedBalance] {
-        try fundFromAssetLockPreflight(recipients: recipients)
+        try Self.fundFromAssetLockPreflight(recipients: recipients)
         let handle = self.handle
         let signerHandle = signer.handle
         let recipientRows = recipients
@@ -699,26 +711,7 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
 
         return try await Task.detached(priority: .userInitiated) {
             () -> [UpdatedBalance] in
-            let ffiAddresses = recipientRows.map { r -> FundingAddressEntryFFI in
-                FundingAddressEntryFFI(
-                    address: PlatformAddressFFI(
-                        address_type: r.addressType,
-                        hash: Self.hashTuple(from: r.hash)
-                    ),
-                    has_balance: r.credits != nil,
-                    balance: r.credits ?? 0
-                )
-            }
-            // Take the fee out of the remainder output. Today the
-            // `None` recipient is structurally the same as the
-            // "change" output on a transfer — it absorbs whatever's
-            // left after explicit outputs + fees.
-            let remainderIndex = UInt16(
-                ffiAddresses.firstIndex(where: { !$0.has_balance }) ?? 0
-            )
-            let feeRows: [FeeStrategyStepFFI] = [
-                FeeStrategyStepFFI(step_type: 1, index: remainderIndex)  // 1 = ReduceOutput
-            ]
+            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
             var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
             let result = withExtendedLifetime((signer, coreSigner)) {
                 ffiAddresses.withUnsafeBufferPointer { addrBp in
@@ -778,7 +771,7 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
                 "outPointTxid must be exactly 32 bytes (was \(outPointTxid.count))"
             )
         }
-        try fundFromAssetLockPreflight(recipients: recipients)
+        try Self.fundFromAssetLockPreflight(recipients: recipients)
         let handle = self.handle
         let signerHandle = signer.handle
         let recipientRows = recipients
@@ -786,37 +779,11 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
 
         return try await Task.detached(priority: .userInitiated) {
             () -> [UpdatedBalance] in
-            var txidTuple: (
-                UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-                UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-                UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-                UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
-            ) = (
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            var outPoint = OutPointFFI(
+                txid: Self.txidTuple(from: outPointTxid),
+                vout: outPointVout
             )
-            outPointTxid.withUnsafeBytes { src in
-                Swift.withUnsafeMutableBytes(of: &txidTuple) { dst in
-                    dst.copyMemory(from: src)
-                }
-            }
-            var outPoint = OutPointFFI(txid: txidTuple, vout: outPointVout)
-            let ffiAddresses = recipientRows.map { r -> FundingAddressEntryFFI in
-                FundingAddressEntryFFI(
-                    address: PlatformAddressFFI(
-                        address_type: r.addressType,
-                        hash: Self.hashTuple(from: r.hash)
-                    ),
-                    has_balance: r.credits != nil,
-                    balance: r.credits ?? 0
-                )
-            }
-            let remainderIndex = UInt16(
-                ffiAddresses.firstIndex(where: { !$0.has_balance }) ?? 0
-            )
-            let feeRows: [FeeStrategyStepFFI] = [
-                FeeStrategyStepFFI(step_type: 1, index: remainderIndex)  // 1 = ReduceOutput
-            ]
+            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
             var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
             let result = withExtendedLifetime((signer, coreSigner)) {
                 ffiAddresses.withUnsafeBufferPointer { addrBp in
@@ -843,11 +810,291 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
         }.value
     }
 
+    // MARK: - Fund an external recipient from a Core asset lock
+
+    /// Pay a THIRD PARTY's platform address from a Core L1 asset lock,
+    /// keeping the remainder (change) on one of this wallet's own
+    /// addresses.
+    ///
+    /// Sibling to [`fundFromAssetLock`]: same orchestration, same
+    /// parameters, same return value. The only delta is on the Rust
+    /// side's recipient pre-flight — explicit-amount recipients may be
+    /// ANY valid P2PKH platform address, not just members of
+    /// `platformAccountIndex`.
+    ///
+    /// Externality is a property of WHICH function you call, not a flag
+    /// on `FundFromAssetLockRecipient` — the same shape the shielded
+    /// funding surface uses. Keep using [`fundFromAssetLock`] for
+    /// self-funding: there a mistyped address is rejected before
+    /// anything is broadcast, while here it is a valid and irreversible
+    /// payment to a stranger.
+    ///
+    /// - Parameters:
+    ///   - amountDuffs: Amount to lock in Core duffs.
+    ///   - fundingAccountIndex: standard-family source index — see
+    ///     [`fundFromAssetLock`].
+    ///   - platformAccountIndex: Platform-payment account that owns the
+    ///     REMAINDER recipient. Explicit-amount recipients are not
+    ///     required to belong to it.
+    ///   - recipients: Exactly one entry must carry `credits = nil` (the
+    ///     remainder, which must be an address of this wallet); at least
+    ///     one entry must carry an explicit amount, otherwise there is
+    ///     no external payment to make and [`fundFromAssetLock`] is the
+    ///     right call.
+    ///   - signer: `KeychainSigner` — see [`fundFromAssetLock`].
+    ///
+    /// Returns `[UpdatedBalance]` for the recipients that resolved to
+    /// this wallet — in practice just the remainder/change address. The
+    /// third party's output is proven and credited on Platform but has
+    /// no local row, so it does not appear here; query its balance to
+    /// observe it.
+    @discardableResult
+    public func fundFromAssetLockExternal(
+        amountDuffs: UInt64,
+        fundingAccountIndex: UInt32,
+        platformAccountIndex: UInt32,
+        recipients: [FundFromAssetLockRecipient],
+        signer: KeychainSigner
+    ) async throws -> [UpdatedBalance] {
+        try Self.fundFromAssetLockExternalPreflight(recipients: recipients)
+        let handle = self.handle
+        let signerHandle = signer.handle
+        let recipientRows = recipients
+        // Constructed on the calling actor so it lives for the entire
+        // detached Task — see `fundFromAssetLock` for why `_ = signer`
+        // is not a substitute.
+        let coreSigner = MnemonicResolver()
+
+        return try await Task.detached(priority: .userInitiated) {
+            () -> [UpdatedBalance] in
+            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
+            var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
+            let result = withExtendedLifetime((signer, coreSigner)) {
+                ffiAddresses.withUnsafeBufferPointer { addrBp in
+                    feeRows.withUnsafeBufferPointer { feeBp in
+                        platform_address_wallet_fund_from_asset_lock_external_signer(
+                            handle,
+                            amountDuffs,
+                            fundingAccountIndex,
+                            platformAccountIndex,
+                            addrBp.baseAddress,
+                            UInt(addrBp.count),
+                            feeBp.baseAddress,
+                            UInt(feeBp.count),
+                            signerHandle,
+                            coreSigner.handle,
+                            &changeset
+                        )
+                    }
+                }
+            }
+            try result.check()
+
+            defer { platform_address_wallet_free_changeset(&changeset) }
+            return Self.decodeChangeset(&changeset)
+        }.value
+    }
+
+    /// Resume a stuck external-recipient funding flow from an
+    /// already-tracked asset lock by outpoint.
+    ///
+    /// Sibling to [`resumeFundFromAssetLock`] (same resume-by-outpoint
+    /// shape) and to [`fundFromAssetLockExternal`] (same relaxed
+    /// recipient rules).
+    ///
+    /// The recipients are a PARAMETER, not something recovered from the
+    /// tracked lock: Rust never learns the destination of an
+    /// address-funding asset lock — it only tracks the L1 outpoint, its
+    /// status and its proof. The host is responsible for round-tripping
+    /// the intended recipient, which is what
+    /// `PersistentAssetLock.recipientPlatformAddressHash` /
+    /// `.recipientIsExternal` record. Resuming with a different
+    /// recipient set pays the new set; the asset lock is a bearer input,
+    /// not a commitment to a destination.
+    ///
+    /// - Parameters:
+    ///   - outPointTxid: 32-byte raw txid (little-endian wire order) —
+    ///     see [`resumeFundFromAssetLock`].
+    ///   - outPointVout: Funding output index.
+    @discardableResult
+    public func resumeFundFromAssetLockExternal(
+        outPointTxid: Data,
+        outPointVout: UInt32,
+        platformAccountIndex: UInt32,
+        recipients: [FundFromAssetLockRecipient],
+        signer: KeychainSigner
+    ) async throws -> [UpdatedBalance] {
+        guard outPointTxid.count == 32 else {
+            throw PlatformWalletError.invalidParameter(
+                "outPointTxid must be exactly 32 bytes (was \(outPointTxid.count))"
+            )
+        }
+        try Self.fundFromAssetLockExternalPreflight(recipients: recipients)
+        let handle = self.handle
+        let signerHandle = signer.handle
+        let recipientRows = recipients
+        let coreSigner = MnemonicResolver()
+
+        return try await Task.detached(priority: .userInitiated) {
+            () -> [UpdatedBalance] in
+            var outPoint = OutPointFFI(
+                txid: Self.txidTuple(from: outPointTxid),
+                vout: outPointVout
+            )
+            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
+            var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
+            let result = withExtendedLifetime((signer, coreSigner)) {
+                ffiAddresses.withUnsafeBufferPointer { addrBp in
+                    feeRows.withUnsafeBufferPointer { feeBp in
+                        platform_address_wallet_resume_fund_from_asset_lock_external_signer(
+                            handle,
+                            &outPoint,
+                            platformAccountIndex,
+                            addrBp.baseAddress,
+                            UInt(addrBp.count),
+                            feeBp.baseAddress,
+                            UInt(feeBp.count),
+                            signerHandle,
+                            coreSigner.handle,
+                            &changeset
+                        )
+                    }
+                }
+            }
+            try result.check()
+
+            defer { platform_address_wallet_free_changeset(&changeset) }
+            return Self.decodeChangeset(&changeset)
+        }.value
+    }
+
+    /// Recipients in the order the Rust side will see them.
+    ///
+    /// `decode_funding_addresses` collects the FFI array into a
+    /// `BTreeMap<PlatformAddress, Option<Credits>>`, and consensus
+    /// resolves `ReduceOutput(index)` positionally against THAT map's key
+    /// order — never against the order the caller happened to list its
+    /// recipients in. `PlatformAddress`'s derived `Ord` orders by variant
+    /// first (P2PKH before P2SH) and then by the 20-byte hash, so
+    /// reproducing it here is a two-key sort.
+    ///
+    /// Sorting before marshalling makes array position and consensus
+    /// output index the same number, which is what lets
+    /// [`remainderStepIndex`] name the remainder output correctly. The
+    /// recipient SET is unaffected — a `BTreeMap` does not care what
+    /// order it was filled in.
+    static func canonicallyOrderedRecipients(
+        _ recipients: [FundFromAssetLockRecipient]
+    ) -> [FundFromAssetLockRecipient] {
+        recipients.sorted { lhs, rhs in
+            if lhs.addressType != rhs.addressType {
+                return lhs.addressType < rhs.addressType
+            }
+            return lhs.hash.lexicographicallyPrecedes(rhs.hash)
+        }
+    }
+
+    /// Position of the remainder (`credits == nil`) recipient within a
+    /// [`canonicallyOrderedRecipients`] list — i.e. the index consensus
+    /// will resolve `ReduceOutput` against.
+    ///
+    /// Callers never supply this index themselves. A positional index
+    /// over a lexicographically-ordered map is a live hazard: adding one
+    /// recipient can shift which output pays the fee, and with a
+    /// third-party payee in the set that means the payee's explicit
+    /// amount silently absorbs the fee instead of the sender's change.
+    /// Computing it here from the canonical order is what prevents that.
+    static func remainderStepIndex(
+        in ordered: [FundFromAssetLockRecipient]
+    ) -> UInt16 {
+        UInt16(ordered.firstIndex(where: { $0.credits == nil }) ?? 0)
+    }
+
+    /// Marshal recipients into the FFI address array plus the matching
+    /// fee strategy.
+    ///
+    /// The fee comes out of the remainder output: the `nil`-credits
+    /// recipient is structurally the "change" output — it absorbs
+    /// whatever is left after the explicit outputs and fees.
+    static func marshalFundingRequest(
+        _ recipients: [FundFromAssetLockRecipient]
+    ) -> (addresses: [FundingAddressEntryFFI], feeStrategy: [FeeStrategyStepFFI]) {
+        let ordered = canonicallyOrderedRecipients(recipients)
+        let addresses = ordered.map { r -> FundingAddressEntryFFI in
+            FundingAddressEntryFFI(
+                address: PlatformAddressFFI(
+                    address_type: r.addressType,
+                    hash: Self.hashTuple(from: r.hash)
+                ),
+                has_balance: r.credits != nil,
+                balance: r.credits ?? 0
+            )
+        }
+        let feeStrategy = [
+            FeeStrategyStepFFI(step_type: 1, index: remainderStepIndex(in: ordered))  // 1 = ReduceOutput
+        ]
+        return (addresses, feeStrategy)
+    }
+
+    /// Copy a 32-byte txid `Data` into the C tuple `OutPointFFI` wants.
+    private static func txidTuple(
+        from data: Data
+    ) -> (
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+    ) {
+        var tuple: (
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+        ) = (
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        )
+        data.withUnsafeBytes { src in
+            Swift.withUnsafeMutableBytes(of: &tuple) { dst in
+                dst.copyMemory(from: src)
+            }
+        }
+        return tuple
+    }
+
+    /// Pre-flight for the external-recipient entry points.
+    ///
+    /// Sibling to [`fundFromAssetLockPreflight`]: every rule there still
+    /// applies verbatim — exactly one remainder, P2PKH only (address
+    /// type `0`), 20-byte hashes. Third-party explicit-amount
+    /// recipients were already permitted by those rules, because
+    /// ownership is not something Swift can check: only the Rust side
+    /// knows which addresses belong to `platformAccountIndex`, and it
+    /// enforces the remaining rule (the remainder must be ours) in
+    /// `fund_from_asset_lock_external`.
+    ///
+    /// The one rule this ADDS: at least one explicit-amount recipient.
+    /// A call with nothing but a remainder makes no external payment at
+    /// all, so it is a caller mistake — [`fundFromAssetLock`] is the
+    /// entry point for pure self-funding, and it validates the
+    /// destination properly.
+    static func fundFromAssetLockExternalPreflight(
+        recipients: [FundFromAssetLockRecipient]
+    ) throws {
+        try Self.fundFromAssetLockPreflight(recipients: recipients)
+        guard recipients.contains(where: { $0.credits != nil }) else {
+            throw PlatformWalletError.invalidParameter(
+                "fundFromAssetLockExternal requires at least one explicit-amount recipient; "
+                    + "a remainder-only request funds nothing externally — use fundFromAssetLock"
+            )
+        }
+    }
+
     /// Validate the recipient list before the FFI sees it. The Rust
     /// side enforces the same invariants — we duplicate them here so
     /// the user gets a synchronous error before paying for the Task
     /// detach + handle marshaling.
-    private func fundFromAssetLockPreflight(
+    static func fundFromAssetLockPreflight(
         recipients: [FundFromAssetLockRecipient]
     ) throws {
         guard !recipients.isEmpty else {

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
@@ -711,25 +711,25 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
 
         return try await Task.detached(priority: .userInitiated) {
             () -> [UpdatedBalance] in
-            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
+            let ffiAddresses = Self.marshalRecipients(recipientRows)
             var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
             let result = withExtendedLifetime((signer, coreSigner)) {
                 ffiAddresses.withUnsafeBufferPointer { addrBp in
-                    feeRows.withUnsafeBufferPointer { feeBp in
-                        platform_address_wallet_fund_from_asset_lock_signer(
-                            handle,
-                            amountDuffs,
-                            fundingAccountIndex,
-                            platformAccountIndex,
-                            addrBp.baseAddress,
-                            UInt(addrBp.count),
-                            feeBp.baseAddress,
-                            UInt(feeBp.count),
-                            signerHandle,
-                            coreSigner.handle,
-                            &changeset
-                        )
-                    }
+                    platform_address_wallet_fund_from_asset_lock_signer(
+                        handle,
+                        amountDuffs,
+                        fundingAccountIndex,
+                        platformAccountIndex,
+                        addrBp.baseAddress,
+                        UInt(addrBp.count),
+                        // Fee strategy is derived Rust-side from the
+                        // recipient map; these parameters are ignored.
+                        nil,
+                        0,
+                        signerHandle,
+                        coreSigner.handle,
+                        &changeset
+                    )
                 }
             }
             try result.check()
@@ -783,24 +783,24 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
                 txid: Self.txidTuple(from: outPointTxid),
                 vout: outPointVout
             )
-            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
+            let ffiAddresses = Self.marshalRecipients(recipientRows)
             var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
             let result = withExtendedLifetime((signer, coreSigner)) {
                 ffiAddresses.withUnsafeBufferPointer { addrBp in
-                    feeRows.withUnsafeBufferPointer { feeBp in
-                        platform_address_wallet_resume_fund_from_asset_lock_signer(
-                            handle,
-                            &outPoint,
-                            platformAccountIndex,
-                            addrBp.baseAddress,
-                            UInt(addrBp.count),
-                            feeBp.baseAddress,
-                            UInt(feeBp.count),
-                            signerHandle,
-                            coreSigner.handle,
-                            &changeset
-                        )
-                    }
+                    platform_address_wallet_resume_fund_from_asset_lock_signer(
+                        handle,
+                        &outPoint,
+                        platformAccountIndex,
+                        addrBp.baseAddress,
+                        UInt(addrBp.count),
+                        // Fee strategy is derived Rust-side from the
+                        // recipient map; these parameters are ignored.
+                        nil,
+                        0,
+                        signerHandle,
+                        coreSigner.handle,
+                        &changeset
+                    )
                 }
             }
             try result.check()
@@ -867,25 +867,25 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
 
         return try await Task.detached(priority: .userInitiated) {
             () -> [UpdatedBalance] in
-            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
+            let ffiAddresses = Self.marshalRecipients(recipientRows)
             var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
             let result = withExtendedLifetime((signer, coreSigner)) {
                 ffiAddresses.withUnsafeBufferPointer { addrBp in
-                    feeRows.withUnsafeBufferPointer { feeBp in
-                        platform_address_wallet_fund_from_asset_lock_external_signer(
-                            handle,
-                            amountDuffs,
-                            fundingAccountIndex,
-                            platformAccountIndex,
-                            addrBp.baseAddress,
-                            UInt(addrBp.count),
-                            feeBp.baseAddress,
-                            UInt(feeBp.count),
-                            signerHandle,
-                            coreSigner.handle,
-                            &changeset
-                        )
-                    }
+                    platform_address_wallet_fund_from_asset_lock_external_signer(
+                        handle,
+                        amountDuffs,
+                        fundingAccountIndex,
+                        platformAccountIndex,
+                        addrBp.baseAddress,
+                        UInt(addrBp.count),
+                        // Fee strategy is derived Rust-side from the
+                        // recipient map; these parameters are ignored.
+                        nil,
+                        0,
+                        signerHandle,
+                        coreSigner.handle,
+                        &changeset
+                    )
                 }
             }
             try result.check()
@@ -941,24 +941,24 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
                 txid: Self.txidTuple(from: outPointTxid),
                 vout: outPointVout
             )
-            let (ffiAddresses, feeRows) = Self.marshalFundingRequest(recipientRows)
+            let ffiAddresses = Self.marshalRecipients(recipientRows)
             var changeset = PlatformAddressChangeSetFFI(updated: nil, updated_count: 0)
             let result = withExtendedLifetime((signer, coreSigner)) {
                 ffiAddresses.withUnsafeBufferPointer { addrBp in
-                    feeRows.withUnsafeBufferPointer { feeBp in
-                        platform_address_wallet_resume_fund_from_asset_lock_external_signer(
-                            handle,
-                            &outPoint,
-                            platformAccountIndex,
-                            addrBp.baseAddress,
-                            UInt(addrBp.count),
-                            feeBp.baseAddress,
-                            UInt(feeBp.count),
-                            signerHandle,
-                            coreSigner.handle,
-                            &changeset
-                        )
-                    }
+                    platform_address_wallet_resume_fund_from_asset_lock_external_signer(
+                        handle,
+                        &outPoint,
+                        platformAccountIndex,
+                        addrBp.baseAddress,
+                        UInt(addrBp.count),
+                        // Fee strategy is derived Rust-side from the
+                        // recipient map; these parameters are ignored.
+                        nil,
+                        0,
+                        signerHandle,
+                        coreSigner.handle,
+                        &changeset
+                    )
                 }
             }
             try result.check()
@@ -968,59 +968,25 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
         }.value
     }
 
-    /// Recipients in the order the Rust side will see them.
+    /// Marshal recipients into the FFI address array.
     ///
-    /// `decode_funding_addresses` collects the FFI array into a
-    /// `BTreeMap<PlatformAddress, Option<Credits>>`, and consensus
-    /// resolves `ReduceOutput(index)` positionally against THAT map's key
-    /// order — never against the order the caller happened to list its
-    /// recipients in. `PlatformAddress`'s derived `Ord` orders by variant
-    /// first (P2PKH before P2SH) and then by the 20-byte hash, so
-    /// reproducing it here is a two-key sort.
+    /// Pure marshalling: one `FundingAddressEntryFFI` per recipient, in
+    /// whatever order the caller supplied. The Rust side collects them
+    /// into a `BTreeMap<PlatformAddress, Option<Credits>>`, so the
+    /// caller's ordering carries no meaning — it is a set.
     ///
-    /// Sorting before marshalling makes array position and consensus
-    /// output index the same number, which is what lets
-    /// [`remainderStepIndex`] name the remainder output correctly. The
-    /// recipient SET is unaffected — a `BTreeMap` does not care what
-    /// order it was filled in.
-    static func canonicallyOrderedRecipients(
+    /// In particular, Swift does NOT compute the fee strategy. The
+    /// `ReduceOutput(index)` step that names the fee-paying output is
+    /// positional against that map's lexicographic key order, which is
+    /// a consensus rule
+    /// (`deduct_fee_from_outputs_or_remaining_balance_of_inputs`); it is
+    /// derived in `platform-wallet` (`remainder_fee_strategy`) so that
+    /// every binding gets the same answer without reimplementing
+    /// `PlatformAddress`'s `Ord`.
+    static func marshalRecipients(
         _ recipients: [FundFromAssetLockRecipient]
-    ) -> [FundFromAssetLockRecipient] {
-        recipients.sorted { lhs, rhs in
-            if lhs.addressType != rhs.addressType {
-                return lhs.addressType < rhs.addressType
-            }
-            return lhs.hash.lexicographicallyPrecedes(rhs.hash)
-        }
-    }
-
-    /// Position of the remainder (`credits == nil`) recipient within a
-    /// [`canonicallyOrderedRecipients`] list — i.e. the index consensus
-    /// will resolve `ReduceOutput` against.
-    ///
-    /// Callers never supply this index themselves. A positional index
-    /// over a lexicographically-ordered map is a live hazard: adding one
-    /// recipient can shift which output pays the fee, and with a
-    /// third-party payee in the set that means the payee's explicit
-    /// amount silently absorbs the fee instead of the sender's change.
-    /// Computing it here from the canonical order is what prevents that.
-    static func remainderStepIndex(
-        in ordered: [FundFromAssetLockRecipient]
-    ) -> UInt16 {
-        UInt16(ordered.firstIndex(where: { $0.credits == nil }) ?? 0)
-    }
-
-    /// Marshal recipients into the FFI address array plus the matching
-    /// fee strategy.
-    ///
-    /// The fee comes out of the remainder output: the `nil`-credits
-    /// recipient is structurally the "change" output — it absorbs
-    /// whatever is left after the explicit outputs and fees.
-    static func marshalFundingRequest(
-        _ recipients: [FundFromAssetLockRecipient]
-    ) -> (addresses: [FundingAddressEntryFFI], feeStrategy: [FeeStrategyStepFFI]) {
-        let ordered = canonicallyOrderedRecipients(recipients)
-        let addresses = ordered.map { r -> FundingAddressEntryFFI in
+    ) -> [FundingAddressEntryFFI] {
+        recipients.map { r -> FundingAddressEntryFFI in
             FundingAddressEntryFFI(
                 address: PlatformAddressFFI(
                     address_type: r.addressType,
@@ -1030,10 +996,6 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
                 balance: r.credits ?? 0
             )
         }
-        let feeStrategy = [
-            FeeStrategyStepFFI(step_type: 1, index: remainderStepIndex(in: ordered))  // 1 = ReduceOutput
-        ]
-        return (addresses, feeStrategy)
     }
 
     /// Copy a 32-byte txid `Data` into the C tuple `OutPointFFI` wants.

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/FundFromAssetLockPlatformAddressView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/FundFromAssetLockPlatformAddressView.swift
@@ -759,6 +759,13 @@ struct FundFromAssetLockPlatformAddressView: View {
         guard let lock = target else { return }
         lock.recipientPlatformAddressHash = recipientHash
         lock.recipientPlatformAddressType = recipientType
+        // This screen only ever funds one of the wallet's OWN platform
+        // addresses (`fundFromAssetLock`), so the recipient hash names
+        // an address that has a `PersistentPlatformAddress` row. Stamp
+        // the discriminator explicitly rather than leaving it `nil`, so
+        // consumers never have to fall back on the legacy
+        // "populated hash implies own" reading.
+        lock.recipientIsExternal = false
         do {
             try modelContext.save()
         } catch {

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Platform/CoreToPlatformIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Platform/CoreToPlatformIntegrationTests.swift
@@ -44,6 +44,140 @@ final class CoreToPlatformIntegrationTests: IntegrationTestCase {
         XCTAssertGreaterThan(try addressWallet.totalCredits(), 0)
     }
 
+    /// Alice's Core funds pay BOB's Platform address.
+    ///
+    /// The end-to-end shape of `fundFromAssetLockExternal`: two
+    /// unrelated wallets, Alice builds the Core asset lock, Bob is
+    /// credited an exact explicit amount, and Alice's own change
+    /// address absorbs the remainder and the fee.
+    ///
+    /// What this pins beyond "it doesn't error":
+    /// - Bob really is credited on Platform, observed from BOB's wallet
+    ///   after a platform-address sync — not inferred from Alice's
+    ///   changeset.
+    /// - Alice's returned changeset carries ONLY her change address.
+    ///   Bob's output is proven and credited, but it resolves to no
+    ///   wallet-owned slot on Alice's side, so reconciliation skips it
+    ///   (the `outcome.resolved == 0` / partial-resolve path). A row for
+    ///   Bob appearing here would mean the wallet had mistaken a
+    ///   third-party payee for one of its own addresses.
+    /// - Alice's change row is persisted, which is what gates
+    ///   `consume_asset_lock` on the Rust side.
+    func testFundExternalRecipientFromCoreAssetLock() async throws {
+        try await env.walletManager.startSpv(config: env.spvConfig)
+        let alice = try await env.makeTestWallet(name: "c2p-external-alice")
+        let bob = try await env.makeTestWallet(name: "c2p-external-bob")
+
+        let coreAddress = try alice.getCoreWallet().nextReceiveAddress()
+        _ = try await env.fund(address: coreAddress, dash: fundingDash)
+        try await alice.waitForSpendable(exactly: fundingDuffs, timeout: 90)
+
+        let aliceChange = try await firstPlatformAddress(
+            walletId: alice.getPlatformWallet().walletId
+        )
+        let bobRecipient = try await firstPlatformAddress(
+            walletId: bob.getPlatformWallet().walletId
+        )
+        XCTAssertNotEqual(
+            aliceChange.hash, bobRecipient.hash,
+            "test setup: the payee must not be one of Alice's own addresses"
+        )
+
+        let signer = KeychainSigner(
+            modelContainer: env.modelContainer,
+            network: .regtest
+        )
+        let aliceAddresses = try alice.getPlatformWallet().platformAddressWallet()
+        let bobAddresses = try bob.getPlatformWallet().platformAddressWallet()
+
+        XCTAssertEqual(
+            try bobAddresses.totalCredits(), 0,
+            "test setup: Bob starts with no platform credits"
+        )
+
+        // 0.1 DASH locked; 0.02 DASH of credits paid to Bob. The rest
+        // (minus the ST fee) comes back to Alice's change address.
+        let assetLockDuffs: UInt64 = 10_000_000
+        // 2_000_000_000 credits == 2_000_000 duffs == 0.02 DASH
+        // (`CREDITS_PER_DUFF` is 1000), comfortably above the
+        // versioned `min_output_amount` of 500_000 credits.
+        let payment: UInt64 = 2_000_000_000
+
+        let updated = try await aliceAddresses.fundFromAssetLockExternal(
+            amountDuffs: assetLockDuffs,
+            fundingAccountIndex: 0,
+            platformAccountIndex: 0,
+            recipients: [
+                .init(
+                    addressType: bobRecipient.type,
+                    hash: bobRecipient.hash,
+                    credits: payment
+                ),
+                .init(addressType: aliceChange.type, hash: aliceChange.hash, credits: nil),
+            ],
+            signer: signer
+        )
+
+        // Only Alice's change output resolves to a wallet-owned slot.
+        XCTAssertEqual(
+            updated.count, 1,
+            "the third party's output must not produce a local balance row"
+        )
+        XCTAssertEqual(updated.first?.hash, aliceChange.hash)
+        XCTAssertGreaterThan(updated.first?.balance ?? 0, 0)
+        XCTAssertFalse(
+            updated.contains(where: { $0.hash == bobRecipient.hash }),
+            "Alice's changeset must never carry Bob's address"
+        )
+
+        // Bob is credited on Platform — observed from Bob's own wallet.
+        try await env.walletManager.syncPlatformAddressNow()
+        try await Wait.until(
+            "Bob's platform address reflects the external funding",
+            timeout: 60,
+            pollInterval: 0.5
+        ) {
+            try bobAddresses.totalCredits() == payment
+        }
+        XCTAssertEqual(
+            try bobAddresses.addressesWithBalances()
+                .first(where: { $0.hash == bobRecipient.hash })?.balance,
+            payment,
+            "Bob must be credited exactly the explicit amount — the fee comes out of "
+                + "Alice's remainder, not out of the payee's output"
+        )
+
+        // Alice's change row reached disk (this is what gates
+        // `consume_asset_lock`), and no row was written for Bob under
+        // Alice's wallet id.
+        let container = env.modelContainer
+        let aliceWalletId = alice.getPlatformWallet().walletId
+        let aliceHash = aliceChange.hash
+        let bobHash = bobRecipient.hash
+        try await Wait.until(
+            "Alice's change address row carries the reconciled balance",
+            timeout: 30,
+            pollInterval: 0.1
+        ) {
+            try await MainActor.run {
+                let ctx = ModelContext(container)
+                let rows = try ctx.fetch(
+                    FetchDescriptor<PersistentPlatformAddress>(
+                        predicate: #Predicate<PersistentPlatformAddress> {
+                            $0.walletId == aliceWalletId
+                        }
+                    )
+                )
+                XCTAssertFalse(
+                    rows.contains(where: { $0.addressHash == bobHash }),
+                    "Bob's address must never be persisted under Alice's wallet"
+                )
+                return rows.first(where: { $0.addressHash == aliceHash })
+                    .map { $0.balance > 0 } ?? false
+            }
+        }
+    }
+
     /// Lowest-index platform address for `walletId`, polled because the
     /// emit lands on the persister's background context.
     private func firstPlatformAddress(

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DashModelMigrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DashModelMigrationTests.swift
@@ -57,4 +57,115 @@ final class DashModelMigrationTests: XCTestCase {
                 FetchDescriptor<PersistentTrackedMasternode>()),
             1)
     }
+
+    /// Guards the freeze itself: `DashSchemaV1.PersistentAssetLock` only
+    /// keeps V1/V2 stores openable if SwiftData names its entity
+    /// "PersistentAssetLock" — i.e. from the UNQUALIFIED type name. If a
+    /// future SwiftData release qualified nested types instead, the frozen
+    /// copy would silently register a *different* entity and the V2 -> V3
+    /// stage would become a drop+create rather than an add-column, so this
+    /// has to fail loudly rather than in the field.
+    func testFrozenAssetLockKeepsTheLiveEntityName() throws {
+        for schema in [
+            Schema(versionedSchema: DashSchemaV1.self),
+            Schema(versionedSchema: DashSchemaV2.self),
+            Schema(versionedSchema: DashSchemaV3.self)
+        ] {
+            let names = schema.entities.map(\.name)
+            XCTAssertTrue(
+                names.contains("PersistentAssetLock"),
+                "expected an entity named PersistentAssetLock, got \(names.sorted())")
+        }
+
+        // V2 and V3 differ ONLY in that one entity's shape, never in which
+        // entities exist — that is what makes the stage lightweight.
+        XCTAssertEqual(
+            Schema(versionedSchema: DashSchemaV2.self).entities.map(\.name).sorted(),
+            Schema(versionedSchema: DashSchemaV3.self).entities.map(\.name).sorted())
+
+        // V1 -> V2 remains exactly "add PersistentTrackedMasternode".
+        XCTAssertEqual(
+            Set(Schema(versionedSchema: DashSchemaV2.self).entities.map(\.name))
+                .subtracting(Schema(versionedSchema: DashSchemaV1.self).entities.map(\.name)),
+            ["PersistentTrackedMasternode"])
+    }
+
+    /// The regression this whole freeze exists for: a store written by the
+    /// schema-V2 definition of `PersistentAssetLock` (no `recipientIsExternal`)
+    /// must still open once the live model has grown that property.
+    ///
+    /// The source store is created from `DashSchemaV2`, which references the
+    /// frozen `DashSchemaV1.PersistentAssetLock` — not the live type — so
+    /// this exercises the real cross-version path rather than trivially
+    /// round-tripping today's model.
+    @MainActor
+    func testV2AssetLockStoreMigratesToV3AndBackfillsRecipientIsExternal() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let storeURL = directory.appendingPathComponent("dash.store")
+
+        let outPointHex = String(repeating: "ab", count: 32) + ":0"
+        let walletId = Data(repeating: 3, count: 32)
+
+        let v2Schema = Schema(versionedSchema: DashSchemaV2.self)
+        let v2Configuration = ModelConfiguration(
+            "DashAssetLockMigrationTest",
+            schema: v2Schema,
+            url: storeURL,
+            allowsSave: true,
+            cloudKitDatabase: .none)
+        var v2Container: ModelContainer? = try ModelContainer(
+            for: v2Schema,
+            migrationPlan: DashMigrationPlan.self,
+            configurations: [v2Configuration])
+        let legacyRow = DashSchemaV1.PersistentAssetLock(
+            outPointHex: outPointHex,
+            walletId: walletId,
+            transactionBytes: Data([1, 2, 3]),
+            fundingTypeRaw: 4,
+            identityIndexRaw: -1,
+            accountIndexRaw: 0,
+            amountDuffs: 100_000,
+            statusRaw: 4)
+        legacyRow.recipientPlatformAddressHash = Data(repeating: 9, count: 20)
+        legacyRow.recipientPlatformAddressType = 0
+        v2Container?.mainContext.insert(legacyRow)
+        try v2Container?.mainContext.save()
+        v2Container = nil
+
+        // Reopen exactly the way `DashModelContainer.create` does.
+        let v3Schema = Schema(versionedSchema: DashSchemaV3.self)
+        let v3Configuration = ModelConfiguration(
+            "DashAssetLockMigrationTest",
+            schema: v3Schema,
+            url: storeURL,
+            allowsSave: true,
+            cloudKitDatabase: .none)
+        let migrated = try ModelContainer(
+            for: v3Schema,
+            migrationPlan: DashMigrationPlan.self,
+            configurations: [v3Configuration])
+
+        let locks = try migrated.mainContext.fetch(
+            FetchDescriptor<PersistentAssetLock>())
+        XCTAssertEqual(locks.count, 1)
+        let lock = try XCTUnwrap(locks.first)
+        XCTAssertEqual(lock.outPointHex, outPointHex)
+        XCTAssertEqual(lock.walletId, walletId)
+        XCTAssertEqual(lock.recipientPlatformAddressHash, Data(repeating: 9, count: 20))
+        XCTAssertEqual(lock.recipientPlatformAddressType, 0)
+        // Backfilled NULL — the documented "treat as own" signal.
+        XCTAssertNil(lock.recipientIsExternal)
+
+        // And the new column is writable on the migrated row.
+        lock.recipientIsExternal = true
+        try migrated.mainContext.save()
+        XCTAssertEqual(
+            try migrated.mainContext.fetch(FetchDescriptor<PersistentAssetLock>())
+                .first?.recipientIsExternal,
+            true)
+    }
 }

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/FundFromAssetLockRecipientTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/FundFromAssetLockRecipientTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+
+@testable import SwiftDashSDK
+
+/// Pins the two host-side decisions in the asset-lock funding surface:
+/// which recipient pays the fee, and which recipient lists are legal.
+///
+/// The fee-strategy step (`ReduceOutput(index)`) is POSITIONAL, and
+/// consensus resolves that position against the transition's outputs
+/// map — a Rust `BTreeMap<PlatformAddress, Option<Credits>>` keyed by
+/// `PlatformAddress`'s derived `Ord` (P2PKH before P2SH, then hash
+/// bytes ascending). The caller's array order has no bearing on it.
+/// `ManagedPlatformAddressWallet` therefore sorts recipients into that
+/// canonical order before marshalling, so array position and consensus
+/// output index are the same number.
+///
+/// The hazard being guarded: computing the index from an arbitrary
+/// caller-supplied order silently re-targets the fee whenever the
+/// remainder is not first lexicographically. With a third-party payee
+/// in the set — the whole point of `fundFromAssetLockExternal` — that
+/// means the payee's explicit amount absorbs the fee instead of the
+/// sender's change.
+final class FundFromAssetLockRecipientTests: XCTestCase {
+    private typealias Recipient = ManagedPlatformAddressWallet.FundFromAssetLockRecipient
+
+    private func recipient(_ tag: UInt8, credits: UInt64?, type: UInt8 = 0) -> Recipient {
+        Recipient(
+            addressType: type,
+            hash: Data(repeating: tag, count: 20),
+            credits: credits
+        )
+    }
+
+    // MARK: - Canonical ordering / fee targeting
+
+    func testRemainderIndexIsLexicographicNotCallerOrder() {
+        // Caller lists payees first; Alice's change sorts FIRST.
+        let alice = recipient(0x0A, credits: nil)
+        let bob = recipient(0xBB, credits: 500)
+        let carol = recipient(0xCC, credits: 700)
+
+        let ordered = ManagedPlatformAddressWallet.canonicallyOrderedRecipients([bob, carol, alice])
+        XCTAssertEqual(ordered.map(\.hash), [alice.hash, bob.hash, carol.hash])
+
+        let index = ManagedPlatformAddressWallet.remainderStepIndex(in: ordered)
+        XCTAssertEqual(
+            index, 0,
+            "the remainder's lexicographic position is 0, even though the caller listed it last"
+        )
+        XCTAssertNil(ordered[Int(index)].credits)
+    }
+
+    func testRemainderIndexWhenRemainderSortsLast() {
+        // The inverse arrangement: caller lists the remainder first, but
+        // it sorts last. A naive "position in the caller's array" answer
+        // would be 0 and would charge the fee to Alice's payee output.
+        let alice = recipient(0x0A, credits: 500)
+        let bob = recipient(0xBB, credits: 700)
+        let carol = recipient(0xCC, credits: nil)
+
+        let ordered = ManagedPlatformAddressWallet.canonicallyOrderedRecipients([carol, alice, bob])
+        let index = ManagedPlatformAddressWallet.remainderStepIndex(in: ordered)
+        XCTAssertEqual(index, 2)
+        XCTAssertNil(ordered[Int(index)].credits)
+    }
+
+    func testMarshalledFeeStrategyTargetsTheRemainderOutput() {
+        let alice = recipient(0x0A, credits: nil)
+        let bob = recipient(0xBB, credits: 500)
+        let carol = recipient(0xCC, credits: 700)
+
+        let request = ManagedPlatformAddressWallet.marshalFundingRequest([bob, carol, alice])
+
+        XCTAssertEqual(request.feeStrategy.count, 1)
+        XCTAssertEqual(request.feeStrategy[0].step_type, 1, "1 = ReduceOutput")
+
+        let index = Int(request.feeStrategy[0].index)
+        XCTAssertFalse(
+            request.addresses[index].has_balance,
+            "ReduceOutput must name the remainder output, not an explicit-amount payee"
+        )
+        // And the marshalled array is in the canonical order the Rust
+        // BTreeMap will reproduce, which is what makes the index valid.
+        let hashes = request.addresses.map { entry in
+            withUnsafeBytes(of: entry.address.hash) { Data($0) }
+        }
+        XCTAssertEqual(hashes, [alice.hash, bob.hash, carol.hash])
+    }
+
+    func testCanonicalOrderPutsP2PKHBeforeP2SH() {
+        // `PlatformAddress` is a Rust enum: the variant discriminant
+        // orders before the payload. (P2SH is rejected downstream, but
+        // the ordering rule is part of the contract being mirrored.)
+        let p2sh = recipient(0x01, credits: 500, type: 1)
+        let p2pkh = recipient(0xFF, credits: nil, type: 0)
+
+        let ordered = ManagedPlatformAddressWallet.canonicallyOrderedRecipients([p2sh, p2pkh])
+        XCTAssertEqual(ordered.map(\.addressType), [0, 1])
+    }
+
+    // MARK: - Preflight
+
+    func testExternalPreflightAcceptsThirdPartyPayeeWithOwnRemainder() throws {
+        try ManagedPlatformAddressWallet.fundFromAssetLockExternalPreflight(
+            recipients: [recipient(0xBB, credits: 500), recipient(0x0A, credits: nil)]
+        )
+    }
+
+    func testExternalPreflightRejectsRemainderOnlyRequest() {
+        // Nothing is being paid externally — that is a call-site mistake,
+        // and `fundFromAssetLock` validates the destination properly.
+        XCTAssertThrowsError(
+            try ManagedPlatformAddressWallet.fundFromAssetLockExternalPreflight(
+                recipients: [recipient(0x0A, credits: nil)]
+            )
+        )
+    }
+
+    func testPreflightsRejectP2SHAndBadHashLengths() {
+        let p2shSet = [recipient(0xBB, credits: 500, type: 1), recipient(0x0A, credits: nil)]
+        XCTAssertThrowsError(
+            try ManagedPlatformAddressWallet.fundFromAssetLockPreflight(recipients: p2shSet)
+        )
+        XCTAssertThrowsError(
+            try ManagedPlatformAddressWallet.fundFromAssetLockExternalPreflight(recipients: p2shSet)
+        )
+
+        let shortHash = [
+            Recipient(addressType: 0, hash: Data(repeating: 0xBB, count: 19), credits: 500),
+            recipient(0x0A, credits: nil),
+        ]
+        XCTAssertThrowsError(
+            try ManagedPlatformAddressWallet.fundFromAssetLockPreflight(recipients: shortHash)
+        )
+        XCTAssertThrowsError(
+            try ManagedPlatformAddressWallet.fundFromAssetLockExternalPreflight(
+                recipients: shortHash)
+        )
+    }
+
+    func testPreflightsRejectWrongRemainderCardinality() {
+        for recipients in [
+            [Recipient](),
+            [recipient(0x0A, credits: 500), recipient(0xBB, credits: 700)],
+            [recipient(0x0A, credits: nil), recipient(0xBB, credits: nil)],
+        ] {
+            XCTAssertThrowsError(
+                try ManagedPlatformAddressWallet.fundFromAssetLockPreflight(recipients: recipients)
+            )
+            XCTAssertThrowsError(
+                try ManagedPlatformAddressWallet.fundFromAssetLockExternalPreflight(
+                    recipients: recipients)
+            )
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/FundFromAssetLockRecipientTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/FundFromAssetLockRecipientTests.swift
@@ -2,24 +2,20 @@ import XCTest
 
 @testable import SwiftDashSDK
 
-/// Pins the two host-side decisions in the asset-lock funding surface:
-/// which recipient pays the fee, and which recipient lists are legal.
+/// Pins the two host-side responsibilities left in the asset-lock
+/// funding surface: marshalling recipients faithfully, and rejecting
+/// recipient lists Swift can check synchronously.
 ///
-/// The fee-strategy step (`ReduceOutput(index)`) is POSITIONAL, and
-/// consensus resolves that position against the transition's outputs
-/// map — a Rust `BTreeMap<PlatformAddress, Option<Credits>>` keyed by
-/// `PlatformAddress`'s derived `Ord` (P2PKH before P2SH, then hash
-/// bytes ascending). The caller's array order has no bearing on it.
-/// `ManagedPlatformAddressWallet` therefore sorts recipients into that
-/// canonical order before marshalling, so array position and consensus
-/// output index are the same number.
-///
-/// The hazard being guarded: computing the index from an arbitrary
-/// caller-supplied order silently re-targets the fee whenever the
-/// remainder is not first lexicographically. With a third-party payee
-/// in the set — the whole point of `fundFromAssetLockExternal` — that
-/// means the payee's explicit amount absorbs the fee instead of the
-/// sender's change.
+/// What is deliberately NOT here any more: canonical ordering and the
+/// `ReduceOutput(index)` fee step. That index is positional against the
+/// transition's outputs `BTreeMap` — a consensus ordering rule
+/// (`PlatformAddress`'s derived `Ord`) — so it is derived in
+/// `platform-wallet` (`remainder_fee_strategy`), where the map is
+/// actually built. Every binding that computed it from array position
+/// mis-targeted the fee whenever the remainder was not also first
+/// lexicographically; see the Rust tests
+/// `remainder_fee_strategy_targets_the_remainder_output` and
+/// `remainder_fee_strategy_handles_a_middle_remainder`.
 final class FundFromAssetLockRecipientTests: XCTestCase {
     private typealias Recipient = ManagedPlatformAddressWallet.FundFromAssetLockRecipient
 
@@ -31,71 +27,42 @@ final class FundFromAssetLockRecipientTests: XCTestCase {
         )
     }
 
-    // MARK: - Canonical ordering / fee targeting
+    // MARK: - Marshalling
 
-    func testRemainderIndexIsLexicographicNotCallerOrder() {
-        // Caller lists payees first; Alice's change sorts FIRST.
+    /// Marshalling is order-preserving and lossless: one FFI row per
+    /// recipient, in the caller's order, with `has_balance` carrying the
+    /// remainder discriminator. The Rust side turns this into a set, so
+    /// the order is not load-bearing — but silently dropping, reordering
+    /// or re-tagging a row would be.
+    func testMarshalPreservesRecipientsOneForOne() {
         let alice = recipient(0x0A, credits: nil)
         let bob = recipient(0xBB, credits: 500)
         let carol = recipient(0xCC, credits: 700)
 
-        let ordered = ManagedPlatformAddressWallet.canonicallyOrderedRecipients([bob, carol, alice])
-        XCTAssertEqual(ordered.map(\.hash), [alice.hash, bob.hash, carol.hash])
+        let rows = ManagedPlatformAddressWallet.marshalRecipients([bob, carol, alice])
 
-        let index = ManagedPlatformAddressWallet.remainderStepIndex(in: ordered)
-        XCTAssertEqual(
-            index, 0,
-            "the remainder's lexicographic position is 0, even though the caller listed it last"
-        )
-        XCTAssertNil(ordered[Int(index)].credits)
-    }
-
-    func testRemainderIndexWhenRemainderSortsLast() {
-        // The inverse arrangement: caller lists the remainder first, but
-        // it sorts last. A naive "position in the caller's array" answer
-        // would be 0 and would charge the fee to Alice's payee output.
-        let alice = recipient(0x0A, credits: 500)
-        let bob = recipient(0xBB, credits: 700)
-        let carol = recipient(0xCC, credits: nil)
-
-        let ordered = ManagedPlatformAddressWallet.canonicallyOrderedRecipients([carol, alice, bob])
-        let index = ManagedPlatformAddressWallet.remainderStepIndex(in: ordered)
-        XCTAssertEqual(index, 2)
-        XCTAssertNil(ordered[Int(index)].credits)
-    }
-
-    func testMarshalledFeeStrategyTargetsTheRemainderOutput() {
-        let alice = recipient(0x0A, credits: nil)
-        let bob = recipient(0xBB, credits: 500)
-        let carol = recipient(0xCC, credits: 700)
-
-        let request = ManagedPlatformAddressWallet.marshalFundingRequest([bob, carol, alice])
-
-        XCTAssertEqual(request.feeStrategy.count, 1)
-        XCTAssertEqual(request.feeStrategy[0].step_type, 1, "1 = ReduceOutput")
-
-        let index = Int(request.feeStrategy[0].index)
-        XCTAssertFalse(
-            request.addresses[index].has_balance,
-            "ReduceOutput must name the remainder output, not an explicit-amount payee"
-        )
-        // And the marshalled array is in the canonical order the Rust
-        // BTreeMap will reproduce, which is what makes the index valid.
-        let hashes = request.addresses.map { entry in
-            withUnsafeBytes(of: entry.address.hash) { Data($0) }
+        XCTAssertEqual(rows.count, 3)
+        let hashes = rows.map { row in
+            withUnsafeBytes(of: row.address.hash) { Data($0) }
         }
-        XCTAssertEqual(hashes, [alice.hash, bob.hash, carol.hash])
+        XCTAssertEqual(hashes, [bob.hash, carol.hash, alice.hash])
+        XCTAssertEqual(rows.map(\.has_balance), [true, true, false])
+        XCTAssertEqual(rows.map(\.balance), [500, 700, 0])
+        XCTAssertEqual(rows.map(\.address.address_type), [0, 0, 0])
     }
 
-    func testCanonicalOrderPutsP2PKHBeforeP2SH() {
-        // `PlatformAddress` is a Rust enum: the variant discriminant
-        // orders before the payload. (P2SH is rejected downstream, but
-        // the ordering rule is part of the contract being mirrored.)
-        let p2sh = recipient(0x01, credits: 500, type: 1)
-        let p2pkh = recipient(0xFF, credits: nil, type: 0)
-
-        let ordered = ManagedPlatformAddressWallet.canonicallyOrderedRecipients([p2sh, p2pkh])
-        XCTAssertEqual(ordered.map(\.addressType), [0, 1])
+    /// No fee-strategy derivation survives in Swift. Guards against the
+    /// helper being reintroduced by a future change that "needs the
+    /// index right here" — the index belongs to `platform-wallet`.
+    func testMarshalDoesNotProduceAFeeStrategy() {
+        let rows = ManagedPlatformAddressWallet.marshalRecipients([
+            recipient(0xCC, credits: 700),
+            recipient(0x0A, credits: nil),
+        ])
+        // The marshaller's entire output is the address array; the
+        // remainder is identified by `has_balance == false`, never by a
+        // positional index computed on this side of the boundary.
+        XCTAssertEqual(rows.filter { !$0.has_balance }.count, 1)
     }
 
     // MARK: - Preflight


### PR DESCRIPTION
## Issue being fixed or feature implemented

Today a Core-chain asset lock can only fund Platform addresses that belong to the sender's own managed wallet account. This adds the ability to fund an **external third party's** Platform address (Alice pays Bob) from a Core asset lock, with the sender's own change address absorbing the remainder and the fee.

The capability already exists at the protocol layer — the only blocker was a wallet-side pre-flight.

**No consensus / rs-dpp / rs-drive-abci production changes are needed.** Consensus never validates output ownership: `AddressFundingFromAssetLockTransition` treats its outputs map as opaque destinations, and the pre-existing `test_simple_asset_lock_funding_to_single_address` already funds arbitrary unrelated addresses. This PR adds a drive-abci test that documents that property explicitly rather than changing any validator.

**rs-sdk needs no changes either.** `packages/rs-sdk/src/platform/transition/top_up_address.rs` is ownership-agnostic — it only does set-equality checks between the requested recipients and the proof-attested `AddressInfos`, which holds identically whether an output is ours or a stranger's.

## What was done?

### `packages/rs-platform-wallet`

- New `PlatformAddressWallet::fund_from_asset_lock_external`, a sibling of `fund_from_asset_lock`. Same signature, same pipeline — both now delegate to a shared `fund_from_asset_lock_inner` whose single point of divergence is a `RecipientOwnership` mode.
  - Explicit-amount (`Some(credits)`) outputs may be **any** valid P2PKH platform address.
  - The single remainder (`None`) output **must still be owned** by `platform_account_index`.
  - P2SH stays rejected for every recipient.
- The existing `fund_from_asset_lock` is deliberately **not** relaxed. For every current caller a mistyped recipient is caught today by the membership check; relaxing it in place would silently convert "typo'd address → typed error before anything is broadcast" into "typo'd address → asset-lock credits irrecoverably delivered to a stranger". Opting in by function name confines that failure mode to callers that mean to pay someone else.
- **Why the remainder must remain sender-owned:** the asset lock is consumed in full, so the `None` bucket receives everything left after the explicit outputs and the fee — i.e. the change. Sending change to a stranger is never the intent, and a caller bug that mixed up which entry was the remainder would leak the *entire lock value* rather than the intended payment. Consensus does not care; this is purely a wallet-level safety rail, and the new drive-abci test is the standing evidence of that distinction.
- The pre-flight is factored into a pure, wallet-free `validate_recipient_map` generic over an ownership oracle, so the rules are unit-testable without constructing a `PlatformAddressWallet`. Shape checks (`validate_recipient_shape`) are shared by both modes.
- **No resume variant at this layer.** Resuming is expressed as `AssetLockFunding::FromExistingAssetLock`, a *value* of the `funding` parameter, so both public entry points already cover fresh-build and resume. (The FFI does expose distinct resume symbols, because a C ABI cannot take a Rust enum.)

### Reconciliation / persistence: no changes needed

`reconcile_address_infos_with_persistence` (`packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs:382-392`) already tolerates third-party recipients: it handles `outcome.resolved == 0` with a warning whose text literally reads *"Expected when every address belongs to a third party"*, and still returns `persisted = true` so `consume_asset_lock` fires correctly. `validate_address_infos_complete` is proof-level and ownership-agnostic, so the third party's output is still proven.

The **mixed** own+external case (the one this feature actually produces) is now pinned by a new provider test: only the sender's remainder output resolves and enters the committed seed, `resolved > 0` so the normal apply-and-persist path runs, and the stranger's address never reaches disk.

### `packages/rs-platform-wallet-ffi`

- `platform_address_wallet_fund_from_asset_lock_external_signer`
- `platform_address_wallet_resume_fund_from_asset_lock_external_signer`

Both reuse `FundingAddressEntryFFI`, `decode_funding_addresses` and the existing fee-strategy parsing verbatim. The existing symbols' ABI is untouched; the P2SH rejection in `TryFrom<PlatformAddressFFI> for PlatformAddress` is unchanged. `src/platform_addresses/mod.rs` already glob-re-exports the module, so no wiring change was needed, and cbindgen picks the new symbols up automatically (verified in the generated header).

Resume takes the recipients as **caller-supplied parameters** rather than recovering them from persisted state, matching the shielded resume entry point: Rust never learns the destination of an address-funding asset lock — only the outpoint, its status and its proof. The consequence is documented on the function: resuming with a different recipient set pays the new set, because the asset lock is a bearer input, not a commitment to a destination.

### `packages/swift-sdk`

- `fundFromAssetLockExternal(...)` / `resumeFundFromAssetLockExternal(...)` as siblings of the existing pair.
- `FundFromAssetLockRecipient` is reused unchanged — **no `isExternal` flag**. Externality is a property of which function you call, matching the shielded side, which keeps "am I allowed to pay a stranger?" a single auditable decision at the call site.
- `fundFromAssetLockExternalPreflight` keeps every rule of the base preflight (exactly one remainder, P2PKH only, 20-byte hashes) and adds one: at least one explicit-amount recipient, since a remainder-only request pays nobody externally and `fundFromAssetLock` is the right entry point for pure self-funding.
- **Fee-strategy index fix (see "Breaking Changes" — behavioural, not API).** The `ReduceOutput(remainderIndex)` step is still computed Swift-side from the recipient array (callers never pass positional indices), but it is now computed over the **canonical order** rather than the caller's array order, and marshalling emits the array in that same order. Consensus resolves `ReduceOutput(i)` against the outputs `BTreeMap`'s lexicographic key order (`PlatformAddress`'s derived `Ord`: P2PKH before P2SH, then hash bytes) — so the previous "position in the caller's array" computation named the wrong output whenever the remainder was not first lexicographically. Sorting before marshalling makes array position and consensus index the same number by construction. The logic is centralised in `canonicallyOrderedRecipients` / `remainderStepIndex` / `marshalFundingRequest` and shared by all four entry points.
- `PersistentAssetLock` gains `recipientIsExternal: Bool?` in the funding-type-4 field family, following the file's "one typed field-family per funding type" convention and doc style. Consumers currently read a populated recipient hash as "this was my own top-up" (dashwallet-ios `PlatformAddressActivityStore.matchesOwnAssetLockTopUp`), so without a discriminator an external send would be misclassified as an incoming own credit. **This DOES require a schema version** (corrected after review — an earlier revision of this PR claimed it did not). A `VersionedSchema` identifies a store by the checksum of the entities it declares, so adding the property to the live model mutated the checksums of the already-registered V1 and V2 schemas in place; a store written by the V2 binary then matched no schema in `DashMigrationPlan.schemas` and `ModelContainer(for:migrationPlan:configurations:)` would fail to open it with Cocoa error 134504 rather than migrating it. The model *list* being unchanged is irrelevant. So V1 and V2 now reference a frozen nested copy of the pre-change model (`DashSchemaV1.PersistentAssetLock`, in the new `Persistence/DashSchemaFrozenModels.swift`), a new `DashSchemaV3` carries the live models, and a lightweight V2 -> V3 stage migrates existing stores. Only `PersistentAssetLock` is frozen; the other 33 models are still referenced live from V1/V2 and retain the same latent defect, which is pre-existing and out of scope here.
- `SwiftExampleApp`'s own-funding screen now stamps `recipientIsExternal = false` alongside the hash it already wrote, so in-repo rows are never ambiguous.

## How Has This Been Tested?

**Executed, all passing:**

| Suite | Result |
|---|---|
| `cargo test -p platform-wallet --lib` | **770 passed, 0 failed** (includes 11 new recipient-validation tests + the new mixed own/external provider test) |
| `cargo test -p platform-wallet-ffi --lib` | **297 passed, 0 failed** (includes 3 new FFI ordering/decoding tests) |
| `cargo test -p drive-abci address_funding_from_asset_lock` | **112 passed, 0 failed** (includes the new `test_asset_lock_funding_to_unrelated_third_party_address`) |
| `swift test --filter FundFromAssetLockRecipientTests` (macOS slice) | **8 passed, 0 failed** |
| `cargo check` / `cargo clippy` on `platform-wallet` + `platform-wallet-ffi` (`--tests`) | clean — zero warnings from either crate |
| `cargo fmt` | applied |
| `swift build --target SwiftDashSDK` + `swift build --build-tests` | clean; the integration target compiles under its `-warnings-as-errors` setting |

New test coverage:

1. **Recipient validation unit tests** (`fund_from_asset_lock.rs`) — there were previously none for `validate_recipient_addresses`. Covers: all-owned (legacy fn still rejects an external explicit recipient), external explicit + owned remainder (accepted), several external recipients (accepted), external remainder (rejected, with the remainder-specific message), nothing owned (rejected), P2SH in both modes, zero remainders, two remainders, empty map, and the BTreeMap remainder-index mapping.
2. **Mixed own+external reconciliation** (`provider.rs`) — patterned on the existing `commit_reconciliation_pool_fallback_skips_untracked_account`.
3. **drive-abci consensus test** — clones the shape of `test_simple_asset_lock_funding_to_single_address` with an explicit-amount unrelated recipient plus a remainder output, and asserts the third party is credited *exactly* the requested amount while the sender's change absorbs the fee.
4. **Fee-strategy remainder-index tests** — in Rust (`platform-wallet` map ordering, `platform-wallet-ffi` decode round-trip) and in Swift (`FundFromAssetLockRecipientTests`), each pinning that the index tracks lexicographic position when the remainder is *not* first in the caller's list, and its mirror image.

**Authored but NOT executed:**

- `CoreToPlatformIntegrationTests.testFundExternalRecipientFromCoreAssetLock` — the Alice-Core → Bob-Platform end-to-end test. It follows the file's existing conventions and **compiles cleanly**, but requires a running local dashmate devnet (`RUN_INTEGRATION_TESTS=1`), which is not available in the authoring environment. It asserts Bob's credited balance from *Bob's own wallet* after a platform-address sync, that Alice's returned changeset carries only her change address, and that no `PersistentPlatformAddress` row for Bob is written under Alice's wallet id.
- `SwiftExampleApp` was not built. The `DashSDKFFI.xcframework` was built for the **macOS slice only** (enough to compile and test the Swift package); the iOS-simulator slice needed by the example app was not produced. The example-app change is a single property assignment and was syntax-checked with `swiftc -parse`, nothing more.
- Kotlin/JNI (`packages/rs-unified-sdk-jni`) was intentionally not extended with the new entry points — see Deferred below.

## Breaking Changes

None to any public API or FFI ABI. Existing Rust, FFI and Swift entry points keep their exact signatures.

*(Corrected after review: an intermediate revision of this branch did drop the `AddressFundsFeeStrategy` argument from `PlatformAddressWallet::fund_from_asset_lock`, which would have broken out-of-tree Rust callers. The argument has since been restored and is accepted and ignored, mirroring the C ABI, where `fee_strategy` / `fee_strategy_count` are also still accepted and ignored. `fund_from_asset_lock_external` omits it — it is new here and has no compatibility debt.)*

One **behavioural** change worth calling out: on the Swift side, `fundFromAssetLock` / `resumeFundFromAssetLock` now target the fee at the true remainder output. Previously, a multi-recipient call whose remainder was not first lexicographically charged the fee to a different output. Because every recipient in that flow belonged to the caller, the old behaviour only misallocated the fee among the user's own addresses — no funds were ever at risk — but it had to be corrected before a third-party payee could be in the set.

Deliberately deferred:

- **P2SH recipients.** Relaxing the P2PKH-only restriction for pure-recipient outputs is a separate follow-up. It is not just a wallet-side rule: `TryFrom<PlatformAddressFFI> for PlatformAddress` rejects the P2SH discriminant outright, so lifting it in the wallet alone would not make P2SH reachable from the SDKs.
- **Kotlin/JNI bridge** for the new entry points, mirroring the existing `platform_address_wallet_fund_from_asset_lock_signer` binding.
- **A companion `dashwallet-ios` PR will follow** that persists the recipient (hash, type and the new `recipientIsExternal` discriminator) and adds the `.coreToPlatform` send route. This PR only adds the model field; it does not change persistence behaviour.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for funding third-party platform addresses from asset locks, including resumed funding.
  * Fees are derived automatically from the designated remainder output.
  * Asset-lock records now track whether recipients are external.
  * Existing funding flows continue to restrict recipients to wallet-owned addresses.

* **Bug Fixes**
  * Improved handling of mixed recipients so only wallet-owned outputs are recorded locally.
  * Added validation for recipient types, duplicates, ordering, and remainder requirements.

* **Chores**
  * Added migration support for the updated asset-lock records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
