### PR TITLE
refactor(drive): unify indexOnly terminal matching into the dpp index matcher

### DIFF
--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
@@ -374,6 +374,67 @@ fn accepts_created_at_in_prefix_when_required() {
         .expect("$createdAt in an index prefix should be accepted when required");
 }
 
+/// The unified matcher: terminals participate as an index's deepest
+/// matchable component, with generic (non-terminal) matches keeping
+/// absolute precedence and difference-scored best-match inside each
+/// class.
+#[test]
+fn terminal_aware_matching_prefers_generic_and_scores_candidates() {
+    use crate::data_contract::document_type::methods::DocumentTypeV0Methods;
+
+    let document_type_ref =
+        &parse_with(likes_schema(), PlatformVersion::latest(), false).expect("likes schema parses");
+
+    // A pure-property cover exists (`byPost` = [postId] → $ownerId used
+    // generically): it must win over `byLiker`'s terminal cover of the
+    // same field, and report the terminal unused.
+    let (index, difference, terminal_used) = document_type_ref
+        .index_for_types_matching_including_terminal(
+            &["postId"],
+            None,
+            &[],
+            |_| true,
+            PlatformVersion::latest(),
+        )
+        .expect("matcher runs")
+        .expect("an index matches");
+    assert_eq!(index.name, "byPost");
+    assert_eq!((difference, terminal_used), (0, false));
+
+    // No pure-property cover for {$ownerId, postId}: `byLiker`
+    // ([$ownerId] → postId) covers it exactly through its terminal
+    // (difference 0) and must beat `byHashtagPost`'s costlier terminal
+    // cover (hashtag unused, difference 1).
+    let (index, difference, terminal_used) = document_type_ref
+        .index_for_types_matching_including_terminal(
+            &["$ownerId", "postId"],
+            None,
+            &[],
+            |_| true,
+            PlatformVersion::latest(),
+        )
+        .expect("matcher runs")
+        .expect("an index matches");
+    assert_eq!(index.name, "byLiker");
+    assert_eq!((difference, terminal_used), (0, true));
+
+    // The full tuple {hashtag, postId, $ownerId} is only coverable with
+    // `byHashtagPost`'s terminal; an unused terminal never costs score,
+    // so the exact cover reports difference 0.
+    let (index, difference, terminal_used) = document_type_ref
+        .index_for_types_matching_including_terminal(
+            &["hashtag", "postId", "$ownerId"],
+            None,
+            &[],
+            |_| true,
+            PlatformVersion::latest(),
+        )
+        .expect("matcher runs")
+        .expect("an index matches");
+    assert_eq!(index.name, "byHashtagPost");
+    assert_eq!((difference, terminal_used), (0, true));
+}
+
 #[test]
 fn rejects_when_every_index_involves_created_at() {
     // Executed-transition proofs locate an entry from the transition's

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -728,13 +728,68 @@ impl Index {
         in_field_name: Option<&str>,
         order_by: &[&str],
     ) -> Option<u16> {
+        Self::matches_over_components(&self.properties, index_names, in_field_name, order_by)
+    }
+
+    /// [`Self::matches`] over an index's full component list, terminal
+    /// included: the terminal (an indexOnly index's member-key property)
+    /// participates in field coverage, the `in`-position rule and the
+    /// order-by suffix exactly as if it were the index's deepest property.
+    ///
+    /// Returns `(difference, terminal_used)` — the difference counts
+    /// unused PREFIX properties only (an unused terminal costs nothing:
+    /// it is the entry level itself, always reachable), so scores stay
+    /// comparable with [`Self::matches`] and an index is never penalized
+    /// for merely having a terminal. On an index without a terminal this
+    /// is exactly [`Self::matches`] with `terminal_used = false`.
+    pub fn matches_including_terminal(
+        &self,
+        index_names: &[&str],
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+    ) -> Option<(u16, bool)> {
+        let Some(terminal) = self.terminal.as_deref() else {
+            return self
+                .matches(index_names, in_field_name, order_by)
+                .map(|difference| (difference, false));
+        };
+
+        // One extended component list, one matching algorithm. The parser
+        // rejects a terminal repeating an index property, so the synthetic
+        // component cannot shadow a prefix property.
+        let mut components = Vec::with_capacity(self.properties.len() + 1);
+        components.extend(self.properties.iter().cloned());
+        components.push(IndexProperty {
+            name: terminal.to_string(),
+            ascending: true,
+        });
+
+        let difference =
+            Self::matches_over_components(&components, index_names, in_field_name, order_by)?;
+        let terminal_used = index_names.contains(&terminal);
+        // An unused terminal was counted as an unused component by the
+        // shared algorithm; take it back out of the score.
+        let difference = if terminal_used {
+            difference
+        } else {
+            difference.saturating_sub(1)
+        };
+        Some((difference, terminal_used))
+    }
+
+    fn matches_over_components(
+        properties: &[IndexProperty],
+        index_names: &[&str],
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+    ) -> Option<u16> {
         // Here we are trying to figure out if the Index matches the order by
         // To do so we take the index and go backwards as we need the order by clauses to be
         // continuous, but they do not need to be at the end.
-        let mut reduced_properties = self.properties.as_slice();
+        let mut reduced_properties = properties;
         // let mut should_ignore: Vec<String> = order_by.iter().map(|&str| str.to_string()).collect();
         if !order_by.is_empty() {
-            for _ in 0..self.properties.len() {
+            for _ in 0..properties.len() {
                 if reduced_properties.len() < order_by.len() {
                     return None;
                 }
@@ -755,23 +810,23 @@ impl Index {
             }
         }
 
-        let last_property = self.properties.last()?;
+        let last_property = properties.last()?;
 
         // the in field can only be on the last or before last property
         if let Some(in_field_name) = in_field_name {
             if last_property.name.as_str() != in_field_name {
                 // it can also be on the before last
-                if self.properties.len() == 1 {
+                if properties.len() == 1 {
                     return None;
                 }
-                let before_last_property = self.properties.get(self.properties.len() - 2)?;
+                let before_last_property = properties.get(properties.len() - 2)?;
                 if before_last_property.name.as_str() != in_field_name {
                     return None;
                 }
             }
         }
 
-        let mut d = self.properties.len();
+        let mut d = properties.len();
 
         for search_name in index_names.iter() {
             if !reduced_properties

--- a/packages/rs-dpp/src/data_contract/document_type/methods/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/methods/mod.rs
@@ -130,6 +130,44 @@ pub trait DocumentTypeV0Methods: DocumentTypeV0Getters + DocumentTypeV0MethodsVe
         }
     }
 
+    /// [`Self::index_for_types_matching`] with terminals (an indexOnly
+    /// index's member-key property) as matchable deepest components. The
+    /// returned bool says whether the winning index consumed its terminal;
+    /// generic (non-terminal) matches always take precedence, so on any
+    /// document type without terminals this is exactly
+    /// [`Self::index_for_types_matching`]. Shares the `index_for_types`
+    /// feature-version gate: terminal participation only changes outcomes
+    /// on indexOnly document types, which cannot exist below protocol
+    /// version 14.
+    fn index_for_types_matching_including_terminal(
+        &self,
+        index_names: &[&str],
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+        filter: impl Fn(&Index) -> bool,
+        platform_version: &PlatformVersion,
+    ) -> Result<Option<(&Index, u16, bool)>, ProtocolError> {
+        match platform_version
+            .dpp
+            .contract_versions
+            .document_type_versions
+            .methods
+            .index_for_types
+        {
+            0 => Ok(self.index_for_types_matching_including_terminal_v0(
+                index_names,
+                in_field_name,
+                order_by,
+                filter,
+            )),
+            version => Err(ProtocolError::UnknownVersionMismatch {
+                method: "index_for_types_matching_including_terminal".to_string(),
+                known_versions: vec![0],
+                received: version,
+            }),
+        }
+    }
+
     fn serialize_value_for_key(
         &self,
         key: &str,

--- a/packages/rs-dpp/src/data_contract/document_type/methods/versioned_methods.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/methods/versioned_methods.rs
@@ -416,6 +416,55 @@ pub trait DocumentTypeV0MethodsVersioned: DocumentTypeV0Getters + DocumentTypeBa
     /// the winner among equally-good candidates is decided by the index map's
     /// name ordering, and a post-check can only reject the winner — never
     /// promote the index that was actually required.
+    /// [`Self::index_for_types_matching_v0`] with the terminal (an
+    /// indexOnly index's member-key property) participating as the
+    /// index's deepest matchable component. Generic matches keep absolute
+    /// precedence: a candidate that covers the query WITHOUT its terminal
+    /// always beats every terminal-using candidate, regardless of score —
+    /// the terminal route is a stand-in for "no ordinary index serves
+    /// this", never a competitor to one that does. Within each class the
+    /// difference scoring (and its index-map-order tie-break) is exactly
+    /// the generic matcher's.
+    fn index_for_types_matching_including_terminal_v0(
+        &self,
+        index_names: &[&str],
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+        filter: impl Fn(&Index) -> bool,
+    ) -> Option<(&Index, u16, bool)> {
+        let mut best_generic: Option<(&Index, u16)> = None;
+        let mut best_generic_difference = u16::MAX;
+        let mut best_terminal: Option<(&Index, u16)> = None;
+        let mut best_terminal_difference = u16::MAX;
+        for (_, index) in self.indexes().iter() {
+            if !filter(index) {
+                continue;
+            }
+            let Some((difference, terminal_used)) =
+                index.matches_including_terminal(index_names, in_field_name, order_by)
+            else {
+                continue;
+            };
+            if terminal_used {
+                if difference < best_terminal_difference {
+                    best_terminal_difference = difference;
+                    best_terminal = Some((index, difference));
+                }
+            } else {
+                if difference == 0 {
+                    return Some((index, 0, false));
+                }
+                if difference < best_generic_difference {
+                    best_generic_difference = difference;
+                    best_generic = Some((index, difference));
+                }
+            }
+        }
+        best_generic
+            .map(|(index, difference)| (index, difference, false))
+            .or(best_terminal.map(|(index, difference)| (index, difference, true)))
+    }
+
     fn index_for_types_matching_v0(
         &self,
         index_names: &[&str],

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -56,37 +56,32 @@ impl DriveDocumentQuery<'_> {
     /// value, so a clause on the terminal lowers directly onto the final
     /// key level — the shape behind both "did I like X" (equality on the
     /// terminal) and keyset pagination (range on the terminal after the
-    /// last seen value, with a limit). The shape requirement: every one of
-    /// the index's prefix properties carries an equality clause (the path
-    /// down to the `0` level must be fully determined), the terminal
-    /// carries the one remaining clause, and `orderBy` names nothing
-    /// outside the index (a range or `in` on the terminal requires
-    /// ordering by it, mirroring the stored-document rule).
+    /// last seen value, with a limit). Index selection is the SAME dpp
+    /// matcher the generic route uses
+    /// ([`index_for_types_matching_including_terminal`]), with terminals
+    /// as matchable deepest components and difference-scored best-match
+    /// semantics — generic matches keep absolute precedence inside the
+    /// matcher itself. What remains here is clause-shape validation on
+    /// the matcher's winner: every prefix property must carry an equality
+    /// clause (the path down to the `0` level must be fully determined),
+    /// the terminal carries the one remaining clause, and `orderBy` names
+    /// nothing outside the index (a range or `in` on the terminal
+    /// requires ordering by it, mirroring the stored-document rule).
     ///
-    /// Returns `Ok(None)` when no index's terminal is named by any clause
-    /// or orderBy (the generic index route owns the query), `Ok(Some(..))`
-    /// with the selected index and the terminal clause — `None` for the
-    /// first keyset page, which has no cursor clause yet and scans the
-    /// member keys in `orderBy` order — and a targeted error when a
-    /// terminal was named but no index satisfies the shape.
+    /// Returns `Ok(None)` when the matcher finds no terminal-using index
+    /// (the generic route's miss error stands), `Ok(Some(..))` with the
+    /// selected index and the terminal clause — `None` for the first
+    /// keyset page, which has no cursor clause yet and scans the member
+    /// keys in `orderBy` order — and a targeted error when a terminal
+    /// index matched but the clause shape does not hold.
+    ///
+    /// [`index_for_types_matching_including_terminal`]:
+    /// dpp::data_contract::document_type::methods::DocumentTypeV0Methods::index_for_types_matching_including_terminal
     pub(crate) fn index_only_terminal_clause_selection(
         &self,
+        platform_version: &PlatformVersion,
     ) -> Result<Option<(&Index, Option<&crate::query::WhereClause>)>, Error> {
-        let terminal_clause_for = |terminal: &str| -> Option<&crate::query::WhereClause> {
-            self.internal_clauses
-                .equal_clauses
-                .get(terminal)
-                .or(match &self.internal_clauses.range_clause {
-                    Some(range_clause) if range_clause.field == terminal => Some(range_clause),
-                    _ => None,
-                })
-                .or_else(|| {
-                    self.internal_clauses
-                        .in_clauses
-                        .iter()
-                        .find(|in_clause| in_clause.field == terminal)
-                })
-        };
+        use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
 
         // Shapes the terminal route can never serve opt out up front, so
         // their generic-route miss errors propagate untouched: a resolved
@@ -97,97 +92,127 @@ impl DriveDocumentQuery<'_> {
             return Ok(None);
         }
 
-        let mut candidate_seen = false;
-        for index in self.document_type.indexes().values() {
-            let Some(terminal) = index.terminal.as_deref() else {
-                continue;
-            };
-            let terminal_clause = terminal_clause_for(terminal);
-            // The index is only a terminal-route candidate when the query
-            // actually names its terminal — through a clause, or through
-            // an orderBy alone (the first keyset page: full prefix
-            // equalities, ordered member-key scan, no cursor clause yet).
-            if terminal_clause.is_none() && !self.order_by.contains_key(terminal) {
-                continue;
-            }
-            candidate_seen = true;
+        // The same field assembly the generic matcher receives.
+        let mut fields = self
+            .internal_clauses
+            .equal_clauses
+            .keys()
+            .map(|field| field.as_str())
+            .collect::<Vec<&str>>();
+        if let Some(range_clause) = &self.internal_clauses.range_clause {
+            fields.push(range_clause.field.as_str());
+        }
+        let in_field = self
+            .internal_clauses
+            .in_clauses
+            .first()
+            .map(|in_clause| in_clause.field.as_str());
+        if let Some(in_field) = in_field {
+            fields.push(in_field);
+        }
+        let order_by_keys: Vec<&str> = self
+            .order_by
+            .keys()
+            .map(|key: &String| {
+                let field = key.as_str();
+                if !fields.contains(&field) {
+                    fields.push(field);
+                }
+                field
+            })
+            .collect();
 
-            // Every prefix property must carry an equality clause: the
-            // path down to the entry level must be fully determined.
-            if !index.properties.iter().all(|property| {
+        let Some((index, _difference, terminal_used)) = self
+            .document_type
+            .index_for_types_matching_including_terminal(
+                fields.as_slice(),
+                in_field,
+                order_by_keys.as_slice(),
+                |_| true,
+                platform_version,
+            )
+            .map_err(|e| Error::Protocol(Box::new(e)))?
+        else {
+            return Ok(None);
+        };
+        if !terminal_used {
+            // A generic cover exists after all — the generic route owns
+            // it (unreachable when this runs after a generic miss, since
+            // both share one matching algorithm).
+            return Ok(None);
+        }
+
+        let terminal =
+            index
+                .terminal
+                .as_deref()
+                .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
+                    "a terminal-using match implies an indexOnly index",
+                )))?;
+        let terminal_clause = self
+            .internal_clauses
+            .equal_clauses
+            .get(terminal)
+            .or(match &self.internal_clauses.range_clause {
+                Some(range_clause) if range_clause.field == terminal => Some(range_clause),
+                _ => None,
+            })
+            .or_else(|| {
                 self.internal_clauses
-                    .equal_clauses
-                    .contains_key(property.name.as_str())
-            }) {
-                continue;
-            }
+                    .in_clauses
+                    .iter()
+                    .find(|in_clause| in_clause.field == terminal)
+            });
 
-            // No clause may be left over: equalities must all sit on the
-            // index's properties (or be the terminal equality), and any
-            // range / `in` clause must BE the terminal clause.
-            let within_index = |field: &str| {
-                field == terminal
-                    || index
-                        .properties
-                        .iter()
-                        .any(|property| property.name == field)
-            };
-            if !self
-                .internal_clauses
+        let shape_error = || {
+            Error::Query(crate::error::query::QuerySyntaxError::Unsupported(
+                "a clause on an indexOnly terminal property requires equality clauses \
+                 on ALL of that index's properties (the path to the entries must be \
+                 fully determined), with no other clauses and orderBy limited to the \
+                 index"
+                    .to_string(),
+            ))
+        };
+
+        // Every prefix property must carry an equality clause: the path
+        // down to the entry level must be fully determined.
+        if !index.properties.iter().all(|property| {
+            self.internal_clauses
                 .equal_clauses
-                .keys()
-                .all(|field| within_index(field))
-            {
-                continue;
-            }
-            if let Some(range_clause) = &self.internal_clauses.range_clause {
-                if range_clause.field != terminal {
-                    continue;
-                }
-            }
-            if !self
-                .internal_clauses
-                .in_clauses
-                .iter()
-                .all(|in_clause| in_clause.field == terminal)
-                || self.internal_clauses.in_clauses.len() > 1
-            {
-                continue;
-            }
-
-            // orderBy must stay within the index; ordering a fully
-            // determined prefix is a no-op, so only the terminal's
-            // direction matters — and a range or `in` terminal clause
-            // requires it, same as the stored-document rule.
-            if !self.order_by.keys().all(|field| within_index(field)) {
-                continue;
-            }
-            if let Some(terminal_clause) = terminal_clause {
-                if terminal_clause.operator.is_range() && !self.order_by.contains_key(terminal) {
-                    return Err(Error::Query(
-                        crate::error::query::QuerySyntaxError::MissingOrderByForRange(
-                            "a range or `in` clause on an indexOnly terminal property \
-                             requires an orderBy on that property",
-                        ),
-                    ));
-                }
-            }
-
-            return Ok(Some((index, terminal_clause)));
+                .contains_key(property.name.as_str())
+        }) {
+            return Err(shape_error());
         }
 
-        if candidate_seen {
-            return Err(Error::Query(
-                crate::error::query::QuerySyntaxError::Unsupported(
-                    "a clause on an indexOnly terminal property requires equality clauses \
-                     on ALL of that index's properties (the path to the entries must be \
-                     fully determined), with no other clauses and orderBy limited to the \
-                     index"
-                        .to_string(),
-                ),
-            ));
+        // No clause may be left over, and any range / `in` clause must BE
+        // the terminal clause. (Field coverage is the matcher's job; the
+        // PLACEMENT of non-equality clauses is the shape rule here.)
+        if let Some(range_clause) = &self.internal_clauses.range_clause {
+            if range_clause.field != terminal {
+                return Err(shape_error());
+            }
         }
-        Ok(None)
+        if !self
+            .internal_clauses
+            .in_clauses
+            .iter()
+            .all(|in_clause| in_clause.field == terminal)
+        {
+            return Err(shape_error());
+        }
+
+        if let Some(terminal_clause) = terminal_clause {
+            if terminal_clause.operator.is_range() && !self.order_by.contains_key(terminal) {
+                return Err(Error::Query(
+                    crate::error::query::QuerySyntaxError::MissingOrderByForRange(
+                        "a range or `in` clause on an indexOnly terminal property \
+                         requires an orderBy on that property",
+                    ),
+                ));
+            }
+        }
+
+        Ok(Some((index, terminal_clause)))
     }
 
     /// Build the path query for a terminal-clause indexOnly query: the
@@ -273,7 +298,7 @@ impl DriveDocumentQuery<'_> {
         match self.select_best_index(platform_version)? {
             crate::query::BestIndexOutcome::Matched(index) => Ok(index),
             crate::query::BestIndexOutcome::NoIndexMatches(no_index_error) => {
-                match self.index_only_terminal_clause_selection()? {
+                match self.index_only_terminal_clause_selection(platform_version)? {
                     Some((index, _)) => Ok(index),
                     None => Err(no_index_error),
                 }
@@ -294,7 +319,7 @@ impl DriveDocumentQuery<'_> {
         match self.select_best_index(platform_version)? {
             crate::query::BestIndexOutcome::Matched(_) => Ok(None),
             crate::query::BestIndexOutcome::NoIndexMatches(no_index_error) => {
-                match self.index_only_terminal_clause_selection()? {
+                match self.index_only_terminal_clause_selection(platform_version)? {
                     Some((index, terminal_clause)) => self
                         .index_only_terminal_path_query(
                             document_type_path.to_vec(),


### PR DESCRIPTION
## Issue being fixed or feature implemented

First of three stacked architecture PRs on #4499 (see its review discussion): the terminal-clause route shipped with a second, hand-rolled index matcher living in rs-drive beside dpp's `index_for_types_matching` — "which index serves this query" was answered in two places, and the terminal matcher took the first satisfying index in declaration order instead of scoring candidates.

## What was done?

**One matching algorithm.** `Index::matches` is extracted into a shared component-list core, and the new `Index::matches_including_terminal` runs the SAME core with the terminal (an indexOnly index's member-key property) as the index's deepest matchable component — field coverage, the `in`-position rule and the order-by contiguous-suffix rule all extend naturally. An unused terminal never costs score (it is the entry level itself, always reachable), so scores stay comparable with the generic matcher's and an index is never penalized for merely having a terminal.

**Precedence encoded in selection, not in routing.** `index_for_types_matching_including_terminal` returns `(index, difference, terminal_used)` with the route precedence inside the matcher itself: a candidate covering the query WITHOUT its terminal always beats every terminal-using candidate (the terminal route is a stand-in for "no ordinary index serves this", never a competitor to one that does), and within each class the difference scoring and index-map-order tie-break are exactly the generic matcher's. On any document type without terminals this is exactly `index_for_types_matching`. Shares the `index_for_types` version gate — terminal participation can only change outcomes on indexOnly document types, which cannot exist below PV14.

**Drive's selection shrinks to shape validation.** The candidate loop in `index_only_terminal_clause_selection` is deleted; it now asks the dpp matcher for the winner and validates clause SHAPE on it — every prefix property equality-bound, non-equality clauses only on the terminal, a terminal range/`in` requires ordering by it. First-match-in-declaration-order becomes difference-scored best-match (`byLiker`'s exact terminal cover now beats `byHashtagPost`'s costlier one for `{$ownerId, postId}`, deterministically).

## How Has This Been Tested?

New dpp test `terminal_aware_matching_prefers_generic_and_scores_candidates` pins the three semantics: generic precedence (`byPost` beats `byLiker`'s terminal cover of the same field), best-match scoring between terminal candidates, and zero-cost unused terminals. All 15 drive indexOnly e2e tests (including every terminal-route and refusal case from #4499), the 699-test drive query suite, 264 dpp index tests and the drive-abci indexOnly pipeline are green; workspace check and clippy `-D warnings` clean.

## Breaking Changes

None on any released surface. Within the unreleased #4499 feature, multi-candidate terminal selection can pick a different (better-scoring) index than declaration order did; selection remains fully deterministic.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**Stack**: #4499 → this → clause classification (`InternalClauses` terminals) → mixed prefix-range + terminal shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
