### PR TITLE
feat(drive)!: preallocated indexOnly index trees created at referenced-document insert

### DIFF
--- a/book/src/drive/index-only-document-types.md
+++ b/book/src/drive/index-only-document-types.md
@@ -156,9 +156,11 @@ Three things change, all bit-compatible with the fallback layout:
   the referring index's dynamic trees, down to the empty `0` member
   bucket, derived through the same tree-type helper the entry walkers use
   — so a preallocated tree is byte-identical to the tree the first
-  entry's create-on-insert path would have made. The trees carry the
-  referenced document creator's storage flags: the poster owns the
-  structural bytes. Shared prefixes (a second post under the same
+  entry's create-on-insert path would have made. The poster pays for the
+  structural bytes; storage flags ride only when the contract itself is
+  deletable, because that is a preallocated tree's one deletion path —
+  entry deletes retain it by design, so entry-level flags would be
+  unrefundable dead weight. Shared prefixes (a second post under the same
   hashtag) deduplicate through the if-not-exists semantics.
 - **Delete side**: removing the last member entry stops the
   empty-tree-pruning climb at the member level, keeping the whole

--- a/book/src/drive/index-only-document-types.md
+++ b/book/src/drive/index-only-document-types.md
@@ -100,9 +100,11 @@ aggregate keywords follow:
 | indexed `$createdAt` requires `$createdAt` in `required` | creation only assigns timestamps for required system times |
 | `documentsMutable: false`, no transfers/trading/history/transient | no stored row, no revision |
 | non-unique, non-contested, `nullSearchable` default | v1 scope |
+| `preallocated` requires a fully reference-determined, non-bucketed path | see [Preallocated index paths](#preallocated-index-paths) |
 
-`indexOnly` and the index set (terminals included) are immutable across
-contract updates — a later-added index could never be backfilled.
+`indexOnly` and the index set (terminals included, `preallocated` flags
+included) are immutable across contract updates — a later-added index
+could never be backfilled.
 
 ## Lifecycle
 
@@ -131,7 +133,50 @@ contract updates — a later-added index could never be backfilled.
   software.
 - **Replace / transfer / purchase / price** are structurally impossible.
 
-## Reads
+## Preallocated index paths
+
+The first entry under a fresh value tuple pays for every tree on its path
+— for a like that is the hashtag value tree, the `postId` property-name
+tree, the post's value tree and the `0` member bucket — while the second
+entry pays for one item insert. When the index path is a pure function of
+a refersTo-referenced document, that lopsidedness is avoidable: an index
+may declare `preallocated: true` iff every index property is either the
+referring property itself (its value is the referenced document's `$id`)
+or a key of that reference's `propertyAgreement` (consensus-equal to a
+referenced-document property), and the reference targets a document type
+of the **same contract**. `byHashtagPost` (`[hashtag, postId]`) qualifies
+— `hashtag` through the agreement, `postId` as the reference;
+`byLiker` (`[$ownerId]`) cannot, since no referenced document determines
+the liker.
+
+Three things change, all bit-compatible with the fallback layout:
+
+- **Insert side** (`insert/add_preallocated_index_tree_operations`):
+  inserting the referenced document also emits if-not-exists creations of
+  the referring index's dynamic trees, down to the empty `0` member
+  bucket, derived through the same tree-type helper the entry walkers use
+  — so a preallocated tree is byte-identical to the tree the first
+  entry's create-on-insert path would have made. The trees carry the
+  referenced document creator's storage flags: the poster owns the
+  structural bytes. Shared prefixes (a second post under the same
+  hashtag) deduplicate through the if-not-exists semantics.
+- **Delete side**: removing the last member entry stops the
+  empty-tree-pruning climb at the member level, keeping the whole
+  apparatus — the group stays in the ranked secondaries at count 0, and a
+  re-entry is again a plain item insert. (Non-preallocated indexes of the
+  same type keep pruning as before.)
+- **Nothing else**: entry insertion keeps its create-if-missing behavior,
+  so correctness never depends on preallocation. Referenced documents
+  created before a contract update introduced a referring type simply
+  hand the first entry the old price, and their trees — created by the
+  fallback — are retained on delete exactly like preallocated ones.
+
+The economics: the referenced document's creator pays for the trees
+whether or not anyone ever references it (which is why the flag is an
+explicit opt-in, per index), every entry from the first on costs the
+same, and "no entries yet" becomes a present-but-empty member bucket —
+provable as zero results, rankable as a zero-count group — instead of an
+absent tree.
 
 An entry's proved `(path, key)` position IS the document, so queries and
 proofs **synthesize** documents through one shared builder

--- a/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/contracts/ContractJson.kt
+++ b/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/contracts/ContractJson.kt
@@ -88,3 +88,45 @@ internal fun documentTypeCapabilities(
         canBeDeleted = schema?.boolField("canBeDeleted")
             ?: config?.boolField("documentsCanBeDeletedContractDefault") ?: true,
     )
+
+/**
+ * Human-readable descriptors for an index's protocol-v14 count / sum /
+ * ranking axes, in display order. Empty for a pre-v14 index. `countable`
+ * may be authored as a boolean or one of its string variants, and the
+ * `averageable` / `rangeAverageable` sugar is desugared into
+ * countable + summable exactly as DPP does.
+ */
+internal fun indexAxisDescriptors(index: JsonObject): List<String> {
+    val descriptors = mutableListOf<String>()
+    val averageable = index.stringField("averageable")
+    val countableRaw = (index["countable"] as? JsonPrimitive)?.content
+    val rangeAverageable = index.boolField("rangeAverageable") == true
+    when {
+        countableRaw == "countableAllowingOffset" -> descriptors += "Countable (offsets)"
+        countableRaw == "true" || countableRaw == "countable" -> descriptors += "Countable"
+        countableRaw == null && averageable != null -> descriptors += "Countable"
+    }
+    if (index.boolField("rangeCountable") == true || rangeAverageable) {
+        descriptors += "Range Count"
+    }
+    val summable = index.stringField("summable") ?: averageable
+    if (summable != null) {
+        descriptors += "Summable ($summable)"
+    }
+    if (index.boolField("rangeSummable") == true || rangeAverageable) {
+        descriptors += "Range Sum"
+    }
+    if (index.boolField("rankedCountable") == true) descriptors += "Ranked by Count"
+    if (index.boolField("rankedSummable") == true) descriptors += "Ranked by Sum"
+    if (index.boolField("rankedAverageable") == true) descriptors += "Ranked by Average"
+    return descriptors
+}
+
+/**
+ * The index's member-key property on an indexOnly document type: the
+ * declared `terminal`, defaulting to `$ownerId` exactly as DPP
+ * normalizes an omitted terminal. `null` on stored (non-indexOnly)
+ * document types, where entries are keyed by document id.
+ */
+internal fun indexTerminal(index: JsonObject, indexOnly: Boolean): String? =
+    index.stringField("terminal") ?: if (indexOnly) "\$ownerId" else null

--- a/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/contracts/ContractJson.kt
+++ b/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/contracts/ContractJson.kt
@@ -52,6 +52,10 @@ internal fun JsonObject.stringField(key: String): String? =
 internal fun JsonObject.intField(key: String): Int? =
     (this[key] as? JsonPrimitive)?.content?.toIntOrNull()
 
+/** For u64-ranged schema fields (e.g. timeRange seconds) that can exceed Int.MAX_VALUE. */
+internal fun JsonObject.longField(key: String): Long? =
+    (this[key] as? JsonPrimitive)?.content?.toLongOrNull()
+
 internal fun JsonObject.boolField(key: String): Boolean? =
     (this[key] as? JsonPrimitive)?.content?.toBooleanStrictOrNull()
 

--- a/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/contracts/DocumentTypeDetailsScreen.kt
+++ b/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/contracts/DocumentTypeDetailsScreen.kt
@@ -144,6 +144,9 @@ fun DocumentTypeDetailsScreen(
             }
 
             FormSection(title = "Document Settings") {
+                if (schema.boolField("indexOnly") == true) {
+                    LabeledContent("Index Only", "Yes (entries are the documents)")
+                }
                 LabeledContent(
                     "Keep History",
                     if (schema.boolField("documentsKeepHistory") == true) "Yes" else "No",
@@ -208,6 +211,14 @@ fun DocumentTypeDetailsScreen(
                                             color = MaterialTheme.colorScheme.tertiary,
                                         )
                                     }
+                                    if (index.boolField("preallocated") == true) {
+                                        Text(
+                                            "PREALLOCATED",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.secondary,
+                                            modifier = Modifier.padding(start = 4.dp),
+                                        )
+                                    }
                                     Icon(
                                         if (isExpanded) Icons.Default.KeyboardArrowUp
                                         else Icons.Default.KeyboardArrowDown,
@@ -229,6 +240,37 @@ fun DocumentTypeDetailsScreen(
                                             )
                                         }
                                     }
+                                indexTerminal(
+                                    index,
+                                    indexOnly = schema.boolField("indexOnly") == true,
+                                )?.let { terminal ->
+                                    Text(
+                                        "Terminal: $terminal",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.secondary,
+                                        modifier = Modifier.padding(start = 8.dp),
+                                    )
+                                }
+                                val axes = indexAxisDescriptors(index)
+                                if (axes.isNotEmpty()) {
+                                    Text(
+                                        axes.joinToString(" · "),
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.padding(start = 8.dp),
+                                    )
+                                }
+                                index.objectField("timeRange")?.let { timeRange ->
+                                    val range = timeRange.intField("range")
+                                    val step = timeRange.intField("step")
+                                    if (range != null && step != null) {
+                                        Text(
+                                            "Time Range: ${range}s windows every ${step}s",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            modifier = Modifier.padding(start = 8.dp),
+                                        )
+                                    }
+                                }
                                 if (index.boolField("nullSearchable") == true) {
                                     Text(
                                         "Null Searchable",

--- a/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/contracts/DocumentTypeDetailsScreen.kt
+++ b/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/contracts/DocumentTypeDetailsScreen.kt
@@ -261,8 +261,8 @@ fun DocumentTypeDetailsScreen(
                                     )
                                 }
                                 index.objectField("timeRange")?.let { timeRange ->
-                                    val range = timeRange.intField("range")
-                                    val step = timeRange.intField("step")
+                                    val range = timeRange.longField("range")
+                                    val step = timeRange.longField("step")
                                     if (range != null && step != null) {
                                         Text(
                                             "Time Range: ${range}s windows every ${step}s",

--- a/packages/kotlin-sdk/KotlinExampleApp/app/src/test/java/org/dashfoundation/example/ui/contracts/IndexKeywordDescriptorsTest.kt
+++ b/packages/kotlin-sdk/KotlinExampleApp/app/src/test/java/org/dashfoundation/example/ui/contracts/IndexKeywordDescriptorsTest.kt
@@ -1,0 +1,96 @@
+package org.dashfoundation.example.ui.contracts
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the protocol-v14 index keyword rendering helpers
+ * ([indexAxisDescriptors], [indexTerminal]) the DocumentTypeDetailsScreen
+ * index rows use: the boolean-or-string `countable` spellings, the
+ * `averageable` / `rangeAverageable` sugar desugar (which must match DPP's),
+ * and the indexOnly `$ownerId` terminal default.
+ */
+class IndexKeywordDescriptorsTest {
+
+    @Test
+    fun preV14IndexHasNoDescriptors() {
+        val index = buildJsonObject {
+            put("name", "byOwner")
+            put("unique", true)
+        }
+        assertEquals(emptyList<String>(), indexAxisDescriptors(index))
+    }
+
+    @Test
+    fun countableParsesBooleanAndStringSpellings() {
+        assertEquals(
+            listOf("Countable"),
+            indexAxisDescriptors(buildJsonObject { put("countable", true) }),
+        )
+        assertEquals(
+            listOf("Countable"),
+            indexAxisDescriptors(buildJsonObject { put("countable", "countable") }),
+        )
+        assertEquals(
+            listOf("Countable (offsets)"),
+            indexAxisDescriptors(buildJsonObject { put("countable", "countableAllowingOffset") }),
+        )
+        assertEquals(
+            emptyList<String>(),
+            indexAxisDescriptors(buildJsonObject { put("countable", "notCountable") }),
+        )
+    }
+
+    @Test
+    fun fullRankedCountIndexListsEveryAxis() {
+        val index = buildJsonObject {
+            put("countable", "countable")
+            put("rangeCountable", true)
+            put("rankedCountable", true)
+        }
+        assertEquals(
+            listOf("Countable", "Range Count", "Ranked by Count"),
+            indexAxisDescriptors(index),
+        )
+    }
+
+    @Test
+    fun averageableSugarDesugarsToCountableAndSummable() {
+        val index = buildJsonObject {
+            put("averageable", "amount")
+            put("rangeAverageable", true)
+        }
+        assertEquals(
+            listOf("Countable", "Range Count", "Summable (amount)", "Range Sum"),
+            indexAxisDescriptors(index),
+        )
+    }
+
+    @Test
+    fun summableLonghandLists() {
+        val index = buildJsonObject {
+            put("summable", "amount")
+            put("rangeSummable", true)
+            put("rankedSummable", true)
+        }
+        assertEquals(
+            listOf("Summable (amount)", "Range Sum", "Ranked by Sum"),
+            indexAxisDescriptors(index),
+        )
+    }
+
+    @Test
+    fun terminalDefaultsToOwnerIdOnlyOnIndexOnlyTypes() {
+        val bare = JsonObject(emptyMap())
+        assertNull(indexTerminal(bare, indexOnly = false))
+        assertEquals("\$ownerId", indexTerminal(bare, indexOnly = true))
+
+        val declared = buildJsonObject { put("terminal", "postId") }
+        assertEquals("postId", indexTerminal(declared, indexOnly = true))
+        assertEquals("postId", indexTerminal(declared, indexOnly = false))
+    }
+}

--- a/packages/rs-dpp/schema/meta_schemas/document/v3/document-meta.json
+++ b/packages/rs-dpp/schema/meta_schemas/document/v3/document-meta.json
@@ -643,6 +643,10 @@
             "minLength": 1,
             "maxLength": 256,
             "description": "Only on indexOnly document types: names the property whose value is this index entry's member key — the docId-analog terminal key under the index's storage marker, stored as an Item instead of a Reference because there is no primary-storage row. Either \"$ownerId\" (the default when omitted) or an identifier property carrying a refersTo declaration (identity, contract, token, or permanentDocument). Must not repeat one of the index's listed properties. Available from protocol version 14."
+          },
+          "preallocated": {
+            "type": "boolean",
+            "description": "Only on indexOnly document types whose index path is fully determined by a same-contract permanentDocument refersTo declaration: every index property must be either the referring property itself (its value is the referenced document's $id) or a key of that declaration's propertyAgreement (consensus-equal to a referenced-document property). When true, creating a referenced document also creates this index's dynamic trees for entries referencing it — paid by the referenced document's creator — and deleting the last entry keeps them, so every entry insert costs the same as the first. Available from protocol version 14."
           }
         },
         "required": [

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
@@ -209,6 +209,10 @@ pub(super) struct ParserGeneration {
     /// earlier generations ignore it exactly as they ignore every other
     /// doctype-level keyword they predate.
     pub admit_index_terminal: bool,
+    /// Whether the index grammar admits the `preallocated` keyword
+    /// (refersTo-determined indexOnly indexes). Forwarded to
+    /// [`Index::try_from_value_map`] exactly like the admissions above.
+    pub admit_index_preallocated: bool,
 }
 
 /// Reject a document type whose name is not a non-empty ASCII
@@ -848,6 +852,7 @@ fn parse_indices(
                             ranked: ctx.generation.admit_ranked,
                             time_range: ctx.generation.admit_time_range,
                             terminal: ctx.generation.admit_index_terminal,
+                            preallocated: ctx.generation.admit_index_preallocated,
                         },
                     )
                     .map_err(consensus_or_protocol_data_contract_error)?;
@@ -1926,6 +1931,22 @@ pub(super) fn apply_index_only(
                 index_name, name,
             )));
         }
+        // Same for `preallocated`: only an indexOnly index's trees are cheap
+        // permanent structure whose member entries carry the data — on a
+        // normal document type the trees hold references to stored rows and
+        // the preallocation/no-prune contract has no meaning.
+        if let Some((index_name, _)) = document_type
+            .indices
+            .iter()
+            .find(|(_, index)| index.preallocated)
+        {
+            return Err(structure_error(format!(
+                "index \"{}\" on document type \"{}\" declares `preallocated`, which is only \
+                 allowed on indexOnly document types (set `indexOnly: true` on the document \
+                 type, or remove the flag)",
+                index_name, name,
+            )));
+        }
         return Ok(());
     }
 
@@ -2182,6 +2203,49 @@ pub(super) fn apply_index_only(
                  \"$createdAt\" must be listed in `required`: document creation only \
                  assigns the timestamp for required system times, and an indexOnly entry \
                  cannot represent a missing value",
+                index_name, name,
+            )));
+        }
+
+        // `preallocated` promises that the whole index path is a pure
+        // function of one same-contract refersTo-referenced document, so the
+        // referenced document's insert can create the trees. A bucketed
+        // index breaks that promise structurally: its leading level is
+        // keyed by grid-qualified bucket starts fanned out from a
+        // timestamp, not by a stored property value the binding could
+        // resolve — and its `$createdAt` source can never be
+        // reference-bound anyway.
+        if index.preallocated && index.time_range.is_some() {
+            return Err(structure_error(format!(
+                "index \"{}\" on indexOnly document type \"{}\" declares `preallocated` \
+                 together with `timeRange`: a bucketed level is keyed by bucket starts \
+                 computed from a timestamp at write time, so its path cannot be \
+                 preallocated from a referenced document",
+                index_name, name,
+            )));
+        }
+
+        // The binding derivation is shared with the rs-drive insert path
+        // (see `index::preallocation`); rejecting a flag with no binding
+        // here is what lets that path trust every `preallocated: true` it
+        // sees.
+        if index.preallocated
+            && index
+                .preallocation_bindings(
+                    &document_type.flattened_properties,
+                    document_type.data_contract_id,
+                )
+                .is_empty()
+        {
+            return Err(structure_error(format!(
+                "index \"{}\" on indexOnly document type \"{}\" declares `preallocated`, \
+                 but its path is not determined by a reference: every index property must \
+                 be either a property with a same-contract permanentDocument `refersTo` \
+                 declaration (the referring property — its value is the referenced \
+                 document's $id) or a key of that declaration's `propertyAgreement` \
+                 (consensus-equal to a referenced-document property). System properties \
+                 like $ownerId cannot be determined by the referenced document, so a \
+                 preallocated index may carry $ownerId only as its terminal",
                 index_name, name,
             )));
         }

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
@@ -109,6 +109,8 @@ impl DocumentTypeV1 {
                 admit_time_range: false,
                 // INDEX ONLY: also a generation-3 keyword; not in this grammar.
                 admit_index_terminal: false,
+                // PREALLOCATED: also a generation-3 keyword; not in this grammar.
+                admit_index_preallocated: false,
             },
             platform_version,
         )

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
@@ -799,3 +799,269 @@ fn index_only_flag_survives_the_dispatcher_at_latest() {
         .expect("likes schema parses through the dispatcher at PV14");
     assert!(document_type.index_only());
 }
+
+// ── preallocated indexes ────────────────────────────────────────────────
+
+/// Replaces `postId`'s `refersTo` declaration in place (`set_value` writes
+/// literal top-level keys, so nested keys need the walk).
+fn set_post_id_refers_to(schema: &mut Value, refers_to: Value) {
+    schema
+        .get_mut("properties")
+        .expect("properties accessible")
+        .expect("properties present")
+        .get_mut("postId")
+        .expect("postId accessible")
+        .expect("postId present")
+        .set_value("refersTo", refers_to)
+        .expect("refersTo applies");
+}
+
+/// The likes schema with `postId` carrying a same-contract
+/// permanentDocument reference to `post` agreeing on `hashtag` — the shape
+/// whose `byHashtagPost` and `byPost` paths are pure functions of the
+/// referenced post, so both may declare `preallocated`.
+fn preallocatable_likes_schema() -> Value {
+    let mut schema = likes_schema();
+    set_post_id_refers_to(
+        &mut schema,
+        platform_value!({
+            "type": "permanentDocument",
+            "documentType": "post",
+            "propertyAgreement": { "hashtag": "hashtag" }
+        }),
+    );
+    schema
+}
+
+#[test]
+fn preallocated_accepts_a_reference_determined_index() {
+    for full_validation in [false, true] {
+        let mut schema = preallocatable_likes_schema();
+        for index_position in [0, 1] {
+            schema
+                .get_mut("indices")
+                .expect("indices accessible")
+                .expect("indices present")
+                .as_array_mut()
+                .expect("indices is an array")
+                .get_mut(index_position)
+                .expect("index exists")
+                .set_value("preallocated", Value::Bool(true))
+                .expect("index key applies");
+        }
+        let document_type = parse_with(schema, PlatformVersion::latest(), full_validation)
+            .expect("a reference-determined preallocated index parses");
+        assert!(
+            document_type
+                .indices
+                .get("byHashtagPost")
+                .unwrap()
+                .preallocated
+        );
+        assert!(document_type.indices.get("byPost").unwrap().preallocated);
+        assert!(!document_type.indices.get("byLiker").unwrap().preallocated);
+
+        // The flag is stamped onto the terminating index level, where the
+        // rs-drive delete walker reads it to skip upward pruning.
+        let hashtag_level = document_type
+            .index_structure
+            .sub_levels()
+            .get("hashtag")
+            .unwrap();
+        let post_level = hashtag_level.sub_levels().get("postId").unwrap();
+        assert!(post_level.has_index_with_type().unwrap().preallocated);
+        let owner_level = document_type
+            .index_structure
+            .sub_levels()
+            .get("$ownerId")
+            .unwrap();
+        assert!(!owner_level.has_index_with_type().unwrap().preallocated);
+    }
+}
+
+#[test]
+fn rejects_preallocated_without_a_document_reference() {
+    // The base schema's `postId` refers to an identity — no referenced
+    // document determines the path.
+    expect_structure_error(
+        parse_with(
+            likes_schema_with_index_key(0, "preallocated", Value::Bool(true)),
+            PlatformVersion::latest(),
+            false,
+        ),
+        "not determined by a reference",
+    );
+}
+
+#[test]
+fn rejects_preallocated_with_an_uncovered_property() {
+    // A permanentDocument reference WITHOUT the hashtag agreement leaves
+    // byHashtagPost's `hashtag` undetermined.
+    let mut schema = likes_schema_with_index_key(0, "preallocated", Value::Bool(true));
+    set_post_id_refers_to(
+        &mut schema,
+        platform_value!({
+            "type": "permanentDocument",
+            "documentType": "post"
+        }),
+    );
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "not determined by a reference",
+    );
+
+    // `byPost` ([postId], terminal $ownerId) stays fully determined by the
+    // reference alone, so the same schema with the flag there parses.
+    let mut schema = likes_schema_with_index_key(1, "preallocated", Value::Bool(true));
+    set_post_id_refers_to(
+        &mut schema,
+        platform_value!({
+            "type": "permanentDocument",
+            "documentType": "post"
+        }),
+    );
+    parse_with(schema, PlatformVersion::latest(), false)
+        .expect("an agreement-free reference still determines a [postId] index");
+}
+
+/// The preallocatable schema with `preallocated: true` on the index at
+/// `index_position` (0 = byHashtagPost, 1 = byPost, 2 = byLiker).
+fn preallocatable_likes_schema_with_flag_on(index_position: usize) -> Value {
+    let mut schema = preallocatable_likes_schema();
+    schema
+        .get_mut("indices")
+        .expect("indices accessible")
+        .expect("indices present")
+        .as_array_mut()
+        .expect("indices is an array")
+        .get_mut(index_position)
+        .expect("index exists")
+        .set_value("preallocated", Value::Bool(true))
+        .expect("index key applies");
+    schema
+}
+
+#[test]
+fn rejects_preallocated_on_owner_prefixed_index() {
+    // byLiker's `$ownerId` prefix can never be determined by the
+    // referenced document.
+    expect_structure_error(
+        parse_with(
+            preallocatable_likes_schema_with_flag_on(2),
+            PlatformVersion::latest(),
+            false,
+        ),
+        "not determined by a reference",
+    );
+}
+
+#[test]
+fn rejects_preallocated_on_cross_contract_reference() {
+    // The reference names a DIFFERENT contract — its document inserts
+    // happen in a subtree this contract's insert path never touches.
+    let mut schema = likes_schema_with_index_key(1, "preallocated", Value::Bool(true));
+    set_post_id_refers_to(
+        &mut schema,
+        platform_value!({
+            "type": "permanentDocument",
+            "contractId": Value::Identifier([2; 32]),
+            "documentType": "post"
+        }),
+    );
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "not determined by a reference",
+    );
+
+    // Naming the declaring contract's own id explicitly counts as
+    // same-contract (the parse helper registers under [1; 32]).
+    let mut schema = likes_schema_with_index_key(1, "preallocated", Value::Bool(true));
+    set_post_id_refers_to(
+        &mut schema,
+        platform_value!({
+            "type": "permanentDocument",
+            "contractId": Value::Identifier([1; 32]),
+            "documentType": "post"
+        }),
+    );
+    parse_with(schema, PlatformVersion::latest(), false)
+        .expect("an own-id reference is a same-contract reference");
+}
+
+#[test]
+fn rejects_preallocated_on_non_index_only_type() {
+    let mut schema = preallocatable_likes_schema();
+    schema
+        .remove_optional_value("indexOnly")
+        .expect("removal applies");
+    for index_value in schema
+        .get_mut("indices")
+        .expect("indices accessible")
+        .expect("indices present")
+        .as_array_mut()
+        .expect("indices is an array")
+    {
+        let _ = index_value.remove_optional_value("terminal");
+    }
+    schema
+        .get_mut("indices")
+        .expect("indices accessible")
+        .expect("indices present")
+        .as_array_mut()
+        .expect("indices is an array")
+        .get_mut(1)
+        .expect("byPost exists")
+        .set_value("preallocated", Value::Bool(true))
+        .expect("index key applies");
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "declares `preallocated`",
+    );
+}
+
+#[test]
+fn preallocated_keyword_is_rejected_below_generation_3_on_both_modes() {
+    let platform_version_13 = PlatformVersion::get(13).expect("PV13 exists");
+    let schema = preallocatable_likes_schema_with_flag_on(1);
+
+    for full_validation in [false, true] {
+        assert!(
+            parse_dispatched(schema.clone(), platform_version_13, full_validation).is_err(),
+            "PV13 must reject the preallocated keyword (full_validation: {full_validation}): \
+             it is not part of generation 2's index grammar"
+        );
+    }
+}
+
+#[test]
+fn rejects_preallocated_on_bucketed_index() {
+    // A bucketed level is keyed by grid-qualified bucket starts computed
+    // from a timestamp at write time — nothing a referenced document could
+    // determine, so `preallocated` + `timeRange` is rejected outright.
+    let mut schema = preallocatable_likes_schema();
+    schema
+        .set_value(
+            "required",
+            platform_value!(["hashtag", "postId", "$createdAt"]),
+        )
+        .expect("required applies");
+    schema
+        .get_mut("indices")
+        .expect("indices accessible")
+        .expect("indices present")
+        .as_array_mut()
+        .expect("indices is an array")
+        .push(platform_value!({
+            "name": "byHourHashtag",
+            "properties": [{ "$createdAt": "asc" }, { "hashtag": "asc" }],
+            "terminal": "$ownerId",
+            "timeRange": { "on": "$createdAt", "range": 3600u64, "step": 900u64 },
+            "countable": true,
+            "rangeCountable": true,
+            "preallocated": true
+        }));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "declares `preallocated` together with `timeRange`",
+    );
+}

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/mod.rs
@@ -274,6 +274,9 @@ fn try_from_schema_generation_3(
             // INDEX ONLY: the `terminal` index keyword, admitted from the
             // same shared generation → admission mapping as the two above.
             admit_index_terminal: IndexGrammarAdmissions::for_schema_generation(3).terminal,
+            // PREALLOCATED: the fourth generation-3 index keyword, from the
+            // same shared mapping.
+            admit_index_preallocated: IndexGrammarAdmissions::for_schema_generation(3).preallocated,
         },
         platform_version,
     )?;

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -4582,6 +4582,7 @@ mod json_convertible_tests {
                 "ranked_averageable": true,
                 "time_range": serde_json::Value::Null,
                 "terminal": serde_json::Value::Null,
+                "preallocated": false,
             })
         );
         let recovered = Index::from_json(json).expect("from_json");

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -25,9 +25,11 @@ use std::cmp::Ordering;
 use std::sync::OnceLock;
 use std::{collections::BTreeMap, convert::TryFrom};
 
+pub mod preallocation;
 pub mod random_index;
 pub mod time_range;
 
+pub use preallocation::{PreallocatedKeySource, PreallocationBinding};
 pub use time_range::TimeRangeTransform;
 
 /// Index-level keyword opting the index's terminal property-name tree into the
@@ -78,6 +80,20 @@ pub const MAX_TIME_RANGE_PHASE_SECONDS: u64 = 31_536_000;
 /// doc-type-level validation rejects it elsewhere. Meta-schema v3+ (protocol
 /// version 14).
 pub const TERMINAL: &str = "terminal";
+/// Index-level keyword opting the index into **path preallocation**: when a
+/// document of the refersTo-referenced type is created, the index's dynamic
+/// trees for entries referencing that document — every value tree down to the
+/// empty `0` member bucket — are created right then, paid by the referenced
+/// document's creator, so the FIRST index entry costs the same as every later
+/// one (an item insert into existing trees). Only meaningful when the whole
+/// index path is a pure function of the referenced document: every index
+/// property must be either the referring property itself (it equals the
+/// referenced document's `$id`) or a key of that property's `refersTo`
+/// `propertyAgreement` (consensus-enforced equal to a referenced-document
+/// property). Only allowed on indexOnly document types with a same-contract
+/// `permanentDocument` reference; the doc-type-level validation rejects every
+/// other shape. See [`preallocation`]. Meta-schema v3+ (protocol version 14).
+pub const PREALLOCATED: &str = "preallocated";
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd)]
@@ -537,6 +553,19 @@ pub struct Index {
     // deserialize.
     #[cfg_attr(feature = "serde-conversion", serde(default))]
     pub terminal: Option<String>,
+    /// On an indexOnly document type whose index path is fully determined by
+    /// a same-contract `permanentDocument` reference (see [`PREALLOCATED`]):
+    /// when `true`, inserting a referenced document also creates this index's
+    /// dynamic trees for entries referencing it, and deleting the last entry
+    /// keeps them (the delete walker skips upward pruning for this index), so
+    /// entry insertion cost is uniform from the first entry on and the
+    /// referenced document's creator owns the structural storage.
+    //
+    // `serde(default)`: added after the struct's serde shape was in the wild
+    // (see the note on `countable` above), so pre-existing JSON must still
+    // deserialize.
+    #[cfg_attr(feature = "serde-conversion", serde(default))]
+    pub preallocated: bool,
 }
 
 /// Which grammar keywords a document meta-schema generation admits for
@@ -555,6 +584,9 @@ pub(crate) struct IndexGrammarAdmissions {
     /// The `terminal` keyword (indexOnly document types; generation 3 and
     /// later).
     pub(crate) terminal: bool,
+    /// The `preallocated` keyword (indexOnly document types with a
+    /// determining refersTo; generation 3 and later).
+    pub(crate) preallocated: bool,
 }
 
 impl IndexGrammarAdmissions {
@@ -567,6 +599,7 @@ impl IndexGrammarAdmissions {
             ranked: generation >= 3,
             time_range: generation >= 3,
             terminal: generation >= 3,
+            preallocated: generation >= 3,
         }
     }
 }
@@ -870,6 +903,7 @@ impl TryFrom<&[(Value, Value)]> for Index {
                 ranked: false,
                 time_range: false,
                 terminal: false,
+                preallocated: false,
             },
         )
     }
@@ -907,6 +941,7 @@ impl Index {
             ranked: ranked_aggregates_allowed,
             time_range: time_range_allowed,
             terminal: terminal_allowed,
+            preallocated: preallocated_allowed,
         } = admissions;
         // Decouple the map
         // It contains properties and a unique key
@@ -962,6 +997,7 @@ impl Index {
         let mut ranked_averageable = false;
         let mut time_range: Option<TimeRangeTransform> = None;
         let mut terminal: Option<String> = None;
+        let mut preallocated = false;
 
         for (key_value, value_value) in index_type_value_map {
             let key = key_value.to_str()?;
@@ -1322,6 +1358,21 @@ impl Index {
                         ));
                     }
                     terminal = Some(terminal_name.to_owned());
+                }
+                // `preallocated` is guarded the same way as `terminal` above:
+                // it joined the grammar at meta-schema v3, so below that the
+                // key falls through to the unknown-property arm. Whether the
+                // declaring document type is indexOnly and the index path is
+                // actually determined by a refersTo declaration are doc-type
+                // facts this parser cannot see; `apply_index_only` in
+                // `try_from_schema::common` enforces both.
+                PREALLOCATED if preallocated_allowed => {
+                    preallocated =
+                        value_value
+                            .as_bool()
+                            .ok_or(DataContractError::ValueWrongType(
+                                "preallocated value must be a boolean".to_string(),
+                            ))?;
                 }
                 "properties" => {
                     let properties =
@@ -1803,6 +1854,7 @@ impl Index {
             ranked_averageable,
             time_range,
             terminal,
+            preallocated,
         })
     }
 }
@@ -1875,6 +1927,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }
     }
 
@@ -1955,6 +2008,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .expect("should parse");
@@ -1970,6 +2024,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -1985,6 +2040,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2017,6 +2073,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2038,6 +2095,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .expect("should parse");
@@ -2059,6 +2117,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2081,6 +2140,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2104,6 +2164,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .expect("should parse");
@@ -2123,6 +2184,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .expect("should parse");
@@ -2147,6 +2209,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .expect("should parse");
@@ -2171,6 +2234,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2193,6 +2257,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2220,6 +2285,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .expect("the parser applies structural rules only");
@@ -2242,6 +2308,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2260,6 +2327,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2282,6 +2350,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2335,6 +2404,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2370,6 +2440,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .expect("should parse");
@@ -2398,6 +2469,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2428,6 +2500,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -2452,6 +2525,7 @@ mod tests {
                 ranked: false,
                 time_range: true,
                 terminal: false,
+                preallocated: false,
             },
         )
         .expect("a non-unique $updatedAt bucketing stays legal");
@@ -2471,6 +2545,7 @@ mod tests {
                 ranked: true,
                 time_range: false,
                 terminal: false,
+                preallocated: false,
             },
         )
         .unwrap_err();
@@ -3452,6 +3527,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         )
         .expect("all three ranked keywords must parse when the grammar allows them");
@@ -3477,6 +3553,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         )
         .expect("index without ranked keywords must parse");
@@ -3518,6 +3595,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         )
         .expect("ranked flags on a compound index must be accepted");
@@ -3547,6 +3625,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         );
         assert!(
@@ -3577,6 +3656,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         );
         assert!(
@@ -3605,6 +3685,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         );
         assert!(
@@ -3630,6 +3711,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         );
         assert!(
@@ -3657,6 +3739,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         );
         assert!(
@@ -3684,6 +3767,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         );
         assert!(
@@ -3713,6 +3797,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         )
         .expect("rankedAverageable on the averageable sugar form must parse");
@@ -3748,6 +3833,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         )
         .expect("rankedAverageable on the explicit longhand form must parse");
@@ -3773,6 +3859,7 @@ mod tests {
                     ranked: true,
                     time_range: true,
                     terminal: true,
+                    preallocated: false,
                 },
             );
             assert!(result.is_err(), "{key} must reject a non-boolean value");
@@ -3804,6 +3891,7 @@ mod tests {
                         ranked: false,
                         time_range: false,
                         terminal: false,
+                        preallocated: false,
                     },
                 );
                 assert!(
@@ -3884,6 +3972,7 @@ mod tests {
                     ranked: true,
                     time_range: true,
                     terminal: true,
+                    preallocated: false,
                 },
             );
             assert!(
@@ -3911,6 +4000,7 @@ mod tests {
                     ranked: true,
                     time_range: true,
                     terminal: true,
+                    preallocated: false,
                 },
             )
             .unwrap_or_else(|e| panic!("{axis} with no nullSearchable key must parse: {e:?}"));
@@ -3934,6 +4024,7 @@ mod tests {
                     ranked: true,
                     time_range: true,
                     terminal: true,
+                    preallocated: false,
                 },
             )
             .unwrap_or_else(|e| {
@@ -3955,6 +4046,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         )
         .expect("nullSearchable: false on a plain index must still parse");
@@ -3971,6 +4063,7 @@ mod tests {
                 ranked: true,
                 time_range: true,
                 terminal: true,
+                preallocated: false,
             },
         )
         .expect("nullSearchable: false on a range-averageable index must still parse");
@@ -4457,6 +4550,7 @@ mod json_convertible_tests {
             ranked_averageable: true,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }
     }
 

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -2050,6 +2050,52 @@ mod tests {
         ));
     }
 
+    /// The `preallocated` keyword parses as a boolean under the
+    /// generation-3 admission, rejects every other value shape, and falls
+    /// through to the unknown-property arm without the admission — the
+    /// same two-sided gating `terminal` and the ranked keywords carry.
+    #[test]
+    fn preallocated_parses_as_boolean_and_is_gated_by_admission() {
+        let admitted = IndexGrammarAdmissions {
+            ranked: false,
+            time_range: false,
+            terminal: false,
+            preallocated: true,
+        };
+
+        let mut map = index_value_map("postId", None);
+        map.push((Value::Text("preallocated".to_string()), Value::Bool(true)));
+        let index =
+            Index::try_from_value_map(map.as_slice(), admitted).expect("boolean should parse");
+        assert!(index.preallocated);
+
+        // Any non-boolean value is a wrong type, not a silent default.
+        let mut map = index_value_map("postId", None);
+        map.push((
+            Value::Text("preallocated".to_string()),
+            Value::Text("yes".to_string()),
+        ));
+        let err = Index::try_from_value_map(map.as_slice(), admitted).unwrap_err();
+        assert!(matches!(err, DataContractError::ValueWrongType(_)));
+
+        // Without the admission the key is not part of the grammar at all
+        // and dies on the unknown-property arm, byte-identical to how a
+        // pre-generation-3 node rejects it.
+        let mut map = index_value_map("postId", None);
+        map.push((Value::Text("preallocated".to_string()), Value::Bool(true)));
+        let err = Index::try_from_value_map(
+            map.as_slice(),
+            IndexGrammarAdmissions {
+                ranked: false,
+                time_range: false,
+                terminal: false,
+                preallocated: false,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, DataContractError::ValueWrongType(_)));
+    }
+
     /// `phase < step` alone is not enough: on a huge step a sub-step phase
     /// can sit years in the *future*, leaving every present-day timestamp
     /// before the grid's first bucket — unindexed, and free to bypass a

--- a/packages/rs-dpp/src/data_contract/document_type/index/preallocation.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/preallocation.rs
@@ -1,0 +1,252 @@
+//! Preallocated index-path bindings.
+//!
+//! A `preallocated` index (see [`super::PREALLOCATED`]) promises that its
+//! whole path is a pure function of one refersTo-referenced document: every
+//! index property is either the referring property itself (whose value is the
+//! referenced document's `$id`) or a key of that property's
+//! `propertyAgreement` (whose value consensus enforces equal to a
+//! referenced-document property at write time). This module derives that
+//! function — the *binding* — from the index and the declaring document
+//! type's properties, so the two consumers cannot drift:
+//!
+//! - contract validation (`apply_index_only` in `try_from_schema::common`)
+//!   rejects the flag when no binding exists, and
+//! - the rs-drive insert path resolves the binding against a referenced
+//!   document being created to know which trees to preallocate.
+//!
+//! Only same-contract references qualify: preallocation happens inside the
+//! referenced document's own insert, and a foreign contract's insert path
+//! cannot know about referring types registered elsewhere (or later).
+
+use crate::data_contract::document_type::property::{
+    DocumentProperty, DocumentPropertyReferenceTarget, DocumentPropertyType,
+};
+use crate::data_contract::document_type::Index;
+use indexmap::IndexMap;
+use platform_value::Identifier;
+
+/// Where one preallocated index-path key comes from, relative to the
+/// referenced document being created.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreallocatedKeySource<'a> {
+    /// The index property is the referring property: its value for entries
+    /// referencing the created document is that document's `$id`.
+    ReferencedDocumentId,
+    /// The index property is bound by the reference's `propertyAgreement`:
+    /// its value is the named property of the referenced document. The two
+    /// sides are validated to share one value kind, so encoding the
+    /// referenced document's value yields the same key bytes the referring
+    /// side would produce.
+    ReferencedDocumentProperty(&'a str),
+}
+
+/// One way a preallocated index's path is determined by a referenced
+/// document: the referring property, the (same-contract) document type it
+/// references, and one key source per index property, in index order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreallocationBinding<'a> {
+    /// The index property carrying the determining `refersTo` declaration.
+    pub referring_property: &'a str,
+    /// The referenced document type (in the declaring contract) whose
+    /// document creation preallocates this index's trees.
+    pub target_document_type_name: &'a str,
+    /// One source per index property, in the index's property order —
+    /// resolving each against a referenced document yields the full index
+    /// path under the declaring document type's subtree.
+    pub key_sources: Vec<PreallocatedKeySource<'a>>,
+}
+
+impl Index {
+    /// Every binding through which this index's path is fully determined by
+    /// a same-contract `permanentDocument` reference. Empty when the index
+    /// cannot be preallocated: validation requires at least one binding for
+    /// `preallocated: true`, and the insert path preallocates once per
+    /// binding whose target is the document type being created.
+    ///
+    /// `flattened_properties` are the declaring document type's flattened
+    /// properties; `own_contract_id` is the declaring contract's id (a
+    /// reference naming it explicitly counts as same-contract).
+    pub fn preallocation_bindings<'a>(
+        &'a self,
+        flattened_properties: &'a IndexMap<String, DocumentProperty>,
+        own_contract_id: Identifier,
+    ) -> Vec<PreallocationBinding<'a>> {
+        let mut bindings = Vec::new();
+        for candidate in &self.properties {
+            let Some(property) = flattened_properties.get(&candidate.name) else {
+                continue;
+            };
+            let DocumentPropertyType::IdentifierWithReference(
+                DocumentPropertyReferenceTarget::PermanentDocument {
+                    contract_id,
+                    document_type_name,
+                    property_agreement,
+                },
+            ) = &property.property_type
+            else {
+                continue;
+            };
+            if contract_id.is_some_and(|id| id != own_contract_id) {
+                continue;
+            }
+            let key_sources: Option<Vec<_>> = self
+                .properties
+                .iter()
+                .map(|index_property| {
+                    if index_property.name == candidate.name {
+                        Some(PreallocatedKeySource::ReferencedDocumentId)
+                    } else {
+                        property_agreement
+                            .get(&index_property.name)
+                            .map(|referenced| {
+                                PreallocatedKeySource::ReferencedDocumentProperty(
+                                    referenced.as_str(),
+                                )
+                            })
+                    }
+                })
+                .collect();
+            if let Some(key_sources) = key_sources {
+                bindings.push(PreallocationBinding {
+                    referring_property: candidate.name.as_str(),
+                    target_document_type_name: document_type_name.as_str(),
+                    key_sources,
+                });
+            }
+        }
+        bindings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_contract::document_type::IndexProperty;
+    use std::collections::BTreeMap;
+
+    fn identifier_reference_property(
+        target_type: &str,
+        contract_id: Option<Identifier>,
+        agreement: &[(&str, &str)],
+    ) -> DocumentProperty {
+        DocumentProperty {
+            property_type: DocumentPropertyType::IdentifierWithReference(
+                DocumentPropertyReferenceTarget::PermanentDocument {
+                    contract_id,
+                    document_type_name: target_type.to_string(),
+                    property_agreement: agreement
+                        .iter()
+                        .map(|(referring, referenced)| {
+                            (referring.to_string(), referenced.to_string())
+                        })
+                        .collect::<BTreeMap<_, _>>(),
+                },
+            ),
+            required: true,
+            required_since: None,
+            transient: false,
+        }
+    }
+
+    fn string_property() -> DocumentProperty {
+        use crate::data_contract::document_type::property::StringPropertySizes;
+        DocumentProperty {
+            property_type: DocumentPropertyType::String(StringPropertySizes {
+                min_length: None,
+                max_length: None,
+            }),
+            required: true,
+            required_since: None,
+            transient: false,
+        }
+    }
+
+    fn index_on(properties: &[&str]) -> Index {
+        Index {
+            name: "test".to_string(),
+            properties: properties
+                .iter()
+                .map(|name| IndexProperty {
+                    name: name.to_string(),
+                    ascending: true,
+                })
+                .collect(),
+            unique: false,
+            null_searchable: true,
+            contested_index: None,
+            countable: Default::default(),
+            range_countable: false,
+            summable: None,
+            range_summable: false,
+            ranked_countable: false,
+            ranked_summable: false,
+            ranked_averageable: false,
+            time_range: None,
+            terminal: Some("$ownerId".to_string()),
+            preallocated: true,
+        }
+    }
+
+    #[test]
+    fn binds_agreement_prefix_and_referring_property() {
+        let own_contract_id = Identifier::from([1u8; 32]);
+        let mut properties = IndexMap::new();
+        properties.insert("hashtag".to_string(), string_property());
+        properties.insert(
+            "postId".to_string(),
+            identifier_reference_property("post", None, &[("hashtag", "hashtag")]),
+        );
+
+        let index = index_on(&["hashtag", "postId"]);
+        let bindings = index.preallocation_bindings(&properties, own_contract_id);
+        assert_eq!(
+            bindings,
+            vec![PreallocationBinding {
+                referring_property: "postId",
+                target_document_type_name: "post",
+                key_sources: vec![
+                    PreallocatedKeySource::ReferencedDocumentProperty("hashtag"),
+                    PreallocatedKeySource::ReferencedDocumentId,
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn no_binding_when_a_property_is_not_determined() {
+        let own_contract_id = Identifier::from([1u8; 32]);
+        let mut properties = IndexMap::new();
+        properties.insert("hashtag".to_string(), string_property());
+        properties.insert(
+            "postId".to_string(),
+            identifier_reference_property("post", None, &[]),
+        );
+
+        // `hashtag` is neither the referring property nor in the agreement.
+        let index = index_on(&["hashtag", "postId"]);
+        assert!(index
+            .preallocation_bindings(&properties, own_contract_id)
+            .is_empty());
+    }
+
+    #[test]
+    fn foreign_contract_reference_does_not_bind_but_own_id_does() {
+        let own_contract_id = Identifier::from([1u8; 32]);
+        let mut foreign = IndexMap::new();
+        foreign.insert(
+            "postId".to_string(),
+            identifier_reference_property("post", Some(Identifier::from([2u8; 32])), &[]),
+        );
+        let index = index_on(&["postId"]);
+        assert!(index
+            .preallocation_bindings(&foreign, own_contract_id)
+            .is_empty());
+
+        let mut own = IndexMap::new();
+        own.insert(
+            "postId".to_string(),
+            identifier_reference_property("post", Some(own_contract_id), &[]),
+        );
+        assert_eq!(index.preallocation_bindings(&own, own_contract_id).len(), 1);
+    }
+}

--- a/packages/rs-dpp/src/data_contract/document_type/index/preallocation.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/preallocation.rs
@@ -71,6 +71,33 @@ impl Index {
         flattened_properties: &'a IndexMap<String, DocumentProperty>,
         own_contract_id: Identifier,
     ) -> Vec<PreallocationBinding<'a>> {
+        self.preallocation_bindings_impl(flattened_properties, own_contract_id, None)
+    }
+
+    /// [`Self::preallocation_bindings`] restricted to bindings whose target
+    /// is `target_document_type_name`. The write path calls this once per
+    /// document insert for every preallocated index of the contract, so
+    /// candidates naming other target types are rejected before their
+    /// key-source vectors are ever allocated.
+    pub fn preallocation_bindings_for_target<'a>(
+        &'a self,
+        flattened_properties: &'a IndexMap<String, DocumentProperty>,
+        own_contract_id: Identifier,
+        target_document_type_name: &str,
+    ) -> Vec<PreallocationBinding<'a>> {
+        self.preallocation_bindings_impl(
+            flattened_properties,
+            own_contract_id,
+            Some(target_document_type_name),
+        )
+    }
+
+    fn preallocation_bindings_impl<'a>(
+        &'a self,
+        flattened_properties: &'a IndexMap<String, DocumentProperty>,
+        own_contract_id: Identifier,
+        only_target_document_type_name: Option<&str>,
+    ) -> Vec<PreallocationBinding<'a>> {
         let mut bindings = Vec::new();
         for candidate in &self.properties {
             let Some(property) = flattened_properties.get(&candidate.name) else {
@@ -87,6 +114,11 @@ impl Index {
                 continue;
             };
             if contract_id.is_some_and(|id| id != own_contract_id) {
+                continue;
+            }
+            if only_target_document_type_name
+                .is_some_and(|target| target != document_type_name.as_str())
+            {
                 continue;
             }
             let key_sources: Option<Vec<_>> = self

--- a/packages/rs-dpp/src/data_contract/document_type/index/random_index.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/random_index.rs
@@ -69,6 +69,7 @@ impl Index {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         })
     }
 }

--- a/packages/rs-dpp/src/data_contract/document_type/index_level/find_first_change.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index_level/find_first_change.rs
@@ -195,4 +195,38 @@ impl IndexLevel {
 
         None
     }
+
+    /// Preallocation counterpart of [`Self::find_first_countability_change`].
+    /// Recursively finds the first index path where the `preallocated` flag
+    /// differs between two `IndexLevel` trees. The flag decides who creates
+    /// (and who is allowed to prune) the index's dynamic trees: turning it on
+    /// would leave every existing referenced document without preallocated
+    /// trees while its delete walker already refuses to prune, and turning it
+    /// off would let last-entry deletes prune trees a referenced document's
+    /// creator paid for as permanent structure — so it is immutable.
+    ///
+    /// Returns `None` if the flag is the same everywhere.
+    #[cfg(feature = "validation")]
+    pub(super) fn find_first_preallocated_change(&self, new: &IndexLevel) -> Option<String> {
+        if let (Some(old_info), Some(new_info)) =
+            (&self.has_index_with_type, &new.has_index_with_type)
+        {
+            if old_info.preallocated != new_info.preallocated {
+                return Some(format!(
+                    "(preallocated: {} -> {})",
+                    old_info.preallocated, new_info.preallocated,
+                ));
+            }
+        }
+
+        for (key, old_sub) in &self.sub_index_levels {
+            if let Some(new_sub) = new.sub_index_levels.get(key) {
+                if let Some(inner_path) = old_sub.find_first_preallocated_change(new_sub) {
+                    return Some(format!("{} -> {}", key, inner_path));
+                }
+            }
+        }
+
+        None
+    }
 }

--- a/packages/rs-dpp/src/data_contract/document_type/index_level/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index_level/mod.rs
@@ -114,6 +114,16 @@ pub struct IndexLevelTypeInfo {
     /// property list (duplicates are rejected), so each terminating level
     /// belongs to exactly one index and the field is unambiguous.
     pub terminal: Option<String>,
+    /// Whether the terminating index is `preallocated` (see
+    /// [`crate::data_contract::document_type::index::PREALLOCATED`]): its
+    /// dynamic trees are created when a refersTo-referenced document is, and
+    /// the delete walker must NOT prune them upward when the last member
+    /// entry goes — removing the entry is the whole delete. Carried on the
+    /// level info for the same reason `terminal` is: the delete walker only
+    /// sees the terminating level, which belongs to exactly one index.
+    /// `false` on every pre-PV14 contract (the grammar rejects the keyword
+    /// below meta-schema v3).
+    pub preallocated: bool,
 }
 
 impl IndexType {
@@ -352,6 +362,9 @@ impl IndexLevel {
                         // generation 3), so stamping it here changes nothing
                         // for any historical index level.
                         terminal: index.terminal.clone(),
+                        // Same PV14+ gating as `terminal` — `false` on
+                        // every historical index level.
+                        preallocated: index.preallocated,
                     });
                 }
             }
@@ -464,6 +477,21 @@ impl IndexLevel {
             );
         }
 
+        // The `preallocated` flag decides who creates the index's dynamic
+        // trees and whether last-entry deletes may prune them — see
+        // `find_first_preallocated_change` for why a flip in either
+        // direction breaks already-written state. Immutable like the flags
+        // above.
+        if let Some(preallocated_change_path) = self.find_first_preallocated_change(new_indices) {
+            return SimpleConsensusValidationResult::new_with_error(
+                DataContractInvalidIndexDefinitionUpdateError::new(
+                    document_type_name.to_string(),
+                    preallocated_change_path,
+                )
+                .into(),
+            );
+        }
+
         SimpleConsensusValidationResult::new()
     }
 }
@@ -497,6 +525,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let old_index_structure =
@@ -533,6 +562,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let new_indices = vec![
@@ -554,6 +584,7 @@ mod tests {
                 ranked_averageable: false,
                 time_range: None,
                 terminal: None,
+                preallocated: false,
             },
             Index {
                 name: "test2".to_string(),
@@ -573,6 +604,7 @@ mod tests {
                 ranked_averageable: false,
                 time_range: None,
                 terminal: None,
+                preallocated: false,
             },
         ];
 
@@ -618,6 +650,7 @@ mod tests {
                 ranked_averageable: false,
                 time_range: None,
                 terminal: None,
+                preallocated: false,
             },
             Index {
                 name: "test2".to_string(),
@@ -637,6 +670,7 @@ mod tests {
                 ranked_averageable: false,
                 time_range: None,
                 terminal: None,
+                preallocated: false,
             },
         ];
 
@@ -658,6 +692,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let old_index_structure =
@@ -701,6 +736,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let new_indices = vec![Index {
@@ -727,6 +763,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let old_index_structure =
@@ -776,6 +813,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let new_indices = vec![Index {
@@ -796,6 +834,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let old_index_structure =
@@ -839,6 +878,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let new_indices = vec![Index {
@@ -859,6 +899,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let old_index_structure =
@@ -902,6 +943,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let new_indices = vec![Index {
@@ -922,6 +964,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let old_index_structure =
@@ -965,6 +1008,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let old_index_structure =
@@ -1008,6 +1052,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let new_indices = vec![Index {
@@ -1028,6 +1073,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let old_index_structure =
@@ -1071,6 +1117,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let new_indices = vec![Index {
@@ -1091,6 +1138,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let old_index_structure =
@@ -1140,6 +1188,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let new_indices = vec![Index {
@@ -1166,6 +1215,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let old_index_structure =
@@ -1215,6 +1265,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let new_indices = vec![Index {
@@ -1241,6 +1292,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let old_index_structure =
@@ -1298,6 +1350,7 @@ mod tests {
             ranked_averageable,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }
     }
 
@@ -1456,6 +1509,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }];
 
         let mut new_indices = old_indices.clone();

--- a/packages/rs-dpp/src/data_contract/document_type/index_level/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index_level/mod.rs
@@ -1531,4 +1531,62 @@ mod tests {
             )] if e.index_path() == "first"
         );
     }
+
+    /// The `preallocated` flag is immutable across contract updates in
+    /// either direction: turning it on leaves existing referenced
+    /// documents without preallocated trees while deletes already refuse
+    /// to prune, and turning it off lets last-entry deletes prune trees a
+    /// referenced document's creator paid for as permanent structure.
+    #[test]
+    fn should_return_invalid_result_if_preallocated_changed() {
+        let platform_version = PlatformVersion::latest();
+        let document_type_name = "test";
+
+        let index_with_preallocated = |preallocated: bool| Index {
+            name: "test".to_string(),
+            properties: vec![IndexProperty {
+                name: "test".to_string(),
+                ascending: false,
+            }],
+            unique: false,
+            null_searchable: true,
+            contested_index: None,
+            countable: IndexCountability::NotCountable,
+            range_countable: false,
+            summable: None,
+            range_summable: false,
+            ranked_countable: false,
+            ranked_summable: false,
+            ranked_averageable: false,
+            time_range: None,
+            terminal: None,
+            preallocated,
+        };
+
+        for (old_flag, new_flag) in [(false, true), (true, false)] {
+            let old_index_structure = IndexLevel::try_from_indices(
+                &[index_with_preallocated(old_flag)],
+                document_type_name,
+                platform_version,
+            )
+            .expect("failed to create old index level");
+            let new_index_structure = IndexLevel::try_from_indices(
+                &[index_with_preallocated(new_flag)],
+                document_type_name,
+                platform_version,
+            )
+            .expect("failed to create new index level");
+
+            let result =
+                old_index_structure.validate_update(document_type_name, &new_index_structure);
+
+            let expected_path = format!("test -> (preallocated: {} -> {})", old_flag, new_flag);
+            assert_matches!(
+                result.errors.as_slice(),
+                [ConsensusError::BasicError(
+                    BasicError::DataContractInvalidIndexDefinitionUpdateError(e)
+                )] if e.index_path() == expected_path
+            );
+        }
+    }
 }

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -48,7 +48,7 @@ use grovedb::Element;
 
 const DOCTYPE: &str = "like";
 
-fn platform_version() -> &'static PlatformVersion {
+pub(super) fn platform_version() -> &'static PlatformVersion {
     PlatformVersion::latest()
 }
 
@@ -75,7 +75,7 @@ fn setup_likes() -> (Drive, DataContract) {
 }
 
 /// `[DataContractDocuments, contract_id, 1, "like"]` — the doctype tree.
-fn doctype_path(contract: &DataContract) -> Vec<Vec<u8>> {
+pub(super) fn doctype_path(contract: &DataContract) -> Vec<Vec<u8>> {
     vec![
         vec![crate::drive::RootTree::DataContractDocuments as u8],
         contract.id().as_bytes().to_vec(),
@@ -84,7 +84,7 @@ fn doctype_path(contract: &DataContract) -> Vec<Vec<u8>> {
     ]
 }
 
-fn read_grove_element(drive: &Drive, path: &[Vec<u8>], key: &[u8]) -> Option<Element> {
+pub(super) fn read_grove_element(drive: &Drive, path: &[Vec<u8>], key: &[u8]) -> Option<Element> {
     let path_refs: Vec<&[u8]> = path.iter().map(|v| v.as_slice()).collect();
     drive
         .grove_get_raw_optional(
@@ -98,7 +98,7 @@ fn read_grove_element(drive: &Drive, path: &[Vec<u8>], key: &[u8]) -> Option<Ele
         .expect("grove_get_raw_optional should succeed")
 }
 
-fn assert_grovedb_is_consistent(drive: &Drive) {
+pub(super) fn assert_grovedb_is_consistent(drive: &Drive) {
     let issues = drive
         .grove
         .verify_grovedb(None, true, false, &platform_version().drive.grove_version)
@@ -110,7 +110,7 @@ fn assert_grovedb_is_consistent(drive: &Drive) {
 }
 
 /// A like on `post` under `hashtag` by `owner`.
-fn build_like(
+pub(super) fn build_like(
     contract: &DataContract,
     hashtag: &str,
     post: [u8; 32],
@@ -132,7 +132,7 @@ fn build_like(
     doc
 }
 
-fn insert_like(
+pub(super) fn insert_like(
     drive: &Drive,
     contract: &DataContract,
     doc: &Document,
@@ -160,7 +160,7 @@ fn insert_like(
     )
 }
 
-fn delete_like(
+pub(super) fn delete_like(
     drive: &Drive,
     contract: &DataContract,
     doc: Document,
@@ -182,7 +182,12 @@ fn delete_like(
     )
 }
 
-fn count_top_k(drive: &Drive, path: &[Vec<u8>], k: u16, descending: bool) -> Vec<(u64, Vec<u8>)> {
+pub(super) fn count_top_k(
+    drive: &Drive,
+    path: &[Vec<u8>],
+    k: u16,
+    descending: bool,
+) -> Vec<(u64, Vec<u8>)> {
     let path_query = grovedb::PathQuery::new_axis(
         path.to_vec(),
         grovedb_query::AxisQuery::top_k(grovedb_query::IndexAxis::Count, k, 0, descending)
@@ -502,7 +507,7 @@ fn estimated_fees_upper_bound_actual_fees() {
 
 use crate::drive::document::query::QueryDocumentsOutcomeV0Methods;
 
-fn likes_query<'a>(
+pub(super) fn likes_query<'a>(
     contract: &'a dpp::prelude::DataContract,
     clauses: Vec<crate::query::WhereClause>,
     limit: Option<u16>,
@@ -1519,7 +1524,7 @@ fn should_refuse_a_delete_spliced_across_two_rows() {
 
 const TIP_DOCTYPE: &str = "tip";
 
-fn tip_doctype_path(contract: &DataContract) -> Vec<Vec<u8>> {
+pub(super) fn tip_doctype_path(contract: &DataContract) -> Vec<Vec<u8>> {
     vec![
         vec![crate::drive::RootTree::DataContractDocuments as u8],
         contract.id().as_bytes().to_vec(),
@@ -1529,7 +1534,7 @@ fn tip_doctype_path(contract: &DataContract) -> Vec<Vec<u8>> {
 }
 
 /// A tip of `amount` on `post` by `owner`.
-fn build_tip(
+pub(super) fn build_tip(
     contract: &DataContract,
     post: [u8; 32],
     owner: [u8; 32],
@@ -1551,7 +1556,7 @@ fn build_tip(
     doc
 }
 
-fn insert_tip(
+pub(super) fn insert_tip(
     drive: &Drive,
     contract: &DataContract,
     doc: &Document,
@@ -1579,7 +1584,7 @@ fn insert_tip(
     )
 }
 
-fn delete_tip(
+pub(super) fn delete_tip(
     drive: &Drive,
     contract: &DataContract,
     doc: Document,
@@ -1601,7 +1606,12 @@ fn delete_tip(
     )
 }
 
-fn sum_top_k(drive: &Drive, path: &[Vec<u8>], k: u16, descending: bool) -> Vec<(i64, Vec<u8>)> {
+pub(super) fn sum_top_k(
+    drive: &Drive,
+    path: &[Vec<u8>],
+    k: u16,
+    descending: bool,
+) -> Vec<(i64, Vec<u8>)> {
     let path_query = grovedb::PathQuery::new_axis(
         path.to_vec(),
         grovedb_query::AxisQuery::top_k(grovedb_query::IndexAxis::Sum, k, 0, descending)

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/mod.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/mod.rs
@@ -28,6 +28,7 @@
 
 mod countable_e2e_tests;
 mod index_only_e2e_tests;
+mod preallocated_index_e2e_tests;
 mod range_countable_index_e2e_tests;
 mod range_summable_index_e2e_tests;
 mod ranked_index_e2e_tests;

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/preallocated_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/preallocated_index_e2e_tests.rs
@@ -1,0 +1,525 @@
+//! End-to-end coverage for **preallocated indexOnly indexes** (meta schema
+//! v3 / PV14): the `preallocated` index keyword, under which creating a
+//! refersTo-referenced document also creates the referring index's dynamic
+//! trees — every value tree down to the empty `0` member bucket — so the
+//! FIRST entry referencing that document costs the same as every later one,
+//! and deleting the last entry keeps the trees instead of pruning them.
+//!
+//! Runs against the `yappr-likes-preallocated` fixture: byte-identical to
+//! the `yappr-likes` contract the sibling [`super::index_only_e2e_tests`]
+//! suite uses, except `byHashtagPost` and `byPost` declare
+//! `preallocated: true` (`byLiker` cannot — its `$ownerId` prefix is not
+//! determined by the referenced post). Three behaviors are pinned:
+//!
+//! - **Post-insert preallocation**: inserting a `post` creates the like
+//!   trees for both preallocated indexes (and only those), the ranked
+//!   secondary reports the post as a zero-count group, and querying the
+//!   empty index works with proof parity.
+//! - **Delete asymmetry**: unliking the last like keeps the preallocated
+//!   trees (contrast the sibling suite's
+//!   `like_delete_removes_entries_and_prunes_drained_groups`) while the
+//!   non-preallocated `byLiker` entry still prunes; re-liking works across
+//!   repeated cycles.
+//! - **Fees**: the poster pays more than under the plain contract, the
+//!   first liker pays less (no tree creation), and the post's `apply:
+//!   false` dry-run — which now sweeps the referring type's layers —
+//!   upper-bounds the applied storage fee.
+
+use super::index_only_e2e_tests::{
+    assert_grovedb_is_consistent, build_like, count_top_k, delete_like, doctype_path, insert_like,
+    likes_query, platform_version, read_grove_element,
+};
+use crate::drive::Drive;
+use crate::util::object_size_info::DocumentInfo::DocumentRefInfo;
+use crate::util::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
+use crate::util::storage_flags::StorageFlags;
+use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+use dpp::block::block_info::BlockInfo;
+use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::data_contract::document_type::random_document::CreateRandomDocument;
+use dpp::document::{Document, DocumentV0Getters, DocumentV0Setters};
+use dpp::fee::fee_result::FeeResult;
+use dpp::platform_value::{Identifier, Value};
+use dpp::prelude::DataContract;
+use dpp::tests::json_document::json_document_to_contract;
+
+const OWNER_POSTER: [u8; 32] = [0x0F; 32];
+const OWNER_1: [u8; 32] = [0x11; 32];
+const OWNER_2: [u8; 32] = [0x22; 32];
+
+fn setup_contract(drive: &Drive, fixture: &str) -> DataContract {
+    let pv = platform_version();
+    let contract = json_document_to_contract(fixture, false, pv)
+        .expect("expected to parse the yappr-likes contract variant");
+    drive
+        .apply_contract(
+            &contract,
+            BlockInfo::default(),
+            true,
+            StorageFlags::optional_default_as_cow(),
+            None,
+            pv,
+        )
+        .expect("expected to apply the contract");
+    contract
+}
+
+fn setup_preallocated_likes() -> (Drive, DataContract) {
+    let drive = setup_drive_with_initial_state_structure(None);
+    let contract = setup_contract(
+        &drive,
+        "tests/supporting_files/contract/yappr-likes/yappr-likes-preallocated-contract.json",
+    );
+    (drive, contract)
+}
+
+fn setup_plain_likes() -> (Drive, DataContract) {
+    let drive = setup_drive_with_initial_state_structure(None);
+    let contract = setup_contract(
+        &drive,
+        "tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json",
+    );
+    (drive, contract)
+}
+
+/// A `post` under `hashtag` by [`OWNER_POSTER`], deterministic per seed.
+fn build_post(contract: &DataContract, hashtag: &str, seed: u64) -> Document {
+    let pv = platform_version();
+    let document_type = contract
+        .document_type_for_name("post")
+        .expect("post doctype exists");
+    let mut doc = document_type
+        .random_document(Some(seed), pv)
+        .expect("random post");
+    let mut props = std::collections::BTreeMap::new();
+    props.insert("hashtag".to_string(), Value::Text(hashtag.to_string()));
+    doc.set_properties(props);
+    doc.set_owner_id(Identifier::from(OWNER_POSTER));
+    doc
+}
+
+fn insert_post(
+    drive: &Drive,
+    contract: &DataContract,
+    doc: &Document,
+    apply: bool,
+) -> Result<FeeResult, crate::error::Error> {
+    let pv = platform_version();
+    let document_type = contract
+        .document_type_for_name("post")
+        .expect("post doctype exists");
+    drive.add_document_for_contract(
+        DocumentAndContractInfo {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((doc, None)),
+                owner_id: None,
+            },
+            contract,
+            document_type,
+        },
+        false,
+        BlockInfo::default(),
+        apply,
+        None,
+        pv,
+        None,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Post-insert preallocation
+// ---------------------------------------------------------------------------
+
+/// Inserting a post creates every dynamic tree of both preallocated like
+/// indexes — the hashtag value tree, the deeper property-name and value
+/// trees, and the empty `0` member buckets — while the non-preallocated
+/// `byLiker` subtree stays untouched. The ranked secondaries see the post
+/// as a real group with count 0.
+#[test]
+fn post_insert_preallocates_referring_like_trees() {
+    let (drive, contract) = setup_preallocated_likes();
+    let post = build_post(&contract, "dash", 1);
+    let post_id = post.id().to_buffer();
+    insert_post(&drive, &contract, &post, true).expect("insert post");
+
+    let base = doctype_path(&contract);
+
+    // byHashtagPost: hashtag → "dash" → postId → <post> → 0, all present.
+    let mut level = base.clone();
+    level.push(b"hashtag".to_vec());
+    assert!(
+        read_grove_element(&drive, &level, b"dash").is_some(),
+        "the hashtag value tree must be preallocated"
+    );
+    level.push(b"dash".to_vec());
+    assert!(
+        read_grove_element(&drive, &level, b"postId").is_some(),
+        "the continuation property-name tree must be preallocated"
+    );
+    level.push(b"postId".to_vec());
+    assert!(
+        read_grove_element(&drive, &level, &post_id).is_some(),
+        "the post's value tree must be preallocated"
+    );
+    level.push(post_id.to_vec());
+    assert!(
+        read_grove_element(&drive, &level, &[0]).is_some(),
+        "the empty member bucket must be preallocated"
+    );
+
+    // byPost: postId → <post> → 0, all present, and the ranked secondary
+    // already carries the post as a zero-count group.
+    let mut by_post_level = base.clone();
+    by_post_level.push(b"postId".to_vec());
+    assert!(read_grove_element(&drive, &by_post_level, &post_id).is_some());
+    let mut member_bucket = by_post_level.clone();
+    member_bucket.push(post_id.to_vec());
+    assert!(read_grove_element(&drive, &member_bucket, &[0]).is_some());
+    assert_eq!(
+        count_top_k(&drive, &by_post_level, 10, true),
+        vec![(0, post_id.to_vec())],
+        "the preallocated group must rank with count 0"
+    );
+
+    // byLiker is not preallocatable: no owner value tree appears.
+    let mut by_liker_level = base.clone();
+    by_liker_level.push(b"$ownerId".to_vec());
+    assert!(
+        read_grove_element(&drive, &by_liker_level, &OWNER_POSTER).is_none(),
+        "the non-preallocated byLiker index must stay empty"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// The empty preallocated index is queryable: zero results, working proofs
+/// — a present-but-empty member bucket, a state the pruning delete path
+/// never used to leave behind.
+#[test]
+fn empty_preallocated_index_serves_queries_with_proof_parity() {
+    use crate::drive::document::query::QueryDocumentsOutcomeV0Methods;
+    use crate::query::{WhereClause, WhereOperator};
+
+    let (drive, contract) = setup_preallocated_likes();
+    let post = build_post(&contract, "dash", 1);
+    let post_id = post.id().to_buffer();
+    insert_post(&drive, &contract, &post, true).expect("insert post");
+
+    let query = likes_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(post_id),
+            },
+        ],
+        Some(10),
+    );
+    let outcome = drive
+        .query_documents(query.clone(), None, false, None, None)
+        .expect("querying an empty preallocated index executes");
+    assert_eq!(
+        outcome.documents().len(),
+        0,
+        "no likes exist yet — the empty bucket must read as zero results"
+    );
+
+    let (proof, _) = query
+        .clone()
+        .execute_with_proof(&drive, None, None, platform_version())
+        .expect("proof over the empty preallocated index generates");
+    let (_root_hash, verified) = query
+        .verify_proof(proof.as_slice(), platform_version())
+        .expect("proof over the empty preallocated index verifies");
+    assert!(verified.is_empty(), "the proof must verify to zero likes");
+}
+
+// ---------------------------------------------------------------------------
+// Delete asymmetry
+// ---------------------------------------------------------------------------
+
+/// Unliking the last like keeps every preallocated tree — the group stays
+/// rankable at count 0 and a re-like needs no tree creation — while the
+/// same delete still prunes the non-preallocated byLiker subtree. Repeated
+/// like/unlike cycles stay consistent.
+#[test]
+fn unlike_keeps_preallocated_trees_and_relike_works() {
+    let (drive, contract) = setup_preallocated_likes();
+    let post = build_post(&contract, "dash", 1);
+    let post_id: [u8; 32] = post.id().to_buffer();
+    insert_post(&drive, &contract, &post, true).expect("insert post");
+
+    let base = doctype_path(&contract);
+    let mut by_post_level = base.clone();
+    by_post_level.push(b"postId".to_vec());
+    let mut member_bucket_path = by_post_level.clone();
+    member_bucket_path.push(post_id.to_vec());
+
+    let like = build_like(&contract, "dash", post_id, OWNER_1, 1);
+    insert_like(&drive, &contract, &like, true).expect("insert like");
+    assert_eq!(
+        count_top_k(&drive, &by_post_level, 10, true),
+        vec![(1, post_id.to_vec())]
+    );
+
+    delete_like(&drive, &contract, like.clone(), true).expect("delete like");
+
+    // The preallocated apparatus survives the drained group…
+    assert!(
+        read_grove_element(&drive, &by_post_level, &post_id).is_some(),
+        "the preallocated value tree must survive the last unlike"
+    );
+    assert!(
+        read_grove_element(&drive, &member_bucket_path, &[0]).is_some(),
+        "the preallocated member bucket must survive the last unlike"
+    );
+    assert_eq!(
+        count_top_k(&drive, &by_post_level, 10, true),
+        vec![(0, post_id.to_vec())],
+        "the drained group must stay ranked at count 0"
+    );
+
+    // …while the non-preallocated byLiker subtree pruned as always.
+    let mut by_liker_level = base.clone();
+    by_liker_level.push(b"$ownerId".to_vec());
+    assert!(
+        read_grove_element(&drive, &by_liker_level, &OWNER_1).is_none(),
+        "the non-preallocated byLiker group must still prune away"
+    );
+
+    // Re-like / unlike cycles keep working against the retained trees.
+    for _cycle in 0..2 {
+        insert_like(&drive, &contract, &like, true).expect("re-like");
+        assert_eq!(
+            count_top_k(&drive, &by_post_level, 10, true),
+            vec![(1, post_id.to_vec())]
+        );
+        delete_like(&drive, &contract, like.clone(), true).expect("unlike again");
+        assert_eq!(
+            count_top_k(&drive, &by_post_level, 10, true),
+            vec![(0, post_id.to_vec())]
+        );
+    }
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+// ---------------------------------------------------------------------------
+// Fees
+// ---------------------------------------------------------------------------
+
+/// The whole point of the flag, in fee form: against the preallocated
+/// contract the post costs MORE (it buys the like trees) and the first
+/// like costs LESS (it creates nothing) than the byte-identical plain
+/// contract charges for the same two inserts.
+#[test]
+fn preallocation_moves_tree_costs_from_first_liker_to_poster() {
+    let (preallocated_drive, preallocated_contract) = setup_preallocated_likes();
+    let (plain_drive, plain_contract) = setup_plain_likes();
+
+    let post = build_post(&preallocated_contract, "dash", 1);
+    let post_id = post.id().to_buffer();
+    let post_fee_preallocated =
+        insert_post(&preallocated_drive, &preallocated_contract, &post, true).expect("insert post");
+    let post_fee_plain =
+        insert_post(&plain_drive, &plain_contract, &post, true).expect("insert post");
+    assert!(
+        post_fee_preallocated.storage_fee > post_fee_plain.storage_fee,
+        "the poster must pay for the preallocated trees: {} <= {}",
+        post_fee_preallocated.storage_fee,
+        post_fee_plain.storage_fee
+    );
+
+    let like = build_like(&preallocated_contract, "dash", post_id, OWNER_1, 1);
+    let like_fee_preallocated =
+        insert_like(&preallocated_drive, &preallocated_contract, &like, true).expect("insert like");
+    let like_fee_plain =
+        insert_like(&plain_drive, &plain_contract, &like, true).expect("insert like");
+    assert!(
+        like_fee_preallocated.storage_fee < like_fee_plain.storage_fee,
+        "the first like must not pay for tree creation: {} >= {}",
+        like_fee_preallocated.storage_fee,
+        like_fee_plain.storage_fee
+    );
+
+    assert_grovedb_is_consistent(&preallocated_drive);
+    assert_grovedb_is_consistent(&plain_drive);
+}
+
+/// The post's `apply: false` dry-run sweeps the referring type's layers
+/// too now; it must keep upper-bounding the applied storage fee — the
+/// invariant consensus fee validation depends on. Same for the (still
+/// tree-free) first like against preallocated state.
+#[test]
+fn estimated_fees_upper_bound_actual_fees_with_preallocation() {
+    let (drive, contract) = setup_preallocated_likes();
+
+    let post = build_post(&contract, "dash", 1);
+    let post_id = post.id().to_buffer();
+    let estimated_post =
+        insert_post(&drive, &contract, &post, false).expect("estimated post insert must work");
+    let actual_post = insert_post(&drive, &contract, &post, true).expect("actual post insert");
+    assert!(
+        estimated_post.storage_fee >= actual_post.storage_fee,
+        "estimated post storage fee {} must upper-bound actual {}",
+        estimated_post.storage_fee,
+        actual_post.storage_fee
+    );
+
+    let like = build_like(&contract, "dash", post_id, OWNER_1, 1);
+    let estimated_like =
+        insert_like(&drive, &contract, &like, false).expect("estimated like insert must work");
+    let actual_like = insert_like(&drive, &contract, &like, true).expect("actual like insert");
+    assert!(
+        estimated_like.storage_fee >= actual_like.storage_fee,
+        "estimated like storage fee {} must upper-bound actual {}",
+        estimated_like.storage_fee,
+        actual_like.storage_fee
+    );
+
+    // The delete dry-run exercises the average-case up-tree sweep with the
+    // preallocated stop height (member level only, no pruning climb).
+    let estimated_delete =
+        delete_like(&drive, &contract, like.clone(), false).expect("estimated delete must work");
+    let actual_delete = delete_like(&drive, &contract, like, true).expect("actual delete");
+    assert!(estimated_delete.processing_fee > 0);
+    assert!(actual_delete.processing_fee > 0);
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// Preallocation composes across posts sharing a hashtag: the second post
+/// finds the shared `dash` value tree already present (if-not-exists) and
+/// only pays for its own subtrees; likes on both posts land in their own
+/// buckets; unliking one post's like never disturbs the other's trees.
+#[test]
+fn shared_hashtag_prefix_preallocates_idempotently() {
+    let (drive, contract) = setup_preallocated_likes();
+
+    let post_a = build_post(&contract, "dash", 1);
+    let post_b = build_post(&contract, "dash", 2);
+    let post_a_id = post_a.id().to_buffer();
+    let post_b_id = post_b.id().to_buffer();
+    insert_post(&drive, &contract, &post_a, true).expect("insert post A");
+    insert_post(&drive, &contract, &post_b, true).expect("insert post B");
+
+    let base = doctype_path(&contract);
+    let mut posts_under_dash = base.clone();
+    posts_under_dash.extend([b"hashtag".to_vec(), b"dash".to_vec(), b"postId".to_vec()]);
+    assert!(read_grove_element(&drive, &posts_under_dash, &post_a_id).is_some());
+    assert!(read_grove_element(&drive, &posts_under_dash, &post_b_id).is_some());
+
+    let like_a = build_like(&contract, "dash", post_a_id, OWNER_1, 1);
+    let like_b = build_like(&contract, "dash", post_b_id, OWNER_2, 2);
+    insert_like(&drive, &contract, &like_a, true).expect("like A");
+    insert_like(&drive, &contract, &like_b, true).expect("like B");
+
+    let mut by_post_level = base.clone();
+    by_post_level.push(b"postId".to_vec());
+    assert_eq!(
+        count_top_k(&drive, &by_post_level, 10, true).len(),
+        2,
+        "both posts rank"
+    );
+
+    delete_like(&drive, &contract, like_a, true).expect("unlike A");
+    let mut post_b_bucket = posts_under_dash.clone();
+    post_b_bucket.push(post_b_id.to_vec());
+    assert!(
+        read_grove_element(&drive, &post_b_bucket, &[0]).is_some(),
+        "post B's trees are untouched by post A's unlike"
+    );
+    let mut post_a_bucket = posts_under_dash.clone();
+    post_a_bucket.push(post_a_id.to_vec());
+    assert!(
+        read_grove_element(&drive, &post_a_bucket, &[0]).is_some(),
+        "post A's preallocated trees survive its unlike"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+// ---------------------------------------------------------------------------
+// Summable preallocated indexes (tip.byPost: count + sum + both ranked axes)
+// ---------------------------------------------------------------------------
+
+/// A summable preallocated index gets its sum-bearing member bucket at
+/// post insert (the shared `terminal_member_tree_type` derivation), sums
+/// track tips, and the drained group survives the last untip at sum 0 —
+/// the sum-surface mirror of the count assertions above.
+#[test]
+fn summable_preallocated_index_preallocates_and_survives_drain() {
+    use super::index_only_e2e_tests::{
+        build_tip, delete_tip, insert_tip, sum_top_k, tip_doctype_path,
+    };
+
+    let (drive, contract) = setup_preallocated_likes();
+    let post = build_post(&contract, "dash", 1);
+    let post_id: [u8; 32] = post.id().to_buffer();
+    insert_post(&drive, &contract, &post, true).expect("insert post");
+
+    // tip.byPost's trees exist before any tip: postId value tree and the
+    // `0` member bucket, and the ranked secondaries carry the post as a
+    // zero group on BOTH axes.
+    let mut by_post_level = tip_doctype_path(&contract);
+    by_post_level.push(b"postId".to_vec());
+    assert!(
+        read_grove_element(&drive, &by_post_level, &post_id).is_some(),
+        "the tip value tree must be preallocated"
+    );
+    let mut member_bucket = by_post_level.clone();
+    member_bucket.push(post_id.to_vec());
+    assert!(
+        read_grove_element(&drive, &member_bucket, &[0]).is_some(),
+        "the sum-bearing member bucket must be preallocated"
+    );
+    assert_eq!(
+        count_top_k(&drive, &by_post_level, 10, true),
+        vec![(0, post_id.to_vec())]
+    );
+    assert_eq!(
+        sum_top_k(&drive, &by_post_level, 10, true),
+        vec![(0, post_id.to_vec())]
+    );
+
+    // Tips contribute; untipping the last one keeps the trees at sum 0.
+    let tip = build_tip(&contract, post_id, OWNER_1, 250, 1);
+    insert_tip(&drive, &contract, &tip, true).expect("insert tip");
+    assert_eq!(
+        sum_top_k(&drive, &by_post_level, 10, true),
+        vec![(250, post_id.to_vec())]
+    );
+
+    delete_tip(&drive, &contract, tip.clone(), true).expect("delete tip");
+    assert!(
+        read_grove_element(&drive, &member_bucket, &[0]).is_some(),
+        "the preallocated sum bucket must survive the last untip"
+    );
+    assert_eq!(
+        sum_top_k(&drive, &by_post_level, 10, true),
+        vec![(0, post_id.to_vec())],
+        "the drained group must stay ranked at sum 0"
+    );
+
+    // Re-tip against the retained trees, and estimation still upper-bounds.
+    let estimated = insert_tip(&drive, &contract, &tip, false).expect("estimated re-tip");
+    let actual = insert_tip(&drive, &contract, &tip, true).expect("re-tip");
+    assert!(
+        estimated.storage_fee >= actual.storage_fee,
+        "estimated tip storage fee {} must upper-bound actual {}",
+        estimated.storage_fee,
+        actual.storage_fee
+    );
+    assert_eq!(
+        sum_top_k(&drive, &by_post_level, 10, true),
+        vec![(250, post_id.to_vec())]
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/preallocated_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/preallocated_index_e2e_tests.rs
@@ -390,6 +390,12 @@ fn should_upper_bound_actual_fees_with_preallocation() {
     let actual_delete = delete_like(&drive, &contract, like, true).expect("actual delete");
     assert!(estimated_delete.processing_fee > 0);
     assert!(actual_delete.processing_fee > 0);
+    assert!(
+        estimated_delete.processing_fee >= actual_delete.processing_fee,
+        "estimated delete processing fee {} must upper-bound actual {}",
+        estimated_delete.processing_fee,
+        actual_delete.processing_fee,
+    );
 
     assert_grovedb_is_consistent(&drive);
 }
@@ -607,6 +613,156 @@ fn should_not_attach_flags_to_preallocated_trees_of_a_permanent_contract() {
     assert!(
         entry.get_flags().is_some(),
         "the member entry must keep its refund-routing flags"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// The complementary flags branch: on a DELETABLE contract the
+/// preallocated trees must retain the creator's flags, so a whole-contract
+/// deletion can route the structural-byte refunds back to the poster —
+/// the one deletion path these trees have.
+#[test]
+fn should_attach_creator_flags_to_preallocated_trees_of_a_deletable_contract() {
+    use dpp::data_contract::config::v0::DataContractConfigSettersV0;
+    use std::borrow::Cow;
+
+    let drive = setup_drive_with_initial_state_structure(None);
+    let pv = platform_version();
+    let mut contract = json_document_to_contract(
+        "tests/supporting_files/contract/yappr-likes/yappr-likes-preallocated-contract.json",
+        false,
+        pv,
+    )
+    .expect("expected to parse the preallocated contract");
+    contract.config_mut().set_can_be_deleted(true);
+    drive
+        .apply_contract(
+            &contract,
+            BlockInfo::default(),
+            true,
+            StorageFlags::optional_default_as_cow(),
+            None,
+            pv,
+        )
+        .expect("expected to apply the deletable contract");
+
+    let post = build_post(&contract, "dash", 1);
+    let post_id: [u8; 32] = post.id().to_buffer();
+    let post_type = contract
+        .document_type_for_name("post")
+        .expect("post doctype exists");
+    drive
+        .add_document_for_contract(
+            DocumentAndContractInfo {
+                owned_document_info: OwnedDocumentInfo {
+                    document_info: DocumentRefInfo((
+                        &post,
+                        Some(Cow::Owned(StorageFlags::SingleEpochOwned(0, OWNER_POSTER))),
+                    )),
+                    owner_id: None,
+                },
+                contract: &contract,
+                document_type: post_type,
+            },
+            false,
+            BlockInfo::default(),
+            true,
+            None,
+            pv,
+            None,
+        )
+        .expect("insert post with owned flags");
+
+    let mut post_value_tree_path = doctype_path(&contract);
+    post_value_tree_path.extend([b"postId".to_vec(), post_id.to_vec()]);
+    let member_bucket = read_grove_element(&drive, &post_value_tree_path, &[0])
+        .expect("the member bucket must be preallocated");
+    let flags = StorageFlags::map_some_element_flags_ref(member_bucket.get_flags())
+        .expect("flags must parse")
+        .expect("a deletable contract's preallocated trees must carry flags");
+    assert_eq!(
+        flags,
+        StorageFlags::SingleEpochOwned(0, OWNER_POSTER),
+        "the poster's epoch-owned flags must ride the preallocated tree"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// A bound target property may be optional on the referenced type. When it
+/// is absent, NO part of the preallocated path may be emitted — a partial
+/// path (the levels before the unresolvable one) would be dead structure no
+/// entry can reach. The fixture's `annotation.byNoteTopic` binds
+/// `[noteId, topic]` to `note`, whose `topic` is optional, putting the
+/// unresolvable key at the SECOND level.
+#[test]
+fn should_not_emit_partial_paths_when_a_bound_property_is_absent() {
+    let (drive, contract) = setup_preallocated_likes();
+    let pv = platform_version();
+    let note_type = contract
+        .document_type_for_name("note")
+        .expect("note doctype exists");
+
+    let insert_note = |doc: &Document| {
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((doc, None)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type: note_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                pv,
+                None,
+            )
+            .expect("insert note")
+    };
+
+    // A note WITHOUT the optional bound `topic`: nothing preallocates —
+    // not even the first-level noteId value tree.
+    let mut bare_note = note_type.random_document(Some(1), pv).expect("random note");
+    bare_note.set_properties(std::collections::BTreeMap::new());
+    bare_note.set_owner_id(Identifier::from(OWNER_POSTER));
+    let bare_note_id: [u8; 32] = bare_note.id().to_buffer();
+    insert_note(&bare_note);
+
+    let mut annotation_by_note = vec![
+        vec![crate::drive::RootTree::DataContractDocuments as u8],
+        contract.id().as_bytes().to_vec(),
+        vec![1],
+        b"annotation".to_vec(),
+        b"noteId".to_vec(),
+    ];
+    assert!(
+        read_grove_element(&drive, &annotation_by_note, &bare_note_id).is_none(),
+        "no level of the path may be emitted when a bound property is absent"
+    );
+
+    // A note WITH the topic preallocates the full path down to the bucket.
+    let mut note = note_type.random_document(Some(2), pv).expect("random note");
+    let mut props = std::collections::BTreeMap::new();
+    props.insert("topic".to_string(), Value::Text("rust".to_string()));
+    note.set_properties(props);
+    note.set_owner_id(Identifier::from(OWNER_POSTER));
+    let note_id: [u8; 32] = note.id().to_buffer();
+    insert_note(&note);
+
+    assert!(read_grove_element(&drive, &annotation_by_note, &note_id).is_some());
+    annotation_by_note.push(note_id.to_vec());
+    assert!(read_grove_element(&drive, &annotation_by_note, b"topic").is_some());
+    annotation_by_note.push(b"topic".to_vec());
+    assert!(read_grove_element(&drive, &annotation_by_note, b"rust").is_some());
+    annotation_by_note.push(b"rust".to_vec());
+    assert!(
+        read_grove_element(&drive, &annotation_by_note, &[0]).is_some(),
+        "the full path must reach the empty member bucket"
     );
 
     assert_grovedb_is_consistent(&drive);

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/preallocated_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/preallocated_index_e2e_tests.rs
@@ -136,7 +136,7 @@ fn insert_post(
 /// `byLiker` subtree stays untouched. The ranked secondaries see the post
 /// as a real group with count 0.
 #[test]
-fn post_insert_preallocates_referring_like_trees() {
+fn should_preallocate_referring_like_trees_on_post_insert() {
     let (drive, contract) = setup_preallocated_likes();
     let post = build_post(&contract, "dash", 1);
     let post_id = post.id().to_buffer();
@@ -196,7 +196,7 @@ fn post_insert_preallocates_referring_like_trees() {
 /// — a present-but-empty member bucket, a state the pruning delete path
 /// never used to leave behind.
 #[test]
-fn empty_preallocated_index_serves_queries_with_proof_parity() {
+fn should_serve_queries_with_proof_parity_on_empty_preallocated_index() {
     use crate::drive::document::query::QueryDocumentsOutcomeV0Methods;
     use crate::query::{WhereClause, WhereOperator};
 
@@ -249,7 +249,7 @@ fn empty_preallocated_index_serves_queries_with_proof_parity() {
 /// same delete still prunes the non-preallocated byLiker subtree. Repeated
 /// like/unlike cycles stay consistent.
 #[test]
-fn unlike_keeps_preallocated_trees_and_relike_works() {
+fn should_keep_preallocated_trees_on_unlike_and_serve_relikes() {
     let (drive, contract) = setup_preallocated_likes();
     let post = build_post(&contract, "dash", 1);
     let post_id: [u8; 32] = post.id().to_buffer();
@@ -319,7 +319,7 @@ fn unlike_keeps_preallocated_trees_and_relike_works() {
 /// like costs LESS (it creates nothing) than the byte-identical plain
 /// contract charges for the same two inserts.
 #[test]
-fn preallocation_moves_tree_costs_from_first_liker_to_poster() {
+fn should_move_tree_costs_from_first_liker_to_poster() {
     let (preallocated_drive, preallocated_contract) = setup_preallocated_likes();
     let (plain_drive, plain_contract) = setup_plain_likes();
 
@@ -357,7 +357,7 @@ fn preallocation_moves_tree_costs_from_first_liker_to_poster() {
 /// invariant consensus fee validation depends on. Same for the (still
 /// tree-free) first like against preallocated state.
 #[test]
-fn estimated_fees_upper_bound_actual_fees_with_preallocation() {
+fn should_upper_bound_actual_fees_with_preallocation() {
     let (drive, contract) = setup_preallocated_likes();
 
     let post = build_post(&contract, "dash", 1);
@@ -399,7 +399,7 @@ fn estimated_fees_upper_bound_actual_fees_with_preallocation() {
 /// only pays for its own subtrees; likes on both posts land in their own
 /// buckets; unliking one post's like never disturbs the other's trees.
 #[test]
-fn shared_hashtag_prefix_preallocates_idempotently() {
+fn should_preallocate_shared_hashtag_prefixes_idempotently() {
     let (drive, contract) = setup_preallocated_likes();
 
     let post_a = build_post(&contract, "dash", 1);
@@ -454,7 +454,7 @@ fn shared_hashtag_prefix_preallocates_idempotently() {
 /// track tips, and the drained group survives the last untip at sum 0 —
 /// the sum-surface mirror of the count assertions above.
 #[test]
-fn summable_preallocated_index_preallocates_and_survives_drain() {
+fn should_preallocate_summable_index_and_survive_drain() {
     use super::index_only_e2e_tests::{
         build_tip, delete_tip, insert_tip, sum_top_k, tip_doctype_path,
     };
@@ -519,6 +519,94 @@ fn summable_preallocated_index_preallocates_and_survives_drain() {
     assert_eq!(
         sum_top_k(&drive, &by_post_level, 10, true),
         vec![(250, post_id.to_vec())]
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// A preallocated tree's one deletion path is the contract's own — entry
+/// deletes retain it by design — so on a non-deletable contract the trees
+/// carry NO storage flags even when the post insert supplies them (flags
+/// would be unrefundable dead bytes charged to the poster), while a like's
+/// member ENTRY inserted with flags carries them as always (entries delete
+/// and refund through their element flags).
+#[test]
+fn should_not_attach_flags_to_preallocated_trees_of_a_permanent_contract() {
+    use std::borrow::Cow;
+
+    let (drive, contract) = setup_preallocated_likes();
+    let pv = platform_version();
+    let post = build_post(&contract, "dash", 1);
+    let post_id: [u8; 32] = post.id().to_buffer();
+
+    let post_type = contract
+        .document_type_for_name("post")
+        .expect("post doctype exists");
+    drive
+        .add_document_for_contract(
+            DocumentAndContractInfo {
+                owned_document_info: OwnedDocumentInfo {
+                    document_info: DocumentRefInfo((
+                        &post,
+                        Some(Cow::Owned(StorageFlags::SingleEpochOwned(0, OWNER_POSTER))),
+                    )),
+                    owner_id: None,
+                },
+                contract: &contract,
+                document_type: post_type,
+            },
+            false,
+            BlockInfo::default(),
+            true,
+            None,
+            pv,
+            None,
+        )
+        .expect("insert post with owned flags");
+
+    let mut post_value_tree_path = doctype_path(&contract);
+    post_value_tree_path.extend([b"postId".to_vec(), post_id.to_vec()]);
+    let member_bucket = read_grove_element(&drive, &post_value_tree_path, &[0])
+        .expect("the member bucket must be preallocated");
+    assert!(
+        member_bucket.get_flags().is_none(),
+        "a preallocated tree of a non-deletable contract must carry no flags, got {:?}",
+        member_bucket.get_flags()
+    );
+
+    let like = build_like(&contract, "dash", post_id, OWNER_1, 1);
+    let like_type = contract
+        .document_type_for_name("like")
+        .expect("like doctype exists");
+    drive
+        .add_document_for_contract(
+            DocumentAndContractInfo {
+                owned_document_info: OwnedDocumentInfo {
+                    document_info: DocumentRefInfo((
+                        &like,
+                        Some(Cow::Owned(StorageFlags::SingleEpochOwned(0, OWNER_1))),
+                    )),
+                    owner_id: None,
+                },
+                contract: &contract,
+                document_type: like_type,
+            },
+            false,
+            BlockInfo::default(),
+            true,
+            None,
+            pv,
+            None,
+        )
+        .expect("insert like with owned flags");
+
+    let mut member_bucket_path = post_value_tree_path.clone();
+    member_bucket_path.push(vec![0]);
+    let entry = read_grove_element(&drive, &member_bucket_path, &OWNER_1)
+        .expect("the like's member entry exists");
+    assert!(
+        entry.get_flags().is_some(),
+        "the member entry must keep its refund-routing flags"
     );
 
     assert_grovedb_is_consistent(&drive);

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/ranked_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/ranked_index_e2e_tests.rs
@@ -803,6 +803,7 @@ fn compound_ranked_index_resolves_its_terminal_level_to_an_indexed_tree() {
         ranked_averageable: true,
         time_range: None,
         terminal: None,
+        preallocated: false,
     };
     let index_structure =
         IndexLevel::try_from_indices([&compound_ranked_index], "dish", platform_version())
@@ -1020,6 +1021,7 @@ fn a_null_unsearchable_ranked_level_is_what_makes_a_phantom_group_possible() {
         ranked_averageable: false,
         time_range: None,
         terminal: None,
+        preallocated: false,
     };
 
     for null_searchable in [false, true] {

--- a/packages/rs-drive/src/drive/document/delete/remove_reference_for_index_level_for_contract_operations/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/remove_reference_for_index_level_for_contract_operations/mod.rs
@@ -1,4 +1,5 @@
 mod v0;
+mod v1;
 
 use crate::drive::Drive;
 use crate::error::drive::DriveError;
@@ -63,6 +64,22 @@ impl Drive {
             .remove_reference_for_index_level_for_contract_operations
         {
             0 => self.remove_reference_for_index_level_for_contract_operations_v0(
+                document_and_contract_info,
+                index_path_info,
+                index_type,
+                any_fields_null,
+                all_fields_null,
+                storage_flags,
+                previous_batch_operations,
+                estimated_costs_only_with_layer_info,
+                event_id,
+                transaction,
+                batch_operations,
+                platform_version,
+            ),
+            // v1 (protocol version 14): the pruning climb stops at the
+            // member level on `preallocated` indexOnly indexes.
+            1 => self.remove_reference_for_index_level_for_contract_operations_v1(
                 document_and_contract_info,
                 index_path_info,
                 index_type,

--- a/packages/rs-drive/src/drive/document/delete/remove_reference_for_index_level_for_contract_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/remove_reference_for_index_level_for_contract_operations/v0/mod.rs
@@ -134,11 +134,28 @@ impl Drive {
             )?;
 
             // Drained groups prune upward exactly as with references, so
-            // ranked secondaries drop the group when its last member goes.
+            // ranked secondaries drop the group when its last member goes —
+            // EXCEPT on a preallocated index, whose trees are permanent
+            // structure the referenced document's creator paid for at its
+            // insert (see `add_preallocated_index_tree_operations`): there
+            // the member entry is the whole delete, and stopping the climb
+            // one level above it (at the emptied `0` bucket's own path)
+            // keeps every tree, so a later entry costs the same as this one
+            // did. Trees a pre-flag fallback created are kept the same way
+            // — if-not-exists inserts make the two histories converge.
+            let stop_path_height = if index_type.preallocated {
+                u16::try_from(key_info_path.len() - 1).map_err(|_| {
+                    Error::Drive(DriveError::CorruptedCodeExecution(
+                        "index path height must fit in u16",
+                    ))
+                })?
+            } else {
+                CONTRACT_DOCUMENTS_PATH_HEIGHT
+            };
             self.batch_delete_up_tree_while_empty(
                 key_info_path,
                 member_key.as_slice(),
-                Some(CONTRACT_DOCUMENTS_PATH_HEIGHT),
+                Some(stop_path_height),
                 delete_apply_type,
                 transaction,
                 previous_batch_operations,

--- a/packages/rs-drive/src/drive/document/delete/remove_reference_for_index_level_for_contract_operations/v1/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/remove_reference_for_index_level_for_contract_operations/v1/mod.rs
@@ -28,9 +28,16 @@ use dpp::version::PlatformVersion;
 
 impl Drive {
     /// Removes the terminal reference.
+    ///
+    /// v1 (protocol version 14) differs from v0 in exactly one place: on a
+    /// `preallocated` indexOnly index, the empty-tree pruning climb stops at
+    /// the member level, keeping the preallocated apparatus the referenced
+    /// document's creator paid for — see
+    /// `add_preallocated_index_tree_operations`. Every other index prunes
+    /// drained groups exactly as v0 does.
     #[inline(always)]
     #[allow(clippy::too_many_arguments)]
-    pub(super) fn remove_reference_for_index_level_for_contract_operations_v0(
+    pub(super) fn remove_reference_for_index_level_for_contract_operations_v1(
         &self,
         document_and_contract_info: &DocumentAndContractInfo,
         index_path_info: PathInfo<0>,
@@ -134,11 +141,28 @@ impl Drive {
             )?;
 
             // Drained groups prune upward exactly as with references, so
-            // ranked secondaries drop the group when its last member goes.
+            // ranked secondaries drop the group when its last member goes —
+            // EXCEPT on a preallocated index, whose trees are permanent
+            // structure the referenced document's creator paid for at its
+            // insert (see `add_preallocated_index_tree_operations`): there
+            // the member entry is the whole delete, and stopping the climb
+            // one level above it (at the emptied `0` bucket's own path)
+            // keeps every tree, so a later entry costs the same as this one
+            // did. Trees a pre-flag fallback created are kept the same way
+            // — if-not-exists inserts make the two histories converge.
+            let stop_path_height = if index_type.preallocated {
+                u16::try_from(key_info_path.len() - 1).map_err(|_| {
+                    Error::Drive(DriveError::CorruptedCodeExecution(
+                        "index path height must fit in u16",
+                    ))
+                })?
+            } else {
+                CONTRACT_DOCUMENTS_PATH_HEIGHT
+            };
             self.batch_delete_up_tree_while_empty(
                 key_info_path,
                 member_key.as_slice(),
-                Some(CONTRACT_DOCUMENTS_PATH_HEIGHT),
+                Some(stop_path_height),
                 delete_apply_type,
                 transaction,
                 previous_batch_operations,

--- a/packages/rs-drive/src/drive/document/index_level_tree_types.rs
+++ b/packages/rs-drive/src/drive/document/index_level_tree_types.rs
@@ -320,6 +320,7 @@ mod tests {
             ranked_summable: false,
             ranked_averageable: false,
             terminal: None,
+            preallocated: false,
         }
     }
 
@@ -451,6 +452,7 @@ mod tests {
             ranked_averageable: true,
             time_range: None,
             terminal: None,
+            preallocated: false,
         };
         let compound = Index {
             name: "byRestaurantChef".to_string(),
@@ -476,6 +478,7 @@ mod tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         };
 
         let index_structure =

--- a/packages/rs-drive/src/drive/document/insert/add_document_for_contract_operations/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_document_for_contract_operations/mod.rs
@@ -1,4 +1,5 @@
 mod v0;
+mod v1;
 
 use crate::drive::Drive;
 use crate::error::drive::DriveError;
@@ -43,9 +44,21 @@ impl Drive {
                 transaction,
                 platform_version,
             ),
+            // v1 (protocol version 14): v0 plus preallocated index trees for
+            // refersTo-bound `preallocated` indexes of referring indexOnly
+            // document types.
+            1 => self.add_document_for_contract_operations_v1(
+                document_and_contract_info,
+                override_document,
+                block_info,
+                previous_batch_operations,
+                estimated_costs_only_with_layer_info,
+                transaction,
+                platform_version,
+            ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "add_document_for_contract_operations".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             })),
         }

--- a/packages/rs-drive/src/drive/document/insert/add_document_for_contract_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_document_for_contract_operations/v0/mod.rs
@@ -59,6 +59,15 @@ impl Drive {
                 platform_version,
             )?;
 
+            self.add_preallocated_index_tree_operations_for_referring_types(
+                &document_and_contract_info,
+                previous_batch_operations,
+                estimated_costs_only_with_layer_info,
+                transaction,
+                &mut batch_operations,
+                platform_version,
+            )?;
+
             return Ok(batch_operations);
         }
 
@@ -148,6 +157,21 @@ impl Drive {
         )?;
 
         self.add_indices_for_top_index_level_for_contract_operations(
+            &document_and_contract_info,
+            previous_batch_operations,
+            estimated_costs_only_with_layer_info,
+            transaction,
+            &mut batch_operations,
+            platform_version,
+        )?;
+
+        // If any indexOnly document type of this contract carries a
+        // `preallocated` index bound to this document type through a
+        // refersTo declaration, create that index's trees for entries
+        // referencing this document now — see
+        // `add_preallocated_index_tree_operations`. A no-op for every
+        // contract without the (PV14+, indexOnly-only) flag.
+        self.add_preallocated_index_tree_operations_for_referring_types(
             &document_and_contract_info,
             previous_batch_operations,
             estimated_costs_only_with_layer_info,

--- a/packages/rs-drive/src/drive/document/insert/add_document_for_contract_operations/v1/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_document_for_contract_operations/v1/mod.rs
@@ -18,9 +18,16 @@ use std::collections::HashMap;
 
 impl Drive {
     /// Gathers the operations to add a document to a contract.
+    ///
+    /// v1 (protocol version 14) is v0 plus preallocated index trees: when
+    /// any indexOnly document type of the contract carries a `preallocated`
+    /// index bound to the inserted document type through a refersTo
+    /// declaration, the insert also creates that index's dynamic trees for
+    /// entries referencing this document — see
+    /// `add_preallocated_index_tree_operations`. Everything else matches v0.
     #[inline(always)]
     #[allow(clippy::too_many_arguments)]
-    pub(super) fn add_document_for_contract_operations_v0(
+    pub(super) fn add_document_for_contract_operations_v1(
         &self,
         document_and_contract_info: DocumentAndContractInfo,
         override_document: bool,
@@ -51,6 +58,15 @@ impl Drive {
             }
 
             self.add_indices_for_top_index_level_for_contract_operations(
+                &document_and_contract_info,
+                previous_batch_operations,
+                estimated_costs_only_with_layer_info,
+                transaction,
+                &mut batch_operations,
+                platform_version,
+            )?;
+
+            self.add_preallocated_index_tree_operations_for_referring_types(
                 &document_and_contract_info,
                 previous_batch_operations,
                 estimated_costs_only_with_layer_info,
@@ -148,6 +164,21 @@ impl Drive {
         )?;
 
         self.add_indices_for_top_index_level_for_contract_operations(
+            &document_and_contract_info,
+            previous_batch_operations,
+            estimated_costs_only_with_layer_info,
+            transaction,
+            &mut batch_operations,
+            platform_version,
+        )?;
+
+        // If any indexOnly document type of this contract carries a
+        // `preallocated` index bound to this document type through a
+        // refersTo declaration, create that index's trees for entries
+        // referencing this document now — see
+        // `add_preallocated_index_tree_operations`. A no-op for every
+        // contract without the (PV14+, indexOnly-only) flag.
+        self.add_preallocated_index_tree_operations_for_referring_types(
             &document_and_contract_info,
             previous_batch_operations,
             estimated_costs_only_with_layer_info,

--- a/packages/rs-drive/src/drive/document/insert/add_preallocated_index_tree_operations/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_preallocated_index_tree_operations/mod.rs
@@ -1,0 +1,452 @@
+//! Preallocation of refersTo-determined indexOnly index trees.
+//!
+//! A `preallocated` index on an indexOnly document type (see
+//! `dpp::data_contract::document_type::index::PREALLOCATED`) has a path that
+//! is a pure function of one same-contract refersTo-referenced document:
+//! every index property is either the referring property (its value is the
+//! referenced document's `$id`) or a `propertyAgreement` key
+//! (consensus-enforced equal to a referenced-document property at entry
+//! write time). So the moment the referenced document is inserted, every
+//! dynamic tree an entry referencing it will ever need — the per-value trees
+//! down to the empty `0` member bucket — is fully known, and this module
+//! creates them right then, charged to the referenced document's creator.
+//!
+//! Every tree is inserted with the same if-not-exists helpers, the same
+//! tree-type derivation ([`index_level_tree_types_with_continuation_demotion`])
+//! and the same estimation layers as the entry-insert walkers
+//! (`add_indices_for_*_for_contract_operations` v2 and the indexOnly
+//! terminal in `add_reference_for_index_level_for_contract_operations`), so
+//! a preallocated tree is bit-identical to the tree the first entry's
+//! create-on-insert path would have made. That fallback stays in place
+//! untouched — preallocation is purely an optimization: referenced documents
+//! created before a contract update introduced the flag (or whose bound
+//! property values have since changed, for a mutable referenced type) simply
+//! get their trees from the first entry as before.
+//!
+//! The counterpart lives in the delete walker: for a preallocated index,
+//! removing the last member entry keeps the trees (no upward pruning), so
+//! entry insertion cost stays uniform from the first entry on. See
+//! `remove_reference_for_index_level_for_contract_operations`.
+//!
+//! Gated in place rather than by a method version: `preallocated` can only
+//! be true on a PV14+ contract (the grammar rejects the keyword below
+//! meta-schema v3), so this code is unreachable for every historical
+//! document — the same gating the indexOnly insert branch relies on.
+
+use crate::drive::document::estimation_costs::estimated_sum_trees_for_value_tree_type::estimated_sum_trees_for_value_tree_type;
+use crate::drive::document::index_level_tree_types::{
+    index_level_tree_types_with_continuation_demotion, terminal_member_tree_type,
+    terminal_value_tree_type,
+};
+use crate::drive::document::paths::contract_document_type_path_vec;
+use crate::drive::document::unique_event_id;
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::fee::FeeError;
+use crate::error::Error;
+use crate::fees::op::LowLevelDriveOperation;
+use crate::util::grove_operations::BatchInsertTreeApplyType;
+use crate::util::object_size_info::DriveKeyInfo::{Key, KeyRef};
+use crate::util::object_size_info::{DocumentAndContractInfo, DocumentInfoV0Methods, PathInfo};
+use crate::util::storage_flags::StorageFlags;
+use crate::util::type_constants::DEFAULT_HASH_SIZE_U8;
+use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::data_contract::config::v0::DataContractConfigGettersV0;
+use dpp::data_contract::document_type::accessors::{DocumentTypeV0Getters, DocumentTypeV2Getters};
+use dpp::data_contract::document_type::{Index, IndexLevel, PreallocatedKeySource};
+use dpp::version::PlatformVersion;
+use grovedb::batch::KeyInfoPath;
+use grovedb::EstimatedLayerCount::{ApproximateElements, PotentiallyAtMaxElements};
+use grovedb::EstimatedLayerSizes::{AllItems, AllSubtrees};
+use grovedb::EstimatedSumTrees::NoSumTrees;
+use grovedb::{EstimatedLayerInformation, TransactionArg, TreeType};
+use std::collections::HashMap;
+
+impl Drive {
+    /// For every preallocated index (on any indexOnly document type of the
+    /// contract) whose binding targets the document type being inserted,
+    /// adds the operations creating that index's dynamic trees for entries
+    /// referencing the inserted document. Trees that already exist — shared
+    /// prefixes with earlier referenced documents, or trees a fallback
+    /// entry-insert created — are left untouched by the if-not-exists
+    /// semantics.
+    pub(super) fn add_preallocated_index_tree_operations_for_referring_types(
+        &self,
+        document_and_contract_info: &DocumentAndContractInfo,
+        previous_batch_operations: &mut Option<&mut Vec<LowLevelDriveOperation>>,
+        estimated_costs_only_with_layer_info: &mut Option<
+            HashMap<KeyInfoPath, EstimatedLayerInformation>,
+        >,
+        transaction: TransactionArg,
+        batch_operations: &mut Vec<LowLevelDriveOperation>,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        let contract = document_and_contract_info.contract;
+        let target_name = document_and_contract_info.document_type.name().as_str();
+
+        for (referring_name, referring_document_type) in contract.document_types() {
+            let referring_type = referring_document_type.as_ref();
+            // `preallocated` is only valid on indexOnly document types, so
+            // this filter also keeps the per-insert scan trivially cheap for
+            // contracts without the feature.
+            if !referring_type.index_only() {
+                continue;
+            }
+            // Same flag rule the entry-insert top-level walker applies to
+            // the referring type — a fallback-created tree carries flags
+            // under exactly this condition — except the flags are the
+            // inserted (referenced) document's: its creator owns the
+            // structural storage and receives any refunds.
+            let storage_flags = if referring_type.documents_mutable()
+                || contract.config().can_be_deleted()
+                || (referring_type.index_only() && referring_type.documents_can_be_deleted())
+            {
+                document_and_contract_info
+                    .owned_document_info
+                    .document_info
+                    .get_storage_flags_ref()
+            } else {
+                None
+            };
+            for index in referring_type.indexes().values() {
+                if !index.preallocated {
+                    continue;
+                }
+                for binding in index
+                    .preallocation_bindings(referring_type.flattened_properties(), contract.id())
+                {
+                    if binding.target_document_type_name != target_name {
+                        continue;
+                    }
+                    self.add_preallocated_index_tree_operations_for_binding(
+                        document_and_contract_info,
+                        referring_name,
+                        referring_type.index_structure(),
+                        index,
+                        &binding.key_sources,
+                        storage_flags,
+                        previous_batch_operations,
+                        estimated_costs_only_with_layer_info,
+                        transaction,
+                        batch_operations,
+                        platform_version,
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Adds the operations preallocating ONE index's trees for entries
+    /// referencing the inserted document: walks the referring type's
+    /// [`IndexLevel`] along the index's properties, resolving each path key
+    /// from the inserted document per the binding's key sources, and creates
+    /// each property-name tree, value tree and the terminal `0` member
+    /// bucket with exactly the tree types and estimation layers the
+    /// entry-insert walkers use.
+    #[allow(clippy::too_many_arguments)]
+    fn add_preallocated_index_tree_operations_for_binding(
+        &self,
+        document_and_contract_info: &DocumentAndContractInfo,
+        referring_type_name: &str,
+        referring_index_structure: &IndexLevel,
+        index: &Index,
+        key_sources: &[PreallocatedKeySource],
+        storage_flags: Option<&StorageFlags>,
+        previous_batch_operations: &mut Option<&mut Vec<LowLevelDriveOperation>>,
+        estimated_costs_only_with_layer_info: &mut Option<
+            HashMap<KeyInfoPath, EstimatedLayerInformation>,
+        >,
+        transaction: TransactionArg,
+        batch_operations: &mut Vec<LowLevelDriveOperation>,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        let drive_version = &platform_version.drive;
+        let contract = document_and_contract_info.contract;
+        let target_document_type = document_and_contract_info.document_type;
+        let document_info = &document_and_contract_info.owned_document_info.document_info;
+        let event_id = unique_event_id();
+
+        let contract_document_type_path =
+            contract_document_type_path_vec(contract.id_ref().as_bytes(), referring_type_name);
+
+        if let Some(estimated_costs_only_with_layer_info) = estimated_costs_only_with_layer_info {
+            // The referring doctype tree layer — mirror of the entry-insert
+            // walkers' top-level entry, but for the referring type.
+            estimated_costs_only_with_layer_info.insert(
+                KeyInfoPath::from_known_owned_path(contract_document_type_path.clone()),
+                EstimatedLayerInformation {
+                    tree_type: TreeType::NormalTree,
+                    estimated_layer_count: ApproximateElements(
+                        referring_index_structure.sub_levels().len() as u32 + 1,
+                    ),
+                    estimated_layer_sizes: AllSubtrees(
+                        DEFAULT_HASH_SIZE_U8,
+                        NoSumTrees,
+                        storage_flags.map(|s| s.serialized_size()),
+                    ),
+                },
+            );
+        }
+
+        let mut current_level = referring_index_structure;
+        let mut index_path_info: Option<PathInfo<0>> = None;
+        // The value tree type of the level above, deciding whether the next
+        // property-name tree needs the zero-contribution wrapper — exactly
+        // the `parent_value_tree_type` the recursive walker threads through.
+        let mut parent_value_tree_type = TreeType::NormalTree;
+
+        for (index_property, key_source) in index.properties.iter().zip(key_sources.iter()) {
+            let property_name = index_property.name.as_str();
+            let sub_level = current_level
+                .sub_levels()
+                .get(property_name)
+                .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
+                    "a preallocated index's property must exist in the index structure",
+                )))?;
+            let tree_types = index_level_tree_types_with_continuation_demotion(sub_level)?;
+            let property_name_tree_type = tree_types.property_name_tree_type;
+            let ranked_axes = tree_types.ranked_axes.as_slice();
+            let value_tree_type = tree_types.value_tree_type;
+
+            // Resolve this level's value key from the inserted (referenced)
+            // document. `$id` for the referring property; the agreed
+            // referenced property otherwise — validated at contract
+            // registration to share one value kind with the referring side,
+            // so the encoded bytes match what an entry insert would write.
+            let source_property = match *key_source {
+                PreallocatedKeySource::ReferencedDocumentId => "$id",
+                PreallocatedKeySource::ReferencedDocumentProperty(referenced) => referenced,
+            };
+            let Some(value_key) = document_info.get_raw_for_document_type(
+                source_property,
+                target_document_type,
+                document_and_contract_info.owned_document_info.owner_id,
+                Some((sub_level, event_id)),
+                platform_version,
+            )?
+            else {
+                // The referenced document does not carry the bound property
+                // (it is optional there): no entry can ever agree with it,
+                // and if that changes on an update the entry-insert fallback
+                // creates the trees. Nothing to preallocate.
+                return Ok(());
+            };
+            if value_key.is_empty() {
+                // A null value takes the null index layout on the entry
+                // side; leave that (never-preallocatable) shape entirely to
+                // the fallback.
+                return Ok(());
+            }
+
+            let mut path_info = match index_path_info.take() {
+                None => {
+                    // First property: its property-name tree is static —
+                    // created at contract registration — so only enter it.
+                    let mut index_path = contract_document_type_path.clone();
+                    index_path.push(Vec::from(property_name.as_bytes()));
+                    if document_info.is_document_size() {
+                        PathInfo::PathWithSizes(KeyInfoPath::from_known_owned_path(index_path))
+                    } else {
+                        PathInfo::PathAsVec::<0>(index_path)
+                    }
+                }
+                Some(mut path_info) => {
+                    // Deeper property-name trees are dynamic: create this
+                    // one inside the parent value tree, wrapped to
+                    // contribute zero when that parent aggregates — the
+                    // same dispatch the recursive walker uses.
+                    let property_name_apply_type = if estimated_costs_only_with_layer_info.is_none()
+                    {
+                        BatchInsertTreeApplyType::StatefulBatchInsertTree
+                    } else {
+                        BatchInsertTreeApplyType::StatelessBatchInsertTree {
+                            in_tree_type: parent_value_tree_type,
+                            tree_type: property_name_tree_type,
+                            flags_len: storage_flags
+                                .map(|s| s.serialized_size())
+                                .unwrap_or_default(),
+                        }
+                    };
+                    let path_key_info =
+                        KeyRef(property_name.as_bytes()).add_path_info(path_info.clone());
+                    if !matches!(parent_value_tree_type, TreeType::NormalTree) {
+                        self.batch_insert_empty_tree_contributing_zero_to_aggregating_parent_if_not_exists(
+                            path_key_info,
+                            parent_value_tree_type,
+                            property_name_tree_type,
+                            ranked_axes,
+                            storage_flags,
+                            property_name_apply_type,
+                            transaction,
+                            previous_batch_operations,
+                            batch_operations,
+                            drive_version,
+                        )?;
+                    } else {
+                        self.batch_insert_empty_index_tree_if_not_exists(
+                            path_key_info,
+                            property_name_tree_type,
+                            ranked_axes,
+                            storage_flags,
+                            property_name_apply_type,
+                            transaction,
+                            previous_batch_operations,
+                            batch_operations,
+                            drive_version,
+                        )?;
+                    }
+                    path_info.push(KeyRef(property_name.as_bytes()))?;
+                    path_info
+                }
+            };
+
+            if let Some(estimated_costs_only_with_layer_info) = estimated_costs_only_with_layer_info
+            {
+                // The property-name layer: children are value trees keyed by
+                // the source property's values (32 bytes for `$id`).
+                let value_key_estimated_size = match key_source {
+                    PreallocatedKeySource::ReferencedDocumentId => DEFAULT_HASH_SIZE_U8 as u16,
+                    PreallocatedKeySource::ReferencedDocumentProperty(_) => document_info
+                        .get_estimated_size_for_document_type(
+                            source_property,
+                            target_document_type,
+                            platform_version,
+                        )?,
+                };
+                if value_key_estimated_size > u8::MAX as u16 {
+                    return Err(Error::Fee(FeeError::Overflow(
+                        "referenced document field is too big for being an index",
+                    )));
+                }
+                estimated_costs_only_with_layer_info.insert(
+                    path_info.clone().convert_to_key_info_path(),
+                    EstimatedLayerInformation {
+                        tree_type: property_name_tree_type,
+                        estimated_layer_count: PotentiallyAtMaxElements,
+                        estimated_layer_sizes: AllSubtrees(
+                            value_key_estimated_size as u8,
+                            estimated_sum_trees_for_value_tree_type(value_tree_type),
+                            storage_flags.map(|s| s.serialized_size()),
+                        ),
+                    },
+                );
+            }
+
+            // The value tree for the resolved key.
+            let value_apply_type = if estimated_costs_only_with_layer_info.is_none() {
+                BatchInsertTreeApplyType::StatefulBatchInsertTree
+            } else {
+                BatchInsertTreeApplyType::StatelessBatchInsertTree {
+                    in_tree_type: property_name_tree_type,
+                    tree_type: value_tree_type,
+                    flags_len: storage_flags
+                        .map(|s| s.serialized_size())
+                        .unwrap_or_default(),
+                }
+            };
+            let path_key_info = value_key.clone().add_path_info(path_info.clone());
+            self.batch_insert_empty_tree_if_not_exists(
+                path_key_info,
+                value_tree_type,
+                storage_flags,
+                value_apply_type,
+                transaction,
+                previous_batch_operations,
+                batch_operations,
+                drive_version,
+            )?;
+            path_info.push(value_key)?;
+
+            if let Some(estimated_costs_only_with_layer_info) = estimated_costs_only_with_layer_info
+            {
+                // The value tree's own layer: its children are the `0`
+                // member bucket plus any continuation property-name trees.
+                estimated_costs_only_with_layer_info.insert(
+                    path_info.clone().convert_to_key_info_path(),
+                    EstimatedLayerInformation {
+                        tree_type: value_tree_type,
+                        estimated_layer_count: ApproximateElements(
+                            sub_level.sub_levels().len() as u32 + 1,
+                        ),
+                        estimated_layer_sizes: AllSubtrees(
+                            DEFAULT_HASH_SIZE_U8,
+                            NoSumTrees,
+                            storage_flags.map(|s| s.serialized_size()),
+                        ),
+                    },
+                );
+            }
+
+            index_path_info = Some(path_info);
+            parent_value_tree_type = value_tree_type;
+            current_level = sub_level;
+        }
+
+        let mut path_info = index_path_info.ok_or(Error::Drive(
+            DriveError::CorruptedCodeExecution("a preallocated index must have properties"),
+        ))?;
+
+        // The terminal `0` member bucket — mirror of the tree-creation half
+        // of `add_index_only_terminal_item_operations` (the member entry
+        // itself is each entry insert's own write).
+        let level_info = current_level.has_index_with_type().ok_or(Error::Drive(
+            DriveError::CorruptedCodeExecution(
+                "a preallocated index must terminate at its last property",
+            ),
+        ))?;
+        let member_tree_type = terminal_member_tree_type(level_info);
+        let member_apply_type = if estimated_costs_only_with_layer_info.is_none() {
+            BatchInsertTreeApplyType::StatefulBatchInsertTree
+        } else {
+            BatchInsertTreeApplyType::StatelessBatchInsertTree {
+                // The `0` tree's parent is the index's value tree — same
+                // aggregate-aware claim the entry-insert terminal makes.
+                in_tree_type: terminal_value_tree_type(level_info),
+                tree_type: member_tree_type,
+                flags_len: storage_flags
+                    .map(|s| s.serialized_size())
+                    .unwrap_or_default(),
+            }
+        };
+        let path_key_info = KeyRef(&[0]).add_path_info(path_info.clone());
+        self.batch_insert_empty_tree_if_not_exists(
+            path_key_info,
+            member_tree_type,
+            storage_flags,
+            member_apply_type,
+            transaction,
+            previous_batch_operations,
+            batch_operations,
+            drive_version,
+        )?;
+
+        if let Some(estimated_costs_only_with_layer_info) = estimated_costs_only_with_layer_info {
+            path_info.push(Key(vec![0]))?;
+            // Same per-entry padding (and sum-item worst case) the
+            // entry-insert terminal claims for this layer — see
+            // `add_index_only_terminal_item_operations`.
+            const INDEX_ONLY_ITEM_ESTIMATED_VALUE_SIZE: u32 =
+                crate::drive::document::INDEX_ONLY_ROW_COMMITMENT_SIZE + 32;
+            let estimated_value_size = if level_info.summable.is_some() {
+                INDEX_ONLY_ITEM_ESTIMATED_VALUE_SIZE + 10
+            } else {
+                INDEX_ONLY_ITEM_ESTIMATED_VALUE_SIZE
+            };
+            estimated_costs_only_with_layer_info.insert(
+                path_info.convert_to_key_info_path(),
+                EstimatedLayerInformation {
+                    tree_type: member_tree_type,
+                    estimated_layer_count: PotentiallyAtMaxElements,
+                    estimated_layer_sizes: AllItems(
+                        DEFAULT_HASH_SIZE_U8,
+                        estimated_value_size,
+                        storage_flags.map(|s| s.serialized_size()),
+                    ),
+                },
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/packages/rs-drive/src/drive/document/insert/add_preallocated_index_tree_operations/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_preallocated_index_tree_operations/mod.rs
@@ -92,15 +92,18 @@ impl Drive {
             if !referring_type.index_only() {
                 continue;
             }
-            // Same flag rule the entry-insert top-level walker applies to
-            // the referring type — a fallback-created tree carries flags
-            // under exactly this condition — except the flags are the
-            // inserted (referenced) document's: its creator owns the
-            // structural storage and receives any refunds.
-            let storage_flags = if referring_type.documents_mutable()
-                || contract.config().can_be_deleted()
-                || (referring_type.index_only() && referring_type.documents_can_be_deleted())
-            {
+            // Flags exist to route refunds when an element is deleted, and
+            // a preallocated tree has exactly one deletion path: the
+            // contract's own — entry deletes retain it by design (the
+            // delete walker's no-prune rule), and entry-level deletability
+            // (`documents_can_be_deleted`) never reaches it. So unlike the
+            // entry walkers' rule, flags ride only when the contract is
+            // deletable; on a permanent contract they would be dead bytes
+            // charged to the referenced document's creator on every tree.
+            // (Fallback-created trees may carry entry-rule flags from
+            // before the no-prune retention — harmless: unrefundable flags
+            // are inert, and if-not-exists inserts never rewrite them.)
+            let storage_flags = if contract.config().can_be_deleted() {
                 document_and_contract_info
                     .owned_document_info
                     .document_info

--- a/packages/rs-drive/src/drive/document/insert/add_preallocated_index_tree_operations/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_preallocated_index_tree_operations/mod.rs
@@ -28,10 +28,13 @@
 //! entry insertion cost stays uniform from the first entry on. See
 //! `remove_reference_for_index_level_for_contract_operations`.
 //!
-//! Gated in place rather than by a method version: `preallocated` can only
-//! be true on a PV14+ contract (the grammar rejects the keyword below
-//! meta-schema v3), so this code is unreachable for every historical
-//! document — the same gating the indexOnly insert branch relies on.
+//! Doubly gated: the caller is `add_document_for_contract_operations_v1`,
+//! selected only by protocol v14's method table
+//! (`DRIVE_DOCUMENT_METHOD_VERSIONS_V4`), and `preallocated` itself cannot
+//! be true below meta-schema v3 — so the platform-version snapshot names
+//! the active insert semantics AND historical documents can never reach
+//! this code. The delete-side counterpart is versioned the same way
+//! (`remove_reference_for_index_level_for_contract_operations_v1`).
 
 use crate::drive::document::estimation_costs::estimated_sum_trees_for_value_tree_type::estimated_sum_trees_for_value_tree_type;
 use crate::drive::document::index_level_tree_types::{
@@ -115,12 +118,14 @@ impl Drive {
                 if !index.preallocated {
                     continue;
                 }
-                for binding in index
-                    .preallocation_bindings(referring_type.flattened_properties(), contract.id())
-                {
-                    if binding.target_document_type_name != target_name {
-                        continue;
-                    }
+                // Target-filtered derivation: candidates naming other
+                // target types are rejected before any binding plan is
+                // allocated — this runs on every document insert.
+                for binding in index.preallocation_bindings_for_target(
+                    referring_type.flattened_properties(),
+                    contract.id(),
+                    target_name,
+                ) {
                     self.add_preallocated_index_tree_operations_for_binding(
                         document_and_contract_info,
                         referring_name,
@@ -192,13 +197,15 @@ impl Drive {
             );
         }
 
+        // Resolve EVERY path key before emitting a single operation: a
+        // missing or null bound value at ANY level means no entry can ever
+        // agree with this document, so nothing must be preallocated — and
+        // bailing mid-walk would leave the earlier levels' tree inserts
+        // already sitting in the batch. Only the stateful path can skip
+        // this way; in estimation mode every key resolves to a worst-case
+        // size, so the dry-run always sweeps the full path.
+        let mut resolved_levels = Vec::with_capacity(index.properties.len());
         let mut current_level = referring_index_structure;
-        let mut index_path_info: Option<PathInfo<0>> = None;
-        // The value tree type of the level above, deciding whether the next
-        // property-name tree needs the zero-contribution wrapper — exactly
-        // the `parent_value_tree_type` the recursive walker threads through.
-        let mut parent_value_tree_type = TreeType::NormalTree;
-
         for (index_property, key_source) in index.properties.iter().zip(key_sources.iter()) {
             let property_name = index_property.name.as_str();
             let sub_level = current_level
@@ -207,16 +214,10 @@ impl Drive {
                 .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
                     "a preallocated index's property must exist in the index structure",
                 )))?;
-            let tree_types = index_level_tree_types_with_continuation_demotion(sub_level)?;
-            let property_name_tree_type = tree_types.property_name_tree_type;
-            let ranked_axes = tree_types.ranked_axes.as_slice();
-            let value_tree_type = tree_types.value_tree_type;
-
-            // Resolve this level's value key from the inserted (referenced)
-            // document. `$id` for the referring property; the agreed
-            // referenced property otherwise — validated at contract
-            // registration to share one value kind with the referring side,
-            // so the encoded bytes match what an entry insert would write.
+            // `$id` for the referring property; the agreed referenced
+            // property otherwise — validated at contract registration to
+            // share one value kind with the referring side, so the encoded
+            // bytes match what an entry insert would write.
             let source_property = match *key_source {
                 PreallocatedKeySource::ReferencedDocumentId => "$id",
                 PreallocatedKeySource::ReferencedDocumentProperty(referenced) => referenced,
@@ -241,6 +242,28 @@ impl Drive {
                 // the fallback.
                 return Ok(());
             }
+            resolved_levels.push((
+                property_name,
+                sub_level,
+                source_property,
+                *key_source,
+                value_key,
+            ));
+            current_level = sub_level;
+        }
+        let terminal_level = current_level;
+
+        let mut index_path_info: Option<PathInfo<0>> = None;
+        // The value tree type of the level above, deciding whether the next
+        // property-name tree needs the zero-contribution wrapper — exactly
+        // the `parent_value_tree_type` the recursive walker threads through.
+        let mut parent_value_tree_type = TreeType::NormalTree;
+
+        for (property_name, sub_level, source_property, key_source, value_key) in resolved_levels {
+            let tree_types = index_level_tree_types_with_continuation_demotion(sub_level)?;
+            let property_name_tree_type = tree_types.property_name_tree_type;
+            let ranked_axes = tree_types.ranked_axes.as_slice();
+            let value_tree_type = tree_types.value_tree_type;
 
             let mut path_info = match index_path_info.take() {
                 None => {
@@ -383,7 +406,6 @@ impl Drive {
 
             index_path_info = Some(path_info);
             parent_value_tree_type = value_tree_type;
-            current_level = sub_level;
         }
 
         let mut path_info = index_path_info.ok_or(Error::Drive(
@@ -393,7 +415,7 @@ impl Drive {
         // The terminal `0` member bucket — mirror of the tree-creation half
         // of `add_index_only_terminal_item_operations` (the member entry
         // itself is each entry insert's own write).
-        let level_info = current_level.has_index_with_type().ok_or(Error::Drive(
+        let level_info = terminal_level.has_index_with_type().ok_or(Error::Drive(
             DriveError::CorruptedCodeExecution(
                 "a preallocated index must terminate at its last property",
             ),

--- a/packages/rs-drive/src/drive/document/insert/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/mod.rs
@@ -33,6 +33,11 @@ mod add_indices_for_index_level_for_contract_operations;
 // This module contains functionality for adding indices for the top index level for contract operations
 mod add_indices_for_top_index_level_for_contract_operations;
 
+// Module: add_preallocated_index_tree_operations
+// This module contains functionality for preallocating refersTo-determined
+// indexOnly index trees when the referenced document is inserted
+mod add_preallocated_index_tree_operations;
+
 // Module: add_reference_for_index_level_for_contract_operations
 // This module contains functionality for adding a reference for an index level for contract operations
 mod add_reference_for_index_level_for_contract_operations;

--- a/packages/rs-drive/src/drive/document/ranked_index_tree_type.rs
+++ b/packages/rs-drive/src/drive/document/ranked_index_tree_type.rs
@@ -194,6 +194,7 @@ mod tests {
             ranked_summable,
             ranked_averageable,
             terminal: None,
+            preallocated: false,
         }
     }
 

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -2171,6 +2171,7 @@ mod range_countable_picker_tests {
             ranked_averageable: false,
             time_range: None,
             terminal: None,
+            preallocated: false,
         }
     }
 
@@ -3544,6 +3545,7 @@ mod time_range_picker_tests {
             ranked_averageable: false,
             time_range,
             terminal: None,
+            preallocated: false,
         }
     }
 

--- a/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
@@ -702,6 +702,7 @@ fn test_index(name: &str, properties: &[&str], summable: Option<&str>) -> Index 
         ranked_averageable: false,
         time_range: None,
         terminal: None,
+        preallocated: false,
     }
 }
 

--- a/packages/rs-drive/src/query/drive_document_sum_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_sum_query/tests.rs
@@ -47,6 +47,7 @@ fn summable_index(name: &str, props: &[&str], summable: Option<&str>) -> Index {
         ranked_averageable: false,
         time_range: None,
         terminal: None,
+        preallocated: false,
     }
 }
 
@@ -68,6 +69,7 @@ fn range_summable_index(name: &str, props: &[&str], summable: &str) -> Index {
         ranked_averageable: false,
         time_range: None,
         terminal: None,
+        preallocated: false,
     }
 }
 

--- a/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-preallocated-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-preallocated-contract.json
@@ -263,6 +263,79 @@
         "b"
       ],
       "additionalProperties": false
+    },
+    "note": {
+      "type": "object",
+      "documentsMutable": false,
+      "canBeDeleted": false,
+      "indices": [
+        {
+          "name": "byTopic",
+          "properties": [
+            {
+              "topic": "asc"
+            }
+          ]
+        }
+      ],
+      "properties": {
+        "topic": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "annotation": {
+      "type": "object",
+      "indexOnly": true,
+      "documentsMutable": false,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byNoteTopic",
+          "properties": [
+            {
+              "noteId": "asc"
+            },
+            {
+              "topic": "asc"
+            }
+          ],
+          "terminal": "$ownerId",
+          "preallocated": true
+        }
+      ],
+      "properties": {
+        "noteId": {
+          "type": "array",
+          "byteArray": true,
+          "minItems": 32,
+          "maxItems": 32,
+          "contentMediaType": "application/x.dash.dpp.identifier",
+          "position": 0,
+          "refersTo": {
+            "type": "permanentDocument",
+            "documentType": "note",
+            "propertyAgreement": {
+              "topic": "topic"
+            }
+          }
+        },
+        "topic": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 1
+        }
+      },
+      "required": [
+        "noteId",
+        "topic"
+      ],
+      "additionalProperties": false
     }
   }
 }

--- a/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-preallocated-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-preallocated-contract.json
@@ -1,0 +1,268 @@
+{
+  "$formatVersion": "0",
+  "id": "AY6xWncZUFv2GCrS5seqKthUfbW9yYyUXtF8diSuHQ4g",
+  "ownerId": "AtirhSVpAWF7dEt6dLAmesC4Sr1MsJ9bFC1nLAoNnq2S",
+  "version": 1,
+  "documentSchemas": {
+    "like": {
+      "type": "object",
+      "indexOnly": true,
+      "documentsMutable": false,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byHashtagPost",
+          "properties": [
+            {
+              "hashtag": "asc"
+            },
+            {
+              "postId": "asc"
+            }
+          ],
+          "terminal": "$ownerId",
+          "countable": "countable",
+          "rangeCountable": true,
+          "rankedCountable": true,
+          "preallocated": true
+        },
+        {
+          "name": "byPost",
+          "properties": [
+            {
+              "postId": "asc"
+            }
+          ],
+          "countable": "countable",
+          "rangeCountable": true,
+          "rankedCountable": true,
+          "preallocated": true
+        },
+        {
+          "name": "byLiker",
+          "properties": [
+            {
+              "$ownerId": "asc"
+            }
+          ],
+          "terminal": "postId"
+        }
+      ],
+      "properties": {
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        },
+        "postId": {
+          "type": "array",
+          "byteArray": true,
+          "minItems": 32,
+          "maxItems": 32,
+          "contentMediaType": "application/x.dash.dpp.identifier",
+          "refersTo": {
+            "type": "permanentDocument",
+            "documentType": "post",
+            "propertyAgreement": {
+              "hashtag": "hashtag"
+            }
+          },
+          "position": 1
+        }
+      },
+      "required": [
+        "hashtag",
+        "postId"
+      ],
+      "additionalProperties": false
+    },
+    "post": {
+      "type": "object",
+      "documentsMutable": false,
+      "canBeDeleted": false,
+      "indices": [
+        {
+          "name": "byHashtag",
+          "properties": [
+            {
+              "hashtag": "asc"
+            }
+          ]
+        }
+      ],
+      "properties": {
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        },
+        "message": {
+          "type": "string",
+          "maxLength": 280,
+          "position": 1
+        }
+      },
+      "required": [
+        "hashtag"
+      ],
+      "additionalProperties": false
+    },
+    "beat": {
+      "type": "object",
+      "indexOnly": true,
+      "documentsMutable": false,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byHourHashtag",
+          "properties": [
+            {
+              "$createdAt": "asc"
+            },
+            {
+              "hashtag": "asc"
+            }
+          ],
+          "terminal": "$ownerId",
+          "timeRange": {
+            "on": "$createdAt",
+            "range": 3600,
+            "step": 900
+          },
+          "countable": "countable",
+          "rangeCountable": true
+        },
+        {
+          "name": "byHashtag",
+          "properties": [
+            {
+              "hashtag": "asc"
+            }
+          ],
+          "terminal": "$ownerId"
+        }
+      ],
+      "properties": {
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        }
+      },
+      "required": [
+        "hashtag",
+        "$createdAt"
+      ],
+      "additionalProperties": false
+    },
+    "tip": {
+      "type": "object",
+      "indexOnly": true,
+      "documentsMutable": false,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byPost",
+          "properties": [
+            {
+              "postId": "asc"
+            }
+          ],
+          "terminal": "$ownerId",
+          "countable": "countable",
+          "rangeCountable": true,
+          "rankedCountable": true,
+          "summable": "amount",
+          "rangeSummable": true,
+          "rankedSummable": true,
+          "preallocated": true
+        },
+        {
+          "name": "byTipperAmount",
+          "properties": [
+            {
+              "$ownerId": "asc"
+            },
+            {
+              "amount": "asc"
+            }
+          ],
+          "terminal": "postId"
+        }
+      ],
+      "properties": {
+        "postId": {
+          "type": "array",
+          "byteArray": true,
+          "minItems": 32,
+          "maxItems": 32,
+          "contentMediaType": "application/x.dash.dpp.identifier",
+          "refersTo": {
+            "type": "permanentDocument",
+            "documentType": "post"
+          },
+          "position": 0
+        },
+        "amount": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000,
+          "position": 1
+        }
+      },
+      "required": [
+        "postId",
+        "amount"
+      ],
+      "additionalProperties": false
+    },
+    "mark": {
+      "type": "object",
+      "indexOnly": true,
+      "documentsMutable": false,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byA",
+          "properties": [
+            {
+              "a": "asc"
+            }
+          ],
+          "terminal": "$ownerId"
+        },
+        {
+          "name": "byB",
+          "properties": [
+            {
+              "b": "asc"
+            }
+          ],
+          "terminal": "$ownerId"
+        }
+      ],
+      "properties": {
+        "a": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        },
+        "b": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 1
+        }
+      },
+      "required": [
+        "a",
+        "b"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/rs-platform-version/src/version/drive_versions/drive_document_method_versions/v4.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_document_method_versions/v4.rs
@@ -89,7 +89,10 @@ pub const DRIVE_DOCUMENT_METHOD_VERSIONS_V4: DriveDocumentMethodVersions =
             delete_document_for_contract_id: 0,
             delete_document_for_contract_apply_and_add_to_operations: 0,
             remove_document_from_primary_storage: 0,
-            remove_reference_for_index_level_for_contract_operations: 0,
+            // v1 at protocol v14: the empty-tree pruning climb stops at the
+            // member level on `preallocated` indexOnly indexes, keeping the
+            // trees the referenced document's insert paid for.
+            remove_reference_for_index_level_for_contract_operations: 1,
             remove_indices_for_index_level_for_contract_operations: 2,
             remove_indices_for_top_index_level_for_contract_operations: 2,
             delete_document_for_contract_id_with_named_type_operations: 0,
@@ -103,7 +106,12 @@ pub const DRIVE_DOCUMENT_METHOD_VERSIONS_V4: DriveDocumentMethodVersions =
             add_history_operations: 0,
             add_document_for_contract: 0,
             add_document_for_contract_apply_and_add_to_operations: 0,
-            add_document_for_contract_operations: 0,
+            // v1 at protocol v14: inserting a document also preallocates the
+            // dynamic trees of `preallocated` indexOnly indexes bound to its
+            // type through refersTo declarations. Insert and delete bump
+            // together: the delete-side no-prune rule is what makes the
+            // preallocated trees permanent structure.
+            add_document_for_contract_operations: 1,
             add_document_to_primary_storage: 0,
             add_indices_for_index_level_for_contract_operations: 2,
             add_indices_for_top_index_level_for_contract_operations: 2,

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Utils/DataContractParser.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Utils/DataContractParser.swift
@@ -282,21 +282,19 @@ public struct DataContractParser {
                 index.nullSearchable = nullSearchable
             }
 
-            // Count axis - `countable` is authored as a bool (true =
-            // "countable") or one of the string variants
+            // Protocol v14 index keywords, persisted VERBATIM as authored.
+            // Interpreting the spellings (countable's bool-or-string forms,
+            // the averageable desugar, the indexOnly $ownerId terminal
+            // default) is DPP protocol logic that stays out of the SDK -
+            // display layers apply it for presentation.
             if let countableBool = indexData["countable"] as? Bool {
-                index.countable = countableBool ? "countable" : nil
-            } else if let countableString = indexData["countable"] as? String,
-                      countableString != "notCountable" {
+                index.countable = countableBool ? "true" : "false"
+            } else if let countableString = indexData["countable"] as? String {
                 index.countable = countableString
             }
             if let rangeCountable = indexData["rangeCountable"] as? Bool {
                 index.rangeCountable = rangeCountable
             }
-
-            // Sum axis, including the `averageable` sugar (shorthand for
-            // countable + summable on the same property - the same desugar
-            // DPP applies)
             if let summable = indexData["summable"] as? String {
                 index.summable = summable
             }
@@ -304,17 +302,11 @@ public struct DataContractParser {
                 index.rangeSummable = rangeSummable
             }
             if let averageable = indexData["averageable"] as? String {
-                index.summable = averageable
-                if index.countable == nil {
-                    index.countable = "countable"
-                }
+                index.averageable = averageable
             }
-            if indexData["rangeAverageable"] as? Bool == true {
-                index.rangeCountable = true
-                index.rangeSummable = true
+            if let rangeAverageable = indexData["rangeAverageable"] as? Bool {
+                index.rangeAverageable = rangeAverageable
             }
-
-            // Ranking axes
             if let rankedCountable = indexData["rankedCountable"] as? Bool {
                 index.rankedCountable = rankedCountable
             }
@@ -324,14 +316,8 @@ public struct DataContractParser {
             if let rankedAverageable = indexData["rankedAverageable"] as? Bool {
                 index.rankedAverageable = rankedAverageable
             }
-
-            // indexOnly member key and preallocation. On an indexOnly
-            // document type an omitted terminal defaults to $ownerId -
-            // the same normalization DPP applies at parse time.
             if let terminal = indexData["terminal"] as? String {
                 index.terminal = terminal
-            } else if documentType.indexOnly {
-                index.terminal = "$ownerId"
             }
             if let preallocated = indexData["preallocated"] as? Bool {
                 index.preallocated = preallocated

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Utils/DataContractParser.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Utils/DataContractParser.swift
@@ -165,6 +165,10 @@ public struct DataContractParser {
                 docType.documentsMutable = mutable
             }
 
+            if let indexOnly = typeDict["indexOnly"] as? Bool {
+                docType.indexOnly = indexOnly
+            }
+
             // The actual field name is just "canBeDeleted" not "documentsCanBeDeleted"
             if let canDelete = typeDict["canBeDeleted"] as? Bool {
                 docType.documentsCanBeDeleted = canDelete
@@ -276,6 +280,67 @@ public struct DataContractParser {
 
             if let nullSearchable = indexData["nullSearchable"] as? Bool {
                 index.nullSearchable = nullSearchable
+            }
+
+            // Count axis - `countable` is authored as a bool (true =
+            // "countable") or one of the string variants
+            if let countableBool = indexData["countable"] as? Bool {
+                index.countable = countableBool ? "countable" : nil
+            } else if let countableString = indexData["countable"] as? String,
+                      countableString != "notCountable" {
+                index.countable = countableString
+            }
+            if let rangeCountable = indexData["rangeCountable"] as? Bool {
+                index.rangeCountable = rangeCountable
+            }
+
+            // Sum axis, including the `averageable` sugar (shorthand for
+            // countable + summable on the same property - the same desugar
+            // DPP applies)
+            if let summable = indexData["summable"] as? String {
+                index.summable = summable
+            }
+            if let rangeSummable = indexData["rangeSummable"] as? Bool {
+                index.rangeSummable = rangeSummable
+            }
+            if let averageable = indexData["averageable"] as? String {
+                index.summable = averageable
+                if index.countable == nil {
+                    index.countable = "countable"
+                }
+            }
+            if indexData["rangeAverageable"] as? Bool == true {
+                index.rangeCountable = true
+                index.rangeSummable = true
+            }
+
+            // Ranking axes
+            if let rankedCountable = indexData["rankedCountable"] as? Bool {
+                index.rankedCountable = rankedCountable
+            }
+            if let rankedSummable = indexData["rankedSummable"] as? Bool {
+                index.rankedSummable = rankedSummable
+            }
+            if let rankedAverageable = indexData["rankedAverageable"] as? Bool {
+                index.rankedAverageable = rankedAverageable
+            }
+
+            // indexOnly member key and preallocation. On an indexOnly
+            // document type an omitted terminal defaults to $ownerId -
+            // the same normalization DPP applies at parse time.
+            if let terminal = indexData["terminal"] as? String {
+                index.terminal = terminal
+            } else if documentType.indexOnly {
+                index.terminal = "$ownerId"
+            }
+            if let preallocated = indexData["preallocated"] as? Bool {
+                index.preallocated = preallocated
+            }
+
+            // Time-range bucketing transform
+            if let timeRange = indexData["timeRange"] as? [String: Any],
+               let timeRangeData = try? JSONSerialization.data(withJSONObject: timeRange, options: []) {
+                index.timeRangeJSON = timeRangeData
             }
 
             // Handle contested - can be bool or object

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentDocumentType.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentDocumentType.swift
@@ -18,6 +18,10 @@ public final class PersistentDocumentType {
     public var documentsCanBeDeleted: Bool
     public var documentsTransferable: Bool
 
+    // indexOnly storage mode (meta-schema v3, protocol version 14): no
+    // stored rows — the index entries ARE the documents
+    public var indexOnly: Bool = false
+
     // Required fields
     public var requiredFieldsJSON: Data?
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentIndex.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentIndex.swift
@@ -14,21 +14,29 @@ public final class PersistentIndex {
     public var nullSearchable: Bool
     public var contested: Bool
 
-    // Count / sum axes (meta-schema v3, protocol version 14).
-    // `countable` is normalized to its string form ("countable" /
-    // "countableAllowingOffset"); the `averageable` sugar is desugared
-    // into `countable` + `summable` exactly as DPP does.
+    // Count / sum axes (meta-schema v3, protocol version 14). Every
+    // keyword is persisted VERBATIM as authored in the contract JSON —
+    // `countable` keeps its boolean-or-string spelling ("true" /
+    // "countable" / "countableAllowingOffset"), and the `averageable` /
+    // `rangeAverageable` sugar is stored as-is rather than desugared.
+    // Interpreting the spellings (DPP's normalization rules) is protocol
+    // logic and stays out of the SDK; display layers map them for
+    // presentation.
     public var countable: String?
     public var rangeCountable: Bool = false
     public var summable: String?
     public var rangeSummable: Bool = false
+    public var averageable: String?
+    public var rangeAverageable: Bool = false
 
     // Ranking axes (each adds one ordered secondary tree)
     public var rankedCountable: Bool = false
     public var rankedSummable: Bool = false
     public var rankedAverageable: Bool = false
 
-    // indexOnly member key (the property whose value keys each entry)
+    // indexOnly member key (the property whose value keys each entry).
+    // Persisted only when declared; an omitted terminal on an indexOnly
+    // type means $ownerId per DPP, a default display layers apply.
     public var terminal: String?
 
     // Preallocation: creating the refersTo-referenced document also

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentIndex.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentIndex.swift
@@ -14,6 +14,30 @@ public final class PersistentIndex {
     public var nullSearchable: Bool
     public var contested: Bool
 
+    // Count / sum axes (meta-schema v3, protocol version 14).
+    // `countable` is normalized to its string form ("countable" /
+    // "countableAllowingOffset"); the `averageable` sugar is desugared
+    // into `countable` + `summable` exactly as DPP does.
+    public var countable: String?
+    public var rangeCountable: Bool = false
+    public var summable: String?
+    public var rangeSummable: Bool = false
+
+    // Ranking axes (each adds one ordered secondary tree)
+    public var rankedCountable: Bool = false
+    public var rankedSummable: Bool = false
+    public var rankedAverageable: Bool = false
+
+    // indexOnly member key (the property whose value keys each entry)
+    public var terminal: String?
+
+    // Preallocation: creating the refersTo-referenced document also
+    // creates this index's trees, and deleting the last entry keeps them
+    public var preallocated: Bool = false
+
+    // Time-range bucketing transform ({on, range, step, phase}), if any
+    public var timeRangeJSON: Data?
+
     // Properties in the index with sorting
     public var propertiesJSON: Data
 
@@ -59,6 +83,13 @@ extension PersistentIndex {
 
     public var contestedDetails: [String: Any]? {
         guard let data = contestedDetailsJSON else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+    }
+
+    /// The timeRange transform ({on, range, step, phase}) if the index
+    /// buckets its first property into time ranges
+    public var timeRange: [String: Any]? {
+        guard let data = timeRangeJSON else { return nil }
         return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
     }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentTypeDetailsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentTypeDetailsView.swift
@@ -257,7 +257,12 @@ struct ExpandableIndexRowView: View {
                         }
                     }
 
-                    if let terminal = index.terminal {
+                    // An omitted terminal on an indexOnly type means
+                    // $ownerId per DPP; the SDK persists verbatim, so the
+                    // display default is applied here.
+                    let displayTerminal = index.terminal
+                        ?? (index.documentType?.indexOnly == true ? "$ownerId" : nil)
+                    if let terminal = displayTerminal {
                         HStack {
                             Text("Terminal:")
                                 .font(.caption)
@@ -282,15 +287,26 @@ struct ExpandableIndexRowView: View {
                         }
                     }
 
-                    // Count / sum / ranking axes (protocol version 14)
+                    // Count / sum / ranking axes (protocol version 14).
+                    // The SDK persists the keywords verbatim, so the
+                    // display mapping - countable's bool-or-string
+                    // spellings and the averageable sugar (shorthand for
+                    // countable + summable, per DPP's desugar) - lives
+                    // here, mirroring the Kotlin example app's
+                    // indexAxisDescriptors helper.
                     let axisLabels: [String] = {
                         var labels: [String] = []
-                        if let countable = index.countable {
-                            labels.append(countable == "countableAllowingOffset" ? "Countable (offsets)" : "Countable")
+                        if index.countable == "countableAllowingOffset" {
+                            labels.append("Countable (offsets)")
+                        } else if index.countable == "true" || index.countable == "countable"
+                            || (index.countable == nil && index.averageable != nil) {
+                            labels.append("Countable")
                         }
-                        if index.rangeCountable { labels.append("Range Count") }
-                        if let summable = index.summable { labels.append("Summable (\(summable))") }
-                        if index.rangeSummable { labels.append("Range Sum") }
+                        if index.rangeCountable || index.rangeAverageable { labels.append("Range Count") }
+                        if let summable = index.summable ?? index.averageable {
+                            labels.append("Summable (\(summable))")
+                        }
+                        if index.rangeSummable || index.rangeAverageable { labels.append("Range Sum") }
                         if index.rankedCountable { labels.append("Ranked by Count") }
                         if index.rankedSummable { labels.append("Ranked by Sum") }
                         if index.rankedAverageable { labels.append("Ranked by Average") }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentTypeDetailsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentTypeDetailsView.swift
@@ -85,6 +85,14 @@ struct DocumentTypeDetailsView: View {
     private var documentSettingsSection: some View {
         Section("Document Settings") {
             VStack(alignment: .leading, spacing: 8) {
+                if documentType.indexOnly {
+                    HStack {
+                        Label("Index Only (entries are the documents)", systemImage: "tray.full.fill")
+                            .foregroundColor(.teal)
+                        Spacer()
+                    }
+                }
+
                 HStack {
                     Label("Keep History", systemImage: documentType.documentsKeepHistory ? "clock.fill" : "clock")
                         .foregroundColor(documentType.documentsKeepHistory ? .blue : .secondary)
@@ -211,6 +219,16 @@ struct ExpandableIndexRowView: View {
                             .cornerRadius(4)
                     }
 
+                    if index.preallocated {
+                        Text("PREALLOCATED")
+                            .font(.caption2)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.teal.opacity(0.2))
+                            .foregroundColor(.teal)
+                            .cornerRadius(4)
+                    }
+
                     Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                         .font(.caption)
                         .foregroundColor(.secondary)
@@ -239,6 +257,17 @@ struct ExpandableIndexRowView: View {
                         }
                     }
 
+                    if let terminal = index.terminal {
+                        HStack {
+                            Text("Terminal:")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            Text(terminal)
+                                .font(.caption)
+                                .foregroundColor(.teal)
+                        }
+                    }
+
                     HStack(spacing: 12) {
                         if index.nullSearchable {
                             Label("Null Searchable", systemImage: "magnifyingglass")
@@ -251,6 +280,34 @@ struct ExpandableIndexRowView: View {
                                 .font(.caption2)
                                 .foregroundColor(.orange)
                         }
+                    }
+
+                    // Count / sum / ranking axes (protocol version 14)
+                    let axisLabels: [String] = {
+                        var labels: [String] = []
+                        if let countable = index.countable {
+                            labels.append(countable == "countableAllowingOffset" ? "Countable (offsets)" : "Countable")
+                        }
+                        if index.rangeCountable { labels.append("Range Count") }
+                        if let summable = index.summable { labels.append("Summable (\(summable))") }
+                        if index.rangeSummable { labels.append("Range Sum") }
+                        if index.rankedCountable { labels.append("Ranked by Count") }
+                        if index.rankedSummable { labels.append("Ranked by Sum") }
+                        if index.rankedAverageable { labels.append("Ranked by Average") }
+                        return labels
+                    }()
+                    if !axisLabels.isEmpty {
+                        Text(axisLabels.joined(separator: " · "))
+                            .font(.caption2)
+                            .foregroundColor(.green)
+                    }
+
+                    if let timeRange = index.timeRange,
+                       let range = timeRange["range"] as? Int,
+                       let step = timeRange["step"] as? Int {
+                        Label("Time Range: \(range)s windows every \(step)s", systemImage: "clock.badge")
+                            .font(.caption2)
+                            .foregroundColor(.cyan)
                     }
 
                     // Show contested details if available

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
@@ -1203,10 +1203,11 @@ struct IndexStorageDetailView: View {
                 FieldRow(label: "Null Searchable", value: record.nullSearchable ? "Yes" : "No")
                 FieldRow(label: "Contested", value: record.contested ? "Yes" : "No")
             }
-            // Protocol v14 index keywords - rows appear only when set, so
-            // pre-v14 indexes render exactly as before
-            if record.countable != nil || record.summable != nil || record.terminal != nil
-                || record.preallocated || record.timeRangeJSON != nil {
+            // Protocol v14 index keywords - persisted verbatim as authored
+            // and rendered raw here (this is the storage debug view); rows
+            // appear only when set, so pre-v14 indexes render as before
+            if record.countable != nil || record.summable != nil || record.averageable != nil
+                || record.terminal != nil || record.preallocated || record.timeRangeJSON != nil {
                 Section("Axes & Storage Mode") {
                     if let countable = record.countable {
                         FieldRow(label: "Countable", value: countable)
@@ -1219,6 +1220,12 @@ struct IndexStorageDetailView: View {
                     }
                     if record.rangeSummable {
                         FieldRow(label: "Range Summable", value: "Yes")
+                    }
+                    if let averageable = record.averageable {
+                        FieldRow(label: "Averageable", value: averageable)
+                    }
+                    if record.rangeAverageable {
+                        FieldRow(label: "Range Averageable", value: "Yes")
                     }
                     if record.rankedCountable {
                         FieldRow(label: "Ranked by Count", value: "Yes")

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
@@ -1203,6 +1203,45 @@ struct IndexStorageDetailView: View {
                 FieldRow(label: "Null Searchable", value: record.nullSearchable ? "Yes" : "No")
                 FieldRow(label: "Contested", value: record.contested ? "Yes" : "No")
             }
+            // Protocol v14 index keywords - rows appear only when set, so
+            // pre-v14 indexes render exactly as before
+            if record.countable != nil || record.summable != nil || record.terminal != nil
+                || record.preallocated || record.timeRangeJSON != nil {
+                Section("Axes & Storage Mode") {
+                    if let countable = record.countable {
+                        FieldRow(label: "Countable", value: countable)
+                    }
+                    if record.rangeCountable {
+                        FieldRow(label: "Range Countable", value: "Yes")
+                    }
+                    if let summable = record.summable {
+                        FieldRow(label: "Summable", value: summable)
+                    }
+                    if record.rangeSummable {
+                        FieldRow(label: "Range Summable", value: "Yes")
+                    }
+                    if record.rankedCountable {
+                        FieldRow(label: "Ranked by Count", value: "Yes")
+                    }
+                    if record.rankedSummable {
+                        FieldRow(label: "Ranked by Sum", value: "Yes")
+                    }
+                    if record.rankedAverageable {
+                        FieldRow(label: "Ranked by Average", value: "Yes")
+                    }
+                    if let terminal = record.terminal {
+                        FieldRow(label: "Terminal", value: terminal)
+                    }
+                    if record.preallocated {
+                        FieldRow(label: "Preallocated", value: "Yes")
+                    }
+                    if let timeRange = record.timeRange,
+                       let range = timeRange["range"] as? Int,
+                       let step = timeRange["step"] as? Int {
+                        FieldRow(label: "Time Range", value: "\(range)s windows every \(step)s")
+                    }
+                }
+            }
             if let props = record.properties, !props.isEmpty {
                 Section("Properties") {
                     ForEach(props, id: \.self) { prop in


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On an indexOnly document type, the first entry under a fresh value tuple pays for every tree on its path — for a like that is the hashtag value tree, the `postId` property-name tree, the post's value tree and the `0` member bucket — while every later entry pays for one item insert. When the index path is a pure function of a refersTo-referenced document (`byHashtagPost`: `hashtag` through the `propertyAgreement`, `postId` as the reference), that lopsidedness is avoidable: the referenced document's insert already knows every tree an entry referencing it will ever need.

This PR adds the `preallocated` index keyword: creating the referenced document (the post) also creates the referring index's dynamic trees, charged to the poster, so the FIRST like costs the same as every later one — and deleting the last like keeps the trees instead of pruning them, so the cost stays uniform across drain/re-like cycles.

## What was done?
<!--- Describe your changes in detail -->

**dpp**
- `preallocated` index keyword (`Index.preallocated`), admitted at meta-schema v3 / generation 3 exactly like `terminal` (`IndexGrammarAdmissions`, unknown-key rejection below PV14); meta-schema entry added
- Binding derivation shared with the write path in `index/preallocation.rs` (`Index::preallocation_bindings`): every index property must be the referring property (→ referenced `$id`) or a `propertyAgreement` key (→ referenced property), same-contract `permanentDocument` target only
- `apply_index_only` rejects the flag on non-indexOnly types, on paths not determined by a reference, and combined with `timeRange` (a bucketed level is keyed by write-time bucket starts)
- `IndexLevelTypeInfo.preallocated` stamped at the terminating level; contract updates reject flips (`find_first_preallocated_change`, wired into `validate_update`)

**drive — insert** (`insert/add_preallocated_index_tree_operations`)
- Post insert emits if-not-exists creations of every bound referring index's dynamic trees down to the empty `0` member bucket, through the same tree-type derivation the entry walkers use (`index_level_tree_types_with_continuation_demotion`, `terminal_member_tree_type` / `terminal_value_tree_type` — sum axes included), with full estimation-layer support; trees carry the poster's storage flags
- Entry insertion keeps its create-if-missing behavior, so preallocation is purely an optimization: posts predating a contract update fall back to first-entry pricing, and shared hashtag prefixes deduplicate through the if-not-exists semantics
- Gated in place: the keyword cannot appear below meta-schema v3, so historical replay is untouched

**drive — delete**
- The indexOnly terminal branch stops the `delete_up_tree_while_empty` climb at the member level for preallocated indexes: drained groups stay in the ranked secondaries at count/sum 0, and a re-entry needs no tree creation; non-preallocated indexes of the same type keep pruning

**docs**
- "Preallocated index paths" section in `book/src/drive/index-only-document-types.md`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

- `try_from_schema/v3/index_only_tests.rs`: acceptance (both validation modes, level-info stamping) plus the rejection matrix — no determining reference, uncovered property, `$ownerId` prefix, cross-contract reference (own-id accepted), non-indexOnly type, `timeRange` combination, below-generation-3 grammar gating
- `index/preallocation.rs` unit tests for the binding derivation
- New `preallocated_index_e2e_tests.rs` against a `yappr-likes-preallocated` fixture (byHashtagPost, byPost and the summable tip.byPost flagged): tree preallocation shape incl. zero-count/zero-sum ranked groups, empty-index queries with proof parity, delete asymmetry (preallocated trees survive, byLiker still prunes) across re-like cycles, fee shift (post costs more / first like costs less than the plain contract), sum-axis drain/re-tip, and estimation upper-bounding for post/like/tip inserts and delete dry-runs
- Regression: dpp indexOnly (45) and index_level (19) suites, rs-drive indexOnly (32) and ranked (85) e2e suites, drive-abci indexOnly pipeline tests (10) — all passing; `cargo check --all-targets` on dpp and drive, verify-only drive build, clippy clean

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

Consensus-affecting, PV14-gated (unreleased): the new keyword changes referenced-document insert operations and suppresses delete-side pruning for flagged indexes. No released network or historical replay is affected. One observable state change under the flag: "no entries yet" is a present-but-empty member bucket (a rankable zero group, provable as zero results) rather than an absent tree.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for preallocated indexes on eligible index-only document types.
  * Preallocated index trees are created when referenced documents are inserted and preserved when entries are removed.
  * Added protocol version 14 schema support and validation for preallocated indexes.
  * Added index-only, preallocation, terminal, axis, and time-range details to Kotlin and Swift example apps.

* **Bug Fixes**
  * Prevented partial tree creation when required reference values are missing.
  * Enforced immutability of preallocation settings after deployment.

* **Tests**
  * Added comprehensive validation, storage, fee, query, and lifecycle coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->