### PR TITLE
feat(drive): skip absent-property indexes on indexOnly writes

### DIFF
--- a/packages/rs-dpp/schema/meta_schemas/document/v3/document-meta.json
+++ b/packages/rs-dpp/schema/meta_schemas/document/v3/document-meta.json
@@ -647,6 +647,10 @@
           "preallocated": {
             "type": "boolean",
             "description": "Only on indexOnly document types whose index path is fully determined by a same-contract permanentDocument refersTo declaration: every index property must be either the referring property itself (its value is the referenced document's $id) or a key of that declaration's propertyAgreement (consensus-equal to a referenced-document property). When true, creating a referenced document also creates this index's dynamic trees for entries referencing it — paid by the referenced document's creator — and deleting the last entry keeps them, so every entry insert costs the same as the first. Available from protocol version 14."
+          },
+          "skipIfAbsent": {
+            "type": "boolean",
+            "description": "Only on indexOnly document types: when true, a document that omits this index's first property writes no entry into this index (and a delete recomputes the same skip), so the index holds only documents carrying the property. The first property is the skip trigger: it must be a top-level schema property NOT listed in `required` (making it the only way an indexOnly property may be optional), and every index involving an optional property must be skipIfAbsent with that property first. Every other property that is not a skip trigger must still appear in at least one non-skipIfAbsent index, and at least one $createdAt-free index must remain non-skipIfAbsent (the executed-transition proof index). An absent trigger is distinct from an empty value: absence skips the index, while any present value — empty included — indexes normally. Available from protocol version 14."
           }
         },
         "required": [
@@ -793,7 +797,7 @@
     },
     "indexOnly": {
       "type": "boolean",
-      "description": "When true, documents of this type are never written to primary storage: the index entries are the rows, each terminating in an Item keyed by the index's `terminal` property instead of a Reference keyed by the document id. Only what is in the indexes exists and is recoverable. Requires: every property required and appearing in at least one index, $ownerId in at least one index (as a property or terminal), documentsMutable: false, no transfers/trading/history/transient properties, and no doctype-level aggregate keywords (use the index-level count flags). Available from protocol version 14."
+      "description": "When true, documents of this type are never written to primary storage: the index entries are the rows, each terminating in an Item keyed by the index's `terminal` property instead of a Reference keyed by the document id. Only what is in the indexes exists and is recoverable. Requires: every property required and appearing in at least one index (except a `skipIfAbsent` index's optional first property), $ownerId in at least one index (as a property or terminal), documentsMutable: false, no transfers/trading/history/transient properties, and no doctype-level aggregate keywords (use the index-level count flags). Available from protocol version 14."
     },
     "tokenCost": {
       "type": "object",

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/common/mod.rs
@@ -213,6 +213,10 @@ pub(super) struct ParserGeneration {
     /// (refersTo-determined indexOnly indexes). Forwarded to
     /// [`Index::try_from_value_map`] exactly like the admissions above.
     pub admit_index_preallocated: bool,
+    /// Whether the index grammar admits the `skipIfAbsent` keyword
+    /// (conditional-participation indexOnly indexes). Forwarded to
+    /// [`Index::try_from_value_map`] exactly like the admissions above.
+    pub admit_index_skip_if_absent: bool,
 }
 
 /// Reject a document type whose name is not a non-empty ASCII
@@ -853,6 +857,7 @@ fn parse_indices(
                             time_range: ctx.generation.admit_time_range,
                             terminal: ctx.generation.admit_index_terminal,
                             preallocated: ctx.generation.admit_index_preallocated,
+                            skip_if_absent: ctx.generation.admit_index_skip_if_absent,
                         },
                     )
                     .map_err(consensus_or_protocol_data_contract_error)?;
@@ -1947,6 +1952,21 @@ pub(super) fn apply_index_only(
                 index_name, name,
             )));
         }
+        // Same for `skipIfAbsent`: conditional participation only means
+        // anything when the index entries ARE the storage — a stored type's
+        // optional properties already have the null index layout.
+        if let Some((index_name, _)) = document_type
+            .indices
+            .iter()
+            .find(|(_, index)| index.skip_if_absent)
+        {
+            return Err(structure_error(format!(
+                "index \"{}\" on document type \"{}\" declares `skipIfAbsent`, which is only \
+                 allowed on indexOnly document types (set `indexOnly: true` on the document \
+                 type, or remove the flag)",
+                index_name, name,
+            )));
+        }
         return Ok(());
     }
 
@@ -2056,10 +2076,60 @@ pub(super) fn apply_index_only(
         if !index.null_searchable {
             return Err(structure_error(format!(
                 "index \"{}\" on indexOnly document type \"{}\" cannot set nullSearchable: \
-                 false: every property of an indexOnly type is required, so no null entries \
-                 exist to suppress",
+                 false: an indexOnly property is either required or an absent-skipping \
+                 index's trigger, so no null entries exist to suppress (a skipIfAbsent \
+                 index writes nothing for an absent trigger; nullSearchable suppresses \
+                 stored-type null-layout entries, which indexOnly types never write)",
                 index_name, name,
             )));
+        }
+        // `skipIfAbsent`: the index participates only for documents that
+        // carry its FIRST property — the skip trigger. The trigger sits at
+        // position 0 so the whole branch is pruned at the top of the index
+        // walk before any tree is inserted: a deeper skip would leave the
+        // prefix trees above it inserted-but-unterminated (the merged index
+        // structure shares levels across indexes, and upward pruning only
+        // runs from a terminal), silently charging for structure no entry
+        // uses. The trigger must be a top-level schema property so its
+        // presence is a single map lookup shared verbatim by the write
+        // walkers (which derive the skip from `required` membership), the
+        // probes (which read the flag), and the row commitment — rules
+        // below force those three views to agree.
+        if index.skip_if_absent {
+            let trigger = &index
+                .properties
+                .first()
+                .expect("non-empty checked above")
+                .name;
+            if trigger.starts_with('$') {
+                return Err(structure_error(format!(
+                    "index \"{}\" on indexOnly document type \"{}\" declares `skipIfAbsent` \
+                     with system property \"{}\" first: the skip trigger must be an \
+                     optional schema property — system properties are always present \
+                     (or, for $createdAt, forced into `required` when indexed), so the \
+                     index could never skip",
+                    index_name, name, trigger,
+                )));
+            }
+            if trigger.contains('.') {
+                return Err(structure_error(format!(
+                    "index \"{}\" on indexOnly document type \"{}\" declares `skipIfAbsent` \
+                     with nested property \"{}\" first: the skip trigger must be a \
+                     top-level property, so that presence is a single lookup with no \
+                     partially-present ancestor states",
+                    index_name, name, trigger,
+                )));
+            }
+            if document_type.required_fields.contains(trigger.as_str()) {
+                return Err(structure_error(format!(
+                    "index \"{}\" on indexOnly document type \"{}\" declares `skipIfAbsent`, \
+                     but its first property \"{}\" is listed in `required`: a required \
+                     trigger can never be absent, so the index could never skip — remove \
+                     \"{}\" from `required` (making this the property's skip trigger) or \
+                     drop the flag",
+                    index_name, name, trigger, trigger,
+                )));
+            }
         }
         // `timeRange` is admitted: a bucketed indexOnly index writes one
         // entry per containing bucket, exactly as stored types do (the
@@ -2251,16 +2321,19 @@ pub(super) fn apply_index_only(
         }
     }
 
-    // At least one index must involve no `$createdAt` at all — the PROOF
-    // index. Executed-transition proofs (waitForStateTransitionResult)
-    // locate the entry a create or delete produced from the transition's
-    // values alone, and a client verifier cannot know the block timestamp
-    // an entry was keyed with; if every index were time-keyed, creates and
-    // deletes of the type would work while every transition-proof request
-    // failed. (Every index already embeds `$ownerId`, so any
-    // `$createdAt`-free index qualifies as the proof index.)
+    // At least one index must involve no `$createdAt` at all AND not be
+    // `skipIfAbsent` — the PROOF index. Executed-transition proofs
+    // (waitForStateTransitionResult) locate the entry a create or delete
+    // produced from the transition's values alone; a client verifier
+    // cannot know the block timestamp an entry was keyed with, and a
+    // skipIfAbsent index has no entry at all for trigger-absent documents.
+    // If every index were time-keyed or skippable, creates and deletes of
+    // the type would work while transition-proof requests failed. (Every
+    // index already embeds `$ownerId`, so any `$createdAt`-free non-skip
+    // index qualifies as the proof index.)
     let has_proof_index = document_type.indices.values().any(|index| {
-        index.terminal.as_deref() != Some(CREATED_AT)
+        !index.skip_if_absent
+            && index.terminal.as_deref() != Some(CREATED_AT)
             && !index
                 .properties
                 .iter()
@@ -2268,46 +2341,116 @@ pub(super) fn apply_index_only(
     });
     if !has_proof_index {
         return Err(structure_error(format!(
-            "indexOnly document type \"{}\" must declare at least one index that does \
-             not involve $createdAt: executed-transition proofs locate entries from the \
-             transition's values alone and cannot reproduce the block timestamp a \
-             time-keyed entry was written with",
+            "indexOnly document type \"{}\" must declare at least one index that neither \
+             involves $createdAt nor sets skipIfAbsent: executed-transition proofs locate \
+             entries from the transition's values alone — they cannot reproduce the block \
+             timestamp a time-keyed entry was written with, and a skipIfAbsent index has \
+             no entry for documents that omit its trigger",
             name,
         )));
     }
 
     // ---- coverage and requiredness --------------------------------------
     // The index content IS the document: a property in no index would not
-    // exist, and an optional property would need the null-layout machinery
-    // this mode deliberately sidesteps.
+    // exist, and an absent value has no representation in an index path.
+    // The one sanctioned hole is a skipIfAbsent index's trigger: it may be
+    // optional because absence removes the whole index entry — there is
+    // genuinely nothing to store. Everything else must be required, and
+    // must be covered by at least one NON-skip index: a skip index carries
+    // no value at all for trigger-absent documents, so a property covered
+    // only by skip indexes would be validated, committed into the row
+    // commitment, and then written nowhere — unrecoverable by any query,
+    // and the document undeletable once the client forgets the value.
+    let skip_triggers: BTreeSet<&str> = document_type
+        .indices
+        .values()
+        .filter(|index| index.skip_if_absent)
+        .filter_map(|index| index.properties.first())
+        .map(|property| property.name.as_str())
+        .collect();
     for (property_name, property) in document_type.flattened_properties.iter() {
         if matches!(property.property_type, DocumentPropertyType::Object(_)) {
             // Containers are covered through their flattened leaves.
             continue;
         }
+        let is_trigger = skip_triggers.contains(property_name.as_str());
         let covered = document_type.indices.values().any(|index| {
-            index.terminal.as_deref() == Some(property_name.as_str())
-                || index
-                    .properties
-                    .iter()
-                    .any(|index_property| index_property.name == *property_name)
+            // A skip index only counts as coverage for its own trigger.
+            (is_trigger || !index.skip_if_absent)
+                && (index.terminal.as_deref() == Some(property_name.as_str())
+                    || index
+                        .properties
+                        .iter()
+                        .any(|index_property| index_property.name == *property_name))
         });
         if !covered {
             return Err(structure_error(format!(
                 "property \"{}\" on indexOnly document type \"{}\" does not appear in any \
-                 index (as a property or terminal): on an indexOnly type only indexed \
-                 values exist and are recoverable, so an unindexed property would be \
-                 silently dropped",
+                 non-skipIfAbsent index (as a property or terminal): on an indexOnly type \
+                 only indexed values exist and are recoverable, and a skipIfAbsent index \
+                 holds no value at all for documents that omit its trigger, so the \
+                 property would be silently dropped",
                 property_name, name,
             )));
         }
         if !document_type.required_fields.contains(property_name) {
-            return Err(structure_error(format!(
-                "property \"{}\" on indexOnly document type \"{}\" must be listed in \
-                 `required`: the index path is the storage, and an absent value would need \
-                 the null index layout this mode deliberately has no equivalent of",
-                property_name, name,
-            )));
+            if !is_trigger {
+                return Err(structure_error(format!(
+                    "property \"{}\" on indexOnly document type \"{}\" must be listed in \
+                     `required`: the index path is the storage, and an absent value would \
+                     need the null index layout this mode deliberately has no equivalent \
+                     of (only the first property of a skipIfAbsent index may be optional)",
+                    property_name, name,
+                )));
+            }
+            // An optional property is exactly a skip trigger, and every
+            // index involving it must be a skipIfAbsent index with the
+            // property FIRST (and never as a terminal). This is the
+            // invariant the write walkers rely on: they skip a top-level
+            // branch keyed by an unrequired property, which is only sound
+            // when no non-skip index (and no deeper level of any index)
+            // reaches through that branch.
+            for (index_name, index) in document_type.indices.iter() {
+                if index.terminal.as_deref() == Some(property_name.as_str()) {
+                    return Err(structure_error(format!(
+                        "optional property \"{}\" on indexOnly document type \"{}\" is the \
+                         terminal of index \"{}\": a terminal is every entry's member key \
+                         and can never be absent — list the property in `required` or \
+                         change the terminal",
+                        property_name, name, index_name,
+                    )));
+                }
+                let position = index
+                    .properties
+                    .iter()
+                    .position(|index_property| index_property.name == *property_name);
+                match position {
+                    None => {}
+                    Some(0) if index.skip_if_absent => {}
+                    Some(0) => {
+                        return Err(structure_error(format!(
+                            "optional property \"{}\" on indexOnly document type \"{}\" is \
+                             the first property of index \"{}\", which does not set \
+                             `skipIfAbsent`: an index participates for every document \
+                             unless it skips, and an absent value has no index \
+                             representation — set `skipIfAbsent: true` on the index or \
+                             list the property in `required`",
+                            property_name, name, index_name,
+                        )));
+                    }
+                    Some(_) => {
+                        return Err(structure_error(format!(
+                            "optional property \"{}\" on indexOnly document type \"{}\" \
+                             appears in index \"{}\" below its first position: an optional \
+                             property may only be the FIRST property of a skipIfAbsent \
+                             index, where absence prunes the whole branch before any tree \
+                             is written — deeper, absence would strand the prefix levels \
+                             above it",
+                            property_name, name, index_name,
+                        )));
+                    }
+                }
+            }
         }
 
         // A required nested leaf inside an OPTIONAL ancestor object is only

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
@@ -111,6 +111,8 @@ impl DocumentTypeV1 {
                 admit_index_terminal: false,
                 // PREALLOCATED: also a generation-3 keyword; not in this grammar.
                 admit_index_preallocated: false,
+                // SKIP IF ABSENT: also a generation-3 keyword; not in this grammar.
+                admit_index_skip_if_absent: false,
             },
             platform_version,
         )

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
@@ -434,7 +434,7 @@ fn rejects_only_bucketed_indexes() {
         .expect("indices apply");
     expect_structure_error(
         parse_with(schema, PlatformVersion::latest(), false),
-        "does not involve $createdAt",
+        "neither involves $createdAt nor sets skipIfAbsent",
     );
 }
 
@@ -591,7 +591,7 @@ fn rejects_when_every_index_involves_created_at() {
         .expect("required applies");
     expect_structure_error(
         parse_with(schema, PlatformVersion::latest(), false),
-        "at least one index that does not involve $createdAt",
+        "neither involves $createdAt nor sets skipIfAbsent",
     );
 }
 
@@ -693,7 +693,7 @@ fn rejects_unindexed_property() {
     );
     expect_structure_error(
         parse_with(schema, PlatformVersion::latest(), false),
-        "does not appear in any index",
+        "does not appear in any non-skipIfAbsent index",
     );
 }
 
@@ -1063,5 +1063,261 @@ fn rejects_preallocated_on_bucketed_index() {
     expect_structure_error(
         parse_with(schema, PlatformVersion::latest(), false),
         "declares `preallocated` together with `timeRange`",
+    );
+}
+
+// ── skipIfAbsent: conditional index participation ───────────────────────
+
+/// The likes schema with `hashtag` optional and `byHashtagPost` marked
+/// `skipIfAbsent` — the canonical conditional-participation shape: an
+/// untagged like writes no `byHashtagPost` entry at all.
+fn skip_likes_schema() -> Value {
+    let mut schema = likes_schema_with_index_key(0, "skipIfAbsent", platform_value!(true));
+    schema
+        .set_value("required", platform_value!(["postId"]))
+        .expect("required applies");
+    schema
+}
+
+/// The base skip schema with one more index appended.
+fn skip_likes_schema_with_extra_index(index: Value) -> Value {
+    let mut schema = skip_likes_schema();
+    schema
+        .get_mut("indices")
+        .expect("indices accessible")
+        .expect("indices present")
+        .as_array_mut()
+        .expect("indices is an array")
+        .push(index);
+    schema
+}
+
+#[test]
+fn accepts_skip_if_absent_index_with_optional_trigger() {
+    let platform_version = PlatformVersion::latest();
+
+    for full_validation in [false, true] {
+        let document_type = parse_with(skip_likes_schema(), platform_version, full_validation)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "skip likes schema should parse (full_validation: {full_validation}): {error}"
+                )
+            });
+
+        assert!(document_type.index_only());
+        assert!(
+            document_type
+                .indices
+                .get("byHashtagPost")
+                .expect("index present")
+                .skip_if_absent,
+            "the flag must survive parsing"
+        );
+        assert!(
+            !document_type.required_fields.contains("hashtag"),
+            "the trigger stays optional"
+        );
+    }
+}
+
+#[test]
+fn rejects_skip_if_absent_on_non_index_only_type() {
+    // A minimal stored doctype (no indexOnly, no terminal) with the flag:
+    // conditional participation only means anything when the entries ARE
+    // the storage.
+    let schema = platform_value!({
+        "type": "object",
+        "properties": {
+            "hashtag": { "type": "string", "maxLength": 63, "position": 0 }
+        },
+        "indices": [
+            {
+                "name": "byHashtag",
+                "properties": [{ "hashtag": "asc" }],
+                "skipIfAbsent": true
+            }
+        ],
+        "additionalProperties": false
+    });
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "declares `skipIfAbsent`",
+    );
+}
+
+#[test]
+fn rejects_skip_if_absent_with_required_first_property() {
+    // Flag on, but `hashtag` still required: the index could never skip.
+    let schema = likes_schema_with_index_key(0, "skipIfAbsent", platform_value!(true));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "but its first property",
+    );
+}
+
+#[test]
+fn rejects_skip_if_absent_with_system_property_trigger() {
+    // byLiker's first property is $ownerId, which is always present.
+    let schema = likes_schema_with_index_key(2, "skipIfAbsent", platform_value!(true));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "system property",
+    );
+}
+
+#[test]
+fn rejects_optional_property_in_non_skip_index() {
+    // `hashtag` is byHashtagPost's trigger, but a second, non-skip index
+    // also leads with it — that index would have to represent absence,
+    // which has no index encoding.
+    let schema = skip_likes_schema_with_extra_index(platform_value!({
+        "name": "byHashtag",
+        "properties": [{ "hashtag": "asc" }],
+        "terminal": "$ownerId"
+    }));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "does not set `skipIfAbsent`",
+    );
+}
+
+#[test]
+fn rejects_optional_property_below_first_position() {
+    // An optional property below position 0 would strand the prefix
+    // levels above it when absent — only a leading trigger prunes the
+    // whole branch before anything is written.
+    // The extra index is deliberately NOT skipIfAbsent: with the flag set,
+    // its required first property (`postId`) would trip the trigger rule
+    // before the position rule is ever reached.
+    let schema = skip_likes_schema_with_extra_index(platform_value!({
+        "name": "byPostHashtag",
+        "properties": [{ "postId": "asc" }, { "hashtag": "asc" }],
+        "terminal": "$ownerId"
+    }));
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "below its first position",
+    );
+}
+
+#[test]
+fn rejects_optional_terminal() {
+    // `postId` is a skip index's trigger (so legitimately optional) but
+    // also another index's terminal — and a terminal is every entry's
+    // member key, which can never be absent.
+    let schema = platform_value!({
+        "type": "object",
+        "indexOnly": true,
+        "documentsMutable": false,
+        "properties": {
+            "postId": {
+                "type": "array",
+                "byteArray": true,
+                "minItems": 32,
+                "maxItems": 32,
+                "contentMediaType": "application/x.dash.dpp.identifier",
+                "refersTo": { "type": "identity" },
+                "position": 0
+            }
+        },
+        "required": [],
+        "indices": [
+            {
+                "name": "byLiker",
+                "properties": [{ "$ownerId": "asc" }],
+                "terminal": "postId"
+            },
+            {
+                "name": "byPost",
+                "properties": [{ "postId": "asc" }],
+                "terminal": "$ownerId",
+                "skipIfAbsent": true
+            }
+        ],
+        "additionalProperties": false
+    });
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "is the terminal of index",
+    );
+}
+
+#[test]
+fn rejects_when_every_proof_candidate_is_skippable() {
+    // The only $createdAt-free index is skipIfAbsent: a trigger-absent
+    // document would have no entry an executed-transition proof could
+    // locate from the transition's values alone.
+    let mut schema = skip_likes_schema();
+    schema
+        .set_value("required", platform_value!(["postId", "$createdAt"]))
+        .expect("required applies");
+    schema
+        .set_value(
+            "indices",
+            platform_value!([
+                {
+                    "name": "byHashtagPost",
+                    "properties": [{ "hashtag": "asc" }, { "postId": "asc" }],
+                    "terminal": "$ownerId",
+                    "skipIfAbsent": true
+                },
+                {
+                    "name": "byTime",
+                    "properties": [{ "$createdAt": "asc" }, { "postId": "asc" }],
+                    "terminal": "$ownerId"
+                }
+            ]),
+        )
+        .expect("indices apply");
+    expect_structure_error(
+        parse_with(schema, PlatformVersion::latest(), false),
+        "nor sets skipIfAbsent",
+    );
+}
+
+#[test]
+fn skip_if_absent_keyword_is_rejected_below_generation_3_on_both_modes() {
+    let platform_version_13 = PlatformVersion::get(13).expect("PV13 exists");
+    let schema = skip_likes_schema();
+
+    for full_validation in [false, true] {
+        assert!(
+            parse_dispatched(schema.clone(), platform_version_13, full_validation).is_err(),
+            "PV13 must reject the skipIfAbsent keyword (full_validation: {full_validation}): \
+             it is not part of generation 2's index grammar"
+        );
+    }
+}
+
+#[test]
+fn skip_if_absent_flag_is_frozen_on_contract_update() {
+    // `validate_index_definitions_unchanged` compares parsed `Index` values
+    // by full equality, so flipping the flag (with the trigger's
+    // requiredness necessarily moving alongside) is a rejected index
+    // change — the walkers derive the skip from `required` membership, so
+    // historical entries would go undeletable if either could drift.
+    use crate::consensus::basic::BasicError;
+    use crate::consensus::ConsensusError;
+
+    let platform_version = PlatformVersion::latest();
+    let old =
+        parse_dispatched(skip_likes_schema(), platform_version, false).expect("skip schema parses");
+    let new =
+        parse_dispatched(likes_schema(), platform_version, false).expect("base schema parses");
+
+    let result = old
+        .as_ref()
+        .validate_update(new.as_ref(), 2, platform_version)
+        .expect("validate_update should not error");
+
+    assert!(
+        result.errors.iter().any(|error| matches!(
+            error,
+            ConsensusError::BasicError(
+                BasicError::DataContractInvalidIndexDefinitionUpdateError(e)
+            ) if e.index_path() == "changed index 'byHashtagPost'"
+        )),
+        "expected a changed-index rejection, got: {:?}",
+        result.errors
     );
 }

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/mod.rs
@@ -277,6 +277,10 @@ fn try_from_schema_generation_3(
             // PREALLOCATED: the fourth generation-3 index keyword, from the
             // same shared mapping.
             admit_index_preallocated: IndexGrammarAdmissions::for_schema_generation(3).preallocated,
+            // SKIP IF ABSENT: the fifth generation-3 index keyword, from the
+            // same shared mapping.
+            admit_index_skip_if_absent: IndexGrammarAdmissions::for_schema_generation(3)
+                .skip_if_absent,
         },
         platform_version,
     )?;

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -94,6 +94,23 @@ pub const TERMINAL: &str = "terminal";
 /// `permanentDocument` reference; the doc-type-level validation rejects every
 /// other shape. See [`preallocation`]. Meta-schema v3+ (protocol version 14).
 pub const PREALLOCATED: &str = "preallocated";
+/// Index-level keyword opting the index into **conditional participation**
+/// on an `indexOnly` document type: when `true`, a document that omits the
+/// index's first property writes no entry into this index, and a delete
+/// recomputes the same skip from its carried values. The first property is
+/// the *skip trigger*: it must be a top-level (non-dotted) schema property
+/// NOT listed in `required` — the only way an indexOnly property may be
+/// optional — and every index involving an optional property must be
+/// `skipIfAbsent` with that property first, which is what keeps the write
+/// walkers' required-derived skip and the probes' flag-derived skip
+/// provably equivalent. Every non-trigger property must still appear in at
+/// least one non-skip index (only indexed values exist on an indexOnly
+/// type, and a skip index cannot carry a value for every document), and at
+/// least one `$createdAt`-free index must remain non-skip to serve as the
+/// executed-transition proof index. Only allowed on indexOnly document
+/// types; the doc-type-level validation rejects every other shape.
+/// Meta-schema v3+ (protocol version 14).
+pub const SKIP_IF_ABSENT: &str = "skipIfAbsent";
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd)]
@@ -566,6 +583,19 @@ pub struct Index {
     // deserialize.
     #[cfg_attr(feature = "serde-conversion", serde(default))]
     pub preallocated: bool,
+    /// On an indexOnly document type: when `true`, a document that omits this
+    /// index's first property — the skip trigger, which must be an optional
+    /// top-level schema property (see [`SKIP_IF_ABSENT`]) — writes no entry
+    /// into this index, and a delete recomputes the same skip from the
+    /// carried values. The index then holds exactly the documents carrying
+    /// the trigger. An absent trigger is distinct from a present-but-empty
+    /// value, which indexes normally.
+    //
+    // `serde(default)`: added after the struct's serde shape was in the wild
+    // (see the note on `countable` above), so pre-existing JSON must still
+    // deserialize.
+    #[cfg_attr(feature = "serde-conversion", serde(default))]
+    pub skip_if_absent: bool,
 }
 
 /// Which grammar keywords a document meta-schema generation admits for
@@ -587,6 +617,9 @@ pub(crate) struct IndexGrammarAdmissions {
     /// The `preallocated` keyword (indexOnly document types with a
     /// determining refersTo; generation 3 and later).
     pub(crate) preallocated: bool,
+    /// The `skipIfAbsent` keyword (indexOnly document types; generation 3
+    /// and later).
+    pub(crate) skip_if_absent: bool,
 }
 
 impl IndexGrammarAdmissions {
@@ -600,6 +633,7 @@ impl IndexGrammarAdmissions {
             time_range: generation >= 3,
             terminal: generation >= 3,
             preallocated: generation >= 3,
+            skip_if_absent: generation >= 3,
         }
     }
 }
@@ -904,6 +938,7 @@ impl TryFrom<&[(Value, Value)]> for Index {
                 time_range: false,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
     }
@@ -942,6 +977,7 @@ impl Index {
             time_range: time_range_allowed,
             terminal: terminal_allowed,
             preallocated: preallocated_allowed,
+            skip_if_absent: skip_if_absent_allowed,
         } = admissions;
         // Decouple the map
         // It contains properties and a unique key
@@ -998,6 +1034,7 @@ impl Index {
         let mut time_range: Option<TimeRangeTransform> = None;
         let mut terminal: Option<String> = None;
         let mut preallocated = false;
+        let mut skip_if_absent = false;
 
         for (key_value, value_value) in index_type_value_map {
             let key = key_value.to_str()?;
@@ -1372,6 +1409,22 @@ impl Index {
                             .as_bool()
                             .ok_or(DataContractError::ValueWrongType(
                                 "preallocated value must be a boolean".to_string(),
+                            ))?;
+                }
+                // `skipIfAbsent` is guarded the same way as `terminal` and
+                // `preallocated` above: it joined the grammar at meta-schema
+                // v3, so below that the key falls through to the
+                // unknown-property arm. Whether the declaring document type
+                // is indexOnly and the first property is a legal skip
+                // trigger are doc-type facts this parser cannot see;
+                // `apply_index_only` in `try_from_schema::common` enforces
+                // both.
+                SKIP_IF_ABSENT if skip_if_absent_allowed => {
+                    skip_if_absent =
+                        value_value
+                            .as_bool()
+                            .ok_or(DataContractError::ValueWrongType(
+                                "skipIfAbsent value must be a boolean".to_string(),
                             ))?;
                 }
                 "properties" => {
@@ -1855,6 +1908,7 @@ impl Index {
             time_range,
             terminal,
             preallocated,
+            skip_if_absent,
         })
     }
 }
@@ -1928,6 +1982,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }
     }
 
@@ -2009,6 +2064,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("should parse");
@@ -2025,6 +2081,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2041,6 +2098,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2061,6 +2119,7 @@ mod tests {
             time_range: false,
             terminal: false,
             preallocated: true,
+            skip_if_absent: false,
         };
 
         let mut map = index_value_map("postId", None);
@@ -2090,6 +2149,7 @@ mod tests {
                 time_range: false,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2120,6 +2180,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2142,6 +2203,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("should parse");
@@ -2164,6 +2226,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2187,6 +2250,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2211,6 +2275,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("should parse");
@@ -2231,6 +2296,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("should parse");
@@ -2256,6 +2322,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("should parse");
@@ -2281,6 +2348,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2304,6 +2372,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2332,6 +2401,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("the parser applies structural rules only");
@@ -2355,6 +2425,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2374,6 +2445,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2397,6 +2469,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2451,6 +2524,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2487,6 +2561,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("should parse");
@@ -2516,6 +2591,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2547,6 +2623,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -2572,6 +2649,7 @@ mod tests {
                 time_range: true,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("a non-unique $updatedAt bucketing stays legal");
@@ -2592,6 +2670,7 @@ mod tests {
                 time_range: false,
                 terminal: false,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .unwrap_err();
@@ -3574,6 +3653,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("all three ranked keywords must parse when the grammar allows them");
@@ -3600,6 +3680,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("index without ranked keywords must parse");
@@ -3642,6 +3723,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("ranked flags on a compound index must be accepted");
@@ -3672,6 +3754,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         );
         assert!(
@@ -3703,6 +3786,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         );
         assert!(
@@ -3732,6 +3816,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         );
         assert!(
@@ -3758,6 +3843,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         );
         assert!(
@@ -3786,6 +3872,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         );
         assert!(
@@ -3814,6 +3901,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         );
         assert!(
@@ -3844,6 +3932,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("rankedAverageable on the averageable sugar form must parse");
@@ -3880,6 +3969,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("rankedAverageable on the explicit longhand form must parse");
@@ -3906,6 +3996,7 @@ mod tests {
                     time_range: true,
                     terminal: true,
                     preallocated: false,
+                    skip_if_absent: false,
                 },
             );
             assert!(result.is_err(), "{key} must reject a non-boolean value");
@@ -3938,6 +4029,7 @@ mod tests {
                         time_range: false,
                         terminal: false,
                         preallocated: false,
+                        skip_if_absent: false,
                     },
                 );
                 assert!(
@@ -4019,6 +4111,7 @@ mod tests {
                     time_range: true,
                     terminal: true,
                     preallocated: false,
+                    skip_if_absent: false,
                 },
             );
             assert!(
@@ -4047,6 +4140,7 @@ mod tests {
                     time_range: true,
                     terminal: true,
                     preallocated: false,
+                    skip_if_absent: false,
                 },
             )
             .unwrap_or_else(|e| panic!("{axis} with no nullSearchable key must parse: {e:?}"));
@@ -4071,6 +4165,7 @@ mod tests {
                     time_range: true,
                     terminal: true,
                     preallocated: false,
+                    skip_if_absent: false,
                 },
             )
             .unwrap_or_else(|e| {
@@ -4093,6 +4188,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("nullSearchable: false on a plain index must still parse");
@@ -4110,6 +4206,7 @@ mod tests {
                 time_range: true,
                 terminal: true,
                 preallocated: false,
+                skip_if_absent: false,
             },
         )
         .expect("nullSearchable: false on a range-averageable index must still parse");
@@ -4597,6 +4694,7 @@ mod json_convertible_tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }
     }
 

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -4727,6 +4727,7 @@ mod json_convertible_tests {
                 "time_range": serde_json::Value::Null,
                 "terminal": serde_json::Value::Null,
                 "preallocated": false,
+                "skip_if_absent": false,
             })
         );
         let recovered = Index::from_json(json).expect("from_json");

--- a/packages/rs-dpp/src/data_contract/document_type/index/preallocation.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/preallocation.rs
@@ -216,6 +216,7 @@ mod tests {
             time_range: None,
             terminal: Some("$ownerId".to_string()),
             preallocated: true,
+            skip_if_absent: false,
         }
     }
 

--- a/packages/rs-dpp/src/data_contract/document_type/index/random_index.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/random_index.rs
@@ -70,6 +70,7 @@ impl Index {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         })
     }
 }

--- a/packages/rs-dpp/src/data_contract/document_type/index_level/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index_level/mod.rs
@@ -526,6 +526,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let old_index_structure =
@@ -563,6 +564,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let new_indices = vec![
@@ -585,6 +587,7 @@ mod tests {
                 time_range: None,
                 terminal: None,
                 preallocated: false,
+                skip_if_absent: false,
             },
             Index {
                 name: "test2".to_string(),
@@ -605,6 +608,7 @@ mod tests {
                 time_range: None,
                 terminal: None,
                 preallocated: false,
+                skip_if_absent: false,
             },
         ];
 
@@ -651,6 +655,7 @@ mod tests {
                 time_range: None,
                 terminal: None,
                 preallocated: false,
+                skip_if_absent: false,
             },
             Index {
                 name: "test2".to_string(),
@@ -671,6 +676,7 @@ mod tests {
                 time_range: None,
                 terminal: None,
                 preallocated: false,
+                skip_if_absent: false,
             },
         ];
 
@@ -693,6 +699,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let old_index_structure =
@@ -737,6 +744,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let new_indices = vec![Index {
@@ -764,6 +772,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let old_index_structure =
@@ -814,6 +823,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let new_indices = vec![Index {
@@ -835,6 +845,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let old_index_structure =
@@ -879,6 +890,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let new_indices = vec![Index {
@@ -900,6 +912,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let old_index_structure =
@@ -944,6 +957,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let new_indices = vec![Index {
@@ -965,6 +979,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let old_index_structure =
@@ -1009,6 +1024,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let old_index_structure =
@@ -1053,6 +1069,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let new_indices = vec![Index {
@@ -1074,6 +1091,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let old_index_structure =
@@ -1118,6 +1136,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let new_indices = vec![Index {
@@ -1139,6 +1158,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let old_index_structure =
@@ -1189,6 +1209,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let new_indices = vec![Index {
@@ -1216,6 +1237,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let old_index_structure =
@@ -1266,6 +1288,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let new_indices = vec![Index {
@@ -1293,6 +1316,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let old_index_structure =
@@ -1351,6 +1375,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }
     }
 
@@ -1510,6 +1535,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }];
 
         let mut new_indices = old_indices.clone();
@@ -1561,6 +1587,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated,
+            skip_if_absent: false,
         };
 
         for (old_flag, new_flag) in [(false, true), (true, false)] {

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -2506,3 +2506,608 @@ fn beat_duplicate_and_overlapping_rows() {
 
     assert_grovedb_is_consistent(&drive);
 }
+
+// ---------------------------------------------------------------------------
+// skipIfAbsent: conditional index participation
+// ---------------------------------------------------------------------------
+//
+// The `mark` doctype's `byB` index is `skipIfAbsent` with the optional `b`
+// as its trigger (and count axes, so sparse counting is observable); the
+// `pin` doctype adds the compound skip shape `byTagXY [tag, x, y]` with an
+// optional BYTE-ARRAY trigger admitting the empty value — the one input
+// class where "skip" (absent) and the null-layout empty key (present,
+// empty encoding) sit one byte apart.
+
+fn mark_type_ref(contract: &DataContract) -> dpp::data_contract::document_type::DocumentTypeRef {
+    contract
+        .document_type_for_name("mark")
+        .expect("mark doctype exists")
+}
+
+/// A property-name tree with no children — the registration-time state a
+/// skip index's tree stays in while every row omits the trigger. Whatever
+/// countability variant registration chose, "empty" means no root key
+/// (and a zero count where the variant carries one).
+fn assert_empty_index_tree(element: Option<Element>, context: &str) {
+    match element {
+        Some(Element::Tree(root, _)) => {
+            assert!(root.is_none(), "{context}: expected an empty tree")
+        }
+        Some(Element::CountTree(root, count, _))
+        | Some(Element::ProvableCountTree(root, count, _)) => {
+            assert!(
+                root.is_none() && count == 0,
+                "{context}: expected an empty count tree, got root {root:?} count {count}"
+            )
+        }
+        Some(Element::ProvableCountIndexedTree(root, secondary, count, _)) => assert!(
+            root.is_none() && secondary.is_none() && count == 0,
+            "{context}: expected an empty indexed count tree"
+        ),
+        other => panic!("{context}: expected a property-name tree, got {other:?}"),
+    }
+}
+
+/// A mark with `a` always present and `b` present only when given — the
+/// trigger-absent form is the whole point of this section.
+fn build_mark(
+    contract: &DataContract,
+    a: &str,
+    b: Option<&str>,
+    owner: [u8; 32],
+    seed: u64,
+) -> Document {
+    let mut doc = mark_type_ref(contract)
+        .random_document(Some(seed), platform_version())
+        .expect("random mark");
+    let mut props = std::collections::BTreeMap::new();
+    props.insert("a".to_string(), Value::Text(a.to_string()));
+    if let Some(b) = b {
+        props.insert("b".to_string(), Value::Text(b.to_string()));
+    }
+    doc.set_properties(props);
+    doc.set_owner_id(Identifier::from(owner));
+    doc
+}
+
+fn insert_mark(
+    drive: &Drive,
+    contract: &DataContract,
+    doc: &Document,
+    apply: bool,
+) -> Result<FeeResult, crate::error::Error> {
+    drive.add_document_for_contract(
+        DocumentAndContractInfo {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((doc, None)),
+                owner_id: None,
+            },
+            contract,
+            document_type: mark_type_ref(contract),
+        },
+        false,
+        BlockInfo::default(),
+        apply,
+        None,
+        platform_version(),
+        None,
+    )
+}
+
+fn delete_mark(
+    drive: &Drive,
+    contract: &DataContract,
+    doc: Document,
+    apply: bool,
+) -> Result<FeeResult, crate::error::Error> {
+    drive.delete_index_only_document_for_contract(
+        doc,
+        contract,
+        mark_type_ref(contract),
+        BlockInfo::default(),
+        apply,
+        None,
+        platform_version(),
+        None,
+    )
+}
+
+/// `[.., "mark"]` / `[.., "pin"]` — sibling doctype trees.
+fn sibling_doctype_path(contract: &DataContract, doctype: &str) -> Vec<Vec<u8>> {
+    let mut path = doctype_path(contract);
+    *path.last_mut().expect("path non-empty") = doctype.as_bytes().to_vec();
+    path
+}
+
+/// A trigger-absent create writes entries ONLY in the non-skip indexes: no
+/// value tree, no member bucket, not a byte under the skip index's
+/// property-name tree — and its delete removes exactly what was written,
+/// leaving other rows' skip entries untouched.
+#[test]
+fn skip_index_absent_trigger_writes_nothing_and_deletes_cleanly() {
+    let (drive, contract) = setup_likes();
+    let mark_path = sibling_doctype_path(&contract, "mark");
+
+    let no_b = build_mark(&contract, "a1", None, OWNER_1, 1);
+    insert_mark(&drive, &contract, &no_b, true).expect("insert trigger-absent mark");
+
+    // byA carries the row: [.., "a", "a1", 0] key OWNER_1, payload = the
+    // commitment over the PRESENT set (no `b` contribution).
+    let expected_commitment = crate::drive::document::index_only_row_commitment(
+        &no_b,
+        mark_type_ref(&contract),
+        platform_version(),
+    )
+    .expect("commitment computes");
+    let mut by_a = mark_path.clone();
+    by_a.extend([b"a".to_vec(), b"a1".to_vec(), vec![0]]);
+    match read_grove_element(&drive, &by_a, &OWNER_1) {
+        Some(Element::Item(data, _)) => assert_eq!(
+            data,
+            expected_commitment.to_vec(),
+            "the non-skip entry carries the present-set commitment"
+        ),
+        other => panic!("expected the byA terminal item, got {other:?}"),
+    }
+
+    // byB's property-name tree exists (registration creates it) but holds
+    // NOTHING: not a value tree, not a member bucket, not a byte.
+    assert_empty_index_tree(
+        read_grove_element(&drive, &mark_path, b"b"),
+        "after a trigger-absent create",
+    );
+
+    // A trigger-present sibling row populates byB, independently.
+    let with_b = build_mark(&contract, "a2", Some("b2"), OWNER_2, 2);
+    insert_mark(&drive, &contract, &with_b, true).expect("insert trigger-present mark");
+    let mut by_b_b2 = mark_path.clone();
+    by_b_b2.extend([b"b".to_vec(), b"b2".to_vec(), vec![0]]);
+    assert!(
+        matches!(
+            read_grove_element(&drive, &by_b_b2, &OWNER_2),
+            Some(Element::Item(..))
+        ),
+        "a trigger-present row writes its skip-index entry normally"
+    );
+
+    // Deleting the trigger-absent row removes byA's entry and leaves the
+    // sibling's skip entry alone.
+    delete_mark(&drive, &contract, no_b, true).expect("delete trigger-absent mark");
+    assert!(
+        read_grove_element(&drive, &by_a, &OWNER_1).is_none(),
+        "the non-skip entry must be gone"
+    );
+    assert!(
+        read_grove_element(&drive, &by_b_b2, &OWNER_2).is_some(),
+        "the sibling's skip entry must survive"
+    );
+
+    // Deleting the sibling drains byB back to the empty tree.
+    delete_mark(&drive, &contract, with_b, true).expect("delete trigger-present mark");
+    assert_empty_index_tree(
+        read_grove_element(&drive, &mark_path, b"b"),
+        "after the last trigger-present row deletes",
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// The commitment pins the exact present-set: a delete whose absence
+/// pattern differs from the create — dropping the trigger, or inventing
+/// one — fails the commitment probe in BOTH directions, so a skip index
+/// can neither be force-pruned nor left with an orphan entry.
+#[test]
+fn skip_index_absence_pattern_binds_the_commitment() {
+    let (drive, contract) = setup_likes();
+
+    // Row 1 was created WITH the trigger; a delete carrying the same
+    // values minus `b` addresses byA's real entry with a different
+    // commitment (all of row 1's entries would survive an accepted probe
+    // in byB only because probes there are vacuous for the forged shape).
+    let with_b = build_mark(&contract, "a1", Some("b1"), OWNER_1, 1);
+    insert_mark(&drive, &contract, &with_b, true).expect("insert trigger-present mark");
+    let forged_without_b = build_mark(&contract, "a1", None, OWNER_1, 2);
+    let error = delete_mark(&drive, &contract, forged_without_b, true)
+        .expect_err("dropping the trigger from the carried values must be refused");
+    assert!(
+        matches!(
+            error,
+            crate::error::Error::Drive(
+                crate::error::drive::DriveError::DeletingDocumentThatDoesNotExist(_)
+            )
+        ),
+        "expected the row-integrity refusal, got: {error}"
+    );
+
+    // Row 2 was created WITHOUT the trigger; a delete carrying an invented
+    // `b` — even one whose byB entry exists, courtesy of row 1 — fails on
+    // byA's commitment.
+    let no_b = build_mark(&contract, "a2", None, OWNER_1, 3);
+    insert_mark(&drive, &contract, &no_b, true).expect("insert trigger-absent mark");
+    let forged_with_b = build_mark(&contract, "a2", Some("b1"), OWNER_1, 4);
+    let error = delete_mark(&drive, &contract, forged_with_b, true)
+        .expect_err("inventing a trigger in the carried values must be refused");
+    assert!(
+        matches!(
+            error,
+            crate::error::Error::Drive(
+                crate::error::drive::DriveError::DeletingDocumentThatDoesNotExist(_)
+            )
+        ),
+        "expected the row-integrity refusal, got: {error}"
+    );
+
+    // Both real rows remain deletable with their true absence patterns.
+    delete_mark(&drive, &contract, with_b, true).expect("the trigger-present row still deletes");
+    delete_mark(&drive, &contract, no_b, true).expect("the trigger-absent row still deletes");
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// Structural uniqueness spans the skip boundary: a trigger-absent and a
+/// trigger-present document of the same owner colliding on a NON-skip
+/// index cannot coexist, in either creation order.
+#[test]
+fn skip_and_non_skip_rows_still_collide_on_shared_entries() {
+    let (drive, contract) = setup_likes();
+
+    let with_b = build_mark(&contract, "a1", Some("b1"), OWNER_1, 1);
+    insert_mark(&drive, &contract, &with_b, true).expect("insert trigger-present mark");
+    let no_b = build_mark(&contract, "a1", None, OWNER_1, 2);
+    let error = insert_mark(&drive, &contract, &no_b, true)
+        .expect_err("the byA entry collides regardless of the trigger");
+    assert!(
+        matches!(
+            error,
+            crate::error::Error::Drive(crate::error::drive::DriveError::CorruptedContractIndexes(
+                _
+            ))
+        ),
+        "expected the duplicate-entry backstop, got: {error}"
+    );
+
+    // Reverse order on a fresh value.
+    let no_b_2 = build_mark(&contract, "a2", None, OWNER_1, 3);
+    insert_mark(&drive, &contract, &no_b_2, true).expect("insert trigger-absent mark");
+    let with_b_2 = build_mark(&contract, "a2", Some("b2"), OWNER_1, 4);
+    let error = insert_mark(&drive, &contract, &with_b_2, true)
+        .expect_err("the byA entry collides in the reverse order too");
+    assert!(
+        matches!(
+            error,
+            crate::error::Error::Drive(crate::error::drive::DriveError::CorruptedContractIndexes(
+                _
+            ))
+        ),
+        "expected the duplicate-entry backstop, got: {error}"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// A skip index's count axes see exactly the trigger-present rows — the
+/// sparse-projection semantics the query gate makes opt-in.
+#[test]
+fn skip_index_counts_reflect_trigger_present_rows_only() {
+    let (drive, contract) = setup_likes();
+    let mark_path = sibling_doctype_path(&contract, "mark");
+
+    for (a, b, owner, seed) in [
+        ("a1", Some("shared"), OWNER_1, 1u64),
+        ("a2", Some("shared"), OWNER_2, 2),
+        ("a3", None, OWNER_3, 3),
+    ] {
+        let mark = build_mark(&contract, a, b, owner, seed);
+        insert_mark(&drive, &contract, &mark, true).expect("insert mark");
+    }
+
+    let mut by_b_level = mark_path.clone();
+    by_b_level.push(b"b".to_vec());
+    match read_grove_element(&drive, &by_b_level, b"shared") {
+        Some(Element::CountTree(_, count, _)) => {
+            assert_eq!(count, 2, "the skip index counts trigger-present rows only")
+        }
+        other => panic!("expected the shared group's CountTree, got {other:?}"),
+    }
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// Fee shape: skipping an index is cheaper than writing it, and the
+/// dry-run stays a valid upper bound for both the trigger-absent create
+/// (value-driven — it skips exactly when apply skips) and its delete
+/// (shape-driven — it deliberately over-estimates the skipped branch).
+#[test]
+fn skip_estimated_fees_upper_bound_actual_fees() {
+    let (drive, contract) = setup_likes();
+
+    let no_b = build_mark(&contract, "a1", None, OWNER_1, 1);
+    let estimated_insert =
+        insert_mark(&drive, &contract, &no_b, false).expect("estimated insert must work");
+    let actual_insert = insert_mark(&drive, &contract, &no_b, true).expect("actual insert");
+    assert!(
+        estimated_insert.storage_fee >= actual_insert.storage_fee,
+        "estimated insert storage fee {} must upper-bound actual {}",
+        estimated_insert.storage_fee,
+        actual_insert.storage_fee
+    );
+
+    // The payoff, measured: the same row with the trigger present pays for
+    // the extra index.
+    let with_b = build_mark(&contract, "a2", Some("b2"), OWNER_2, 2);
+    let actual_insert_with_b =
+        insert_mark(&drive, &contract, &with_b, true).expect("actual insert with trigger");
+    assert!(
+        actual_insert_with_b.storage_fee > actual_insert.storage_fee,
+        "a trigger-present row ({}) must cost more than a trigger-absent one ({})",
+        actual_insert_with_b.storage_fee,
+        actual_insert.storage_fee
+    );
+
+    let estimated_delete =
+        delete_mark(&drive, &contract, no_b.clone(), false).expect("estimated delete must work");
+    let actual_delete = delete_mark(&drive, &contract, no_b, true).expect("actual delete");
+    assert!(estimated_delete.processing_fee > 0);
+    assert!(actual_delete.processing_fee > 0);
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+// ── pin: the compound skip shape and the empty-encoding trigger ─────────
+
+fn pin_type_ref(contract: &DataContract) -> dpp::data_contract::document_type::DocumentTypeRef {
+    contract
+        .document_type_for_name("pin")
+        .expect("pin doctype exists")
+}
+
+/// A pin with required `x`/`y` and the byte-array trigger `tag` present
+/// only when given — `Some(&[])` is the PRESENT-but-empty form, whose
+/// tree-key encoding is empty bytes (the null-layout lane), one byte away
+/// from absence.
+fn build_pin(
+    contract: &DataContract,
+    tag: Option<&[u8]>,
+    x: &str,
+    y: &str,
+    owner: [u8; 32],
+    seed: u64,
+) -> Document {
+    let mut doc = pin_type_ref(contract)
+        .random_document(Some(seed), platform_version())
+        .expect("random pin");
+    let mut props = std::collections::BTreeMap::new();
+    if let Some(tag) = tag {
+        props.insert("tag".to_string(), Value::Bytes(tag.to_vec()));
+    }
+    props.insert("x".to_string(), Value::Text(x.to_string()));
+    props.insert("y".to_string(), Value::Text(y.to_string()));
+    doc.set_properties(props);
+    doc.set_owner_id(Identifier::from(owner));
+    doc
+}
+
+fn insert_pin(
+    drive: &Drive,
+    contract: &DataContract,
+    doc: &Document,
+    apply: bool,
+) -> Result<FeeResult, crate::error::Error> {
+    drive.add_document_for_contract(
+        DocumentAndContractInfo {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((doc, None)),
+                owner_id: None,
+            },
+            contract,
+            document_type: pin_type_ref(contract),
+        },
+        false,
+        BlockInfo::default(),
+        apply,
+        None,
+        platform_version(),
+        None,
+    )
+}
+
+fn delete_pin(
+    drive: &Drive,
+    contract: &DataContract,
+    doc: Document,
+    apply: bool,
+) -> Result<FeeResult, crate::error::Error> {
+    drive.delete_index_only_document_for_contract(
+        doc,
+        contract,
+        pin_type_ref(contract),
+        BlockInfo::default(),
+        apply,
+        None,
+        platform_version(),
+        None,
+    )
+}
+
+fn pin_query<'a>(
+    contract: &'a DataContract,
+    clauses: Vec<crate::query::WhereClause>,
+    limit: Option<u16>,
+) -> crate::query::DriveDocumentQuery<'a> {
+    crate::query::DriveDocumentQuery {
+        contract,
+        document_type: pin_type_ref(contract),
+        internal_clauses: crate::query::InternalClauses::extract_from_clauses(
+            clauses,
+            platform_version(),
+        )
+        .expect("clauses extract"),
+        offset: None,
+        limit,
+        order_by: Default::default(),
+        start_at: None,
+        start_at_included: false,
+        block_time_ms: None,
+        resolved_time_ranges: vec![],
+    }
+}
+
+/// The admissibility gate: a query binding everything BUT the trigger must
+/// not route to the skip index — the matcher alone would admit it within
+/// the difference budget and silently omit every trigger-absent row. The
+/// same query WITH the trigger bound routes there and sees exactly the
+/// trigger-present rows, with proof parity.
+#[test]
+fn trigger_unbound_queries_do_not_route_to_a_skip_index() {
+    use crate::error::query::QuerySyntaxError;
+    use crate::query::{WhereClause, WhereOperator};
+    use dpp::document::DocumentV0Getters;
+
+    let (drive, contract) = setup_likes();
+
+    let tagged = build_pin(&contract, Some(&[1u8]), "x1", "y1", OWNER_1, 1);
+    insert_pin(&drive, &contract, &tagged, true).expect("insert tagged pin");
+    let untagged = build_pin(&contract, None, "x1", "y1", OWNER_2, 2);
+    insert_pin(&drive, &contract, &untagged, true).expect("insert untagged pin");
+
+    // {x, y} bound, trigger unbound: byX lacks y, byY lacks x, and the
+    // skip index byTagXY must be inadmissible — so no index serves it.
+    let unbound = pin_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "x".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("x1".to_string()),
+            },
+            WhereClause {
+                field: "y".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("y1".to_string()),
+            },
+        ],
+        Some(10),
+    );
+    let error = drive
+        .query_documents(unbound, None, false, None, None)
+        .expect_err("a trigger-unbound query must not route to the skip index");
+    assert!(
+        matches!(
+            error,
+            crate::error::Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(_))
+        ),
+        "expected the no-index refusal, got: {error}"
+    );
+
+    // Binding the trigger opts into the sparse semantics: only the tagged
+    // row comes back.
+    let bound = pin_query(
+        &contract,
+        vec![
+            WhereClause {
+                field: "tag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Bytes(vec![1u8]),
+            },
+            WhereClause {
+                field: "x".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("x1".to_string()),
+            },
+            WhereClause {
+                field: "y".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("y1".to_string()),
+            },
+        ],
+        Some(10),
+    );
+    let outcome = drive
+        .query_documents(bound.clone(), None, false, None, None)
+        .expect("the trigger-bound query executes");
+    let documents = outcome.documents();
+    assert_eq!(
+        documents.len(),
+        1,
+        "only the tagged row lives in the skip index"
+    );
+    assert_eq!(documents[0].owner_id().to_buffer(), OWNER_1);
+
+    // Proof parity on the sparse read.
+    let (proof, _) = bound
+        .clone()
+        .execute_with_proof(&drive, None, None, platform_version())
+        .expect("sparse proof generation");
+    let (_root, verified) = bound
+        .verify_proof(proof.as_slice(), platform_version())
+        .expect("sparse proof verification");
+    assert_eq!(verified.len(), 1);
+    assert_eq!(verified[0].id(), documents[0].id());
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// Present-but-empty is NOT absent: an empty byte-array trigger encodes to
+/// an empty tree key (the null-layout lane) and the row participates in
+/// the skip index; walker, probes, and commitment all agree, and the two
+/// forms coexist and delete independently.
+#[test]
+fn empty_byte_array_trigger_takes_the_value_lane_not_the_skip_lane() {
+    let (drive, contract) = setup_likes();
+    let pin_path = sibling_doctype_path(&contract, "pin");
+
+    let empty_tag = build_pin(&contract, Some(&[]), "x1", "y1", OWNER_1, 1);
+    let absent_tag = build_pin(&contract, None, "x2", "y2", OWNER_1, 2);
+
+    // The commitments must differ even over otherwise-identical values:
+    // absent emits nothing, empty emits `name ‖ 00000000`.
+    let empty_on_same_values = build_pin(&contract, Some(&[]), "x2", "y2", OWNER_1, 3);
+    let commitment_empty = crate::drive::document::index_only_row_commitment(
+        &empty_on_same_values,
+        pin_type_ref(&contract),
+        platform_version(),
+    )
+    .expect("commitment computes");
+    let commitment_absent = crate::drive::document::index_only_row_commitment(
+        &absent_tag,
+        pin_type_ref(&contract),
+        platform_version(),
+    )
+    .expect("commitment computes");
+    assert_ne!(
+        commitment_empty, commitment_absent,
+        "absent and present-but-empty must commit differently"
+    );
+
+    insert_pin(&drive, &contract, &empty_tag, true).expect("insert empty-tag pin");
+    insert_pin(&drive, &contract, &absent_tag, true).expect("insert absent-tag pin");
+
+    // The empty-tag row's skip-index entry sits under the EMPTY value key.
+    let mut empty_lane = pin_path.clone();
+    empty_lane.extend([
+        b"tag".to_vec(),
+        Vec::new(),
+        b"x".to_vec(),
+        b"x1".to_vec(),
+        b"y".to_vec(),
+        b"y1".to_vec(),
+        vec![0],
+    ]);
+    assert!(
+        matches!(
+            read_grove_element(&drive, &empty_lane, &OWNER_1),
+            Some(Element::Item(..))
+        ),
+        "the empty-encoding trigger writes a real entry under the empty key"
+    );
+
+    // Both rows delete with their true forms.
+    delete_pin(&drive, &contract, empty_tag, true).expect("delete empty-tag pin");
+    assert!(
+        read_grove_element(&drive, &empty_lane, &OWNER_1).is_none(),
+        "the empty-lane entry must be gone"
+    );
+    delete_pin(&drive, &contract, absent_tag, true).expect("delete absent-tag pin");
+
+    assert_grovedb_is_consistent(&drive);
+}

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/ranked_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/ranked_index_e2e_tests.rs
@@ -804,6 +804,7 @@ fn compound_ranked_index_resolves_its_terminal_level_to_an_indexed_tree() {
         time_range: None,
         terminal: None,
         preallocated: false,
+        skip_if_absent: false,
     };
     let index_structure =
         IndexLevel::try_from_indices([&compound_ranked_index], "dish", platform_version())
@@ -1022,6 +1023,7 @@ fn a_null_unsearchable_ranked_level_is_what_makes_a_phantom_group_possible() {
         time_range: None,
         terminal: None,
         preallocated: false,
+        skip_if_absent: false,
     };
 
     for null_searchable in [false, true] {

--- a/packages/rs-drive/src/drive/document/delete/remove_indices_for_top_index_level_for_contract_operations/v2/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/remove_indices_for_top_index_level_for_contract_operations/v2/mod.rs
@@ -132,7 +132,7 @@ impl Drive {
 
             // with the example of the dashpay contract's first index
             // the index path is now something likeDataContracts/ContractID/Documents(1)/$ownerId
-            let document_top_field = document_and_contract_info
+            let document_top_field = match document_and_contract_info
                 .owned_document_info
                 .document_info
                 .get_raw_for_document_type(
@@ -141,8 +141,26 @@ impl Drive {
                     document_and_contract_info.owned_document_info.owner_id,
                     Some((sub_level, event_id)),
                     platform_version,
-                )?
-                .unwrap_or_default();
+                )? {
+                Some(document_top_field) => document_top_field,
+                // An unrequired top-level property on an indexOnly type is a
+                // skipIfAbsent index's trigger: the insert walker wrote no
+                // entries through this branch for a trigger-absent document,
+                // so its delete removes none — mirroring the insert skip is
+                // what keeps delete-by-values exact. The delete's estimation
+                // dry-run runs on a worst-case document info that always
+                // resolves a value, so estimation sweeps this branch as
+                // written — a deliberate over-estimate that keeps the dry
+                // run an upper bound.
+                None if document_type.index_only()
+                    && !document_type.required_fields().contains(property_name) =>
+                {
+                    continue;
+                }
+                // A stored type's absent value keeps its null-layout empty
+                // key.
+                None => DriveKeyInfo::default(),
+            };
 
             if let Some(estimated_costs_only_with_layer_info) = estimated_costs_only_with_layer_info
             {

--- a/packages/rs-drive/src/drive/document/index_level_tree_types.rs
+++ b/packages/rs-drive/src/drive/document/index_level_tree_types.rs
@@ -453,6 +453,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         };
         let compound = Index {
             name: "byRestaurantChef".to_string(),
@@ -479,6 +480,7 @@ mod tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         };
 
         let index_structure =

--- a/packages/rs-drive/src/drive/document/index_only.rs
+++ b/packages/rs-drive/src/drive/document/index_only.rs
@@ -66,28 +66,6 @@ impl Drive {
         .into())
     }
 
-    /// The first index of `document_type` that embeds `$ownerId` (as
-    /// terminal or prefix property). The indexOnly parser guarantees one
-    /// exists — its absence is a corrupted contract.
-    pub fn index_only_owner_bearing_index<'a>(
-        document_type: &'a DocumentTypeRef,
-    ) -> Result<&'a Index, Error> {
-        document_type
-            .indexes()
-            .values()
-            .find(|index| {
-                index.terminal.as_deref() == Some(dpp::document::property_names::OWNER_ID)
-                    || index
-                        .properties
-                        .iter()
-                        .any(|property| property.name == dpp::document::property_names::OWNER_ID)
-            })
-            .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
-                "an indexOnly document type must have an $ownerId-bearing index; the \
-                 contract parser enforces it",
-            )))
-    }
-
     /// The grove paths and member key of `document`'s entries under
     /// `index`: each path is `[DataContractDocuments, contract_id, 1,
     /// doctype, (<level key>, <value key>)*, 0]` with the terminal
@@ -100,7 +78,13 @@ impl Drive {
     /// [`TimeRangeTransform::entry_keys_for_raw`] — the same derivation
     /// the index walkers write with, so probe and write paths cannot
     /// drift (including the edge rules: a pre-origin timestamp produces
-    /// NO entries, so it produces no probe paths either).
+    /// NO entries, so it produces no probe paths either). A `skipIfAbsent`
+    /// index whose trigger (first property) the document omits likewise
+    /// produces NO paths (and an empty member key) — the write walkers
+    /// skipped the branch, so there is nothing to probe; the zero-path
+    /// case flows through both consumers with the correct semantics
+    /// (vacuously consistent for the delete probe, no duplicate for the
+    /// create probe).
     ///
     /// [`TimeRangeTransform::entry_keys_for_raw`]:
     /// dpp::data_contract::document_type::TimeRangeTransform::entry_keys_for_raw
@@ -122,10 +106,31 @@ impl Drive {
                     platform_version,
                 )?
                 .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
-                    "every indexOnly property must have a value: the parser requires \
-                     them all and the transitions carry them all",
+                    "every required indexOnly property must have a value: the parser \
+                     requires them and the transitions carry them",
                 )))
         };
+
+        // A skipIfAbsent index participates only when the document carries
+        // its trigger — the first property, which the parser guarantees is
+        // the only one that may be absent. Mirror the write walkers' skip
+        // exactly: no trigger, no entries.
+        if index.skip_if_absent {
+            let trigger = &index
+                .properties
+                .first()
+                .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
+                    "a skipIfAbsent index has at least one property; the contract parser \
+                     enforces it",
+                )))?
+                .name;
+            if document
+                .get_raw_for_document_type(trigger, document_type, owner_id, platform_version)?
+                .is_none()
+            {
+                return Ok((Vec::new(), Vec::new()));
+            }
+        }
 
         let prefix: Vec<Vec<u8>> = vec![
             vec![crate::drive::RootTree::DataContractDocuments as u8],

--- a/packages/rs-drive/src/drive/document/index_only_row_commitment.rs
+++ b/packages/rs-drive/src/drive/document/index_only_row_commitment.rs
@@ -25,7 +25,11 @@ pub const INDEX_ONLY_ROW_COMMITMENT_SIZE: u32 = 32;
 
 /// The **row commitment** stored as every indexOnly terminal item's payload:
 /// `hash_double(owner ‖ (name ‖ raw index bytes)* ‖ [$createdAt bytes])`
-/// over ALL of the document's properties in sorted-name order.
+/// over the document's PRESENT properties in sorted-name order. A required
+/// property must be present (an absence there is an internal error); an
+/// optional property — a skipIfAbsent index's trigger, the only kind of
+/// optional property the parser admits — simply contributes nothing when
+/// absent, its name included.
 ///
 /// This is what binds the independently stored index projections of one
 /// document back into one logical row: a delete recomputes the commitment
@@ -34,7 +38,21 @@ pub const INDEX_ONLY_ROW_COMMITMENT_SIZE: u32 = 32;
 /// the same owner — fails the comparison on whichever entry belongs to the
 /// other row. Without it, entry existence alone cannot distinguish "one
 /// document's projections" from "several documents' projections that
-/// happen to coexist".
+/// happen to coexist". Committing the exact present-set extends that to
+/// absence games: a delete carrying a different absence pattern than the
+/// create (dropping the trigger, or inventing one) hashes differently and
+/// fails every probe, so a skipped index can neither be force-pruned nor
+/// left with an orphan entry.
+///
+/// The variable present-set stays unambiguous under this framing: absent
+/// means the property's NAME is not emitted at all, while a present empty
+/// value emits `name ‖ 00000000`. Parsing the preimage left-to-right is
+/// deterministic because a property name (schema-validated to
+/// `[a-zA-Z0-9-_]`, dotted at flattening joints) never contains a 0x00
+/// byte, while every length prefix starts with one (index-borne values are
+/// capped far below 2^24 bytes), and the one name-less tail segment starts
+/// with `$` — so equal preimages imply equal (owner, present-set, values,
+/// createdAt). Pinned by the absence tests in the e2e battery.
 #[cfg(any(feature = "server", feature = "verify"))]
 pub fn index_only_row_commitment(
     document: &Document,
@@ -69,12 +87,27 @@ pub fn index_only_row_commitment_with_preimage_size(
     property_names.sort();
 
     for property_name in property_names {
-        let raw = document
-            .get_raw_for_document_type(property_name, document_type, owner_id, platform_version)?
-            .ok_or(Error::Drive(DriveError::CorruptedCodeExecution(
-                "indexOnly row commitment requires every property value; the parser \
-                 requires them all and the transitions carry them all",
-            )))?;
+        let Some(raw) = document.get_raw_for_document_type(
+            property_name,
+            document_type,
+            owner_id,
+            platform_version,
+        )?
+        else {
+            if document_type
+                .required_fields()
+                .contains(property_name.as_str())
+            {
+                return Err(Error::Drive(DriveError::CorruptedCodeExecution(
+                    "indexOnly row commitment requires every required property value; the \
+                     parser requires them and the transitions carry them",
+                )));
+            }
+            // An optional property (a skipIfAbsent trigger) contributes
+            // nothing when absent — not even its name — so the commitment
+            // pins the exact present-set.
+            continue;
+        };
         preimage.extend_from_slice(property_name.as_bytes());
         preimage.extend_from_slice(&(raw.len() as u32).to_be_bytes());
         preimage.extend_from_slice(&raw);

--- a/packages/rs-drive/src/drive/document/insert/add_indices_for_top_index_level_for_contract_operations/v2/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_indices_for_top_index_level_for_contract_operations/v2/mod.rs
@@ -139,7 +139,7 @@ impl Drive {
 
             // with the example of the dashpay contract's first index
             // the index path is now something likeDataContracts/ContractID/Documents(1)/$ownerId
-            let document_top_field = document_and_contract_info
+            let document_top_field = match document_and_contract_info
                 .owned_document_info
                 .document_info
                 .get_raw_for_document_type(
@@ -148,8 +148,29 @@ impl Drive {
                     document_and_contract_info.owned_document_info.owner_id,
                     Some((sub_level, event_id)),
                     platform_version,
-                )?
-                .unwrap_or_default();
+                )? {
+                Some(document_top_field) => document_top_field,
+                // An unrequired top-level property on an indexOnly type is a
+                // skipIfAbsent index's trigger (the parser admits no other
+                // optional property), and every index through this branch is
+                // such an index — an absent trigger writes NOTHING: no
+                // property-name tree, no descent, no entries. Skipping
+                // before any operation is emitted is what keeps the branch
+                // free of stranded prefix trees; the probes mirror this
+                // exact condition in `index_only_entry_paths_and_key`. A
+                // create's estimation dry-run reads the real document (so it
+                // skips exactly when apply skips), and the timestamp of a
+                // bucketed level can never land here (its source is
+                // `$createdAt`, required whenever indexed).
+                None if document_type.index_only()
+                    && !document_type.required_fields().contains(property_name) =>
+                {
+                    continue;
+                }
+                // A stored type's absent value keeps its null-layout empty
+                // key.
+                None => DriveKeyInfo::default(),
+            };
 
             // here we are inserting the value tree (per distinct property value)
             // under the top-level property-name tree. The top-level property-name

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -2172,6 +2172,7 @@ mod range_countable_picker_tests {
             time_range: None,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }
     }
 
@@ -3546,6 +3547,7 @@ mod time_range_picker_tests {
             time_range,
             terminal: None,
             preallocated: false,
+            skip_if_absent: false,
         }
     }
 

--- a/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
@@ -703,6 +703,7 @@ fn test_index(name: &str, properties: &[&str], summable: Option<&str>) -> Index 
         time_range: None,
         terminal: None,
         preallocated: false,
+        skip_if_absent: false,
     }
 }
 

--- a/packages/rs-drive/src/query/drive_document_sum_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_sum_query/tests.rs
@@ -48,6 +48,7 @@ fn summable_index(name: &str, props: &[&str], summable: Option<&str>) -> Index {
         time_range: None,
         terminal: None,
         preallocated: false,
+        skip_if_absent: false,
     }
 }
 
@@ -70,6 +71,7 @@ fn range_summable_index(name: &str, props: &[&str], summable: &str) -> Index {
         time_range: None,
         terminal: None,
         preallocated: false,
+        skip_if_absent: false,
     }
 }
 

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -35,7 +35,7 @@
 
 use crate::error::drive::DriveError;
 use crate::error::Error;
-use crate::query::DriveDocumentQuery;
+use crate::query::{index_admissible_for_skip_if_absent, DriveDocumentQuery};
 use crate::verify::RootHash;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
@@ -170,7 +170,15 @@ impl DriveDocumentQuery<'_> {
                 // resolved time ranges may bind to bucket keys, and those
                 // opted out above — a raw query name-matching a bucketed
                 // index's properties must not walk its grid-keyed levels.
-                |index| index.time_range.is_none(),
+                // A skipIfAbsent index additionally requires its trigger
+                // bound — it is a sparse projection, and the matcher alone
+                // would admit a trigger-unbound query within the
+                // difference budget (see
+                // [`index_admissible_for_skip_if_absent`]).
+                |index| {
+                    index.time_range.is_none()
+                        && index_admissible_for_skip_if_absent(index, &fields)
+                },
                 platform_version,
             )
             .map_err(|e| Error::Protocol(Box::new(e)))?
@@ -668,10 +676,13 @@ impl DriveDocumentQuery<'_> {
 
 /// The index an executed-transition proof (waitForStateTransitionResult)
 /// runs against: the first `$ownerId`-bearing index that involves no
-/// `$createdAt` — the verifier cannot know the block timestamp the entry
-/// was keyed with, so a time-keyed entry cannot be located client-side.
-/// The parser guarantees an owner-bearing index exists; one avoiding
-/// `$createdAt` is a v1 proof-surface requirement.
+/// `$createdAt` AND is not `skipIfAbsent` — the verifier cannot know the
+/// block timestamp a time-keyed entry was written with, and a skipIfAbsent
+/// index has no entry at all for a trigger-absent document, so neither can
+/// anchor a proof that must exist for every create/delete. The parser
+/// guarantees such an index exists (`apply_index_only`'s proof-index rule
+/// mirrors exactly this predicate); prover and verifier share this one
+/// selector, so they can never disagree on the anchor.
 pub fn index_only_proof_index<'a>(document_type: &'a DocumentTypeRef) -> Result<&'a Index, Error> {
     use dpp::document::property_names::{CREATED_AT, OWNER_ID};
     document_type
@@ -682,12 +693,12 @@ pub fn index_only_proof_index<'a>(document_type: &'a DocumentTypeRef) -> Result<
                 || index.properties.iter().any(|p| p.name == OWNER_ID);
             let carries_created_at = index.terminal.as_deref() == Some(CREATED_AT)
                 || index.properties.iter().any(|p| p.name == CREATED_AT);
-            carries_owner && !carries_created_at
+            carries_owner && !carries_created_at && !index.skip_if_absent
         })
         .ok_or(Error::Query(
             crate::error::query::QuerySyntaxError::Unsupported(
                 "executed-transition proofs for an indexOnly type need an \
-                 $ownerId-bearing index that does not involve $createdAt"
+                 $ownerId-bearing, non-skipIfAbsent index that does not involve $createdAt"
                     .to_string(),
             ),
         ))

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -927,6 +927,34 @@ pub fn index_admissible_for_resolved_time_range(
     }
 }
 
+/// Whether a query binding `fields` (its equal/in/range and order-by
+/// fields, as assembled for the index matcher) may be served by `index`
+/// given its `skipIfAbsent` participation.
+///
+/// A `skipIfAbsent` index holds only the documents that carry its trigger
+/// (the first property) — it is a SPARSE projection of the document type.
+/// The generic matcher does not require contiguously bound prefixes: an
+/// unused property, the leading trigger included, merely counts toward the
+/// difference score, so without this gate a query that never mentions the
+/// trigger could route here and silently omit every trigger-absent
+/// document — a result a complete index would have included (and the
+/// positional path lowering would additionally mis-assemble the prefix
+/// gap). Requiring the trigger among the query's fields makes the sparse
+/// semantics opt-in: whoever binds the trigger is asking "among documents
+/// carrying this property", which is exactly what the index holds. The
+/// count pickers and the multiple-`In` route need no such gate — their
+/// exact-cover / contiguous-prefix matching already binds position 0.
+#[cfg(any(feature = "server", feature = "verify"))]
+pub fn index_admissible_for_skip_if_absent(index: &Index, fields: &[&str]) -> bool {
+    if !index.skip_if_absent {
+        return true;
+    }
+    index
+        .properties
+        .first()
+        .is_some_and(|trigger| fields.contains(&trigger.name.as_str()))
+}
+
 /// Rejects a query whose resolution provenance and clause shapes disagree:
 /// every field in `resolved_time_ranges` must appear in the where
 /// clauses as exactly one `Equal` clause — the only shape
@@ -2204,7 +2232,10 @@ impl<'a> DriveDocumentQuery<'a> {
             fields.as_slice(),
             in_field,
             order_by_keys.as_slice(),
-            |index| index_admissible_for_resolved_time_range(index, &self.resolved_time_ranges),
+            |index| {
+                index_admissible_for_resolved_time_range(index, &self.resolved_time_ranges)
+                    && index_admissible_for_skip_if_absent(index, &fields)
+            },
             platform_version,
         )?
         else {

--- a/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json
@@ -238,7 +238,10 @@
               "b": "asc"
             }
           ],
-          "terminal": "$ownerId"
+          "terminal": "$ownerId",
+          "skipIfAbsent": true,
+          "countable": "countable",
+          "rangeCountable": true
         }
       ],
       "properties": {
@@ -256,8 +259,75 @@
         }
       },
       "required": [
-        "a",
-        "b"
+        "a"
+      ],
+      "additionalProperties": false
+    },
+    "pin": {
+      "type": "object",
+      "indexOnly": true,
+      "documentsMutable": false,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byTagXY",
+          "properties": [
+            {
+              "tag": "asc"
+            },
+            {
+              "x": "asc"
+            },
+            {
+              "y": "asc"
+            }
+          ],
+          "terminal": "$ownerId",
+          "skipIfAbsent": true
+        },
+        {
+          "name": "byX",
+          "properties": [
+            {
+              "x": "asc"
+            }
+          ],
+          "terminal": "$ownerId"
+        },
+        {
+          "name": "byY",
+          "properties": [
+            {
+              "y": "asc"
+            }
+          ],
+          "terminal": "$ownerId"
+        }
+      ],
+      "properties": {
+        "tag": {
+          "type": "array",
+          "byteArray": true,
+          "minItems": 0,
+          "maxItems": 8,
+          "position": 0
+        },
+        "x": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 1
+        },
+        "y": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 2
+        }
+      },
+      "required": [
+        "x",
+        "y"
       ],
       "additionalProperties": false
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Storage half of the `skipIfAbsent` stack (grammar in #4522, which this PR is based on): a document that omits a skip index's trigger writes no entry into that index, and a delete recomputes the same skip from its carried values. This is what makes an untagged like stop paying `byHashtagPost`'s ranked chain.

The core soundness invariant: the write walkers, the validation probes, and the row commitment must derive the skip from facts that provably agree — the walkers from `required` membership, the probes from the parsed flag, the commitment from the present value set — with #4522's admission rules as the bridge between them.

## What was done?

- **Walkers** (top-level v2, insert + delete): an absent value for an unrequired property on an indexOnly type prunes the whole branch before any tree insert — no property-name tree, no descent, no entries. No new `IndexLevel` flag: the parser guarantees every index through such a branch is `skipIfAbsent` with that property first. A create's estimation dry-run reads the real document, so it skips exactly when apply skips; the delete dry-run's worst-case document info never skips, deliberately keeping it an upper bound. Stored-type null-layout behavior untouched.
- **Row commitment**: an absent optional property contributes nothing to the preimage, its name included, so the commitment pins the exact present-set — a delete carrying a different absence pattern than the create fails every probe (no force-pruning a skip index, no orphaned entries). The variable present-set stays injectively parseable (property names cannot contain `0x00`; every length prefix starts with one); documented at the preimage and pinned by tests. Delete-side hash billing shrinks with the preimage automatically.
- **Probes**: `index_only_entry_paths_and_key` returns zero paths for a trigger-absent skip index; the existing zero-path semantics (delete probe vacuously consistent, create probe not-a-duplicate) mean the abci and storage-layer probe loops need no changes at all.
- **Proof anchor**: `index_only_proof_index` — the single selector shared by prover and verifier — now also refuses `skipIfAbsent` indexes, mirroring the dpp rule that guarantees a non-skip, `$createdAt`-free index exists.
- **Query routing gate** (found by adversarial review of the design): the generic matcher admits an index with an unused *leading* property inside `MAX_INDEX_DIFFERENCE`, so a trigger-unbound query could route to the sparse index and silently omit every trigger-absent row. New `index_admissible_for_skip_if_absent` (same shape and call sites as the resolved-time-range admissibility filter) requires the trigger among the query's assembled fields, at `select_best_index` and the terminal route. The count pickers and the multiple-`In` route already bind position 0 structurally and need no gate. Sparse semantics are thereby opt-in: binding the trigger is asking "among documents carrying this property".
- Removed the uncalled `index_only_owner_bearing_index`.
- **Fixture**: `mark.b` becomes optional with `byB` `skipIfAbsent` (+ count axes so sparse counting is observable); new `pin` doctype pins the compound skip shape `[tag, x, y]` and the empty byte-array trigger — the one input where the skip lane and the null-layout empty-key lane sit one byte apart.

## How Has This Been Tested?

Seven new e2e tests in the indexOnly battery (40 total passing): trigger-absent create writes only non-skip entries with byB's tree staying literally empty, and deletes mirror the skip exactly; absence-pattern forgery refused in both directions (trigger dropped from a with-trigger row, trigger invented for a without-trigger row — even when the invented entry exists courtesy of another row); duplicate collisions across the skip boundary in both creation orders; skip-index counts see trigger-present rows only; a trigger-unbound `{x, y}` query is refused routing to the skip index while the trigger-bound query returns exactly the sparse rows with proof parity; the present-but-empty byte-array trigger takes the value lane (distinct commitment, real entry under the empty key, independent deletes); and fee pinning — estimated ≥ actual on the trigger-absent create, and trigger-present > trigger-absent (the measured payoff). The pre-existing splice, preallocated (10), and drive-abci (10) batteries all pass against the updated fixture. `cargo check --workspace` clean.

## Breaking Changes

None — PV14 unreleased; all changed code paths are PV14-only or indexOnly-only.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed (book section lands with the final PR of the stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)