### PR TITLE
feat(drive): serve mixed prefix-pivot and terminal shapes on indexOnly queries

### DIFF
--- a/book/src/drive/index-only-document-types.md
+++ b/book/src/drive/index-only-document-types.md
@@ -128,8 +128,12 @@ an equality answers "did I like X" in one query, and a range ordered by
 the terminal (`terminal > <last seen>`, with a limit) walks the entries
 page by page — **keyset pagination**, the indexOnly replacement for
 id-shaped `startAt` cursors, which cannot address a position whose
-synthesized id is a one-way hash. Both shapes prove and verify through
-the same shared path-query builder.
+synthesized id is a one-way hash. Mixed shapes are served through a
+**prefix pivot**: one range or `in` clause may sit on a prefix property
+instead of the terminal (`hashtag == h AND postId > p AND $ownerId ==
+me`), with everything above the pivot equality-bound, everything below
+it unconstrained, and the terminal clause an equality. All shapes prove
+and verify through the same shared path-query builder.
 
 Not supported on the read surface: by-`$id` fetches (no primary tree —
 rejected with guidance) and `startAt` cursors (rejected with the keyset

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -731,17 +731,22 @@ impl Index {
         Self::matches_over_components(&self.properties, index_names, in_field_name, order_by)
     }
 
-    /// [`Self::matches`] over an index's full component list, terminal
-    /// included: the terminal (an indexOnly index's member-key property)
-    /// participates in field coverage, the `in`-position rule and the
-    /// order-by suffix exactly as if it were the index's deepest property.
+    /// [`Self::matches`] with the index's terminal (an indexOnly index's
+    /// member-key property) as a matchable component. The terminal is the
+    /// entry level itself — ALWAYS the index's deepest component — so it
+    /// never participates in the prefix's order-by reduction: a
+    /// constrained terminal leaves prefix ordering intact (each fully
+    /// determined path holds at most one entry per member key), a
+    /// terminal named in `order_by` must be its LAST (deepest) entry, and
+    /// a terminal `in` field trivially satisfies the deepest-position
+    /// rule. The prefix properties then match through the exact
+    /// [`Self::matches`] algorithm.
     ///
     /// Returns `(difference, terminal_used)` — the difference counts
-    /// unused PREFIX properties only (an unused terminal costs nothing:
-    /// it is the entry level itself, always reachable), so scores stay
-    /// comparable with [`Self::matches`] and an index is never penalized
-    /// for merely having a terminal. On an index without a terminal this
-    /// is exactly [`Self::matches`] with `terminal_used = false`.
+    /// unused PREFIX properties only (an unused terminal costs nothing),
+    /// so scores stay comparable with [`Self::matches`]. On an index
+    /// without a terminal this is exactly [`Self::matches`] with
+    /// `terminal_used = false`.
     pub fn matches_including_terminal(
         &self,
         index_names: &[&str],
@@ -754,26 +759,32 @@ impl Index {
                 .map(|difference| (difference, false));
         };
 
-        // One extended component list, one matching algorithm. The parser
-        // rejects a terminal repeating an index property, so the synthetic
-        // component cannot shadow a prefix property.
-        let mut components = Vec::with_capacity(self.properties.len() + 1);
-        components.extend(self.properties.iter().cloned());
-        components.push(IndexProperty {
-            name: terminal.to_string(),
-            ascending: true,
-        });
-
-        let difference =
-            Self::matches_over_components(&components, index_names, in_field_name, order_by)?;
         let terminal_used = index_names.contains(&terminal);
-        // An unused terminal was counted as an unused component by the
-        // shared algorithm; take it back out of the score.
-        let difference = if terminal_used {
-            difference
-        } else {
-            difference.saturating_sub(1)
+        let prefix_fields: Vec<&str> = index_names
+            .iter()
+            .copied()
+            .filter(|field| *field != terminal)
+            .collect();
+        let prefix_order_by: &[&str] = match order_by.iter().position(|field| *field == terminal) {
+            // Ordering by the terminal is ordering the deepest level —
+            // admissible only as the ordering's last entry.
+            Some(position) if position + 1 == order_by.len() => &order_by[..position],
+            Some(_) => return None,
+            None => order_by,
         };
+        let prefix_in_field = match in_field_name {
+            // An `in` on the terminal sits at the deepest position by
+            // construction; the prefix keeps no `in` constraint.
+            Some(field) if field == terminal => None,
+            other => other,
+        };
+
+        let difference = Self::matches_over_components(
+            &self.properties,
+            &prefix_fields,
+            prefix_in_field,
+            prefix_order_by,
+        )?;
         Some((difference, terminal_used))
     }
 

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -822,6 +822,306 @@ fn should_serve_terminal_range_keyset_pagination() {
     assert_grovedb_is_consistent(&drive);
 }
 
+/// Mixed shape: a range on a PREFIX property (the pivot) with a terminal
+/// equality — `hashtag == h AND postId > p AND $ownerId == me`. The path
+/// stops at the pivot, the range selects its values, and the terminal
+/// equality runs beneath each of them. Proved and unproved paths agree.
+#[test]
+fn should_serve_prefix_pivot_with_terminal_equality() {
+    use crate::query::{OrderClause, WhereClause, WhereOperator};
+    use dpp::document::DocumentV0Getters;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    for (post, owner, seed) in [
+        (POST_A, OWNER_1, 1u64),
+        (POST_B, OWNER_1, 2),
+        (POST_B, OWNER_2, 3),
+    ] {
+        let like = build_like(&contract, "dash", post, owner, seed);
+        insert_like(&drive, &contract, &like, true).expect("insert like");
+    }
+
+    let mut query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::GreaterThan,
+                value: Value::Identifier(POST_A),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(10),
+    );
+    query.order_by.insert(
+        "postId".to_string(),
+        OrderClause {
+            field: "postId".to_string(),
+            ascending: true,
+        },
+    );
+
+    let outcome = drive
+        .query_documents(query.clone(), None, false, None, None)
+        .expect("pivot query executes");
+    let documents = outcome.documents();
+    assert_eq!(documents.len(), 1, "only OWNER_1's like beyond POST_A");
+    assert_eq!(documents[0].owner_id().to_buffer(), OWNER_1);
+    assert_eq!(
+        documents[0]
+            .properties()
+            .get("postId")
+            .expect("postId recovered")
+            .to_identifier_bytes()
+            .expect("identifier"),
+        POST_B.to_vec()
+    );
+
+    let (proof, _) = query
+        .clone()
+        .execute_with_proof(&drive, None, None, platform_version())
+        .expect("pivot proof generation");
+    let (_root, verified) = query
+        .verify_proof(proof.as_slice(), platform_version())
+        .expect("pivot proof verification");
+    assert_eq!(verified.len(), 1);
+    assert_eq!(verified[0].id(), documents[0].id());
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// A pivot on the FIRST property with the one below it unconstrained:
+/// `hashtag >= h AND $ownerId == me` walks every post under each matched
+/// hashtag through an insert-all level before the terminal equality.
+#[test]
+fn should_serve_first_property_pivot_with_unconstrained_below() {
+    use crate::query::{OrderClause, WhereClause, WhereOperator};
+    use dpp::document::DocumentV0Getters;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    for (post, owner, seed) in [
+        (POST_A, OWNER_1, 1u64),
+        (POST_B, OWNER_1, 2),
+        (POST_B, OWNER_2, 3),
+    ] {
+        let like = build_like(&contract, "dash", post, owner, seed);
+        insert_like(&drive, &contract, &like, true).expect("insert like");
+    }
+
+    let mut query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::GreaterThanOrEquals,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(10),
+    );
+    query.order_by.insert(
+        "hashtag".to_string(),
+        OrderClause {
+            field: "hashtag".to_string(),
+            ascending: true,
+        },
+    );
+
+    let outcome = drive
+        .query_documents(query.clone(), None, false, None, None)
+        .expect("first-property pivot query executes");
+    let documents = outcome.documents();
+    assert_eq!(documents.len(), 2, "both of OWNER_1's likes");
+    let mut posts: Vec<Vec<u8>> = documents
+        .iter()
+        .map(|document| {
+            assert_eq!(document.owner_id().to_buffer(), OWNER_1);
+            document
+                .properties()
+                .get("postId")
+                .expect("postId recovered")
+                .to_identifier_bytes()
+                .expect("identifier")
+        })
+        .collect();
+    posts.sort();
+    assert_eq!(posts, vec![POST_A.to_vec(), POST_B.to_vec()]);
+
+    let (proof, _) = query
+        .clone()
+        .execute_with_proof(&drive, None, None, platform_version())
+        .expect("first-property pivot proof generation");
+    let (_root, verified) = query
+        .verify_proof(proof.as_slice(), platform_version())
+        .expect("first-property pivot proof verification");
+    let mut verified_ids: Vec<_> = verified.iter().map(|d| d.id()).collect();
+    let mut queried_ids: Vec<_> = documents.iter().map(|d| d.id()).collect();
+    verified_ids.sort();
+    queried_ids.sort();
+    assert_eq!(verified_ids, queried_ids);
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// A pivot demands a terminal EQUALITY — two simultaneous non-equality
+/// levels have no single pagination order.
+#[test]
+fn should_refuse_pivot_with_terminal_range() {
+    use crate::error::query::QuerySyntaxError;
+    use crate::query::{OrderClause, WhereClause, WhereOperator};
+    use assert_matches::assert_matches;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    let mut query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::In,
+                value: Value::Array(vec![Value::Identifier(POST_A), Value::Identifier(POST_B)]),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::GreaterThan,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(10),
+    );
+    for field in ["postId", "$ownerId"] {
+        query.order_by.insert(
+            field.to_string(),
+            OrderClause {
+                field: field.to_string(),
+                ascending: true,
+            },
+        );
+    }
+    let error = drive
+        .query_documents(query, None, false, None, None)
+        .expect_err("a pivot with a terminal range must be refused");
+    assert_matches!(
+        &error,
+        crate::error::Error::Query(QuerySyntaxError::Unsupported(message))
+            if message.contains("EQUALITY clause on the terminal"),
+        "unexpected error: {error}"
+    );
+}
+
+/// An equality BELOW the pivot is not yet supported and must be refused
+/// rather than silently scanned.
+#[test]
+fn should_refuse_equality_below_pivot() {
+    use crate::error::query::QuerySyntaxError;
+    use crate::query::{OrderClause, WhereClause, WhereOperator};
+    use assert_matches::assert_matches;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    let mut query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::GreaterThan,
+                value: Value::Text("c".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(POST_A),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(10),
+    );
+    for field in ["hashtag", "postId"] {
+        query.order_by.insert(
+            field.to_string(),
+            OrderClause {
+                field: field.to_string(),
+                ascending: true,
+            },
+        );
+    }
+    let error = drive
+        .query_documents(query, None, false, None, None)
+        .expect_err("an equality below the pivot must be refused");
+    assert_matches!(
+        &error,
+        crate::error::Error::Query(QuerySyntaxError::Unsupported(message))
+            if message.contains("BELOW a pivot"),
+        "unexpected error: {error}"
+    );
+}
+
+/// A pivot range without an orderBy on it is refused, mirroring the
+/// stored-document rule.
+#[test]
+fn should_require_order_by_for_pivot_range() {
+    use crate::error::query::QuerySyntaxError;
+    use crate::query::{WhereClause, WhereOperator};
+    use assert_matches::assert_matches;
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    let query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::GreaterThan,
+                value: Value::Identifier(POST_A),
+            },
+            WhereClause {
+                field: "$ownerId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(OWNER_1),
+            },
+        ],
+        Some(10),
+    );
+    let error = drive
+        .query_documents(query, None, false, None, None)
+        .expect_err("a pivot range without orderBy must be refused");
+    assert_matches!(
+        &error,
+        crate::error::Error::Query(QuerySyntaxError::MissingOrderByForRange(_)),
+        "unexpected error: {error}"
+    );
+}
+
 /// A terminal clause whose index prefix is not fully determined is
 /// refused with the shape requirement — never a wrong-answer scan.
 #[test]

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -49,6 +49,22 @@ use dpp::version::PlatformVersion;
 use grovedb::GroveDb;
 use std::collections::BTreeMap;
 
+/// A resolved indexOnly terminal route: the matcher's winning index, the
+/// clause on its terminal, and — for mixed shapes — the *prefix pivot*: a
+/// range or `in` clause sitting on one of the index's prefix properties
+/// (by position), with every property above it equality-bound and every
+/// property below it unconstrained.
+pub(crate) struct IndexOnlyTerminalRoute<'a> {
+    /// The index the entries are addressed through.
+    pub index: &'a Index,
+    /// The clause on the index's terminal property; `None` only for the
+    /// first keyset page (order-by on the terminal, no cursor clause yet).
+    pub terminal_clause: Option<&'a crate::query::WhereClause>,
+    /// `(position, clause)` of a range / `in` clause on a prefix
+    /// property. When present the terminal clause is always an equality.
+    pub prefix_pivot: Option<(usize, &'a crate::query::WhereClause)>,
+}
+
 impl DriveDocumentQuery<'_> {
     /// The terminal-clause route for indexOnly queries.
     ///
@@ -68,19 +84,26 @@ impl DriveDocumentQuery<'_> {
     /// nothing outside the index (a range or `in` on the terminal
     /// requires ordering by it, mirroring the stored-document rule).
     ///
+    /// Mixed shapes are served through a *prefix pivot*: one range or
+    /// `in` clause may sit on a prefix property instead of the terminal
+    /// (`hashtag == h AND postId > p AND $ownerId == me`), provided every
+    /// property above the pivot is equality-bound, properties below it
+    /// are unconstrained, the terminal clause is an equality, and the
+    /// pivot is ordered by (`MissingOrderByForRange` otherwise).
+    ///
     /// Returns `Ok(None)` when the matcher finds no terminal-using index
     /// (the generic route's miss error stands), `Ok(Some(..))` with the
-    /// selected index and the terminal clause — `None` for the first
-    /// keyset page, which has no cursor clause yet and scans the member
-    /// keys in `orderBy` order — and a targeted error when a terminal
-    /// index matched but the clause shape does not hold.
+    /// resolved route — `terminal_clause: None` only for the first keyset
+    /// page, which has no cursor clause yet and scans the member keys in
+    /// `orderBy` order — and a targeted error when a terminal index
+    /// matched but the clause shape does not hold.
     ///
     /// [`index_for_types_matching_including_terminal`]:
     /// dpp::data_contract::document_type::methods::DocumentTypeV0Methods::index_for_types_matching_including_terminal
     pub(crate) fn index_only_terminal_clause_selection(
         &self,
         platform_version: &PlatformVersion,
-    ) -> Result<Option<(&Index, Option<&crate::query::WhereClause>)>, Error> {
+    ) -> Result<Option<IndexOnlyTerminalRoute<'_>>, Error> {
         use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
 
         // Shapes the terminal route can never serve opt out up front, so
@@ -178,80 +201,160 @@ impl DriveDocumentQuery<'_> {
                     .find(|in_clause| in_clause.field == terminal)
             });
 
-        let shape_error = || {
+        let shape_error = |message: &str| {
             Error::Query(crate::error::query::QuerySyntaxError::Unsupported(
-                "a clause on an indexOnly terminal property requires equality clauses \
-                 on ALL of that index's properties (the path to the entries must be \
-                 fully determined), with no other clauses and orderBy limited to the \
-                 index"
-                    .to_string(),
+                message.to_string(),
             ))
         };
 
-        // Every prefix property must carry an equality clause: the path
-        // down to the entry level must be fully determined.
-        if !index.properties.iter().all(|property| {
-            self.internal_clauses
-                .equal_clauses
-                .contains_key(property.name.as_str())
-        }) {
-            return Err(shape_error());
-        }
-
-        // No clause may be left over, and any range / `in` clause must BE
-        // the terminal clause. (Field coverage is the matcher's job; the
-        // PLACEMENT of non-equality clauses is the shape rule here.)
-        if let Some(range_clause) = &self.internal_clauses.range_clause {
-            if range_clause.field != terminal {
-                return Err(shape_error());
-            }
-        }
-        if !self
+        // The one non-equality, non-terminal clause — the prefix pivot
+        // candidate. (Field coverage is the matcher's job; PLACEMENT of
+        // non-equality clauses is the shape rule here.)
+        let position_of = |field: &str| -> Option<usize> {
+            index
+                .properties
+                .iter()
+                .position(|property| property.name == field)
+        };
+        let mut prefix_pivot: Option<(usize, &crate::query::WhereClause)> = None;
+        for clause in self
             .internal_clauses
-            .in_clauses
+            .range_clause
             .iter()
-            .all(|in_clause| in_clause.field == terminal)
+            .chain(self.internal_clauses.in_clauses.iter())
         {
-            return Err(shape_error());
-        }
-
-        if let Some(terminal_clause) = terminal_clause {
-            if terminal_clause.operator.is_range() && !self.order_by.contains_key(terminal) {
-                return Err(Error::Query(
-                    crate::error::query::QuerySyntaxError::MissingOrderByForRange(
-                        "a range or `in` clause on an indexOnly terminal property \
-                         requires an orderBy on that property",
-                    ),
+            if clause.field == terminal {
+                continue;
+            }
+            let Some(position) = position_of(&clause.field) else {
+                // Not on the terminal, not on a prefix property — the
+                // matcher could not have covered it. Unreachable.
+                return Err(Error::Drive(DriveError::CorruptedCodeExecution(
+                    "a matched terminal route cannot carry a clause outside the index",
+                )));
+            };
+            if prefix_pivot.is_some() {
+                return Err(shape_error(
+                    "an indexOnly terminal query supports at most one range or `in` \
+                     clause on a prefix property (the pivot)",
                 ));
             }
+            prefix_pivot = Some((position, clause));
         }
 
-        Ok(Some((index, terminal_clause)))
+        match prefix_pivot {
+            None => {
+                // Fully determined prefix: every prefix property must
+                // carry an equality clause — the path down to the entry
+                // level admits no gaps.
+                if !index.properties.iter().all(|property| {
+                    self.internal_clauses
+                        .equal_clauses
+                        .contains_key(property.name.as_str())
+                }) {
+                    return Err(shape_error(
+                        "a clause on an indexOnly terminal property requires equality \
+                         clauses on ALL of that index's properties (the path to the \
+                         entries must be fully determined), with no other clauses and \
+                         orderBy limited to the index",
+                    ));
+                }
+                if let Some(terminal_clause) = terminal_clause {
+                    if terminal_clause.operator.is_range() && !self.order_by.contains_key(terminal)
+                    {
+                        return Err(Error::Query(
+                            crate::error::query::QuerySyntaxError::MissingOrderByForRange(
+                                "a range or `in` clause on an indexOnly terminal property \
+                                 requires an orderBy on that property",
+                            ),
+                        ));
+                    }
+                }
+            }
+            Some((pivot_position, pivot_clause)) => {
+                // Mixed shape: everything above the pivot equality-bound,
+                // everything below it unconstrained, terminal clause an
+                // equality, pivot ordered by.
+                let terminal_is_equality =
+                    self.internal_clauses.equal_clauses.contains_key(terminal);
+                if !terminal_is_equality {
+                    return Err(shape_error(
+                        "a range or `in` clause on an indexOnly prefix property requires \
+                         an EQUALITY clause on the terminal: two simultaneous non-equality \
+                         levels have no single pagination order",
+                    ));
+                }
+                for (position, property) in index.properties.iter().enumerate() {
+                    let has_equality = self
+                        .internal_clauses
+                        .equal_clauses
+                        .contains_key(property.name.as_str());
+                    if position < pivot_position && !has_equality {
+                        return Err(shape_error(
+                            "every prefix property ABOVE a pivot range/`in` clause must \
+                             carry an equality clause",
+                        ));
+                    }
+                    if position > pivot_position && has_equality {
+                        return Err(shape_error(
+                            "prefix properties BELOW a pivot range/`in` clause must be \
+                             unconstrained: an equality below the pivot is not yet \
+                             supported",
+                        ));
+                    }
+                }
+                if !self.order_by.contains_key(pivot_clause.field.as_str()) {
+                    return Err(Error::Query(
+                        crate::error::query::QuerySyntaxError::MissingOrderByForRange(
+                            "a range or `in` clause on an indexOnly prefix property \
+                             requires an orderBy on that property",
+                        ),
+                    ));
+                }
+            }
+        }
+
+        Ok(Some(IndexOnlyTerminalRoute {
+            index,
+            terminal_clause,
+            prefix_pivot,
+        }))
     }
 
-    /// Build the path query for a terminal-clause indexOnly query: the
-    /// fully determined prefix path down to the `0` entry level, with the
-    /// terminal clause lowered over the member keys. One builder for the
-    /// server's execution, the prover and the verifier.
+    /// Build the path query for a terminal-clause indexOnly query. One
+    /// builder for the server's execution, the prover and the verifier.
+    ///
+    /// Without a pivot: the fully determined prefix path down to the `0`
+    /// entry level, with the terminal clause lowered over the member
+    /// keys. With a prefix pivot: the path stops at the pivot property,
+    /// the pivot clause ranges over its values, and a subquery chain
+    /// walks each selected value through the unconstrained properties
+    /// below it (`insert_all` per level) down to `0`, where the terminal
+    /// equality selects the member key.
     pub(crate) fn index_only_terminal_path_query(
         &self,
         document_type_path: Vec<Vec<u8>>,
-        index: &Index,
-        terminal_clause: Option<&crate::query::WhereClause>,
+        route: &IndexOnlyTerminalRoute<'_>,
         platform_version: &PlatformVersion,
     ) -> Result<grovedb::PathQuery, Error> {
         use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
 
-        let terminal_direction = |field: &str| {
+        let IndexOnlyTerminalRoute {
+            index,
+            terminal_clause,
+            prefix_pivot,
+        } = route;
+
+        let direction_for = |field: &str, fallback: bool| {
             self.order_by
                 .get(field)
                 .map(|order_clause| order_clause.ascending)
-                .unwrap_or(true)
+                .unwrap_or(fallback)
         };
-        let final_query = match terminal_clause {
+        let terminal_query = match terminal_clause {
             Some(terminal_clause) => {
                 let left_to_right = if terminal_clause.operator.is_range() {
-                    terminal_direction(terminal_clause.field.as_str())
+                    direction_for(terminal_clause.field.as_str(), true)
                 } else {
                     true
                 };
@@ -270,20 +373,76 @@ impl DriveDocumentQuery<'_> {
                         "terminal-route selection guarantees an indexOnly index",
                     ),
                 ))?;
-                let mut query = grovedb::Query::new_with_direction(terminal_direction(terminal));
+                let mut query = grovedb::Query::new_with_direction(direction_for(terminal, true));
                 query.insert_all();
                 query
             }
         };
 
         let mut path = document_type_path;
-        for property in index.properties.iter() {
+        let (final_query, path_property_count) = match prefix_pivot {
+            None => {
+                // Fully determined prefix: the path descends every
+                // property's value; the terminal query runs at `0`.
+                (terminal_query, index.properties.len())
+            }
+            Some((pivot_position, pivot_clause)) => {
+                // The pivot clause ranges over its property's values;
+                // below it, one `insert_all` level per unconstrained
+                // property, then `0` and the terminal equality. Built
+                // innermost-out.
+                let mut chain = terminal_query;
+                let mut chain_is_terminal = true;
+                for position in ((pivot_position + 1)..index.properties.len()).rev() {
+                    let property = &index.properties[position];
+                    let mut values_query = grovedb::Query::new_with_direction(direction_for(
+                        &property.name,
+                        property.ascending,
+                    ));
+                    values_query.insert_all();
+                    if chain_is_terminal {
+                        values_query.set_subquery_key(vec![0]);
+                    } else {
+                        values_query.set_subquery_key(
+                            index.properties[position + 1].name.as_bytes().to_vec(),
+                        );
+                    }
+                    values_query.set_subquery(chain);
+                    chain = values_query;
+                    chain_is_terminal = false;
+                }
+
+                let mut pivot_query = pivot_clause.to_path_query(
+                    self.document_type,
+                    &None,
+                    direction_for(pivot_clause.field.as_str(), true),
+                    platform_version,
+                )?;
+                if chain_is_terminal {
+                    // The pivot is the last property: `0` sits directly
+                    // under each of its values.
+                    pivot_query.set_subquery_key(vec![0]);
+                } else {
+                    pivot_query.set_subquery_key(
+                        index.properties[pivot_position + 1]
+                            .name
+                            .as_bytes()
+                            .to_vec(),
+                    );
+                }
+                pivot_query.set_subquery(chain);
+                (pivot_query, *pivot_position)
+            }
+        };
+
+        for property in index.properties.iter().take(path_property_count) {
             let where_clause = self
                 .internal_clauses
                 .equal_clauses
                 .get(property.name.as_str())
                 .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
-                    "terminal-route selection guarantees an equality per prefix property",
+                    "terminal-route selection guarantees an equality per determined prefix \
+                     property",
                 )))?;
             path.push(property.name.as_bytes().to_vec());
             path.push(self.document_type.serialize_value_for_key(
@@ -292,7 +451,12 @@ impl DriveDocumentQuery<'_> {
                 platform_version,
             )?);
         }
-        path.push(vec![0]);
+        match prefix_pivot {
+            None => path.push(vec![0]),
+            Some((pivot_position, _)) => {
+                path.push(index.properties[*pivot_position].name.as_bytes().to_vec())
+            }
+        }
 
         Ok(grovedb::PathQuery::new(
             path,
@@ -313,7 +477,7 @@ impl DriveDocumentQuery<'_> {
             crate::query::BestIndexOutcome::Matched(index) => Ok(index),
             crate::query::BestIndexOutcome::NoIndexMatches(no_index_error) => {
                 match self.index_only_terminal_clause_selection(platform_version)? {
-                    Some((index, _)) => Ok(index),
+                    Some(route) => Ok(route.index),
                     None => Err(no_index_error),
                 }
             }
@@ -334,11 +498,10 @@ impl DriveDocumentQuery<'_> {
             crate::query::BestIndexOutcome::Matched(_) => Ok(None),
             crate::query::BestIndexOutcome::NoIndexMatches(no_index_error) => {
                 match self.index_only_terminal_clause_selection(platform_version)? {
-                    Some((index, terminal_clause)) => self
+                    Some(route) => self
                         .index_only_terminal_path_query(
                             document_type_path.to_vec(),
-                            index,
-                            terminal_clause,
+                            &route,
                             platform_version,
                         )
                         .map(Some),


### PR DESCRIPTION
## Issue being fixed or feature implemented

Third of three stacked architecture PRs on #4499 (on top of #4502 and #4503): the scoped-out expressiveness gap. Mixed shapes like `hashtag == h AND postId > p AND $ownerId == me` — a range on a prefix property plus a terminal equality — were served by neither route: the terminal route demanded all-prefix equalities, and the generic route cannot bind a terminal.

## What was done?

**The prefix pivot.** One range or `in` clause may sit on a prefix property instead of the terminal, provided: every property above the pivot is equality-bound, properties below it are unconstrained, the terminal clause is an equality, and the pivot is ordered by. A pivot with a terminal *range* is refused with guidance — two simultaneous non-equality levels have no single pagination order — as are equalities below the pivot (not yet supported, refused rather than silently scanned) and a pivot missing its `orderBy` (`MissingOrderByForRange`, mirroring the stored-document rule).

**Construction.** The path stops at the pivot property; the pivot clause ranges over its values; a subquery chain walks each selected value through the unconstrained levels (`insert_all` per property) down to the `0` entry level, where the terminal equality selects the member key. Still one builder shared by the server's execution, the prover and the verifier, and result trios still synthesize through the unchanged one-builder synthesis.

**Terminal position semantics pinned down in the matcher** (this is what actually forced #4502's unified matcher, as predicted): the terminal is ALWAYS the index's deepest component, so it never participates in the prefix's order-by reduction — a constrained terminal leaves prefix ordering intact (each fully determined path holds at most one entry per member key), a terminal named in `orderBy` must be its last entry, and a terminal `in`-field trivially satisfies the deepest-position rule. The prefix then matches through the exact stored-type algorithm, so the platform-wide order-by model (order by the deepest used components) applies to the prefix unchanged.

The route selection returns a typed `IndexOnlyTerminalRoute { index, terminal_clause, prefix_pivot }`, consuming #4503's clause classification for its entry check.

## How Has This Been Tested?

Five new e2e tests in the shared suite (21 total):
- `should_serve_prefix_pivot_with_terminal_equality` — pivot on the last prefix property, proved/unproved parity
- `should_serve_first_property_pivot_with_unconstrained_below` — pivot on the first property, one `insert_all` level below, parity
- `should_refuse_pivot_with_terminal_range` — typed `Unsupported` with the pagination-order rationale
- `should_refuse_equality_below_pivot` — typed `Unsupported`
- `should_require_order_by_for_pivot_range` — typed `MissingOrderByForRange`

All 21 drive indexOnly e2e tests, the 699-test query suite, 265 dpp index tests and the drive-abci pipeline green; verify-only build, workspace check and clippy `-D warnings` clean. Book chapter updated.

## Breaking Changes

None — every newly served shape was previously rejected, and all previously served shapes keep their routes and results.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**Stack**: #4499 → #4502 (unified matcher) → #4503 (clause classification) → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
