### PR TITLE
fix(dpp): unbreak v4.2-dev — fmt gate and propertyAgreement compile breaks

### DIFF
--- a/packages/js-evo-sdk/README.md
+++ b/packages/js-evo-sdk/README.md
@@ -161,6 +161,10 @@ const contract = await sdk.contracts.fetch(contractId);
 
 for (const ref of contract.documentTypeReferences('note')) {
   // { path: 'author', type: 'identityPublicKey', keyIdProperty: 'authorKeyId' }
+  // A permanentDocument reference may additionally carry a write-time
+  // equality binding between the two documents' properties:
+  // { path: 'postId', type: 'permanentDocument', contractId, documentType: 'post',
+  //   propertyAgreement: { hashtag: 'hashtag' } }
   console.log(ref.path, ref.type);
 }
 

--- a/packages/rs-dpp/src/data_contract/document_type/property/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/property/mod.rs
@@ -7292,6 +7292,7 @@ mod tests {
             DocumentPropertyReferenceTarget::PermanentDocument {
                 contract_id: None,
                 document_type_name: "note".to_string(),
+                property_agreement: Default::default(),
             },
             DocumentPropertyReferenceTarget::IdentityPublicKey {
                 key_id_property: "signerKeyId".to_string(),

--- a/packages/rs-dpp/src/document/document_factory/v0/mod.rs
+++ b/packages/rs-dpp/src/document/document_factory/v0/mod.rs
@@ -1,6 +1,8 @@
 use crate::consensus::basic::document::InvalidDocumentTypeError;
 use crate::data_contract::accessors::v0::DataContractV0Getters;
-use crate::data_contract::document_type::accessors::{DocumentTypeV0Getters, DocumentTypeV2Getters};
+use crate::data_contract::document_type::accessors::{
+    DocumentTypeV0Getters, DocumentTypeV2Getters,
+};
 use crate::data_contract::document_type::DocumentTypeRef;
 use crate::data_contract::errors::DataContractError;
 use crate::data_contract::DataContract;

--- a/packages/wasm-dpp2/src/data_contract/document_type_reference.rs
+++ b/packages/wasm-dpp2/src/data_contract/document_type_reference.rs
@@ -53,6 +53,14 @@ export type DocumentPropertyReferenceTarget =
        * reference dangling.
        */
       documentType: string;
+      /**
+       * Write-time equality bindings between the two documents:
+       * `{ <referring property path>: <referenced property path> }`.
+       * Consensus refuses a write whose referring property does not equal
+       * the referenced document's property (code 40127). Absent — not
+       * `{}`-valued — when the declaration carries none.
+       */
+      propertyAgreement?: Record<string, string>;
     }
   | {
       type: 'identityPublicKey';
@@ -131,6 +139,7 @@ fn reference_to_js(
         DocumentPropertyReferenceTarget::PermanentDocument {
             contract_id,
             document_type_name,
+            property_agreement,
         } => {
             let effective = contract_id.unwrap_or(declaring_contract_id);
             set_field(
@@ -145,6 +154,18 @@ fn reference_to_js(
                 &JsValue::from_str(document_type_name),
                 path,
             )?;
+            // `propertyAgreement` binds a referring property to a property
+            // of the referenced document (consensus-enforced equality at
+            // write time). Absent — not `{}`-valued — when the declaration
+            // carries none, matching the schema's own omission and the
+            // absent-field convention of the other optional target fields.
+            if !property_agreement.is_empty() {
+                let agreement = Object::new();
+                for (referring, referenced) in property_agreement {
+                    set_field(&agreement, referring, &JsValue::from_str(referenced), path)?;
+                }
+                set_field(&object, "propertyAgreement", &agreement, path)?;
+            }
         }
         DocumentPropertyReferenceTarget::IdentityPublicKey { key_id_property } => {
             set_field(

--- a/packages/wasm-dpp2/tests/unit/DocumentPropertyReference.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/DocumentPropertyReference.spec.ts
@@ -53,9 +53,12 @@ const schemas = {
       sourceContract: identifierProperty(1, { type: 'contract' }),
       paidWith: identifierProperty(2, { type: 'token' }),
       // `contractId` omitted: targets the declaring contract itself.
+      // `propertyAgreement` binds the referring document's property to
+      // the referenced document's (write-time equality, PV14 #4505).
       parentNoteId: identifierProperty(3, {
         type: 'permanentDocument',
         documentType: 'note',
+        propertyAgreement: { signerKeyId: 'signerKeyId' },
       }),
       otherDoc: identifierProperty(4, {
         type: 'permanentDocument',
@@ -104,6 +107,7 @@ type Reference = {
   contractId?: { toBase58(): string };
   documentType?: string;
   keyIdProperty?: string;
+  propertyAgreement?: Record<string, string>;
 };
 
 describe('DataContract — refersTo declarations (v14)', () => {
@@ -167,6 +171,27 @@ describe('DataContract — refersTo declarations (v14)', () => {
 
       expect(other.contractId!.toBase58()).to.equal(foreignContractId);
       expect(other.documentType).to.equal('thing');
+    });
+
+    it('should carry the propertyAgreement map when declared', () => {
+      const contract = buildContract(14);
+      const references = contract.documentTypeReferences('note') as Reference[];
+      const parent = references.find((reference) => reference.path === 'parentNoteId')!;
+
+      expect(parent.propertyAgreement).to.deep.equal({ signerKeyId: 'signerKeyId' });
+    });
+
+    /**
+     * Absent — not `{}`-valued — when the declaration carries none,
+     * matching the schema's own omission and the absent-field convention
+     * of the other optional target fields.
+     */
+    it('should omit propertyAgreement for a reference declaring none', () => {
+      const contract = buildContract(14);
+      const references = contract.documentTypeReferences('note') as Reference[];
+      const other = references.find((reference) => reference.path === 'otherDoc')!;
+
+      expect(other).to.not.have.property('propertyAgreement');
     });
 
     it('should carry keyIdProperty for an identityPublicKey reference', () => {


### PR DESCRIPTION
## Issue being fixed or feature implemented

`v4.2-dev` fails to build after three PRs merged in parallel without cross-rebases (#4450, #4505, #4510). This PR is the single unbreak:

1. **fmt gate**: the import line #4510 added to `document_factory/v0/mod.rs` landed unformatted — `cargo fmt --check --all` fails on every PR.
2. **E0063** (`dpp` lib tests): #4450's `reference_targets_are_exhaustively_mirrored` test constructs `PermanentDocument` without the `property_agreement` field #4505 added.
3. **E0027** (`wasm-dpp2`, blocks wasm-sdk / js-evo-sdk): #4450's exhaustive destructure of the same variant doesn't mention the field. Includes the fix from #4514 — rather than ignoring the field, the reference metadata surfaces it (`propertyAgreement: { referring: referenced }`, absent when undeclared), with TS typings, presence/absence specs, and README.

Supersedes #4514 (its commit is cherry-picked here so one merge makes the base green).

## How Has This Been Tested?

- `cargo fmt --check --all` passes
- `cargo check -p dpp -p wasm-dpp2 -p wasm-sdk --all-targets` passes (each failed on `v4.2-dev`)
- `cargo test -p dpp --lib reference_targets_are_exhaustively_mirrored` passes
- wasm-dpp2 build + 1157 specs; wasm32 lane (`cargo test -p wasm-sdk --target wasm32-unknown-unknown`, not covered by CI) — 6 passed
- clippy `-D warnings` on wasm-dpp2 + wasm-sdk clean

## Breaking Changes

None — additive JS metadata field; no consensus surface touched.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)