### PR TITLE
fix(dpp): compile wasm-dpp2 after propertyAgreement and expose it on reference metadata

### DIFF
--- a/packages/js-evo-sdk/README.md
+++ b/packages/js-evo-sdk/README.md
@@ -161,6 +161,10 @@ const contract = await sdk.contracts.fetch(contractId);
 
 for (const ref of contract.documentTypeReferences('note')) {
   // { path: 'author', type: 'identityPublicKey', keyIdProperty: 'authorKeyId' }
+  // A permanentDocument reference may additionally carry a write-time
+  // equality binding between the two documents' properties:
+  // { path: 'postId', type: 'permanentDocument', contractId, documentType: 'post',
+  //   propertyAgreement: { hashtag: 'hashtag' } }
   console.log(ref.path, ref.type);
 }
 

--- a/packages/wasm-dpp2/src/data_contract/document_type_reference.rs
+++ b/packages/wasm-dpp2/src/data_contract/document_type_reference.rs
@@ -53,6 +53,14 @@ export type DocumentPropertyReferenceTarget =
        * reference dangling.
        */
       documentType: string;
+      /**
+       * Write-time equality bindings between the two documents:
+       * `{ <referring property path>: <referenced property path> }`.
+       * Consensus refuses a write whose referring property does not equal
+       * the referenced document's property (code 40127). Absent — not
+       * `{}`-valued — when the declaration carries none.
+       */
+      propertyAgreement?: Record<string, string>;
     }
   | {
       type: 'identityPublicKey';
@@ -131,6 +139,7 @@ fn reference_to_js(
         DocumentPropertyReferenceTarget::PermanentDocument {
             contract_id,
             document_type_name,
+            property_agreement,
         } => {
             let effective = contract_id.unwrap_or(declaring_contract_id);
             set_field(
@@ -145,6 +154,18 @@ fn reference_to_js(
                 &JsValue::from_str(document_type_name),
                 path,
             )?;
+            // `propertyAgreement` binds a referring property to a property
+            // of the referenced document (consensus-enforced equality at
+            // write time). Absent — not `{}`-valued — when the declaration
+            // carries none, matching the schema's own omission and the
+            // absent-field convention of the other optional target fields.
+            if !property_agreement.is_empty() {
+                let agreement = Object::new();
+                for (referring, referenced) in property_agreement {
+                    set_field(&agreement, referring, &JsValue::from_str(referenced), path)?;
+                }
+                set_field(&object, "propertyAgreement", &agreement, path)?;
+            }
         }
         DocumentPropertyReferenceTarget::IdentityPublicKey { key_id_property } => {
             set_field(

--- a/packages/wasm-dpp2/tests/unit/DocumentPropertyReference.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/DocumentPropertyReference.spec.ts
@@ -53,9 +53,12 @@ const schemas = {
       sourceContract: identifierProperty(1, { type: 'contract' }),
       paidWith: identifierProperty(2, { type: 'token' }),
       // `contractId` omitted: targets the declaring contract itself.
+      // `propertyAgreement` binds the referring document's property to
+      // the referenced document's (write-time equality, PV14 #4505).
       parentNoteId: identifierProperty(3, {
         type: 'permanentDocument',
         documentType: 'note',
+        propertyAgreement: { signerKeyId: 'signerKeyId' },
       }),
       otherDoc: identifierProperty(4, {
         type: 'permanentDocument',
@@ -104,6 +107,7 @@ type Reference = {
   contractId?: { toBase58(): string };
   documentType?: string;
   keyIdProperty?: string;
+  propertyAgreement?: Record<string, string>;
 };
 
 describe('DataContract — refersTo declarations (v14)', () => {
@@ -167,6 +171,27 @@ describe('DataContract — refersTo declarations (v14)', () => {
 
       expect(other.contractId!.toBase58()).to.equal(foreignContractId);
       expect(other.documentType).to.equal('thing');
+    });
+
+    it('should carry the propertyAgreement map when declared', () => {
+      const contract = buildContract(14);
+      const references = contract.documentTypeReferences('note') as Reference[];
+      const parent = references.find((reference) => reference.path === 'parentNoteId')!;
+
+      expect(parent.propertyAgreement).to.deep.equal({ signerKeyId: 'signerKeyId' });
+    });
+
+    /**
+     * Absent — not `{}`-valued — when the declaration carries none,
+     * matching the schema's own omission and the absent-field convention
+     * of the other optional target fields.
+     */
+    it('should omit propertyAgreement for a reference declaring none', () => {
+      const contract = buildContract(14);
+      const references = contract.documentTypeReferences('note') as Reference[];
+      const other = references.find((reference) => reference.path === 'otherDoc')!;
+
+      expect(other).to.not.have.property('propertyAgreement');
     });
 
     it('should carry keyIdProperty for an identityPublicKey reference', () => {


### PR DESCRIPTION
## Issue being fixed or feature implemented

**`v4.2-dev` does not compile right now.** #4450 (refersTo reference metadata) and #4505 (`propertyAgreement` on permanentDocument references) were developed in parallel and merged without a rebase between them: #4450's exhaustive destructure of `DocumentPropertyReferenceTarget::PermanentDocument` doesn't mention the `property_agreement` field #4505 added, so wasm-dpp2 fails `E0027` — and wasm-sdk / js-evo-sdk with it. No CI ran on the combination before the merge.

## What was done?

Rather than papering over the field with `..`, surface it — the metadata accessor exists to report what a contract declares, and `propertyAgreement` is now part of that:

- `reference_to_js` destructures `property_agreement` and, when non-empty, emits it as a plain `{ referring: referenced }` object on the `permanentDocument` reference. Absent — not `{}`-valued — when the declaration carries none, matching the schema's own omission and the absent-field convention of the other optional target fields.
- The hand-written TS custom section documents the new optional field (emits into `dist/dpp.d.ts`; the compressed d.ts never carries these types, unchanged).
- Specs: the fixture's self-referencing `parentNoteId` now declares an agreement; two new specs pin presence (deep-equal) and absence (`not.have.property`). 1157 wasm-dpp2 specs pass.
- js-evo-sdk README's refersTo section shows the new field.

## How Has This Been Tested?

- `cargo check -p wasm-dpp2 -p wasm-sdk --all-targets` (fails E0027 on `v4.2-dev`, passes here)
- `cargo clippy -p wasm-dpp2 -p wasm-sdk --all-features --all-targets -- -D warnings` clean
- wasm32 test lane (`cargo test -p wasm-sdk --target wasm32-unknown-unknown`) — 6 passed; this lane is not run by CI, and it is where #4450-style breaks hide
- `yarn workspace @dashevo/wasm-dpp2 build` + `test` — 1157 passing; lint 0 errors (1 pre-existing warning in an unrelated spec)

## Breaking Changes

None — additive JS metadata field; no consensus surface touched.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document references can now define property agreements, linking specific properties between referenced documents.
  * Property agreement metadata is preserved when declared and omitted when unavailable.

* **Documentation**
  * Added README guidance and an example for configuring property agreements on permanent document references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->