### PR TITLE
test(test-suite): indexOnly document lifecycle functional spec

### DIFF
--- a/packages/platform-test-suite/test/functional/platform/IndexOnlyDocument.spec.js
+++ b/packages/platform-test-suite/test/functional/platform/IndexOnlyDocument.spec.js
@@ -1,0 +1,422 @@
+const Dash = require('dash');
+const { expect } = require('chai');
+
+const createClientWithFundedWallet = require('../../../lib/test/createClientWithFundedWallet');
+const generateRandomIdentifier = require('../../../lib/test/utils/generateRandomIdentifier');
+const waitForSTPropagated = require('../../../lib/waitForSTPropagated');
+
+const {
+  Errors: {
+    StateTransitionBroadcastError,
+  },
+  PlatformProtocol: {
+    Identifier,
+  },
+} = Dash;
+
+describe('Platform', () => {
+  describe('IndexOnlyDocument', function main() {
+    this.timeout(900000);
+
+    const POST_HASHTAG = 'dash';
+
+    let client;
+    let identity;
+    let secondIdentity;
+    let dataContract;
+    let dataContractDocumentSchemas;
+    let post;
+    let like;
+    let fetchedLike;
+
+    before(async () => {
+      dataContractDocumentSchemas = {
+        post: {
+          type: 'object',
+          documentsMutable: false,
+          canBeDeleted: false,
+          indices: [
+            {
+              name: 'byHashtag',
+              properties: [{ hashtag: 'asc' }],
+            },
+          ],
+          properties: {
+            hashtag: {
+              type: 'string',
+              minLength: 1,
+              maxLength: 63,
+              position: 0,
+            },
+            message: {
+              type: 'string',
+              maxLength: 280,
+              position: 1,
+            },
+          },
+          required: ['hashtag'],
+          additionalProperties: false,
+        },
+        like: {
+          type: 'object',
+          indexOnly: true,
+          documentsMutable: false,
+          canBeDeleted: true,
+          indices: [
+            {
+              name: 'byHashtagPost',
+              properties: [{ hashtag: 'asc' }, { postId: 'asc' }],
+              terminal: '$ownerId',
+              countable: 'countable',
+              rangeCountable: true,
+              rankedCountable: true,
+            },
+            {
+              name: 'byPost',
+              properties: [{ postId: 'asc' }],
+            },
+            {
+              name: 'byLiker',
+              properties: [{ $ownerId: 'asc' }],
+              terminal: 'postId',
+            },
+          ],
+          properties: {
+            hashtag: {
+              type: 'string',
+              minLength: 1,
+              maxLength: 63,
+              position: 0,
+            },
+            postId: {
+              type: 'array',
+              byteArray: true,
+              minItems: 32,
+              maxItems: 32,
+              contentMediaType: Identifier.MEDIA_TYPE,
+              refersTo: {
+                type: 'permanentDocument',
+                documentType: 'post',
+                propertyAgreement: {
+                  hashtag: 'hashtag',
+                },
+              },
+              position: 1,
+            },
+          },
+          required: ['hashtag', 'postId'],
+          additionalProperties: false,
+        },
+      };
+
+      client = await createClientWithFundedWallet(400000000); // 4 Dash
+
+      identity = await client.platform.identities.register(200000000);
+
+      // Additional wait time to mitigate testnet latency
+      await waitForSTPropagated();
+
+      secondIdentity = await client.platform.identities.register(100000000);
+
+      // Additional wait time to mitigate testnet latency
+      await waitForSTPropagated();
+    });
+
+    after(async () => {
+      if (client) {
+        await client.disconnect();
+      }
+    });
+
+    it('should register a data contract with an indexOnly document type', async () => {
+      dataContract = await client.platform.contracts.create(
+        dataContractDocumentSchemas,
+        identity,
+      );
+
+      await client.platform.contracts.publish(dataContract, identity);
+
+      // Additional wait time to mitigate testnet latency
+      await waitForSTPropagated();
+
+      client.getApps().set('yappr', {
+        contractId: dataContract.getId(),
+        contract: dataContract,
+      });
+
+      const fetchedDataContract = await client.platform.contracts.get(
+        dataContract.getId(),
+      );
+
+      expect(fetchedDataContract.toObject()).to.be.deep.equal(dataContract.toObject());
+      expect(fetchedDataContract.toObject().documentSchemas.like.indexOnly).to.be.true();
+    });
+
+    it('should fail to create a like that refers to a nonexistent post', async () => {
+      const orphanedLike = await client.platform.documents.create(
+        'yappr.like',
+        identity,
+        {
+          hashtag: POST_HASHTAG,
+          postId: await generateRandomIdentifier(),
+        },
+      );
+
+      let broadcastError;
+
+      try {
+        await client.platform.documents.broadcast({
+          create: [orphanedLike],
+        }, identity);
+      } catch (e) {
+        broadcastError = e;
+      }
+
+      expect(broadcastError).to.be.an.instanceOf(StateTransitionBroadcastError);
+      // ReferencedEntityNotFoundError
+      expect(broadcastError.code).to.equal(40120);
+    });
+
+    it('should fail to create a like whose hashtag disagrees with its post', async () => {
+      post = await client.platform.documents.create(
+        'yappr.post',
+        identity,
+        {
+          hashtag: POST_HASHTAG,
+          message: 'a post worth liking',
+        },
+      );
+
+      await client.platform.documents.broadcast({
+        create: [post],
+      }, identity);
+
+      // Additional wait time to mitigate testnet latency
+      await waitForSTPropagated();
+
+      const disagreeingLike = await client.platform.documents.create(
+        'yappr.like',
+        identity,
+        {
+          hashtag: 'otherhashtag',
+          postId: post.getId(),
+        },
+      );
+
+      let broadcastError;
+
+      try {
+        await client.platform.documents.broadcast({
+          create: [disagreeingLike],
+        }, identity);
+      } catch (e) {
+        broadcastError = e;
+      }
+
+      expect(broadcastError).to.be.an.instanceOf(StateTransitionBroadcastError);
+      // ReferencedDocumentPropertyMismatchError: refersTo propertyAgreement
+      // binds the like's hashtag to the referenced post's
+      expect(broadcastError.code).to.equal(40127);
+    });
+
+    it('should create a like that agrees with its post', async () => {
+      like = await client.platform.documents.create(
+        'yappr.like',
+        identity,
+        {
+          hashtag: POST_HASHTAG,
+          postId: post.getId(),
+        },
+      );
+
+      await client.platform.documents.broadcast({
+        create: [like],
+      }, identity);
+
+      // Additional wait time to mitigate testnet latency
+      await waitForSTPropagated();
+    });
+
+    it('should fail to create an identical like by the same identity', async () => {
+      const duplicateLike = await client.platform.documents.create(
+        'yappr.like',
+        identity,
+        {
+          hashtag: POST_HASHTAG,
+          postId: post.getId(),
+        },
+      );
+
+      let broadcastError;
+
+      try {
+        await client.platform.documents.broadcast({
+          create: [duplicateLike],
+        }, identity);
+      } catch (e) {
+        broadcastError = e;
+      }
+
+      expect(broadcastError).to.be.an.instanceOf(StateTransitionBroadcastError);
+      // DuplicateUniqueIndexError: on an indexOnly type ANY existing entry
+      // collides, so every index is a uniqueness constraint over its value
+      // projection plus owner
+      expect(broadcastError.code).to.equal(40105);
+    });
+
+    it('should synthesize likes from index entries when queried through an index', async () => {
+      // A query through the subset index [postId] yields a projection:
+      // only what the entry position stores (postId in the path, the
+      // $ownerId terminal in the member key)
+      const projectedLikes = await client.platform.documents.get(
+        'yappr.like',
+        { where: [['postId', '==', post.getId()]] },
+      );
+
+      expect(projectedLikes).to.have.lengthOf(1);
+
+      const [projectedLike] = projectedLikes;
+
+      expect(projectedLike.getOwnerId().toString()).to.equal(identity.getId().toString());
+      expect(projectedLike.get('postId').toString()).to.equal(post.getId().toString());
+      expect(projectedLike.get('hashtag')).to.be.undefined();
+
+      // A query through the [hashtag, postId] index covers every property
+      // of the like, so the synthesized document is complete
+      const [fullLike] = await client.platform.documents.get(
+        'yappr.like',
+        {
+          where: [
+            ['hashtag', '==', POST_HASHTAG],
+            ['postId', '==', post.getId()],
+          ],
+        },
+      );
+
+      expect(fullLike).to.exist();
+      expect(fullLike.getOwnerId().toString()).to.equal(identity.getId().toString());
+      expect(fullLike.get('hashtag')).to.equal(POST_HASHTAG);
+      expect(fullLike.get('postId').toString()).to.equal(post.getId().toString());
+
+      // The synthesized $id is deterministic over the proved index
+      // position, NOT the id the create transition carried — nothing on
+      // chain is ever addressed by it
+      expect(fullLike.getId().toString()).to.not.equal(like.getId().toString());
+
+      fetchedLike = fullLike;
+    });
+
+    it('should fail to fetch an indexOnly document by id', async () => {
+      let fetchError;
+
+      try {
+        await client.platform.documents.get(
+          'yappr.like',
+          { where: [['$id', '==', fetchedLike.getId()]] },
+        );
+      } catch (e) {
+        fetchError = e;
+      }
+
+      expect(fetchError).to.exist();
+      expect(fetchError.message).to.match(/indexOnly documents cannot be fetched by id/);
+    });
+
+    it('should delete a like by its values', async () => {
+      // The delete carries the document's full value tuple (there is no
+      // stored row and no id to delete by), so it must be built from a
+      // document fetched through an index that covers every property
+      await client.platform.documents.broadcast({
+        delete: [fetchedLike],
+      }, identity);
+
+      // Additional wait time to mitigate testnet latency
+      await waitForSTPropagated();
+
+      const likes = await client.platform.documents.get(
+        'yappr.like',
+        { where: [['postId', '==', post.getId()]] },
+      );
+
+      expect(likes).to.have.lengthOf(0);
+    });
+
+    it('should allow a second identity to like the same post but not to delete another identity\'s like', async () => {
+      // Re-create the first identity's like so the second identity's
+      // identical values face an existing entry
+      like = await client.platform.documents.create(
+        'yappr.like',
+        identity,
+        {
+          hashtag: POST_HASHTAG,
+          postId: post.getId(),
+        },
+      );
+
+      await client.platform.documents.broadcast({
+        create: [like],
+      }, identity);
+
+      // Additional wait time to mitigate testnet latency
+      await waitForSTPropagated();
+
+      // Deletes are self-authorizing: the network computes the entry tuple
+      // with owner = signer, so the second identity can only ever address
+      // its own entries and the first identity's like surfaces as not found
+      const [firstIdentityLike] = await client.platform.documents.get(
+        'yappr.like',
+        {
+          where: [
+            ['hashtag', '==', POST_HASHTAG],
+            ['postId', '==', post.getId()],
+          ],
+        },
+      );
+
+      firstIdentityLike.setOwnerId(secondIdentity.getId());
+
+      let broadcastError;
+
+      try {
+        await client.platform.documents.broadcast({
+          delete: [firstIdentityLike],
+        }, secondIdentity);
+      } catch (e) {
+        broadcastError = e;
+      }
+
+      expect(broadcastError).to.be.an.instanceOf(StateTransitionBroadcastError);
+      // DocumentNotFoundError
+      expect(broadcastError.code).to.equal(40101);
+
+      // Identical values under a different terminal are a different entry,
+      // not a duplicate
+      const secondLike = await client.platform.documents.create(
+        'yappr.like',
+        secondIdentity,
+        {
+          hashtag: POST_HASHTAG,
+          postId: post.getId(),
+        },
+      );
+
+      await client.platform.documents.broadcast({
+        create: [secondLike],
+      }, secondIdentity);
+
+      // Additional wait time to mitigate testnet latency
+      await waitForSTPropagated();
+
+      const likes = await client.platform.documents.get(
+        'yappr.like',
+        { where: [['postId', '==', post.getId()]] },
+      );
+
+      expect(likes).to.have.lengthOf(2);
+      expect(likes.map((doc) => doc.getOwnerId().toString())).to.have.members([
+        identity.getId().toString(),
+        secondIdentity.getId().toString(),
+      ]);
+    });
+  });
+});

--- a/packages/platform-test-suite/test/functional/platform/IndexOnlyDocument.spec.js
+++ b/packages/platform-test-suite/test/functional/platform/IndexOnlyDocument.spec.js
@@ -264,26 +264,12 @@ describe('Platform', () => {
       expect(broadcastError.code).to.equal(40105);
     });
 
-    it('should synthesize likes from index entries when queried through an index', async () => {
-      // A query through the subset index [postId] yields a projection:
-      // only what the entry position stores (postId in the path, the
-      // $ownerId terminal in the member key)
-      const projectedLikes = await client.platform.documents.get(
-        'yappr.like',
-        { where: [['postId', '==', post.getId()]] },
-      );
-
-      expect(projectedLikes).to.have.lengthOf(1);
-
-      const [projectedLike] = projectedLikes;
-
-      expect(projectedLike.getOwnerId().toString()).to.equal(identity.getId().toString());
-      expect(projectedLike.get('postId').toString()).to.equal(post.getId().toString());
-      expect(projectedLike.get('hashtag')).to.be.undefined();
-
+    it('should synthesize likes from index entries when queried through a covering index', async () => {
       // A query through the [hashtag, postId] index covers every property
-      // of the like, so the synthesized document is complete
-      const [fullLike] = await client.platform.documents.get(
+      // of the like (prefix properties from the path, the $ownerId
+      // terminal from the member key), so the synthesized document is
+      // complete
+      const likes = await client.platform.documents.get(
         'yappr.like',
         {
           where: [
@@ -293,7 +279,10 @@ describe('Platform', () => {
         },
       );
 
-      expect(fullLike).to.exist();
+      expect(likes).to.have.lengthOf(1);
+
+      const [fullLike] = likes;
+
       expect(fullLike.getOwnerId().toString()).to.equal(identity.getId().toString());
       expect(fullLike.get('hashtag')).to.equal(POST_HASHTAG);
       expect(fullLike.get('postId').toString()).to.equal(post.getId().toString());
@@ -304,6 +293,26 @@ describe('Platform', () => {
       expect(fullLike.getId().toString()).to.not.equal(like.getId().toString());
 
       fetchedLike = fullLike;
+    });
+
+    it('should fail to query a subset-index projection without proofs', async () => {
+      // The subset index [postId] synthesizes a projection without the
+      // required hashtag; a partial document cannot be expressed in the
+      // serialized non-proof response, so it only travels the proved read
+      // surface (where the client synthesizes it from the proof itself)
+      let fetchError;
+
+      try {
+        await client.platform.documents.get(
+          'yappr.like',
+          { where: [['postId', '==', post.getId()]] },
+        );
+      } catch (e) {
+        fetchError = e;
+      }
+
+      expect(fetchError).to.exist();
+      expect(fetchError.message).to.match(/does not cover every required property/);
     });
 
     it('should fail to fetch an indexOnly document by id', async () => {
@@ -335,7 +344,12 @@ describe('Platform', () => {
 
       const likes = await client.platform.documents.get(
         'yappr.like',
-        { where: [['postId', '==', post.getId()]] },
+        {
+          where: [
+            ['hashtag', '==', POST_HASHTAG],
+            ['postId', '==', post.getId()],
+          ],
+        },
       );
 
       expect(likes).to.have.lengthOf(0);
@@ -409,7 +423,12 @@ describe('Platform', () => {
 
       const likes = await client.platform.documents.get(
         'yappr.like',
-        { where: [['postId', '==', post.getId()]] },
+        {
+          where: [
+            ['hashtag', '==', POST_HASHTAG],
+            ['postId', '==', post.getId()],
+          ],
+        },
       );
 
       expect(likes).to.have.lengthOf(2);

--- a/packages/rs-dpp/src/document/document_factory/v0/mod.rs
+++ b/packages/rs-dpp/src/document/document_factory/v0/mod.rs
@@ -1,6 +1,6 @@
 use crate::consensus::basic::document::InvalidDocumentTypeError;
 use crate::data_contract::accessors::v0::DataContractV0Getters;
-use crate::data_contract::document_type::accessors::DocumentTypeV0Getters;
+use crate::data_contract::document_type::accessors::{DocumentTypeV0Getters, DocumentTypeV2Getters};
 use crate::data_contract::document_type::DocumentTypeRef;
 use crate::data_contract::errors::DataContractError;
 use crate::data_contract::DataContract;
@@ -27,7 +27,7 @@ use crate::prelude::{BlockHeight, CoreBlockHeight, TimestampMillis};
 use crate::state_transition::batch_transition::{
     batched_transition::{
         document_transition_action_type::DocumentTransitionActionType, DocumentCreateTransition,
-        DocumentDeleteTransition, DocumentReplaceTransition,
+        DocumentDeleteTransition, DocumentIndexOnlyDeleteTransition, DocumentReplaceTransition,
     },
     BatchTransition, BatchTransitionV0,
 };
@@ -510,6 +510,32 @@ impl DocumentFactoryV0 {
                     }
                     .into());
                 }
+
+                // Deleting an indexOnly document is a different OPERATION
+                // from deleting a stored one (delete-by-values vs
+                // delete-by-id), so the factory picks the transition kind
+                // from the doctype's storage mode. Index-only documents
+                // carry no revision (there is no stored row to revise), so
+                // the revision gate only applies to the by-id path.
+                if document_type.index_only() {
+                    let nonce = nonce_counter
+                        .entry((document.owner_id(), document_type.data_contract_id()))
+                        .or_default();
+                    let transition = DocumentIndexOnlyDeleteTransition::from_document(
+                        document,
+                        document_type,
+                        token_payment_info,
+                        *nonce,
+                        platform_version,
+                        None,
+                        None,
+                    )?;
+
+                    *nonce += 1;
+
+                    return Ok(transition.into());
+                }
+
                 let Some(_document_revision) = document.revision() else {
                     return Err(DocumentError::RevisionAbsentError {
                         document: Box::new(document),
@@ -545,13 +571,18 @@ impl DocumentFactoryV0 {
 #[cfg(test)]
 mod test {
     use data_contracts::SystemDataContract;
+    use platform_value::platform_value;
     use platform_version::version::PlatformVersion;
     use std::collections::BTreeMap;
 
     use crate::data_contract::accessors::v0::DataContractV0Getters;
+    use crate::data_contract::config::DataContractConfig;
+    use crate::data_contract::document_type::DocumentType;
     use crate::document::document_factory::DocumentFactoryV0;
     use crate::document::{Document, DocumentV0};
     use crate::identifier::Identifier;
+    use crate::state_transition::batch_transition::batched_transition::document_index_only_delete_transition::v0::v0_methods::DocumentIndexOnlyDeleteTransitionV0Methods;
+    use crate::state_transition::batch_transition::batched_transition::document_transition::DocumentTransition;
     use crate::system_data_contracts::load_system_data_contract;
 
     #[test]
@@ -608,5 +639,132 @@ mod test {
         assert!(result.is_ok(), "The function should succeed");
         let transitions = result.unwrap();
         assert_eq!(transitions.len(), 1, "There should be one transition");
+    }
+
+    #[test]
+    /// The factory picks the delete KIND from the doctype's storage mode:
+    /// an indexOnly type gets a delete-by-values transition carrying the
+    /// document's properties, and no revision is required (synthesized
+    /// index-only documents carry none).
+    fn delete_index_only_documents_produces_index_only_delete_kind() {
+        let platform_version = PlatformVersion::latest();
+        let config = DataContractConfig::default_for_version(platform_version)
+            .expect("default config available");
+
+        let schema = platform_value!({
+            "type": "object",
+            "indexOnly": true,
+            "documentsMutable": false,
+            "canBeDeleted": true,
+            "properties": {
+                "hashtag": {
+                    "type": "string",
+                    "maxLength": 63,
+                    "position": 0
+                },
+                "postId": {
+                    "type": "array",
+                    "byteArray": true,
+                    "minItems": 32,
+                    "maxItems": 32,
+                    "contentMediaType": "application/x.dash.dpp.identifier",
+                    "refersTo": { "type": "identity" },
+                    "position": 1
+                }
+            },
+            "required": ["hashtag", "postId"],
+            "indices": [
+                {
+                    "name": "byPost",
+                    "properties": [{ "postId": "asc" }]
+                },
+                {
+                    "name": "byLiker",
+                    "properties": [{ "$ownerId": "asc" }],
+                    "terminal": "postId"
+                },
+                {
+                    "name": "byHashtagPost",
+                    "properties": [{ "hashtag": "asc" }, { "postId": "asc" }],
+                    "terminal": "$ownerId"
+                }
+            ],
+            "additionalProperties": false
+        });
+
+        let contract_id = Identifier::new([1; 32]);
+        let document_type = DocumentType::try_from_schema(
+            contract_id,
+            1,
+            config.version(),
+            "like",
+            schema,
+            None,
+            &BTreeMap::new(),
+            &config,
+            false,
+            &mut vec![],
+            platform_version,
+        )
+        .expect("the indexOnly like schema parses");
+        let document_type_ref = document_type.as_ref();
+
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "hashtag".to_string(),
+            platform_value::Value::Text("dash".to_string()),
+        );
+        properties.insert(
+            "postId".to_string(),
+            platform_value::Value::Identifier([2; 32]),
+        );
+        let document = Document::V0(DocumentV0 {
+            contract_version: None,
+            id: Identifier::random(),
+            owner_id: Identifier::random(),
+            properties,
+            // Synthesized index-only documents have no revision — the
+            // by-id path's revision gate must not apply here.
+            revision: None,
+            created_at: None,
+            updated_at: None,
+            transferred_at: None,
+            created_at_block_height: None,
+            updated_at_block_height: None,
+            transferred_at_block_height: None,
+            created_at_core_block_height: None,
+            updated_at_core_block_height: None,
+            transferred_at_core_block_height: None,
+            creator_id: None,
+        });
+
+        let mut nonce_counter = BTreeMap::new();
+        let transitions = DocumentFactoryV0::document_delete_transitions(
+            vec![(document, document_type_ref, None)],
+            &mut nonce_counter,
+            platform_version,
+        )
+        .expect("the delete transition builds");
+
+        assert_eq!(transitions.len(), 1, "There should be one transition");
+        let DocumentTransition::IndexOnlyDelete(transition) = &transitions[0] else {
+            panic!(
+                "an indexOnly doctype must produce an indexOnlyDelete transition, got {}",
+                transitions[0]
+            );
+        };
+        let data = transition.data();
+        assert_eq!(
+            data.get("hashtag"),
+            Some(&platform_value::Value::Text("dash".to_string()))
+        );
+        assert_eq!(
+            data.get("postId"),
+            Some(&platform_value::Value::Identifier([2; 32]))
+        );
+        assert!(
+            !data.contains_key("$createdAt"),
+            "$createdAt must not ride along when the doctype does not require it"
+        );
     }
 }

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -650,6 +650,89 @@ fn should_synthesize_query_documents_with_proof_parity() {
     assert_grovedb_is_consistent(&drive);
 }
 
+/// The raw serialized read — the wire the non-proof GetDocuments endpoint
+/// returns — must carry the synthesized documents' serialized bytes when
+/// the queried index covers every property, and refuse a subset
+/// projection with guidance: the serialized document format has no way to
+/// express a missing required property, so partial projections only
+/// travel the proved read surface, where the client synthesizes them
+/// itself.
+#[test]
+fn should_serialize_synthesized_documents_on_raw_no_proof_reads() {
+    use crate::error::query::QuerySyntaxError;
+    use crate::error::Error;
+    use crate::query::{WhereClause, WhereOperator};
+    use dpp::document::serialization_traits::DocumentPlatformConversionMethodsV0;
+    use dpp::document::{Document, DocumentV0Getters};
+    use dpp::platform_value::Value;
+
+    let (drive, contract) = setup_likes();
+    let like = build_like(&contract, "dash", POST_A, OWNER_1, 1);
+    insert_like(&drive, &contract, &like, true).expect("insert like");
+
+    let document_type = contract
+        .document_type_for_name(DOCTYPE)
+        .expect("like doctype exists");
+
+    // Covering index ([hashtag, postId] → $ownerId): the synthesized
+    // document is complete and must round-trip through the wire bytes.
+    let covering = likes_query(
+        &contract,
+        vec![WhereClause {
+            field: "hashtag".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Text("dash".to_string()),
+        }],
+        Some(10),
+    );
+    let (serialized, _, _) = covering
+        .execute_raw_results_no_proof(&drive, None, None, platform_version())
+        .expect("covering raw read executes");
+    assert_eq!(serialized.len(), 1, "one like under #dash");
+    let document = Document::from_bytes(&serialized[0], document_type, platform_version())
+        .expect("wire bytes must round-trip through from_bytes");
+    assert_eq!(
+        document.properties().get("hashtag"),
+        Some(&Value::Text("dash".to_string()))
+    );
+    assert_eq!(
+        document
+            .properties()
+            .get("postId")
+            .expect("postId recovered")
+            .to_identifier_bytes()
+            .expect("identifier"),
+        POST_A.to_vec()
+    );
+    assert_eq!(document.owner_id().to_buffer(), OWNER_1);
+
+    // Subset index ([$ownerId] → postId): the projection has no hashtag,
+    // which is required — it cannot be serialized, so the raw read must
+    // refuse with guidance instead of returning bytes no client can parse.
+    let subset = likes_query(
+        &contract,
+        vec![WhereClause {
+            field: "$ownerId".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Identifier(OWNER_1),
+        }],
+        Some(10),
+    );
+    let error = subset
+        .execute_raw_results_no_proof(&drive, None, None, platform_version())
+        .expect_err("a subset projection cannot travel the serialized wire");
+    assert!(
+        matches!(
+            &error,
+            Error::Query(QuerySyntaxError::Unsupported(message))
+                if message.contains("does not cover every required property")
+        ),
+        "expected covering guidance, got: {error}"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
 /// "Did I like X" as a single query: equality on the terminal property
 /// through `byLiker` ([$ownerId] → postId) — the prefix equality fixes the
 /// path, the terminal equality selects one member key. Proved and

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -2520,6 +2520,45 @@ impl<'a> DriveDocumentQuery<'a> {
         drive_operations: &mut Vec<LowLevelDriveOperation>,
         platform_version: &PlatformVersion,
     ) -> Result<(Vec<Vec<u8>>, u16), Error> {
+        // indexOnly documents have no stored bodies — the raw elements under
+        // the entries are row commitments, not documents. Synthesize the
+        // documents from their (path, key) positions and serialize them into
+        // the wire shape this path's callers return. An index that does not
+        // cover every required property cannot produce a serializable
+        // document: partial projections only travel the proved read surface,
+        // where the client synthesizes them itself from the proof.
+        {
+            use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
+            if self.document_type.index_only() {
+                let (documents, skipped) = self.execute_index_only_documents_no_proof_internal(
+                    drive,
+                    transaction,
+                    drive_operations,
+                    platform_version,
+                )?;
+                let serialized = documents
+                    .into_iter()
+                    .map(|document| {
+                        document
+                            .serialize(self.document_type, self.contract, platform_version)
+                            .map_err(|error| match error {
+                                ProtocolError::DataContractError(
+                                    dpp::data_contract::errors::DataContractError::MissingRequiredKey(_),
+                                ) => Error::Query(QuerySyntaxError::Unsupported(
+                                    "this indexOnly query's index does not cover every required \
+                                     property, so the documents it synthesizes cannot be \
+                                     serialized into a non-proof response; query through an \
+                                     index covering all properties, or use a proved query"
+                                        .to_string(),
+                                )),
+                                other => other.into(),
+                            })
+                    })
+                    .collect::<Result<Vec<_>, Error>>()?;
+                return Ok((serialized, skipped));
+            }
+        }
+
         let path_query = self.construct_path_query_operations(
             drive,
             false,


### PR DESCRIPTION
## Issue being fixed or feature implemented

indexOnly document types (protocol v14) had full e2e coverage at the Rust layers (rs-drive `index_only_e2e_tests`, rs-drive-abci `batch/tests/document/index_only`), but no JS functional spec in `platform-test-suite` — the layer that exercises the whole stack (js-dash-sdk → wasm-dpp → DAPI → drive-abci → drive) against a live network. Two gaps blocked writing one, and the spec surfaced a third:

1. The legacy `DocumentFactory` (the construction path wasm-dpp / js-dash-sdk use) mapped every delete to a by-id `DocumentDeleteTransition`, which the structure gates reject for indexOnly types — deletion of an indexOnly document is its own transition kind, `DocumentIndexOnlyDeleteTransition` (delete-by-values).
2. Found by the new spec's first live run: `DriveDocumentQuery::execute_raw_results_no_proof` — which the non-proof `GetDocuments` handler calls directly — returned the raw grovedb elements for indexOnly types. Those are 32-byte row commitments, not documents, so clients blew up parsing them (`Document::from_bytes: unknown version, received: 111`).

## What was done?

- **feat(dpp)**: `DocumentFactoryV0::document_delete_transitions` now picks the delete kind from the doctype's storage mode, mirroring the dispatch already in the batch-transition v0/v1 builders: `index_only()` → `DocumentIndexOnlyDeleteTransition::from_document` (no revision gate — synthesized index-only documents carry none), stored types → the by-id path, byte-identical to before. Unit test pins the dispatch, the carried data, and that `$createdAt` stays out when the doctype doesn't require it. No wasm-dpp changes were needed — its transition wrappers already handle the kind.
- **fix(drive)**: `execute_raw_results_no_proof_internal` routes indexOnly queries through the same synthesis executor `Drive::query_documents` uses and serializes the synthesized documents into the wire bytes clients expect. A subset-index projection lacks required properties the serialized document format cannot omit (`serialize_v3` has no presence flag for required fields), so it is refused with guidance to query through a covering index — projections still travel the proved read surface, where the client synthesizes them from the proof itself. New rs-drive e2e test pins the covering-index `from_bytes` round trip and the subset refusal.
- **test(suite)**: new `test/functional/platform/IndexOnlyDocument.spec.js`, modeled on `Document.spec.js`/`contacts.spec.js`. It registers an inline yappr-style contract (stored `post` + indexOnly `like` with `refersTo`/`propertyAgreement`) and covers, in order:
  1. contract with an indexOnly doctype registers and round-trips;
  2. a like on a nonexistent post is rejected (`ReferencedEntityNotFoundError`, 40120);
  3. a like whose hashtag disagrees with its post is rejected (`propertyAgreement`, `ReferencedDocumentPropertyMismatchError`, 40127);
  4. an agreeing like creates;
  5. an identical like by the same identity is rejected (`DuplicateUniqueIndexError`, 40105 — any existing entry collides);
  6. querying through the covering `[hashtag, postId]` index returns documents synthesized from index positions, carrying the created values and owner, with a deterministic `$id` that is not the create's id;
  7. a subset-index query (`postId ==`, byPost) is refused on the non-proof wire with covering guidance;
  8. fetching by `$id` is rejected with guidance (no primary-key tree);
  9. a by-values delete through `documents.broadcast({ delete: [...] })` succeeds and the entry disappears from queries;
  10. a second identity can like the same post (same values, different terminal — not a duplicate), and cannot delete the first identity's like: deletes are self-authorizing (the entry tuple is computed with owner = signer), so it surfaces as `DocumentNotFoundError` (40101).

Every broadcast in the suite also verifies its executed-transition proof via the EvoSDK-backed proof verifier, which for indexOnly batches takes the `ExecutionNotProved` → `waitForAffectedState` path — so the spec exercises the indexOnly executed-proof surface (outcome always `AffectedState`, never `ExecutionProved`) on each create and delete. The skipped/broken `waitForStateTransitionResult.spec.js` was deliberately not extended (it is `describe.skip`'d and stale).

## How Has This Been Tested?

- `IndexOnlyDocument.spec.js`: 10/10 passing against a local dashmate network (`yarn setup` + `yarn start`) built from this branch.
- `Document.spec.js`: 8/8 passing on the same network (stored-type deletes/queries unaffected).
- `cargo test -p dpp` (4018 passed) and `cargo test -p drive --lib` (3478 passed, includes the 33 indexOnly e2e tests and the new raw-reads test).
- `cargo clippy --all-targets -- -D warnings` clean for `dpp` and `drive`.
- `yarn lint` clean in `platform-test-suite`.

## Breaking Changes

None. The by-id delete path is byte-identical for stored types; the raw no-proof read path previously returned unparseable bytes for indexOnly types (nothing could have depended on it).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deleting index-only documents using their property values, without requiring a revision.
  * Index-only query results can now be returned as complete serialized documents when the index covers all required properties.

* **Bug Fixes**
  * Queries using incomplete index projections are now rejected with a clear unsupported-query error.
  * Added validation for duplicate references, authorization, deletion behavior, and document property consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->