### PR TITLE
feat(dpp)!: refersTo propertyAgreement binds referring and referenced document properties

### DIFF
--- a/book/src/drive/index-only-document-types.md
+++ b/book/src/drive/index-only-document-types.md
@@ -85,7 +85,11 @@ contract updates — a later-added index could never be backfilled.
   uniqueness constraint over its value projection plus owner — for likes,
   the `[postId]` index is the one-like-per-(post, owner) rule. `refersTo`
   validation runs unchanged (it reads transition values, not storage), so a
-  like on a nonexistent post is rejected.
+  like on a nonexistent post is rejected — and a `propertyAgreement`
+  declaration on the reference (`{ "hashtag": "hashtag" }`) binds the
+  like's own property to the referenced post's: the referenced document is
+  already fetched for the existence check, so the equality comparison adds
+  no reads, and a like whose hashtag disagrees with its post's is refused.
 - **Delete** is its own transition kind,
   `DocumentIndexOnlyDeleteTransition { base, data }` (`$action:
   "indexOnlyDelete"`), carrying the full value tuple (`$createdAt` under

--- a/packages/rs-dpp/schema/meta_schemas/document/v3/document-meta.json
+++ b/packages/rs-dpp/schema/meta_schemas/document/v3/document-meta.json
@@ -137,6 +137,21 @@
               "minLength": 1,
               "maxLength": 256,
               "pattern": "^[a-zA-Z0-9-_]{1,64}(\\.[a-zA-Z0-9-_]{1,64})*$"
+            },
+            "propertyAgreement": {
+              "description": "permanentDocument references only: each { referring property: referenced property } pair must hold as an equality between the referring document's value and the referenced document's value, enforced by consensus at document write time; both properties must exist and share one property type, validated at contract registration",
+              "type": "object",
+              "minProperties": 1,
+              "maxProperties": 10,
+              "propertyNames": {
+                "pattern": "^[a-zA-Z0-9-_]{1,64}(\\.[a-zA-Z0-9-_]{1,64})*$"
+              },
+              "additionalProperties": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "pattern": "^[a-zA-Z0-9-_]{1,64}(\\.[a-zA-Z0-9-_]{1,64})*$"
+              }
             }
           },
           "required": [

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/mod.rs
@@ -396,9 +396,47 @@ fn apply_property_reference_v0(
                 ));
             }
 
+            let property_agreement = match refers_to_map.get(property_names::PROPERTY_AGREEMENT) {
+                None => BTreeMap::new(),
+                Some(agreement_value) => {
+                    let agreement_map = agreement_value.to_btree_ref_string_map()?;
+                    if agreement_map.is_empty() || agreement_map.len() > 10 {
+                        return Err(DataContractError::InvalidContractStructure(
+                            "permanentDocument refersTo propertyAgreement must declare \
+                             between 1 and 10 property pairs"
+                                .to_string(),
+                        ));
+                    }
+                    agreement_map
+                        .iter()
+                        .map(|(referring_property, referenced_value)| {
+                            let referenced_property =
+                                referenced_value.as_text().ok_or_else(|| {
+                                    DataContractError::InvalidContractStructure(
+                                        "propertyAgreement values must be referenced \
+                                         property paths (strings)"
+                                            .to_string(),
+                                    )
+                                })?;
+                            for path in [referring_property.as_str(), referenced_property] {
+                                if path.is_empty() || path.len() > 256 {
+                                    return Err(DataContractError::InvalidContractStructure(
+                                        "propertyAgreement property paths must be between 1 \
+                                         and 256 characters"
+                                            .to_string(),
+                                    ));
+                                }
+                            }
+                            Ok((referring_property.clone(), referenced_property.to_string()))
+                        })
+                        .collect::<Result<BTreeMap<String, String>, DataContractError>>()?
+                }
+            };
+
             DocumentPropertyReferenceTarget::PermanentDocument {
                 contract_id,
                 document_type_name: document_type_name.to_string(),
+                property_agreement,
             }
         }
         "identityPublicKey" => {
@@ -423,6 +461,19 @@ fn apply_property_reference_v0(
             )))
         }
     };
+
+    // `propertyAgreement` compares against a referenced DOCUMENT's values —
+    // no other target kind has a document body to agree with.
+    if refers_to_map.contains_key(property_names::PROPERTY_AGREEMENT)
+        && !matches!(
+            target,
+            DocumentPropertyReferenceTarget::PermanentDocument { .. }
+        )
+    {
+        return Err(DataContractError::InvalidContractStructure(
+            "propertyAgreement is only allowed on permanentDocument references".to_string(),
+        ));
+    }
 
     Ok(DocumentPropertyType::IdentifierWithReference(target))
 }
@@ -554,6 +605,144 @@ mod tests {
     }
 
     #[test]
+    fn should_parse_property_agreement_on_permanent_document_refers_to() {
+        let document_type = try_document_type_from_schema(json!({
+            "type": "object",
+            "properties": {
+                "hashtag": { "type": "string", "position": 0, "maxLength": 63 },
+                "postId": {
+                    "type": "array",
+                    "byteArray": true,
+                    "minItems": 32,
+                    "maxItems": 32,
+                    "contentMediaType": "application/x.dash.dpp.identifier",
+                    "position": 1,
+                    "refersTo": {
+                        "type": "permanentDocument",
+                        "documentType": "post",
+                        "propertyAgreement": { "hashtag": "hashtag" }
+                    }
+                }
+            },
+            "required": [],
+            "additionalProperties": false
+        }))
+        .expect("should parse");
+
+        let property_type = document_type
+            .as_ref()
+            .flattened_properties()
+            .get("postId")
+            .map(|p| p.property_type.clone())
+            .expect("property should be present");
+
+        let DocumentPropertyType::IdentifierWithReference(
+            DocumentPropertyReferenceTarget::PermanentDocument {
+                property_agreement, ..
+            },
+        ) = property_type
+        else {
+            panic!("expected a permanentDocument reference");
+        };
+        assert_eq!(
+            property_agreement,
+            BTreeMap::from([("hashtag".to_string(), "hashtag".to_string())])
+        );
+    }
+
+    #[test]
+    fn should_reject_property_agreement_on_non_document_reference() {
+        let err = try_document_type_from_schema(json!({
+            "type": "object",
+            "properties": {
+                "toUserId": {
+                    "type": "array",
+                    "byteArray": true,
+                    "minItems": 32,
+                    "maxItems": 32,
+                    "contentMediaType": "application/x.dash.dpp.identifier",
+                    "position": 0,
+                    "refersTo": {
+                        "type": "identity",
+                        "propertyAgreement": { "hashtag": "hashtag" }
+                    }
+                }
+            },
+            "required": [],
+            "additionalProperties": false
+        }))
+        .expect_err("should fail");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("propertyAgreement is only allowed on permanentDocument"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn should_reject_empty_property_agreement() {
+        let err = try_document_type_from_schema(json!({
+            "type": "object",
+            "properties": {
+                "postId": {
+                    "type": "array",
+                    "byteArray": true,
+                    "minItems": 32,
+                    "maxItems": 32,
+                    "contentMediaType": "application/x.dash.dpp.identifier",
+                    "position": 0,
+                    "refersTo": {
+                        "type": "permanentDocument",
+                        "documentType": "post",
+                        "propertyAgreement": {}
+                    }
+                }
+            },
+            "required": [],
+            "additionalProperties": false
+        }))
+        .expect_err("should fail");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("between 1 and 10 property pairs"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn should_reject_non_string_property_agreement_values() {
+        let err = try_document_type_from_schema(json!({
+            "type": "object",
+            "properties": {
+                "postId": {
+                    "type": "array",
+                    "byteArray": true,
+                    "minItems": 32,
+                    "maxItems": 32,
+                    "contentMediaType": "application/x.dash.dpp.identifier",
+                    "position": 0,
+                    "refersTo": {
+                        "type": "permanentDocument",
+                        "documentType": "post",
+                        "propertyAgreement": { "hashtag": 7 }
+                    }
+                }
+            },
+            "required": [],
+            "additionalProperties": false
+        }))
+        .expect_err("should fail");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("must be referenced property paths"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
     fn should_parse_permanent_document_refers_to() {
         let contract_id = Identifier::from([7u8; 32]);
 
@@ -592,6 +781,7 @@ mod tests {
                 DocumentPropertyReferenceTarget::PermanentDocument {
                     contract_id: Some(contract_id),
                     document_type_name: "note".to_string(),
+                    property_agreement: Default::default(),
                 }
             )
         );
@@ -633,6 +823,7 @@ mod tests {
                 DocumentPropertyReferenceTarget::PermanentDocument {
                     contract_id: None,
                     document_type_name: "note".to_string(),
+                    property_agreement: Default::default(),
                 }
             )
         );

--- a/packages/rs-dpp/src/data_contract/document_type/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/mod.rs
@@ -89,6 +89,7 @@ pub(crate) mod property_names {
     pub const CONTRACT_ID: &str = "contractId";
     pub const DOCUMENT_TYPE: &str = "documentType";
     pub const KEY_ID_PROPERTY: &str = "keyIdProperty";
+    pub const PROPERTY_AGREEMENT: &str = "propertyAgreement";
     pub const DOCUMENTS_COUNTABLE: &str = "documentsCountable";
     pub const RANGE_COUNTABLE: &str = "rangeCountable";
     /// Doctype-level flag naming the property whose values are summed into

--- a/packages/rs-dpp/src/data_contract/document_type/property/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/property/mod.rs
@@ -102,6 +102,15 @@ pub enum DocumentPropertyReferenceTarget {
         /// the declaring contract itself
         contract_id: Option<Identifier>,
         document_type_name: String,
+        /// Property agreement: each `{referring property: referenced
+        /// property}` pair must hold as an EQUALITY between the referring
+        /// document's value and the referenced document's value, checked by
+        /// consensus at document write time (the referenced document is
+        /// already fetched for existence validation, so agreement adds no
+        /// reads). Declarations are validated at contract registration:
+        /// both properties must exist and share one property type.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        property_agreement: BTreeMap<String, String>,
     },
     /// A specific public key of an identity: the property value holds the
     /// identity id and the named sibling property of the same document type
@@ -125,6 +134,7 @@ impl std::fmt::Display for DocumentPropertyReferenceTarget {
             DocumentPropertyReferenceTarget::PermanentDocument {
                 contract_id: Some(contract_id),
                 document_type_name,
+                ..
             } => write!(
                 f,
                 "permanent document (contract {contract_id}, document type {document_type_name})"
@@ -132,6 +142,7 @@ impl std::fmt::Display for DocumentPropertyReferenceTarget {
             DocumentPropertyReferenceTarget::PermanentDocument {
                 contract_id: None,
                 document_type_name,
+                ..
             } => write!(
                 f,
                 "permanent document (own contract, document type {document_type_name})"
@@ -7247,6 +7258,7 @@ mod tests {
             DocumentPropertyReferenceTarget::PermanentDocument {
                 contract_id: Some(contract_id),
                 document_type_name: "note".to_string(),
+                property_agreement: Default::default(),
             }
             .to_string(),
             format!("permanent document (contract {contract_id}, document type note)")
@@ -7255,6 +7267,7 @@ mod tests {
             DocumentPropertyReferenceTarget::PermanentDocument {
                 contract_id: None,
                 document_type_name: "note".to_string(),
+                property_agreement: Default::default(),
             }
             .to_string(),
             "permanent document (own contract, document type note)"

--- a/packages/rs-dpp/src/errors/consensus/codes.rs
+++ b/packages/rs-dpp/src/errors/consensus/codes.rs
@@ -318,6 +318,8 @@ impl ErrorWithCode for StateError {
             Self::ReferencedIdentityKeyNotFoundError(_) => 40123,
             Self::ReferencedIdentityKeyDisabledError(_) => 40124,
             Self::ReferencedKeyIdPropertyInvalidError(_) => 40125,
+            Self::ReferencedDocumentPropertyAgreementInvalidError(_) => 40126,
+            Self::ReferencedDocumentPropertyMismatchError(_) => 40127,
 
             // Identity Errors: 40200-40299
             Self::IdentityAlreadyExistsError(_) => 40200,

--- a/packages/rs-dpp/src/errors/consensus/state/document/mod.rs
+++ b/packages/rs-dpp/src/errors/consensus/state/document/mod.rs
@@ -15,6 +15,8 @@ pub mod document_timestamps_are_equal_error;
 pub mod document_timestamps_mismatch_error;
 pub mod duplicate_unique_index_error;
 pub mod invalid_document_revision_error;
+pub mod referenced_document_property_agreement_invalid_error;
+pub mod referenced_document_property_mismatch_error;
 pub mod referenced_document_type_deletable_error;
 pub mod referenced_document_type_not_found_error;
 pub mod referenced_entity_not_found_error;

--- a/packages/rs-dpp/src/errors/consensus/state/document/referenced_document_property_agreement_invalid_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/state/document/referenced_document_property_agreement_invalid_error.rs
@@ -1,0 +1,63 @@
+use crate::consensus::state::state_error::StateError;
+use crate::consensus::ConsensusError;
+use crate::ProtocolError;
+use bincode::{Decode, Encode};
+use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
+use thiserror::Error;
+
+#[derive(
+    Error, Debug, Clone, PartialEq, Eq, Encode, Decode, PlatformSerialize, PlatformDeserialize,
+)]
+#[error("invalid propertyAgreement pair {referring_property} -> {referenced_property} declared at {path}: {reason}")]
+#[platform_serialize(unversioned)]
+pub struct ReferencedDocumentPropertyAgreementInvalidError {
+    /*
+
+    DO NOT CHANGE ORDER OF FIELDS WITHOUT INTRODUCING OF NEW VERSION
+
+    */
+    path: String,
+    referring_property: String,
+    referenced_property: String,
+    reason: String,
+}
+
+impl ReferencedDocumentPropertyAgreementInvalidError {
+    pub fn new(
+        path: String,
+        referring_property: String,
+        referenced_property: String,
+        reason: String,
+    ) -> Self {
+        Self {
+            path,
+            referring_property,
+            referenced_property,
+            reason,
+        }
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub fn referring_property(&self) -> &str {
+        &self.referring_property
+    }
+
+    pub fn referenced_property(&self) -> &str {
+        &self.referenced_property
+    }
+
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+impl From<ReferencedDocumentPropertyAgreementInvalidError> for ConsensusError {
+    fn from(err: ReferencedDocumentPropertyAgreementInvalidError) -> Self {
+        Self::StateError(StateError::ReferencedDocumentPropertyAgreementInvalidError(
+            err,
+        ))
+    }
+}

--- a/packages/rs-dpp/src/errors/consensus/state/document/referenced_document_property_mismatch_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/state/document/referenced_document_property_mismatch_error.rs
@@ -1,0 +1,50 @@
+use crate::consensus::state::state_error::StateError;
+use crate::consensus::ConsensusError;
+use crate::ProtocolError;
+use bincode::{Decode, Encode};
+use platform_serialization_derive::{PlatformDeserialize, PlatformSerialize};
+use thiserror::Error;
+
+#[derive(
+    Error, Debug, Clone, PartialEq, Eq, Encode, Decode, PlatformSerialize, PlatformDeserialize,
+)]
+#[error("the document's {referring_property} does not agree with the referenced document's {referenced_property} (propertyAgreement on {path})")]
+#[platform_serialize(unversioned)]
+pub struct ReferencedDocumentPropertyMismatchError {
+    /*
+
+    DO NOT CHANGE ORDER OF FIELDS WITHOUT INTRODUCING OF NEW VERSION
+
+    */
+    path: String,
+    referring_property: String,
+    referenced_property: String,
+}
+
+impl ReferencedDocumentPropertyMismatchError {
+    pub fn new(path: String, referring_property: String, referenced_property: String) -> Self {
+        Self {
+            path,
+            referring_property,
+            referenced_property,
+        }
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub fn referring_property(&self) -> &str {
+        &self.referring_property
+    }
+
+    pub fn referenced_property(&self) -> &str {
+        &self.referenced_property
+    }
+}
+
+impl From<ReferencedDocumentPropertyMismatchError> for ConsensusError {
+    fn from(err: ReferencedDocumentPropertyMismatchError) -> Self {
+        Self::StateError(StateError::ReferencedDocumentPropertyMismatchError(err))
+    }
+}

--- a/packages/rs-dpp/src/errors/consensus/state/state_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/state/state_error.rs
@@ -46,6 +46,8 @@ use crate::consensus::state::document::referenced_document_type_not_found_error:
 use crate::consensus::state::document::referenced_entity_not_found_error::ReferencedEntityNotFoundError;
 use crate::consensus::state::document::referenced_identity_key_disabled_error::ReferencedIdentityKeyDisabledError;
 use crate::consensus::state::document::referenced_identity_key_not_found_error::ReferencedIdentityKeyNotFoundError;
+use crate::consensus::state::document::referenced_document_property_agreement_invalid_error::ReferencedDocumentPropertyAgreementInvalidError;
+use crate::consensus::state::document::referenced_document_property_mismatch_error::ReferencedDocumentPropertyMismatchError;
 use crate::consensus::state::document::referenced_key_id_property_invalid_error::ReferencedKeyIdPropertyInvalidError;
 use crate::consensus::state::document::document_incorrect_purchase_price_error::DocumentIncorrectPurchasePriceError;
 use crate::consensus::state::document::document_not_for_sale_error::DocumentNotForSaleError;
@@ -386,6 +388,14 @@ pub enum StateError {
 
     #[error(transparent)]
     ReferencedKeyIdPropertyInvalidError(ReferencedKeyIdPropertyInvalidError),
+
+    #[error(transparent)]
+    ReferencedDocumentPropertyAgreementInvalidError(
+        ReferencedDocumentPropertyAgreementInvalidError,
+    ),
+
+    #[error(transparent)]
+    ReferencedDocumentPropertyMismatchError(ReferencedDocumentPropertyMismatchError),
 }
 
 impl From<StateError> for ConsensusError {
@@ -511,6 +521,27 @@ mod tests {
                 )
             )),
             98
+        );
+        assert_eq!(
+            discriminant_of(StateError::ReferencedDocumentPropertyAgreementInvalidError(
+                ReferencedDocumentPropertyAgreementInvalidError::new(
+                    "like.postId".to_string(),
+                    "hashtag".to_string(),
+                    "hashtag".to_string(),
+                    "missing".to_string(),
+                )
+            )),
+            99
+        );
+        assert_eq!(
+            discriminant_of(StateError::ReferencedDocumentPropertyMismatchError(
+                ReferencedDocumentPropertyMismatchError::new(
+                    "postId".to_string(),
+                    "hashtag".to_string(),
+                    "hashtag".to_string(),
+                )
+            )),
+            100
         );
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/document/document_reference_validation/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/document/document_reference_validation/v0/mod.rs
@@ -11,6 +11,7 @@ use dpp::data_contract::document_type::{
     DocumentPropertyReferenceTarget, DocumentPropertyType, DocumentTypeRef,
 };
 use dpp::data_contract::DataContract;
+use dpp::errors::consensus::state::document::referenced_document_property_mismatch_error::ReferencedDocumentPropertyMismatchError;
 use dpp::errors::consensus::state::document::referenced_document_type_deletable_error::ReferencedDocumentTypeDeletableError;
 use dpp::errors::consensus::state::document::referenced_document_type_not_found_error::ReferencedDocumentTypeNotFoundError;
 use dpp::errors::consensus::state::document::referenced_entity_not_found_error::ReferencedEntityNotFoundError;
@@ -109,17 +110,28 @@ fn validate_document_type_references_v0(
     platform_version: &PlatformVersion,
 ) -> Result<SimpleConsensusValidationResult, Error> {
     for (path, property) in document_type.flattened_properties() {
-        if let Some(changed) = changed_fields {
-            if !is_changed_field(changed, path) {
-                continue;
-            }
-        }
-
         let DocumentPropertyType::IdentifierWithReference(reference_target) =
             &property.property_type
         else {
             continue;
         };
+
+        if let Some(changed) = changed_fields {
+            // A propertyAgreement pair binds the referring property too:
+            // replacing it must re-validate the reference even when the
+            // reference property itself is untouched.
+            let agreement_property_changed = match reference_target {
+                DocumentPropertyReferenceTarget::PermanentDocument {
+                    property_agreement, ..
+                } => property_agreement
+                    .keys()
+                    .any(|referring_property| is_changed_field(changed, referring_property)),
+                _ => false,
+            };
+            if !is_changed_field(changed, path) && !agreement_property_changed {
+                continue;
+            }
+        }
 
         let referenced_id = match document_data.get_optional_identifier_at_path(path) {
             Ok(Some(referenced_id)) => referenced_id,
@@ -182,6 +194,7 @@ fn validate_document_type_references_v0(
             DocumentPropertyReferenceTarget::PermanentDocument {
                 contract_id: referenced_contract_id,
                 document_type_name,
+                property_agreement,
             } => {
                 // An absent contract id targets the declaring contract itself; the
                 // declaring contract may also name its own id explicitly. Either
@@ -254,7 +267,7 @@ fn validate_document_type_references_v0(
                     ));
                 }
 
-                fetch_document_with_id(
+                let referenced_document = fetch_document_with_id(
                     platform.drive,
                     referenced_contract,
                     referenced_document_type,
@@ -263,8 +276,63 @@ fn validate_document_type_references_v0(
                     execution_context,
                     transaction,
                     platform_version,
-                )?
-                .is_some()
+                )?;
+
+                // Property agreement: the referenced document is already in
+                // hand for the existence check, so comparing the declared
+                // pairs adds no reads. Each side is normalized through its
+                // OWN document type's key encoding — one deterministic
+                // normal form per value kind, so an identifier stored as
+                // bytes and one carried as an identifier compare equal.
+                if let Some(referenced_document) = &referenced_document {
+                    use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
+                    use dpp::document::DocumentV0Getters;
+
+                    for (referring_property, referenced_property) in property_agreement {
+                        let mismatch = || {
+                            SimpleConsensusValidationResult::new_with_error(
+                                ReferencedDocumentPropertyMismatchError::new(
+                                    path.to_string(),
+                                    referring_property.clone(),
+                                    referenced_property.clone(),
+                                )
+                                .into(),
+                            )
+                        };
+                        let Ok(Some(referring_value)) =
+                            document_data.get_optional_at_path(referring_property)
+                        else {
+                            return Ok(mismatch());
+                        };
+                        let Ok(Some(referenced_value)) = referenced_document
+                            .properties()
+                            .get_optional_at_path(referenced_property)
+                        else {
+                            return Ok(mismatch());
+                        };
+                        let Ok(referring_encoded) = document_type.serialize_value_for_key(
+                            referring_property,
+                            referring_value,
+                            platform_version,
+                        ) else {
+                            return Ok(mismatch());
+                        };
+                        let Ok(referenced_encoded) = referenced_document_type
+                            .serialize_value_for_key(
+                                referenced_property,
+                                referenced_value,
+                                platform_version,
+                            )
+                        else {
+                            return Ok(mismatch());
+                        };
+                        if referring_encoded != referenced_encoded {
+                            return Ok(mismatch());
+                        }
+                    }
+                }
+
+                referenced_document.is_some()
             }
             DocumentPropertyReferenceTarget::IdentityPublicKey { key_id_property } => {
                 // The referenced key id is carried by the named sibling property

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
@@ -443,6 +443,82 @@ pub(super) mod index_only_tests {
         );
     }
 
+    /// The yappr fixture's `like.postId` reference declares
+    /// `propertyAgreement: { hashtag: hashtag }` — a like whose hashtag
+    /// disagrees with the referenced post's is refused at write time.
+    /// (The passing direction is exercised by every other test in this
+    /// suite: posts and likes share `hashtag: dash`.)
+    #[tokio::test]
+    async fn test_like_with_disagreeing_hashtag_is_refused() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let platform_state = platform.state.load();
+        let mut rng = StdRng::seed_from_u64(4243);
+
+        let (alice, alice_signer, alice_key) =
+            setup_identity(&mut platform, 958, dash_to_credits!(1.0));
+        let contract = register_likes(&platform, alice.id(), platform_version);
+        let like_type = contract
+            .document_type_for_name("like")
+            .expect("like doctype exists");
+
+        // The post lives under #dash…
+        let post = create_post(
+            &platform,
+            &platform_state,
+            &contract,
+            alice.id(),
+            &alice_key,
+            2,
+            &alice_signer,
+            &mut rng,
+            platform_version,
+        )
+        .await;
+
+        // …but the like claims #btc: the propertyAgreement must refuse it.
+        let entropy = Bytes32::random_with_rng(&mut rng);
+        let mut disagreeing_like = build_like(
+            &contract,
+            alice.id(),
+            post.id(),
+            entropy,
+            &mut rng,
+            platform_version,
+        );
+        disagreeing_like.set("hashtag", "btc".into());
+
+        let create = BatchTransition::new_document_creation_transition_from_document(
+            disagreeing_like,
+            like_type,
+            entropy.0,
+            &alice_key,
+            3,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the create transition");
+
+        let result = process_and_commit(&platform, &platform_state, &create, platform_version);
+        assert_eq!(result.valid_count(), 0);
+        assert_matches!(
+            result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::PaidConsensusError {
+                error: ConsensusError::StateError(
+                    StateError::ReferencedDocumentPropertyMismatchError(_)
+                ),
+                ..
+            }],
+            "a like disagreeing with its post's hashtag must be refused"
+        );
+    }
+
     /// The structure gate pairs delete KINDS with storage modes: a plain
     /// (by-id) delete on an indexOnly type is refused. (The factory
     /// auto-selects the indexOnlyDelete kind — this test assembles the

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/replacement.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/replacement.rs
@@ -23,6 +23,171 @@ mod replacement_tests {
     /// Creates a document from `contract_path`'s message type, applies `create_setup`
     /// to it, processes the creation (asserting success), then applies `replace_mutation`
     /// and processes the replacement, returning its execution result.
+    /// propertyAgreement on replace: changing the REFERRING property while
+    /// leaving the reference untouched must re-validate the agreement —
+    /// the changed-fields gate binds the agreement's referring properties,
+    /// not only the reference property itself.
+    #[tokio::test]
+    async fn should_document_replace_fail_when_agreement_property_diverges() {
+        use crate::platform_types::platform_state::PlatformState;
+        use crate::rpc::core::MockCoreRPCLike;
+        use crate::test::helpers::setup::TempPlatform;
+        use dpp::state_transition::StateTransition;
+
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let mut rng = StdRng::seed_from_u64(4433);
+        let platform_state = platform.state.load();
+
+        let (identity, signer, key) = setup_identity(&mut platform, 958, dash_to_credits!(0.1));
+
+        let contract = setup_contract(
+            &platform.drive,
+            "tests/supporting_files/contract/reference-validation/reference-validation-contract-agreement-valid.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            None,
+            None,
+        );
+
+        let process = |platform: &TempPlatform<MockCoreRPCLike>,
+                       platform_state: &PlatformState,
+                       transition: &StateTransition| {
+            let serialized = transition
+                .serialize_to_bytes()
+                .expect("expected the transition to serialize");
+            let transaction = platform.drive.grove.start_transaction();
+            let result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[serialized],
+                    platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+            result
+                .execution_results()
+                .first()
+                .expect("expected one execution result")
+                .clone()
+        };
+
+        // A note with topic "alpha" for the message to agree with.
+        let note_type = contract
+            .document_type_for_name("note")
+            .expect("expected the note document type");
+        let note_entropy = Bytes32::random_with_rng(&mut rng);
+        let mut note = note_type
+            .random_document_with_identifier_and_entropy(
+                &mut rng,
+                identity.id(),
+                note_entropy,
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                platform_version,
+            )
+            .expect("expected a random note");
+        note.set("topic", "alpha".into());
+        let note_create = BatchTransition::new_document_creation_transition_from_document(
+            note.clone(),
+            note_type,
+            note_entropy.0,
+            &key,
+            2,
+            0,
+            None,
+            &signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the note create transition");
+        assert_matches!(
+            process(&platform, &platform_state, &note_create),
+            StateTransitionExecutionResult::SuccessfulExecution { .. }
+        );
+
+        // An agreeing message referencing it.
+        let message_type = contract
+            .document_type_for_name("message")
+            .expect("expected the message document type");
+        let message_entropy = Bytes32::random_with_rng(&mut rng);
+        let mut message = message_type
+            .random_document_with_identifier_and_entropy(
+                &mut rng,
+                identity.id(),
+                message_entropy,
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                platform_version,
+            )
+            .expect("expected a random message");
+        message.set(
+            "noteId",
+            dpp::platform_value::Value::Identifier(note.id().to_buffer()),
+        );
+        message.set("topic", "alpha".into());
+        let message_create = BatchTransition::new_document_creation_transition_from_document(
+            message.clone(),
+            message_type,
+            message_entropy.0,
+            &key,
+            3,
+            0,
+            None,
+            &signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the message create transition");
+        assert_matches!(
+            process(&platform, &platform_state, &message_create),
+            StateTransitionExecutionResult::SuccessfulExecution { .. }
+        );
+
+        // Replace ONLY the referring property: the reference is untouched,
+        // so this must be caught by the agreement-aware changed-fields gate.
+        message.set("topic", "beta".into());
+        message.increment_revision().expect("revision increments");
+        let message_replace = BatchTransition::new_document_replacement_transition_from_document(
+            message,
+            message_type,
+            &key,
+            4,
+            0,
+            None,
+            &signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the message replace transition");
+        assert_matches!(
+            process(&platform, &platform_state, &message_replace),
+            StateTransitionExecutionResult::PaidConsensusError {
+                error: ConsensusError::StateError(
+                    StateError::ReferencedDocumentPropertyMismatchError(_)
+                ),
+                ..
+            }
+        );
+    }
+
     async fn run_reference_validation_create_then_replace<C, R>(
         contract_path: &str,
         create_setup: C,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_common/data_contract_reference_validation/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_common/data_contract_reference_validation/v0/mod.rs
@@ -3,6 +3,7 @@ use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dpp::data_contract::document_type::{DocumentPropertyReferenceTarget, DocumentPropertyType};
 use dpp::data_contract::DataContract;
+use dpp::errors::consensus::state::document::referenced_document_property_agreement_invalid_error::ReferencedDocumentPropertyAgreementInvalidError;
 use dpp::errors::consensus::state::document::referenced_document_type_deletable_error::ReferencedDocumentTypeDeletableError;
 use dpp::errors::consensus::state::document::referenced_document_type_not_found_error::ReferencedDocumentTypeNotFoundError;
 use dpp::errors::consensus::state::document::referenced_key_id_property_invalid_error::ReferencedKeyIdPropertyInvalidError;
@@ -37,6 +38,20 @@ use crate::execution::types::state_transition_execution_context::{
 ///
 /// The error paths name the failing declaration as
 /// `documentTypeName.propertyPath`. Validation stops at the first invalid
+/// Whether two property types hold the same KIND of value for agreement
+/// purposes: sizes and other constraints may differ (both sides validated
+/// their own documents already), and an identifier is one kind whether or
+/// not it carries its own reference annotation.
+fn same_value_kind(a: &DocumentPropertyType, b: &DocumentPropertyType) -> bool {
+    let normalized_kind = |property_type: &DocumentPropertyType| match property_type {
+        DocumentPropertyType::Identifier | DocumentPropertyType::IdentifierWithReference(_) => {
+            std::mem::discriminant(&DocumentPropertyType::Identifier)
+        }
+        other => std::mem::discriminant(other),
+    };
+    normalized_kind(a) == normalized_kind(b)
+}
+
 /// declaration: this bounds the billed work an invalid contract can cause and
 /// matches document write-time reference validation. Foreign contract
 /// resolutions are memoized per contract id, so a contract declaring many
@@ -101,6 +116,7 @@ pub(super) fn validate_data_contract_references_v0(
             let DocumentPropertyReferenceTarget::PermanentDocument {
                 contract_id,
                 document_type_name,
+                property_agreement,
             } = reference_target
             else {
                 continue;
@@ -179,6 +195,59 @@ pub(super) fn validate_data_contract_references_v0(
                     )
                     .into(),
                 ));
+            }
+
+            // propertyAgreement declarations: both sides must exist, be
+            // plain values (not containers), and share one value kind — a
+            // cross-kind equality could never be satisfied and would brick
+            // every create of the declaring document type.
+            for (referring_property, referenced_property) in property_agreement {
+                let invalid = |reason: &str| {
+                    SimpleConsensusValidationResult::new_with_error(
+                        ReferencedDocumentPropertyAgreementInvalidError::new(
+                            declaration_path.clone(),
+                            referring_property.clone(),
+                            referenced_property.clone(),
+                            reason.to_string(),
+                        )
+                        .into(),
+                    )
+                };
+                if referring_property == path {
+                    return Ok(invalid(
+                        "the referring property cannot be the reference property itself",
+                    ));
+                }
+                let declaring_document_type = document_type.as_ref();
+                let Some(referring) = declaring_document_type
+                    .flattened_properties()
+                    .get(referring_property)
+                else {
+                    return Ok(invalid(
+                        "the declaring document type does not define the referring property",
+                    ));
+                };
+                let Some(referenced) = referenced_document_type
+                    .flattened_properties()
+                    .get(referenced_property)
+                else {
+                    return Ok(invalid(
+                        "the referenced document type does not define the referenced property",
+                    ));
+                };
+                if matches!(referring.property_type, DocumentPropertyType::Object(_))
+                    || matches!(referenced.property_type, DocumentPropertyType::Object(_))
+                {
+                    return Ok(invalid(
+                        "agreement properties must be plain values, not object containers",
+                    ));
+                }
+                if !same_value_kind(&referring.property_type, &referenced.property_type) {
+                    return Ok(invalid(
+                        "the two properties must share one value kind: a cross-kind \
+                         equality could never be satisfied",
+                    ));
+                }
             }
         }
     }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
@@ -5380,6 +5380,55 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn should_register_contract_with_valid_property_agreement() {
+            let result = run_contract_create(
+                "tests/supporting_files/contract/reference-validation/reference-validation-contract-agreement-valid.json",
+            )
+            .await;
+
+            assert_matches!(
+                result,
+                StateTransitionExecutionResult::SuccessfulExecution { .. }
+            );
+        }
+
+        #[tokio::test]
+        async fn should_reject_agreement_on_missing_referenced_property() {
+            let result = run_contract_create(
+                "tests/supporting_files/contract/reference-validation/reference-validation-contract-agreement-missing-property.json",
+            )
+            .await;
+
+            assert_matches!(
+                result,
+                StateTransitionExecutionResult::PaidConsensusError {
+                    error: ConsensusError::StateError(
+                        StateError::ReferencedDocumentPropertyAgreementInvalidError(_)
+                    ),
+                    ..
+                }
+            );
+        }
+
+        #[tokio::test]
+        async fn should_reject_agreement_between_different_value_kinds() {
+            let result = run_contract_create(
+                "tests/supporting_files/contract/reference-validation/reference-validation-contract-agreement-kind-mismatch.json",
+            )
+            .await;
+
+            assert_matches!(
+                result,
+                StateTransitionExecutionResult::PaidConsensusError {
+                    error: ConsensusError::StateError(
+                        StateError::ReferencedDocumentPropertyAgreementInvalidError(_)
+                    ),
+                    ..
+                }
+            );
+        }
+
+        #[tokio::test]
         async fn should_register_contract_with_valid_identity_key_reference() {
             let result = run_contract_create(
                 "tests/supporting_files/contract/reference-validation/reference-validation-contract-identity-key-registration-valid.json",

--- a/packages/rs-drive-abci/tests/supporting_files/contract/reference-validation/reference-validation-contract-agreement-kind-mismatch.json
+++ b/packages/rs-drive-abci/tests/supporting_files/contract/reference-validation/reference-validation-contract-agreement-kind-mismatch.json
@@ -1,0 +1,58 @@
+{
+  "$formatVersion": "1",
+  "id": "8Bqs6itzfoDXzmgQibYZQABbqYsXmawVf7SKe3mKDQVg",
+  "ownerId": "2b994p95akyNFKtkDnDvBRUotDbkH54MHwGbhQLr5gcU",
+  "version": 1,
+  "documentSchemas": {
+    "note": {
+      "type": "object",
+      "canBeDeleted": false,
+      "properties": {
+        "content": {
+          "type": "string",
+          "position": 0,
+          "maxLength": 100
+        },
+        "topic": {
+          "type": "string",
+          "position": 1,
+          "maxLength": 63
+        },
+        "count": {
+          "type": "integer",
+          "position": 2
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    "message": {
+      "type": "object",
+      "documentsMutable": true,
+      "properties": {
+        "noteId": {
+          "type": "array",
+          "byteArray": true,
+          "minItems": 32,
+          "maxItems": 32,
+          "contentMediaType": "application/x.dash.dpp.identifier",
+          "position": 0,
+          "refersTo": {
+            "type": "permanentDocument",
+            "documentType": "note",
+            "propertyAgreement": {
+              "topic": "count"
+            }
+          }
+        },
+        "topic": {
+          "type": "string",
+          "position": 1,
+          "maxLength": 100
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/rs-drive-abci/tests/supporting_files/contract/reference-validation/reference-validation-contract-agreement-missing-property.json
+++ b/packages/rs-drive-abci/tests/supporting_files/contract/reference-validation/reference-validation-contract-agreement-missing-property.json
@@ -1,0 +1,54 @@
+{
+  "$formatVersion": "1",
+  "id": "7Bqs6itzfoDXzmgQibYZQABbqYsXmawVf7SKe3mKDQVf",
+  "ownerId": "2b994p95akyNFKtkDnDvBRUotDbkH54MHwGbhQLr5gcU",
+  "version": 1,
+  "documentSchemas": {
+    "note": {
+      "type": "object",
+      "canBeDeleted": false,
+      "properties": {
+        "content": {
+          "type": "string",
+          "position": 0,
+          "maxLength": 100
+        },
+        "topic": {
+          "type": "string",
+          "position": 1,
+          "maxLength": 63
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    "message": {
+      "type": "object",
+      "documentsMutable": true,
+      "properties": {
+        "noteId": {
+          "type": "array",
+          "byteArray": true,
+          "minItems": 32,
+          "maxItems": 32,
+          "contentMediaType": "application/x.dash.dpp.identifier",
+          "position": 0,
+          "refersTo": {
+            "type": "permanentDocument",
+            "documentType": "note",
+            "propertyAgreement": {
+              "topic": "nonexistent"
+            }
+          }
+        },
+        "topic": {
+          "type": "string",
+          "position": 1,
+          "maxLength": 100
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/rs-drive-abci/tests/supporting_files/contract/reference-validation/reference-validation-contract-agreement-valid.json
+++ b/packages/rs-drive-abci/tests/supporting_files/contract/reference-validation/reference-validation-contract-agreement-valid.json
@@ -1,0 +1,54 @@
+{
+  "$formatVersion": "1",
+  "id": "6Bqs6itzfoDXzmgQibYZQABbqYsXmawVf7SKe3mKDQVe",
+  "ownerId": "2b994p95akyNFKtkDnDvBRUotDbkH54MHwGbhQLr5gcU",
+  "version": 1,
+  "documentSchemas": {
+    "note": {
+      "type": "object",
+      "canBeDeleted": false,
+      "properties": {
+        "content": {
+          "type": "string",
+          "position": 0,
+          "maxLength": 100
+        },
+        "topic": {
+          "type": "string",
+          "position": 1,
+          "maxLength": 63
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    "message": {
+      "type": "object",
+      "documentsMutable": true,
+      "properties": {
+        "noteId": {
+          "type": "array",
+          "byteArray": true,
+          "minItems": 32,
+          "maxItems": 32,
+          "contentMediaType": "application/x.dash.dpp.identifier",
+          "position": 0,
+          "refersTo": {
+            "type": "permanentDocument",
+            "documentType": "note",
+            "propertyAgreement": {
+              "topic": "topic"
+            }
+          }
+        },
+        "topic": {
+          "type": "string",
+          "position": 1,
+          "maxLength": 100
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json
@@ -61,7 +61,10 @@
           "contentMediaType": "application/x.dash.dpp.identifier",
           "refersTo": {
             "type": "permanentDocument",
-            "documentType": "post"
+            "documentType": "post",
+            "propertyAgreement": {
+              "hashtag": "hashtag"
+            }
           },
           "position": 1
         }

--- a/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
+++ b/packages/wasm-dpp/src/errors/consensus/consensus_error.rs
@@ -95,6 +95,8 @@ use dpp::consensus::state::address_funds::{AddressDoesNotExistError, AddressInva
 use dpp::consensus::state::document::referenced_document_type_deletable_error::ReferencedDocumentTypeDeletableError;
 use dpp::consensus::state::document::referenced_identity_key_disabled_error::ReferencedIdentityKeyDisabledError;
 use dpp::consensus::state::document::referenced_identity_key_not_found_error::ReferencedIdentityKeyNotFoundError;
+use dpp::consensus::state::document::referenced_document_property_agreement_invalid_error::ReferencedDocumentPropertyAgreementInvalidError;
+use dpp::consensus::state::document::referenced_document_property_mismatch_error::ReferencedDocumentPropertyMismatchError;
 use dpp::consensus::state::document::referenced_key_id_property_invalid_error::ReferencedKeyIdPropertyInvalidError;
 use dpp::consensus::state::document::referenced_document_type_not_found_error::ReferencedDocumentTypeNotFoundError;
 use dpp::consensus::state::shielded::insufficient_pool_notes_error::InsufficientPoolNotesError;
@@ -494,6 +496,12 @@ pub fn from_state_error(state_error: &StateError) -> JsValue {
         }
         StateError::ReferencedKeyIdPropertyInvalidError(e) => {
             generic_consensus_error!(ReferencedKeyIdPropertyInvalidError, e).into()
+        }
+        StateError::ReferencedDocumentPropertyAgreementInvalidError(e) => {
+            generic_consensus_error!(ReferencedDocumentPropertyAgreementInvalidError, e).into()
+        }
+        StateError::ReferencedDocumentPropertyMismatchError(e) => {
+            generic_consensus_error!(ReferencedDocumentPropertyMismatchError, e).into()
         }
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

indexOnly follow-up: **refersTo property agreement**. A `like` references a `post` and both carry a `hashtag`, but nothing bound them — a like under `#dash` could reference a post living under `#btc`, silently corrupting every hashtag-scoped count and ranking. Contracts can now declare that a property of the referring document must EQUAL a property of the referenced document, enforced by consensus at write time.

## What was done?

**Schema.** A `permanentDocument` reference may declare `"propertyAgreement": { "<referring property>": "<referenced property>" }` (1–10 pairs, dotted paths admitted). Meta-schema v3 gains the keyword — the file is explicitly editable until the PV14 release ships — and the parser (`apply_property_reference`, PV14-only) accepts it only on `permanentDocument` references. `DocumentPropertyReferenceTarget::PermanentDocument` gains the field; contracts serialize their schemas and rebuild document types on load, so nothing changes on the wire.

**Zero new reads — the headline of the design pass.** Both validation layers already fetch exactly what agreement needs:

- **Contract registration** (`data_contract_reference_validation`, in place): the referenced doctype is already resolved (foreign contracts memoized + billed). Declarations are validated there — both properties exist, are plain values (no object containers), the referring property is not the reference itself, and the two share one **value kind** (sizes may differ; `Identifier` with or without its own reference annotation counts as one kind). A cross-kind equality could never be satisfied and would brick every create of the doctype, so it is refused at registration with the new `ReferencedDocumentPropertyAgreementInvalidError` (40126).
- **Document write time** (`document_reference_validation`, in place): the full referenced document was already fetched for the existence check and its body discarded. Now each pair is compared — through the two doctypes' own **key encodings**, giving one deterministic normal form per value kind, so an identifier stored as bytes and one carried as an identifier compare equal. Any absence or inequality → the new `ReferencedDocumentPropertyMismatchError` (40127). Replace transitions re-validate when the reference OR any referring agreement property changed (the changed-fields gate now binds the agreement's referring properties too).

Both errors are appended to `StateError` (append-only wire enum, discriminants pinned 99/100).

## How Has This Been Tested?

- **dpp parser** (4 tests): the keyword parses and populates the target on `permanentDocument`; refused on other reference types; empty map refused; non-string values refused.
- **Contract registration** (3 tests): valid agreement registers; missing referenced property refused; cross-kind (string↔integer) refused — each pinned to the typed error.
- **Write time**: the yappr-likes fixture now declares `{ "hashtag": "hashtag" }` on `like.postId`, so every existing lifecycle test exercises the agreeing direction implicitly; a new test pins the refusal of a `#btc` like on a `#dash` post.
- **Replace side**: a new test creates an agreeing note+message pair, then replaces ONLY the message's referring property — proving the agreement-aware changed-fields gate fires with the reference untouched.
- Full document pipeline suite (172 tests), drive indexOnly e2e (21, parsing the updated fixture), workspace `--all-targets` and clippy `-D warnings` clean.

## Breaking Changes

Consensus: a new contract keyword and two new consensus errors, all PV14-only (unreleased) and extended in place per the stack convention. Contracts without the keyword parse and validate byte-identically; below PV14 the keyword is rejected by meta-schema v2 as before.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

Remaining indexOnly follow-ups (tracked, not here): platform-test-suite functional spec, sum axes via SumItem, timeRange buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
