### PR TITLE
feat(drive)!: sum axes on indexOnly indexes via ItemWithSumItem terminals

### DIFF
--- a/book/src/drive/index-only-document-types.md
+++ b/book/src/drive/index-only-document-types.md
@@ -33,12 +33,25 @@ refersTo-typed identifier property (identity, contract, token, permanent
 document) — is the member key, sitting exactly where a normal non-unique
 index keys by document id; the element is an `Item` instead of a
 `Reference` because there is nothing to point at. The `0` storage marker,
-value-tree types, and the count/ranked tree derivation are byte-identical
-to the ordinary non-unique layout, which is what lets the protocol v14
-ranked machinery (see [Document Ranked Trees](./document-ranked-trees.md))
-serve index-only types unchanged: "the five most-liked posts in `#dash`"
-is an O(log n + k) read with an O(log n + k) proof, and Items count in
+value-tree types, and the count/sum/ranked tree derivation are
+byte-identical to the ordinary non-unique layout, which is what lets the
+protocol v14 ranked machinery (see
+[Document Ranked Trees](./document-ranked-trees.md)) serve index-only
+types unchanged: "the five most-liked posts in `#dash`" is an
+O(log n + k) read with an O(log n + k) proof, and Items count in
 count/ranked trees exactly as References do.
+
+The **sum axes** compose the same way: a `summable: "<prop>"` index
+stores `ItemWithSumItem(<row commitment>, <amount>)` terminals — the same
+commitment payload, plus the summed property's value — so entries
+contribute to ancestor sum trees exactly as stored types'
+`ReferenceWithSumItem` references do ("total tipped to this post", "top
+posts by total tipped" via `rankedSummable`). The doctype-level summable
+cross-checks (one canonical summed property, i64-safe integer type,
+`required` membership) apply unchanged, and on delete grovedb reads the
+amount off the stored element and propagates the subtraction — the
+falsified-amount case dies on the commitment probe first, since the
+amount is one of the committed properties.
 
 **Governing principle: only what is in the indexes exists and is
 recoverable.** Prefix property values live in the path, the terminal id in
@@ -72,7 +85,7 @@ aggregate keywords follow:
 | terminal is `$ownerId` or a single-id refersTo property | the member key must alone be a referable entity id (`identityPublicKey` is compound and rejected) |
 | indexed `$createdAt` requires `$createdAt` in `required` | creation only assigns timestamps for required system times |
 | `documentsMutable: false`, no transfers/trading/history/transient | no stored row, no revision |
-| non-unique, non-contested, `nullSearchable` default, no `timeRange`, count axes only | v1 scope; sum axes and buckets are follow-ups |
+| non-unique, non-contested, `nullSearchable` default, no `timeRange` | v1 scope; buckets are a follow-up |
 
 `indexOnly` and the index set (terminals included) are immutable across
 contract updates — a later-added index could never be backfilled.
@@ -121,8 +134,9 @@ by the presence of the entry its values produce under the **proof index**
 (the first `$ownerId`-bearing index not involving `$createdAt` — contract
 admission guarantees one exists) and a delete by its absence, with the
 proved entry's payload checked against the transition-derived row
-commitment; prover and verifier build the same single-entry path query
-from the transition. The outcome is always `AffectedState`, never
+commitment (and, when the proof index is summable, the proved sum
+contribution against the created document's amount); prover and verifier
+build the same single-entry path query from the transition. The outcome is always `AffectedState`, never
 `ExecutionProved`: the commitment carries neither id, entropy nor nonce,
 so a snapshot cannot bind one specific transition's execution.
 

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
@@ -2047,16 +2047,13 @@ pub(super) fn apply_index_only(
                 index_name, name,
             )));
         }
-        if index.summable.is_some() || index.ranked_summable || index.ranked_averageable {
-            return Err(structure_error(format!(
-                "index \"{}\" on indexOnly document type \"{}\" cannot use the sum axes \
-                 (summable / rangeSummable / rankedSummable / rankedAverageable / the \
-                 averageable sugar): indexOnly terminals are plain Items carrying no sum \
-                 contribution; only the count axes (countable / rangeCountable / \
-                 rankedCountable) are supported",
-                index_name, name,
-            )));
-        }
+        // The sum axes (summable / rangeSummable / rankedSummable /
+        // rankedAverageable / the averageable sugar) are admitted: a
+        // summable index's terminal entry is an
+        // `ItemWithSumItem(commitment, amount)` carrying the summed
+        // property's value, and the doctype-level summable cross-checks
+        // (canonical property, i64-safe integer type, `required`
+        // membership) run for every doctype, indexOnly included.
 
         let terminal = index.terminal.as_deref().expect("normalized to Some above");
 

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
@@ -286,11 +286,27 @@ fn rejects_null_searchable_false() {
 }
 
 #[test]
-fn rejects_sum_axes() {
-    // The summable declaration itself has to survive the aggregate
-    // cross-checks (integer type, required) so that the indexOnly-specific
-    // rejection is the one that fires.
+fn accepts_summable_index() {
+    // The sum axes are admitted on indexOnly indexes: the terminal entry
+    // becomes an `ItemWithSumItem(commitment, amount)`. The summable
+    // declaration goes through the same doctype-level aggregate
+    // cross-checks as stored types (integer type, required membership),
+    // and the summed property must still satisfy the indexOnly
+    // every-property-indexed rule — here it joins byLiker's prefix.
     let mut schema = likes_schema_with_index_key(2, "summable", platform_value!("likeWeight"));
+    schema
+        .get_mut("indices")
+        .expect("indices accessible")
+        .expect("indices present")
+        .as_array_mut()
+        .expect("indices is an array")
+        .get_mut(2)
+        .expect("index exists")
+        .set_value(
+            "properties",
+            platform_value!([{ "$ownerId": "asc" }, { "likeWeight": "asc" }]),
+        )
+        .expect("index properties apply");
     schema
         .get_mut("properties")
         .expect("properties accessible")
@@ -306,9 +322,25 @@ fn rejects_sum_axes() {
             platform_value!(["hashtag", "postId", "likeWeight"]),
         )
         .expect("required applies");
+    let document_type =
+        parse_with(schema, PlatformVersion::latest(), false).expect("summable index admitted");
+    let summable_index = document_type
+        .indices
+        .values()
+        .find(|index| index.summable.is_some())
+        .expect("an index carries the summable declaration");
+    assert_eq!(summable_index.summable.as_deref(), Some("likeWeight"));
+}
+
+#[test]
+fn rejects_summable_naming_non_integer_property() {
+    // The doctype-level aggregate cross-checks (shared with stored types)
+    // still apply to indexOnly indexes: a summable naming a string
+    // property fails the integer-type rule.
+    let schema = likes_schema_with_index_key(2, "summable", platform_value!("hashtag"));
     expect_structure_error(
         parse_with(schema, PlatformVersion::latest(), false),
-        "sum axes",
+        "integer type",
     );
 }
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
@@ -1155,4 +1155,224 @@ mod index_only_executed_proof_tests {
             "expected the entry-still-present refusal, got: {error}"
         );
     }
+
+    /// A signed `tip` create for the given amount — the summable-type
+    /// counterpart of `signed_mark_create`. The `tip` doctype's proof index
+    /// (`byPost`) is summable, so its entries are
+    /// `ItemWithSumItem(commitment, amount)` and the executed-proof
+    /// verifier must check the proved sum contribution alongside the
+    /// commitment.
+    async fn signed_tip_create(
+        contract: &DataContract,
+        owner: Identifier,
+        post_id: Identifier,
+        amount: u64,
+        nonce: u64,
+        key: &dpp::identity::IdentityPublicKey,
+        signer: &SimpleSigner,
+        rng: &mut StdRng,
+        platform_version: &PlatformVersion,
+    ) -> (StateTransition, Document) {
+        use dpp::document::DocumentV0Setters;
+        let tip_type = contract
+            .document_type_for_name("tip")
+            .expect("tip doctype exists");
+        let entropy = Bytes32::random_with_rng(rng);
+        let mut tip = tip_type
+            .random_document_with_identifier_and_entropy(
+                rng,
+                owner,
+                entropy,
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                platform_version,
+            )
+            .expect("expected a random tip");
+        tip.set(
+            "postId",
+            dpp::platform_value::Value::Identifier(post_id.to_buffer()),
+        );
+        tip.set("amount", dpp::platform_value::Value::U64(amount));
+        let create = BatchTransition::new_document_creation_transition_from_document(
+            tip.clone(),
+            tip_type,
+            entropy.0,
+            key,
+            nonce,
+            0,
+            None,
+            signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the create transition");
+        (create, tip)
+    }
+
+    /// The summable lifecycle through executed proofs: a `tip` create
+    /// proves and verifies against its `ItemWithSumItem` entry, a forged
+    /// transition claiming a different amount at the same entry position
+    /// is refused on the sum contribution, and the executed delete proves
+    /// the entry absent.
+    #[tokio::test]
+    async fn test_executed_summable_tip_proofs_and_forged_amount_refused() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let platform_state = platform.state.load();
+        let mut rng = StdRng::seed_from_u64(4645);
+
+        let (alice, alice_signer, alice_key) =
+            setup_identity(&mut platform, 958, dash_to_credits!(1.0));
+        let contract = register_likes(&platform, alice.id(), platform_version);
+        let contract_arc = Arc::new(contract.clone());
+
+        let post = create_post(
+            &platform,
+            &platform_state,
+            &contract,
+            alice.id(),
+            &alice_key,
+            2,
+            &alice_signer,
+            &mut rng,
+            platform_version,
+        )
+        .await;
+
+        let (create, tip) = signed_tip_create(
+            &contract,
+            alice.id(),
+            post.id(),
+            150,
+            3,
+            &alice_key,
+            &alice_signer,
+            &mut rng,
+            platform_version,
+        )
+        .await;
+        let result = process_and_commit(&platform, &platform_state, &create, platform_version);
+        assert_eq!(
+            result.valid_count(),
+            1,
+            "the tip create must execute: {:?}",
+            result.execution_results()
+        );
+
+        // ── prove + verify the executed create ─────────────────────────
+        let proof = platform
+            .drive
+            .prove_state_transition(&create, None, platform_version)
+            .expect("expected to prove the executed create")
+            .into_data()
+            .expect("expected proof bytes");
+        let lookup = |_id: &dpp::identifier::Identifier| Ok(Some(Arc::clone(&contract_arc)));
+        let (root_hash, outcome) = Drive::verify_state_transition_was_executed_with_proof(
+            &create,
+            &BlockInfo::default(),
+            proof.as_slice(),
+            &lookup,
+            platform_version,
+        )
+        .expect("expected the executed summable create proof to verify");
+        assert_ne!(root_hash, [0u8; 32]);
+        let StateTransitionProofResult::VerifiedDocuments(documents) = outcome.into_result() else {
+            panic!("expected verified documents");
+        };
+        let (_, verified_tip) = documents.into_iter().next().expect("one document");
+        let verified_tip = verified_tip.expect("the created tip is present");
+        assert_eq!(
+            verified_tip
+                .properties()
+                .get("amount")
+                .expect("amount present")
+                .to_integer::<u64>()
+                .expect("integer"),
+            150
+        );
+
+        // ── forged amount at the same entry position is refused ────────
+        // Signed but never processed: the same (post, owner) addresses the
+        // same `byPost` entry — the amount is not in that index's path —
+        // but the stored sum contribution is the real row's 150.
+        let (forged_create, _forged_tip) = signed_tip_create(
+            &contract,
+            alice.id(),
+            post.id(),
+            999,
+            4,
+            &alice_key,
+            &alice_signer,
+            &mut rng,
+            platform_version,
+        )
+        .await;
+        let proof = platform
+            .drive
+            .prove_state_transition(&forged_create, None, platform_version)
+            .expect("expected to prove the entry position")
+            .into_data()
+            .expect("expected proof bytes");
+        let error = Drive::verify_state_transition_was_executed_with_proof(
+            &forged_create,
+            &BlockInfo::default(),
+            proof.as_slice(),
+            &lookup,
+            platform_version,
+        )
+        .expect_err("a forged amount must not verify as executed");
+        assert!(
+            error.to_string().contains("sum contribution"),
+            "expected the sum-contribution refusal, got: {error}"
+        );
+
+        // ── prove + verify the executed delete ─────────────────────────
+        let tip_type = contract
+            .document_type_for_name("tip")
+            .expect("tip doctype exists");
+        let delete = BatchTransition::new_document_deletion_transition_from_document(
+            tip,
+            tip_type,
+            &alice_key,
+            4,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the delete transition");
+        let result = process_and_commit(&platform, &platform_state, &delete, platform_version);
+        assert_eq!(
+            result.valid_count(),
+            1,
+            "the tip delete must execute: {:?}",
+            result.execution_results()
+        );
+
+        let proof = platform
+            .drive
+            .prove_state_transition(&delete, None, platform_version)
+            .expect("expected to prove the executed delete")
+            .into_data()
+            .expect("expected proof bytes");
+        let (root_hash, outcome) = Drive::verify_state_transition_was_executed_with_proof(
+            &delete,
+            &BlockInfo::default(),
+            proof.as_slice(),
+            &lookup,
+            platform_version,
+        )
+        .expect("expected the executed summable delete proof to verify");
+        assert_ne!(root_hash, [0u8; 32]);
+        let StateTransitionProofResult::VerifiedDocuments(documents) = outcome.into_result() else {
+            panic!("expected verified documents");
+        };
+        let (_, absent) = documents.into_iter().next().expect("one entry");
+        assert!(absent.is_none(), "the deleted tip must be proven absent");
+    }
 }

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -15,6 +15,10 @@
 //! | `byPost`        | `[postId]`            | `$ownerId` | countable + range + ranked  |
 //! | `byLiker`       | `[$ownerId]`          | `postId`   | none                        |
 //!
+//! plus the `tip` doctype (sum axes — see the sum-axes section at the
+//! bottom) and the `mark` doctype (two single-property indexes, the
+//! splice-prone shape).
+//!
 //! Three layers are pinned. The *registration shape*: no `[0]` primary-key
 //! tree is created for the doctype, while the top-level property-name trees
 //! (including `byPost`'s `ProvableCountIndexedTree`) are. The *entry
@@ -1498,6 +1502,436 @@ fn should_refuse_a_delete_spliced_across_two_rows() {
             None,
         )
         .expect("the other real row must still delete");
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+// ---------------------------------------------------------------------------
+// Sum axes: ItemWithSumItem terminal entries (the `tip` doctype)
+// ---------------------------------------------------------------------------
+//
+// The `tip` doctype pins the sum-axis storage mode: `byPost` —
+// `[postId] → $ownerId` with the full count AND sum axis set
+// (`summable: "amount"` + range + ranked on both) — stores
+// `ItemWithSumItem(commitment, amount)` terminals, while
+// `byTipperAmount` — `[$ownerId, amount] → postId`, no axes — keeps
+// plain `Item(commitment)` terminals on the same rows.
+
+const TIP_DOCTYPE: &str = "tip";
+
+fn tip_doctype_path(contract: &DataContract) -> Vec<Vec<u8>> {
+    vec![
+        vec![crate::drive::RootTree::DataContractDocuments as u8],
+        contract.id().as_bytes().to_vec(),
+        vec![1],
+        TIP_DOCTYPE.as_bytes().to_vec(),
+    ]
+}
+
+/// A tip of `amount` on `post` by `owner`.
+fn build_tip(
+    contract: &DataContract,
+    post: [u8; 32],
+    owner: [u8; 32],
+    amount: u64,
+    seed: u64,
+) -> Document {
+    let pv = platform_version();
+    let document_type = contract
+        .document_type_for_name(TIP_DOCTYPE)
+        .expect("tip doctype exists");
+    let mut doc = document_type
+        .random_document(Some(seed), pv)
+        .expect("random document");
+    let mut props = std::collections::BTreeMap::new();
+    props.insert("postId".to_string(), Value::Identifier(post));
+    props.insert("amount".to_string(), Value::U64(amount));
+    doc.set_properties(props);
+    doc.set_owner_id(Identifier::from(owner));
+    doc
+}
+
+fn insert_tip(
+    drive: &Drive,
+    contract: &DataContract,
+    doc: &Document,
+    apply: bool,
+) -> Result<FeeResult, crate::error::Error> {
+    let pv = platform_version();
+    let document_type = contract
+        .document_type_for_name(TIP_DOCTYPE)
+        .expect("tip doctype exists");
+    drive.add_document_for_contract(
+        DocumentAndContractInfo {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((doc, None)),
+                owner_id: None,
+            },
+            contract,
+            document_type,
+        },
+        false,
+        BlockInfo::default(),
+        apply,
+        None,
+        pv,
+        None,
+    )
+}
+
+fn delete_tip(
+    drive: &Drive,
+    contract: &DataContract,
+    doc: Document,
+    apply: bool,
+) -> Result<FeeResult, crate::error::Error> {
+    let pv = platform_version();
+    let document_type = contract
+        .document_type_for_name(TIP_DOCTYPE)
+        .expect("tip doctype exists");
+    drive.delete_index_only_document_for_contract(
+        doc,
+        contract,
+        document_type,
+        BlockInfo::default(),
+        apply,
+        None,
+        pv,
+        None,
+    )
+}
+
+fn sum_top_k(drive: &Drive, path: &[Vec<u8>], k: u16, descending: bool) -> Vec<(i64, Vec<u8>)> {
+    let path_query = grovedb::PathQuery::new_axis(
+        path.to_vec(),
+        grovedb_query::AxisQuery::top_k(grovedb_query::IndexAxis::Sum, k, 0, descending)
+            .keys_only(),
+    );
+    match drive
+        .grove
+        .run_path_query(
+            &path_query,
+            true,
+            true,
+            true,
+            grovedb::query_result_type::QueryResultType::QueryKeyElementPairResultType,
+            None,
+            &platform_version().drive.grove_version,
+        )
+        .unwrap()
+        .expect("the keys-only sum-axis read must succeed")
+    {
+        grovedb::PathQueryRun::AxisKeys {
+            keys: grovedb::AxisKeys::Sum(pairs),
+            ..
+        } => pairs,
+        other => panic!("expected sum keys, got {other:?}"),
+    }
+}
+
+/// The unproved point-lookup sum of `amount` over tips whose `postId`
+/// equals `post` — the query surface a "total tipped to this post"
+/// feature reads.
+fn tips_total_for_post(drive: &Drive, contract: &DataContract, post: [u8; 32]) -> i64 {
+    use crate::query::drive_document_sum_query::{
+        DocumentSumRequest, DocumentSumResponse, SumMode,
+    };
+    let document_type = contract
+        .document_type_for_name(TIP_DOCTYPE)
+        .expect("tip doctype exists");
+    let drive_config = crate::config::DriveConfig::default();
+    let request = DocumentSumRequest {
+        contract,
+        document_type,
+        sum_property: "amount".to_string(),
+        where_clauses: vec![crate::query::WhereClause {
+            field: "postId".to_string(),
+            operator: crate::query::WhereOperator::Equal,
+            value: Value::Identifier(post),
+        }],
+        resolved_time_ranges: vec![],
+        order_clauses: vec![],
+        mode: SumMode::Aggregate,
+        limit: None,
+        prove: false,
+        drive_config: &drive_config,
+    };
+    match drive
+        .execute_document_sum_request(request, None, platform_version())
+        .expect("the point-lookup sum must execute")
+    {
+        DocumentSumResponse::Aggregate(sum) => sum,
+        other => panic!("expected an aggregate sum, got {other:?}"),
+    }
+}
+
+/// A summable index's terminal entries are `ItemWithSumItem(commitment,
+/// amount)` — the same commitment every plain entry of the row carries,
+/// plus the summed property's value — while a non-summable index on the
+/// same doctype keeps plain `Item` terminals.
+#[test]
+fn tip_insert_writes_sum_bearing_terminal_items() {
+    let (drive, contract) = setup_likes();
+    let tip = build_tip(&contract, POST_A, OWNER_1, 100, 1);
+    insert_tip(&drive, &contract, &tip, true).expect("insert tip");
+
+    let document_type = contract
+        .document_type_for_name(TIP_DOCTYPE)
+        .expect("tip doctype exists");
+    let expected_commitment =
+        crate::drive::document::index_only_row_commitment(&tip, document_type, platform_version())
+            .expect("commitment computes");
+
+    // byPost (summable): [.., postId, POST_A, 0] key OWNER_1 →
+    // ItemWithSumItem(commitment, 100).
+    let mut by_post = tip_doctype_path(&contract);
+    by_post.extend([b"postId".to_vec(), POST_A.to_vec(), vec![0]]);
+    match read_grove_element(&drive, &by_post, &OWNER_1) {
+        Some(Element::ItemWithSumItem(data, sum_value, _)) => {
+            assert_eq!(
+                data,
+                expected_commitment.to_vec(),
+                "the sum-bearing terminal still carries the row commitment"
+            );
+            assert_eq!(sum_value, 100, "the sum item carries the tip's amount");
+        }
+        other => panic!("expected an ItemWithSumItem at the byPost terminal, got {other:?}"),
+    }
+
+    // byTipperAmount (no axes): [.., $ownerId, OWNER_1, amount, <100>, 0]
+    // key POST_A → plain Item(commitment). The amount path segment uses the
+    // property's key encoding.
+    use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
+    let encoded_amount = document_type
+        .serialize_value_for_key("amount", &Value::U64(100), platform_version())
+        .expect("amount encodes");
+    let mut by_tipper_amount = tip_doctype_path(&contract);
+    by_tipper_amount.extend([
+        b"$ownerId".to_vec(),
+        OWNER_1.to_vec(),
+        b"amount".to_vec(),
+        encoded_amount,
+        vec![0],
+    ]);
+    match read_grove_element(&drive, &by_tipper_amount, &POST_A) {
+        Some(Element::Item(data, _)) => assert_eq!(
+            data,
+            expected_commitment.to_vec(),
+            "the non-summable index keeps a plain commitment Item on the same row"
+        ),
+        other => panic!("expected a plain Item at the byTipperAmount terminal, got {other:?}"),
+    }
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// Sum aggregation across entries: per-post totals via the point-lookup
+/// sum query (unproved and proved agree), and the ranked Sum axis orders
+/// posts by total tipped.
+#[test]
+fn tips_sum_and_rank_posts() {
+    use crate::query::drive_document_sum_query::index_picker::find_summable_index_for_where_clauses;
+    use crate::query::drive_document_sum_query::{
+        DocumentSumRequest, DocumentSumResponse, DriveDocumentSumQuery, SumMode,
+    };
+    use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
+
+    let (drive, contract) = setup_likes();
+    // POST_A: 100 + 250 = 350; POST_B: 40.
+    insert_tip(
+        &drive,
+        &contract,
+        &build_tip(&contract, POST_A, OWNER_1, 100, 1),
+        true,
+    )
+    .expect("tip 1");
+    insert_tip(
+        &drive,
+        &contract,
+        &build_tip(&contract, POST_A, OWNER_2, 250, 2),
+        true,
+    )
+    .expect("tip 2");
+    insert_tip(
+        &drive,
+        &contract,
+        &build_tip(&contract, POST_B, OWNER_1, 40, 3),
+        true,
+    )
+    .expect("tip 3");
+
+    assert_eq!(tips_total_for_post(&drive, &contract, POST_A), 350);
+    assert_eq!(tips_total_for_post(&drive, &contract, POST_B), 40);
+
+    // Proved parity: the proof of the same point lookup verifies and
+    // yields the same total.
+    let document_type = contract
+        .document_type_for_name(TIP_DOCTYPE)
+        .expect("tip doctype exists");
+    let post_a_clause = crate::query::WhereClause {
+        field: "postId".to_string(),
+        operator: crate::query::WhereOperator::Equal,
+        value: Value::Identifier(POST_A),
+    };
+    let drive_config = crate::config::DriveConfig::default();
+    let request = DocumentSumRequest {
+        contract: &contract,
+        document_type,
+        sum_property: "amount".to_string(),
+        where_clauses: vec![post_a_clause.clone()],
+        resolved_time_ranges: vec![],
+        order_clauses: vec![],
+        mode: SumMode::Aggregate,
+        limit: None,
+        prove: true,
+        drive_config: &drive_config,
+    };
+    let proof_bytes = match drive
+        .execute_document_sum_request(request, None, platform_version())
+        .expect("the proved point-lookup sum must execute")
+    {
+        DocumentSumResponse::Proof(bytes) => bytes,
+        other => panic!("expected proof bytes, got {other:?}"),
+    };
+    let index = find_summable_index_for_where_clauses(
+        document_type.indexes(),
+        std::slice::from_ref(&post_a_clause),
+        "amount",
+        &[],
+    )
+    .expect("byPost covers `postId == POST_A`");
+    let sum_query = DriveDocumentSumQuery {
+        document_type,
+        contract_id: contract.id().to_buffer(),
+        document_type_name: TIP_DOCTYPE.to_string(),
+        index,
+        where_clauses: vec![post_a_clause],
+        sum_property: "amount".to_string(),
+    };
+    let verifier_path_query = sum_query
+        .point_lookup_sum_path_query(platform_version())
+        .expect("verifier path query builds");
+    let (_root_hash, proved) = grovedb::GroveDb::verify_query(
+        &proof_bytes,
+        &verifier_path_query,
+        &platform_version().drive.grove_version,
+    )
+    .expect("the sum proof must verify");
+    let proved_total: i64 = proved
+        .into_iter()
+        .filter_map(|(_path, _key, element)| element)
+        .map(|element| element.sum_value_or_default())
+        .sum();
+    assert_eq!(proved_total, 350, "proved and unproved totals must agree");
+
+    // Ranked Sum axis on byPost's property-name tree: POST_A (350) above
+    // POST_B (40).
+    let mut post_tree = tip_doctype_path(&contract);
+    post_tree.push(b"postId".to_vec());
+    let top = sum_top_k(&drive, &post_tree, 10, true);
+    assert_eq!(
+        top,
+        vec![(350, POST_A.to_vec()), (40, POST_B.to_vec())],
+        "the Sum axis ranks posts by total tipped"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// Delete-by-values on a summable type: grovedb reads the amount off the
+/// stored element and subtracts it from every ancestor sum — totals and
+/// rankings follow, and drained groups prune.
+#[test]
+fn tip_delete_subtracts_sums_and_prunes_drained_groups() {
+    let (drive, contract) = setup_likes();
+    let tip_1 = build_tip(&contract, POST_A, OWNER_1, 100, 1);
+    let tip_2 = build_tip(&contract, POST_A, OWNER_2, 250, 2);
+    let tip_3 = build_tip(&contract, POST_B, OWNER_1, 40, 3);
+    insert_tip(&drive, &contract, &tip_1, true).expect("tip 1");
+    insert_tip(&drive, &contract, &tip_2, true).expect("tip 2");
+    insert_tip(&drive, &contract, &tip_3, true).expect("tip 3");
+
+    delete_tip(&drive, &contract, tip_2, true).expect("delete tip 2");
+    assert_eq!(
+        tips_total_for_post(&drive, &contract, POST_A),
+        100,
+        "the deleted tip's amount is subtracted from the post's total"
+    );
+
+    let mut post_tree = tip_doctype_path(&contract);
+    post_tree.push(b"postId".to_vec());
+    assert_eq!(
+        sum_top_k(&drive, &post_tree, 10, true),
+        vec![(100, POST_A.to_vec()), (40, POST_B.to_vec())],
+        "the ranking re-orders after the subtraction"
+    );
+
+    // Draining POST_A prunes its group from the ranked tree entirely.
+    delete_tip(&drive, &contract, tip_1, true).expect("delete tip 1");
+    assert_eq!(
+        sum_top_k(&drive, &post_tree, 10, true),
+        vec![(40, POST_B.to_vec())],
+        "a drained post drops out of the ranking"
+    );
+    assert!(
+        read_grove_element(&drive, &post_tree, &POST_A).is_none(),
+        "the drained post's value tree is pruned"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// The commitment probe covers the amount: a delete whose values carry a
+/// falsified amount addresses the same byPost entry (the amount is not in
+/// that index's path) but fails the row-commitment comparison.
+#[test]
+fn tip_delete_with_falsified_amount_is_refused() {
+    let (drive, contract) = setup_likes();
+    let tip = build_tip(&contract, POST_A, OWNER_1, 100, 1);
+    insert_tip(&drive, &contract, &tip, true).expect("insert tip");
+
+    let falsified = build_tip(&contract, POST_A, OWNER_1, 999, 2);
+    let error = delete_tip(&drive, &contract, falsified, true)
+        .expect_err("a falsified amount must be refused");
+    assert!(
+        matches!(
+            error,
+            crate::error::Error::Drive(
+                crate::error::drive::DriveError::DeletingDocumentThatDoesNotExist(_)
+            )
+        ),
+        "expected the row-integrity refusal, got: {error}"
+    );
+
+    // The honest tuple still deletes, and the sum drains to zero.
+    delete_tip(&drive, &contract, tip, true).expect("the real tuple must still delete");
+    assert_eq!(tips_total_for_post(&drive, &contract, POST_A), 0);
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// The estimation twin covers the sum-bearing element and tree variants:
+/// dry-run fees upper-bound applied fees for a summable indexOnly type.
+#[test]
+fn tip_estimated_fees_upper_bound_actual_fees() {
+    let (drive, contract) = setup_likes();
+    let tip = build_tip(&contract, POST_A, OWNER_1, 100, 1);
+
+    let estimated_insert =
+        insert_tip(&drive, &contract, &tip, false).expect("estimated insert must work");
+    let actual_insert = insert_tip(&drive, &contract, &tip, true).expect("actual insert");
+    assert!(
+        estimated_insert.storage_fee >= actual_insert.storage_fee,
+        "estimated insert storage fee {} must upper-bound actual {}",
+        estimated_insert.storage_fee,
+        actual_insert.storage_fee
+    );
+
+    let estimated_delete =
+        delete_tip(&drive, &contract, tip.clone(), false).expect("estimated delete must work");
+    let actual_delete = delete_tip(&drive, &contract, tip, true).expect("actual delete");
+    assert!(estimated_delete.processing_fee > 0);
+    assert!(actual_delete.processing_fee > 0);
 
     assert_grovedb_is_consistent(&drive);
 }

--- a/packages/rs-drive/src/drive/document/delete/remove_reference_for_index_level_for_contract_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/remove_reference_for_index_level_for_contract_operations/v0/mod.rs
@@ -3,15 +3,16 @@ use grovedb::batch::KeyInfoPath;
 
 use grovedb::EstimatedLayerCount::PotentiallyAtMaxElements;
 use grovedb::EstimatedLayerSizes::{AllItems, AllReference, AllSubtrees};
-use grovedb::{EstimatedLayerInformation, MaybeTree, TransactionArg, TreeType};
+use grovedb::{EstimatedLayerInformation, MaybeTree, TransactionArg};
 
+use dpp::data_contract::document_type::IndexLevelTypeInfo;
 use dpp::data_contract::document_type::IndexType::{ContestedResourceIndex, NonUniqueIndex};
-use dpp::data_contract::document_type::{IndexCountability, IndexLevelTypeInfo};
 use grovedb::EstimatedSumTrees::NoSumTrees;
 use std::collections::HashMap;
 
 use crate::drive::constants::CONTRACT_DOCUMENTS_PATH_HEIGHT;
 use crate::drive::document::document_reference_size;
+use crate::drive::document::index_level_tree_types::terminal_member_tree_type;
 use crate::error::drive::DriveError;
 use crate::util::storage_flags::StorageFlags;
 use dpp::document::document_methods::DocumentMethodsV0;
@@ -58,7 +59,8 @@ impl Drive {
         let document_type = document_and_contract_info.document_type;
 
         // indexOnly terminal: the member key is the terminal property's
-        // value and the stored element is an empty `Item` — mirror of the
+        // value and the stored element is a commitment `Item` (an
+        // `ItemWithSumItem` under a summable index) — mirror of the
         // insert-side branch in
         // `add_reference_for_index_level_for_contract_operations_v0`.
         // `terminal` can only be `Some` on a PV14+ indexOnly contract, so
@@ -66,10 +68,18 @@ impl Drive {
         if let Some(terminal_property) = index_type.terminal.as_deref() {
             key_info_path.push(KnownKey(vec![0]));
 
-            let member_tree_type = match index_type.countable {
-                IndexCountability::NotCountable => TreeType::NormalTree,
-                IndexCountability::Countable => TreeType::CountTree,
-                IndexCountability::CountableAllowingOffset => TreeType::ProvableCountTree,
+            let member_tree_type = terminal_member_tree_type(index_type);
+
+            // Sum-bearing entries (`ItemWithSumItem`) carry the i64 sum
+            // item alongside the commitment payload; mirror the insert
+            // side's 10-byte worst case. Delete-side sum-decrement is
+            // implicit: grovedb reads the amount off the stored element
+            // and propagates the subtraction — same as stored-type
+            // `ReferenceWithSumItem` entries below.
+            let estimated_value_size = if index_type.summable.is_some() {
+                crate::drive::document::INDEX_ONLY_ROW_COMMITMENT_SIZE + 10
+            } else {
+                crate::drive::document::INDEX_ONLY_ROW_COMMITMENT_SIZE
             };
 
             if let Some(estimated_costs_only_with_layer_info) = estimated_costs_only_with_layer_info
@@ -81,7 +91,7 @@ impl Drive {
                         estimated_layer_count: PotentiallyAtMaxElements,
                         estimated_layer_sizes: AllItems(
                             DEFAULT_HASH_SIZE_U8,
-                            crate::drive::document::INDEX_ONLY_ROW_COMMITMENT_SIZE,
+                            estimated_value_size,
                             storage_flags.map(|s| s.serialized_size()),
                         ),
                     },
@@ -113,7 +123,7 @@ impl Drive {
             let delete_apply_type = Self::stateless_delete_of_non_tree_for_costs(
                 AllItems(
                     DEFAULT_HASH_SIZE_U8,
-                    crate::drive::document::INDEX_ONLY_ROW_COMMITMENT_SIZE,
+                    estimated_value_size,
                     storage_flags.map(|s| s.serialized_size()),
                 ),
                 &key_info_path,
@@ -148,39 +158,15 @@ impl Drive {
             key_info_path.push(KnownKey(vec![0]));
 
             // Mirror the insert path: tree variant is driven by the
-            // composition of the index's countability AND summability.
-            // See the matching dispatch table in
-            // `add_reference_for_index_level_for_contract_operations_v0`
-            // — eight cases over the v3 sum-tree-expanded TreeType
-            // set (NormalTree / CountTree / ProvableCountTree /
-            // SumTree / ProvableSumTree / CountSumTree /
-            // ProvableCountSumTree / ProvableCountProvableSumTree).
-            let count_provable = matches!(
-                index_type.countable,
-                IndexCountability::CountableAllowingOffset
-            );
-            let count_root_only =
-                matches!(index_type.countable, IndexCountability::Countable) && !count_provable;
-            let sum_provable = index_type.range_summable;
-            let sum_root_only = index_type.summable.is_some() && !sum_provable;
-            let want_count = count_provable || count_root_only;
-            let want_sum = sum_provable || sum_root_only;
-            let reference_tree_type =
-                match (count_provable, count_root_only, sum_provable, sum_root_only) {
-                    (false, false, false, false) => TreeType::NormalTree,
-                    (false, true, false, false) => TreeType::CountTree,
-                    (true, _, false, false) => TreeType::ProvableCountTree,
-                    (false, false, false, true) => TreeType::SumTree,
-                    (false, false, true, _) => TreeType::ProvableSumTree,
-                    (false, true, false, true) => TreeType::CountSumTree,
-                    (true, _, false, true) => TreeType::ProvableCountSumTree,
-                    (true, _, true, _) => TreeType::ProvableCountProvableSumTree,
-                    (false, true, true, _) => TreeType::ProvableCountProvableSumTree,
-                };
-            let _ = (want_count, want_sum); // narrative parity with the dispatch table.
+            // composition of the index's countability AND summability —
+            // `terminal_member_tree_type` is the shared dispatch (eight
+            // cases over the v3 sum-tree-expanded TreeType set), used
+            // by both sides so the delete's estimation layers cannot
+            // drift from the trees the insert actually created.
+            let reference_tree_type = terminal_member_tree_type(index_type);
 
-            // Delete-side sum-decrement is implicit: when `want_sum`,
-            // the existing reference at `[..., 0, doc_id]` is an
+            // Delete-side sum-decrement is implicit: under a summable
+            // index, the existing reference at `[..., 0, doc_id]` is an
             // `Element::ItemWithSumItem(doc_id, amount_i64, flags)`
             // (written by the insert path). The contribution is
             // recovered from the reference element itself — Drive

--- a/packages/rs-drive/src/drive/document/index_level_tree_types.rs
+++ b/packages/rs-drive/src/drive/document/index_level_tree_types.rs
@@ -76,7 +76,9 @@
 use crate::drive::document::ranked_index_tree_type::property_name_tree_type_and_ranked_axes;
 use crate::error::Error;
 use crate::util::object_size_info::DriveKeyInfo;
-use dpp::data_contract::document_type::{IndexLevel, TimeRangeTransform};
+use dpp::data_contract::document_type::{
+    IndexCountability, IndexLevel, IndexLevelTypeInfo, TimeRangeTransform,
+};
 use grovedb::batch::key_info::KeyInfo;
 use grovedb::element::IndexAxis;
 use grovedb::TreeType;
@@ -190,6 +192,40 @@ pub(crate) fn time_range_index_keys<'a>(
             .into_iter()
             .map(DriveKeyInfo::Key)
             .collect(),
+    }
+}
+
+/// The tree type of the `0` member bucket at an index's terminal level
+/// — the tree holding one member per document (stored types: references
+/// keyed by document id; indexOnly types: entry items keyed by the
+/// terminal property's value). Composed from the index's countability
+/// and summability axes, per-axis provable vs root-only (grovedb PR
+/// 670's expanded `TreeType` set) — see the dispatch commentary in
+/// `add_reference_for_index_level_for_contract_operations`.
+///
+/// Single source of truth for the four terminal branches (insert/delete
+/// × stored/indexOnly): the insert side creates the tree and the delete
+/// side emits `EstimatedLayerInformation` describing it, and any drift
+/// produces dry-run fees that disagree with applied fees.
+pub(crate) fn terminal_member_tree_type(index_type: &IndexLevelTypeInfo) -> TreeType {
+    let count_provable = matches!(
+        index_type.countable,
+        IndexCountability::CountableAllowingOffset
+    );
+    let count_root_only =
+        matches!(index_type.countable, IndexCountability::Countable) && !count_provable;
+    let sum_provable = index_type.range_summable;
+    let sum_root_only = index_type.summable.is_some() && !sum_provable;
+    match (count_provable, count_root_only, sum_provable, sum_root_only) {
+        (false, false, false, false) => TreeType::NormalTree,
+        (false, true, false, false) => TreeType::CountTree,
+        (true, _, false, false) => TreeType::ProvableCountTree,
+        (false, false, false, true) => TreeType::SumTree,
+        (false, false, true, _) => TreeType::ProvableSumTree,
+        (false, true, false, true) => TreeType::CountSumTree,
+        (true, _, false, true) => TreeType::ProvableCountSumTree,
+        (true, _, true, _) => TreeType::ProvableCountProvableSumTree,
+        (false, true, true, _) => TreeType::ProvableCountProvableSumTree,
     }
 }
 

--- a/packages/rs-drive/src/drive/document/index_only.rs
+++ b/packages/rs-drive/src/drive/document/index_only.rs
@@ -172,6 +172,13 @@ impl Drive {
         )?;
         Ok(match element {
             Some(grovedb::Element::Item(payload, _)) => payload == expected_commitment.as_slice(),
+            // Summable indexes store `ItemWithSumItem(commitment, amount)`;
+            // the commitment payload plays the same binding role, and the
+            // amount needs no separate check — it is one of the document's
+            // properties, so it is already covered by the commitment.
+            Some(grovedb::Element::ItemWithSumItem(payload, _, _)) => {
+                payload == expected_commitment.as_slice()
+            }
             _ => false,
         })
     }

--- a/packages/rs-drive/src/drive/document/insert/add_reference_for_index_level_for_contract_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_reference_for_index_level_for_contract_operations/v0/mod.rs
@@ -1,4 +1,5 @@
 use crate::drive::constants::STORAGE_FLAGS_SIZE;
+use crate::drive::document::index_level_tree_types::terminal_member_tree_type;
 use crate::drive::document::{
     document_reference_size, make_document_reference, make_document_reference_with_sum_item,
     read_document_sum_contribution,
@@ -21,7 +22,7 @@ use crate::util::object_size_info::{
 use crate::util::storage_flags::StorageFlags;
 use crate::util::type_constants::DEFAULT_HASH_SIZE_U8;
 use dpp::data_contract::document_type::methods::DocumentTypeBasicMethods;
-use dpp::data_contract::document_type::{IndexCountability, IndexLevelTypeInfo};
+use dpp::data_contract::document_type::IndexLevelTypeInfo;
 use dpp::document::document_methods::DocumentMethodsV0;
 use dpp::document::Document;
 use dpp::document::DocumentV0Getters;
@@ -98,35 +99,14 @@ impl Drive {
         //   per-node)
         //
         // Same dispatch shape as the primary-key tree dispatcher's v1
-        // arm in `primary_key_tree_type.rs` — see that file for the
-        // full table. The `IndexLevelTypeInfo`'s `summable` carries
-        // the property name the reference's sum-item will contribute
-        // (read below to construct the `Element::ReferenceWithSumItem`
-        // that replaces a plain `Element::Reference` under summable
-        // indexes).
-        let count_provable = matches!(
-            index_type.countable,
-            IndexCountability::CountableAllowingOffset
-        );
-        let count_root_only =
-            matches!(index_type.countable, IndexCountability::Countable) && !count_provable;
-        let sum_provable = index_type.range_summable;
-        let sum_root_only = index_type.summable.is_some() && !sum_provable;
-        let want_count = count_provable || count_root_only;
-        let want_sum = sum_provable || sum_root_only;
-        let reference_tree_type =
-            match (count_provable, count_root_only, sum_provable, sum_root_only) {
-                (false, false, false, false) => TreeType::NormalTree,
-                (false, true, false, false) => TreeType::CountTree,
-                (true, _, false, false) => TreeType::ProvableCountTree,
-                (false, false, false, true) => TreeType::SumTree,
-                (false, false, true, _) => TreeType::ProvableSumTree,
-                (false, true, false, true) => TreeType::CountSumTree,
-                (true, _, false, true) => TreeType::ProvableCountSumTree,
-                (true, _, true, _) => TreeType::ProvableCountProvableSumTree,
-                (false, true, true, _) => TreeType::ProvableCountProvableSumTree,
-            };
-        let _ = (want_count, want_sum); // computed for narrative parity with the dispatch table; no longer used after exhaustive match.
+        // arm in `primary_key_tree_type.rs` — see
+        // `terminal_member_tree_type` for the full table (shared with
+        // the delete side and the indexOnly terminal branches). The
+        // `IndexLevelTypeInfo`'s `summable` carries the property name
+        // the reference's sum-item will contribute (read below to
+        // construct the `Element::ReferenceWithSumItem` that replaces a
+        // plain `Element::Reference` under summable indexes).
+        let reference_tree_type = terminal_member_tree_type(index_type);
 
         // Element-shape selector. Under a summable index path the
         // reference element MUST be
@@ -367,11 +347,12 @@ impl Drive {
     }
 
     /// The indexOnly terminal: writes `[…index path, 0, <terminal value>] →
-    /// Item(b"", flags)` — the member key is the terminal property's value
-    /// (`$ownerId` or a refersTo-typed identifier) sitting exactly where a
-    /// normal non-unique index keys by document id, and the element is an
-    /// empty `Item` because the entry IS the row. Storage flags ride the
-    /// element flags for epoch/owner refunds, exactly as on references.
+    /// Item(commitment, flags)` — the member key is the terminal property's
+    /// value (`$ownerId` or a refersTo-typed identifier) sitting exactly
+    /// where a normal non-unique index keys by document id, and the element
+    /// payload is the row commitment because the entry IS the row. Storage
+    /// flags ride the element flags for epoch/owner refunds, exactly as on
+    /// references.
     ///
     /// Existence check semantics: the entry is inserted with
     /// `if_not_exists`, and an existing entry is an error. ABCI state
@@ -380,8 +361,16 @@ impl Drive {
     /// the same backstop role the unique-index "reference already exists"
     /// above plays.
     ///
-    /// Only count axes reach here: the parser rejects sum axes on indexOnly
-    /// indexes, so the `0` tree type never carries a sum.
+    /// Under a summable index the element is
+    /// `ItemWithSumItem(commitment, amount, flags)` instead — the same
+    /// payload, plus the summed property's value read off the document, so
+    /// the entry contributes to the ancestor sum trees exactly as a
+    /// `ReferenceWithSumItem` does for stored types. On delete, grovedb
+    /// reads the amount off the stored element and propagates the
+    /// subtraction — the delete path needs no sum-specific logic. The
+    /// amount is one of the document's properties, so it is already covered
+    /// by the row commitment: a delete carrying a falsified amount fails
+    /// the commitment probe before anything is removed.
     #[allow(clippy::too_many_arguments)]
     fn add_index_only_terminal_item_operations(
         &self,
@@ -400,11 +389,8 @@ impl Drive {
     ) -> Result<(), Error> {
         let drive_version = &platform_version.drive;
 
-        let member_tree_type = match index_type.countable {
-            IndexCountability::NotCountable => TreeType::NormalTree,
-            IndexCountability::Countable => TreeType::CountTree,
-            IndexCountability::CountableAllowingOffset => TreeType::ProvableCountTree,
-        };
+        let member_tree_type = terminal_member_tree_type(index_type);
+        let sum_property_name: Option<&str> = index_type.summable.as_deref();
 
         // The `0` storage-marker tree, byte-identical in position to the
         // non-unique layout above.
@@ -447,11 +433,28 @@ impl Drive {
         const INDEX_ONLY_ITEM_ESTIMATED_VALUE_SIZE: u32 =
             crate::drive::document::INDEX_ONLY_ROW_COMMITMENT_SIZE + 16;
 
-        let item_space = Element::required_item_space(
-            INDEX_ONLY_ITEM_ESTIMATED_VALUE_SIZE,
-            STORAGE_FLAGS_SIZE,
-            &drive_version.grove_version,
-        )?;
+        // Sum-bearing entries additionally carry the i64 sum item in the
+        // element envelope; 10 bytes is the worst case the sum-aware space
+        // helpers reserve.
+        let estimated_value_size = if sum_property_name.is_some() {
+            INDEX_ONLY_ITEM_ESTIMATED_VALUE_SIZE + 10
+        } else {
+            INDEX_ONLY_ITEM_ESTIMATED_VALUE_SIZE
+        };
+
+        let item_space = if sum_property_name.is_some() {
+            Element::required_item_with_sum_item_space(
+                INDEX_ONLY_ITEM_ESTIMATED_VALUE_SIZE,
+                STORAGE_FLAGS_SIZE,
+                &drive_version.grove_version,
+            )?
+        } else {
+            Element::required_item_space(
+                INDEX_ONLY_ITEM_ESTIMATED_VALUE_SIZE,
+                STORAGE_FLAGS_SIZE,
+                &drive_version.grove_version,
+            )?
+        };
 
         if let Some(estimated_costs_only_with_layer_info) = estimated_costs_only_with_layer_info {
             estimated_costs_only_with_layer_info.insert(
@@ -461,7 +464,7 @@ impl Drive {
                     estimated_layer_count: PotentiallyAtMaxElements,
                     estimated_layer_sizes: AllItems(
                         DEFAULT_HASH_SIZE_U8,
-                        INDEX_ONLY_ITEM_ESTIMATED_VALUE_SIZE,
+                        estimated_value_size,
                         storage_flags.map(|s| s.serialized_size()),
                     ),
                 },
@@ -519,10 +522,26 @@ impl Drive {
 
         let key_element_info = match &member_key {
             Some(member_key) => {
-                let item = Element::new_item_with_flags(
-                    item_value,
-                    StorageFlags::map_to_some_element_flags(*storage_flags),
-                );
+                let element_flags = StorageFlags::map_to_some_element_flags(*storage_flags);
+                let item = match sum_property_name {
+                    Some(prop_name) => {
+                        let (document, _) = document_and_contract_info
+                            .owned_document_info
+                            .document_info
+                            .get_borrowed_document_and_storage_flags()
+                            .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
+                                "indexOnly summable terminal insert needs a document to read \
+                                 the sum contribution from",
+                            )))?;
+                        let sum_value = read_document_sum_contribution(document, prop_name)?;
+                        Element::new_item_with_sum_item_with_flags(
+                            item_value,
+                            sum_value,
+                            element_flags,
+                        )
+                    }
+                    None => Element::new_item_with_flags(item_value, element_flags),
+                };
                 KeyElement((member_key.as_slice(), item))
             }
             None => KeyUnknownElementSize((
@@ -546,7 +565,7 @@ impl Drive {
             BatchInsertApplyType::StatelessBatchInsert {
                 in_tree_type: member_tree_type,
                 target: QueryTargetValue(
-                    INDEX_ONLY_ITEM_ESTIMATED_VALUE_SIZE
+                    estimated_value_size
                         + storage_flags
                             .map(|s| s.serialized_size())
                             .unwrap_or_default(),

--- a/packages/rs-drive/src/drive/document/mod.rs
+++ b/packages/rs-drive/src/drive/document/mod.rs
@@ -12,7 +12,7 @@ use crate::util::storage_flags::StorageFlags;
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 #[cfg(feature = "server")]
 use dpp::data_contract::document_type::DocumentTypeRef;
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 use dpp::document::Document;
 #[cfg(feature = "server")]
 use dpp::document::DocumentV0Getters;

--- a/packages/rs-drive/src/drive/document/mod.rs
+++ b/packages/rs-drive/src/drive/document/mod.rs
@@ -188,10 +188,13 @@ pub(crate) fn make_document_reference_with_sum_item(
     )
 }
 
-#[cfg(feature = "server")]
+#[cfg(any(feature = "server", feature = "verify"))]
 /// Read a document's `<sum_property>` field and convert it to `i64`
 /// for use as the sum contribution in
-/// [`make_document_item_with_sum_item`].
+/// [`make_document_item_with_sum_item`]. Also used on the verify side:
+/// the executed-transition verifier recomputes the expected sum
+/// contribution of a proved summable indexOnly entry from the created
+/// document.
 ///
 /// The DPP validator guarantees the named property exists and is in
 /// the document's `required` array — a missing value here means

--- a/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/state_transition/verify_state_transition_was_executed_with_proof/v0/mod.rs
@@ -202,14 +202,6 @@ impl Drive {
 
                                 let (root_hash, result) = match document_transition {
                                     DocumentTransition::Create(create_transition) => {
-                                        let Some(grovedb::Element::Item(payload, _)) =
-                                            entry_element
-                                        else {
-                                            return Err(Error::Proof(ProofError::IncorrectProof(format!(
-                                                "proof did not contain the indexOnly entry item expected to exist after create of {}",
-                                                create_transition.base().id()
-                                            ))));
-                                        };
                                         let expected_document =
                                             Document::try_from_create_transition(
                                                 create_transition,
@@ -219,6 +211,54 @@ impl Drive {
                                                 &document_type,
                                                 platform_version,
                                             )?;
+                                        // The entry's element shape follows the
+                                        // proof index's sum axis: a summable
+                                        // index stores `ItemWithSumItem(
+                                        // commitment, amount)`, a plain one
+                                        // stores `Item(commitment)`. The shapes
+                                        // are checked strictly — an element of
+                                        // the wrong shape is a wrong proof, and
+                                        // for the sum-bearing shape the proved
+                                        // amount must equal the created
+                                        // document's contribution (the value
+                                        // the write path froze into the
+                                        // element).
+                                        let proof_index = crate::query::index_only_synthesis::index_only_proof_index(&document_type)?;
+                                        let payload = match (
+                                            entry_element,
+                                            proof_index.summable.as_deref(),
+                                        ) {
+                                            (Some(grovedb::Element::Item(payload, _)), None) => {
+                                                payload
+                                            }
+                                            (
+                                                Some(grovedb::Element::ItemWithSumItem(
+                                                    payload,
+                                                    sum_value,
+                                                    _,
+                                                )),
+                                                Some(sum_property),
+                                            ) => {
+                                                let expected_sum =
+                                                    crate::drive::document::read_document_sum_contribution(
+                                                        &expected_document,
+                                                        sum_property,
+                                                    )?;
+                                                if sum_value != expected_sum {
+                                                    return Err(Error::Proof(ProofError::IncorrectProof(format!(
+                                                        "the proved indexOnly entry's sum contribution does not match the created document {}",
+                                                        create_transition.base().id()
+                                                    ))));
+                                                }
+                                                payload
+                                            }
+                                            _ => {
+                                                return Err(Error::Proof(ProofError::IncorrectProof(format!(
+                                                    "proof did not contain the indexOnly entry item expected to exist after create of {}",
+                                                    create_transition.base().id()
+                                                ))));
+                                            }
+                                        };
                                         // Entry presence alone only proves that
                                         // SOME row projects onto this position;
                                         // the stored row commitment binds the

--- a/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json
@@ -107,6 +107,66 @@
       ],
       "additionalProperties": false
     },
+    "tip": {
+      "type": "object",
+      "indexOnly": true,
+      "documentsMutable": false,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byPost",
+          "properties": [
+            {
+              "postId": "asc"
+            }
+          ],
+          "terminal": "$ownerId",
+          "countable": "countable",
+          "rangeCountable": true,
+          "rankedCountable": true,
+          "summable": "amount",
+          "rangeSummable": true,
+          "rankedSummable": true
+        },
+        {
+          "name": "byTipperAmount",
+          "properties": [
+            {
+              "$ownerId": "asc"
+            },
+            {
+              "amount": "asc"
+            }
+          ],
+          "terminal": "postId"
+        }
+      ],
+      "properties": {
+        "postId": {
+          "type": "array",
+          "byteArray": true,
+          "minItems": 32,
+          "maxItems": 32,
+          "contentMediaType": "application/x.dash.dpp.identifier",
+          "refersTo": {
+            "type": "permanentDocument",
+            "documentType": "post"
+          },
+          "position": 0
+        },
+        "amount": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000,
+          "position": 1
+        }
+      },
+      "required": [
+        "postId",
+        "amount"
+      ],
+      "additionalProperties": false
+    },
     "mark": {
       "type": "object",
       "indexOnly": true,


### PR DESCRIPTION
## Issue being fixed or feature implemented

indexOnly document types (the #4491–#4505 stack) supported only the count axes: an entry contributes 1 to its prefix groups. Value-weighted features — a `tip` doctype where each entry carries an `amount`, with per-post totals and a "top posts by total tipped" leaderboard — had no storage mode: the parser rejected every sum keyword on indexOnly indexes.

## What was done?

**The unlock is an element grovedb already has**: `Element::ItemWithSumItem(payload, sum, flags)`. A summable indexOnly index's terminal entry becomes `ItemWithSumItem(row commitment, amount)` — the same 32-byte commitment payload every plain entry carries (all splice/ownership guarantees intact), plus the summed property's value — so entries contribute to ancestor sum trees exactly as stored types' `ReferenceWithSumItem` references do, and the existing sum / ranked-sum query surfaces serve indexOnly types with **zero query-side changes** (the pickers are index-shape-driven).

- **dpp**: the indexOnly sum-axes rejection is removed. No new rules were needed — the doctype-level summable cross-checks (one canonical summed property, i64-safe integer type, `required` membership) run for every doctype, and the indexOnly every-property-indexed rule forces the summed property into an index, keeping it recoverable and covered by the row commitment.
- **drive write path**: the terminal `0` member tree now composes countability × summability through a shared `terminal_member_tree_type` dispatch — one source of truth replacing the duplicated inline tables in the stored insert/delete branches and the count-only maps in the indexOnly branches. The summable insert branch writes `ItemWithSumItem` with the amount read off the document (`read_document_sum_contribution`, cfg widened to `verify`); estimation reserves the 10-byte worst-case sum item on both sides.
- **delete**: needs no sum-specific logic — grovedb reads the amount off the stored element and propagates the subtraction. A delete carrying a falsified amount fails the commitment probe before anything is removed (the amount is a committed property).
- **probes/verify**: the commitment probe accepts the sum-bearing shape; the executed-transition verifier strictly matches the element shape to the proof index's sum axis and additionally checks the proved sum contribution against the created document's amount.
- **fixture/tests**: the yappr fixture gains a `tip` doctype (`byPost` `[postId] → $ownerId` with the full count+sum axis set; `byTipperAmount` `[$ownerId, amount] → postId` with none). E2e pins: element shapes per index, per-post totals via point-lookup sum (unproved + proved parity through `GroveDb::verify_query`), ranked Sum-axis ordering, delete subtraction + drained-group pruning, falsified-amount refusal, estimated ≥ actual fees. ABCI: the full executed-proof lifecycle on the summable type, including a forged-amount transition refused on the sum contribution.
- **book**: the indexOnly chapter's constraint matrix and element description updated.

## How Has This Been Tested?

- `cargo test -p dpp --features validation index_only` — 34 passed (rejection test rewritten into admission + cross-check coverage)
- `cargo test -p drive --features server,verify,fixtures-and-mocks --lib index_only` / `sum` — 26 / 168 passed
- `cargo test -p drive-abci index_only` — 9 passed
- `cargo clippy -p dpp -p drive -p drive-abci --all-features --all-targets -- -D warnings` clean; `cargo check --workspace --all-features` clean

## Breaking Changes

Consensus-breaking on the unreleased PV14 only: contracts declaring sum axes on indexOnly indexes were rejected and can now register; summable indexOnly indexes lay down sum-typed trees and sum-bearing elements. No released protocol version changes behavior.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**

- [x] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Index-only document types now support summable indexes.
  * Summed values are stored, aggregated, ranked, and updated when documents are deleted.
  * Proof verification validates both document commitments and summed contributions.
  * Added support for combined count and sum index behaviors.

* **Bug Fixes**
  * Rejected forged sum amounts and invalid summable property definitions.
  * Improved storage estimation and cleanup for summable index entries.

* **Tests**
  * Added comprehensive coverage for summable index creation, deletion, ranking, aggregation, proofs, and fee estimation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->