### PR TITLE
feat(platform): propertyAgreement over absent properties

### DIFF
--- a/book/src/drive/index-only-document-types.md
+++ b/book/src/drive/index-only-document-types.md
@@ -79,7 +79,7 @@ Each entry's 32-byte payload is
 over the document's PRESENT properties in sorted-name order
 (`index_only_row_commitment`) — every required property must be present,
 and an optional property (a `skipIfAbsent` trigger, the only optional
-kind) contributes nothing when absent, its name included. It binds the
+kind) contributes nothing when absent, not even its name. It binds the
 independently stored index projections of one document back into one
 logical row: a delete recomputes the commitment from its submitted
 values, and every probed entry must carry it. A values tuple spliced from

--- a/book/src/drive/index-only-document-types.md
+++ b/book/src/drive/index-only-document-types.md
@@ -76,14 +76,20 @@ There is no document beyond that.
 
 Each entry's 32-byte payload is
 `hash_double(owner ‖ (name ‖ length ‖ raw index bytes)* ‖ [$createdAt])`
-over ALL of the document's properties in sorted-name order
-(`index_only_row_commitment`). It binds the independently stored index
-projections of one document back into one logical row: a delete recomputes
-the commitment from its submitted values, and every probed entry must
-carry it. A values tuple spliced from two different creates — even two
-creates by the same owner — fails the comparison on whichever entry
-belongs to the other row. Entry existence alone cannot make that
-distinction; the commitment is what does.
+over the document's PRESENT properties in sorted-name order
+(`index_only_row_commitment`) — every required property must be present,
+and an optional property (a `skipIfAbsent` trigger, the only optional
+kind) contributes nothing when absent, its name included. It binds the
+independently stored index projections of one document back into one
+logical row: a delete recomputes the commitment from its submitted
+values, and every probed entry must carry it. A values tuple spliced from
+two different creates — even two creates by the same owner — fails the
+comparison on whichever entry belongs to the other row. Entry existence
+alone cannot make that distinction; the commitment is what does. The
+present-set is part of what is committed: absent (no name emitted) and
+present-but-empty (`name ‖ 00000000`) hash differently, and the variable
+present-set stays unambiguous because property names never contain a
+zero byte while every length prefix starts with one.
 
 ## Constraint matrix (parse-time, `apply_index_only`)
 
@@ -93,18 +99,65 @@ aggregate keywords follow:
 
 | Constraint | Why |
 |---|---|
-| every property in `required`; every ancestor of an indexed dotted path required | the index path is the storage; no null layout exists |
-| every property appears in ≥ 1 index (prefix or terminal) | an unindexed property would be silently dropped |
+| every property in `required` — except a `skipIfAbsent` index's trigger; every ancestor of an indexed dotted path required | the index path is the storage; no null layout exists — the one sanctioned hole removes the whole entry instead |
+| every non-trigger property appears in ≥ 1 **non-skip** index (prefix or terminal) | only indexed values exist, and a skip index carries no value for trigger-absent documents — covered only there, a property would be validated and committed yet written nowhere |
 | **every index embeds `$ownerId`** (prefix or terminal) | entries are self-authorizing: a delete computed with owner = signer can only ever address the signer's own entries |
+| ≥ 1 index is `$createdAt`-free AND non-`skipIfAbsent` — the **proof index** | executed-transition proofs locate entries from the transition's values alone: they can neither reproduce a block timestamp nor anchor on an entry that may not exist |
 | terminal is `$ownerId` or a single-id refersTo property | the member key must alone be a referable entity id (`identityPublicKey` is compound and rejected) |
 | indexed `$createdAt` requires `$createdAt` in `required` | creation only assigns timestamps for required system times |
 | `documentsMutable: false`, no transfers/trading/history/transient | no stored row, no revision |
 | non-unique, non-contested, `nullSearchable` default | v1 scope |
 | `preallocated` requires a fully reference-determined, non-bucketed path | see [Preallocated index paths](#preallocated-index-paths) |
+| `skipIfAbsent` requires its first property to be an optional, top-level schema property | see [Conditional participation](#conditional-participation-skipifabsent) |
 
-`indexOnly` and the index set (terminals included, `preallocated` flags
-included) are immutable across contract updates — a later-added index
-could never be backfilled.
+`indexOnly` and the index set (terminals included, `preallocated` and
+`skipIfAbsent` flags included) are immutable across contract updates — a
+later-added index could never be backfilled, and the walkers derive the
+skip from `required` membership, which therefore cannot drift from
+historical entries either.
+
+## Conditional participation (skipIfAbsent)
+
+An index may declare `skipIfAbsent: true`: a document that omits the
+index's FIRST property — the **skip trigger** — writes no entry into that
+index at all, and a delete recomputes the same skip from its carried
+values. The trigger is the one property that may leave `required`, and
+the rules keep three views provably equivalent: the write walkers skip a
+top-level branch keyed by an unrequired property (every index through
+such a branch is a skip index — the parser admits an optional property
+only at position 0 of skip indexes, never as a terminal), the probes
+derive zero entry paths from the parsed flag, and the row commitment
+pins the exact present-set so a delete with a different absence pattern
+fails every probe — a skip index can neither be force-pruned nor left
+with an orphan entry.
+
+Why the FIRST property: the merged index structure shares prefix levels
+across indexes and prunes empty trees only upward from a terminal. A
+deeper skip would leave the prefix levels above the absent property
+inserted but unterminated — silently charged, never reclaimed. At the
+top of the branch, absence writes nothing at all. (This also makes
+`skipIfAbsent` + `timeRange` structurally impossible: a bucketed source
+is `$createdAt`, which is required whenever indexed.)
+
+The semantics are a **sparse projection**: the index holds exactly the
+documents carrying its trigger. Counts, ranked reads and absence proofs
+over it answer "among documents with this property" — a proved empty
+position means "no *tagged* like", not "no like". The query router makes
+that opt-in: a skip index is admissible only when the query binds its
+trigger (equality, `in`, range or order-by); the generic matcher alone
+would admit a trigger-unbound query within its difference budget and
+silently omit every trigger-absent row. Structural uniqueness still
+spans the skip boundary — a trigger-absent and a trigger-present
+document colliding on any shared non-skip entry cannot coexist. An
+absent trigger is distinct from a present-but-empty value, which indexes
+normally under its (possibly empty) encoded key.
+
+The economics are the point: each ranked index costs roughly the same on
+every write, so a per-hashtag ranked index on a like doctype used to tax
+every like — tagged or not — and forced a `''` sentinel onto the
+referenced post's hashtag. With `byHashtagPost` as a skip index, an
+untagged like pays only for the indexes it actually appears in, and the
+sentinel disappears (see the absence-aware `propertyAgreement` below).
 
 ## Lifecycle
 
@@ -119,6 +172,12 @@ could never be backfilled.
   like's own property to the referenced post's: the referenced document is
   already fetched for the existence check, so the equality comparison adds
   no reads, and a like whose hashtag disagrees with its post's is refused.
+  Absence is part of the agreement, strictly: both sides absent agree, one
+  side absent is the same mismatch a differing value would be — a like may
+  omit its hashtag exactly when its post has none (anything laxer would
+  let likes on tagged posts silently deflate per-tag aggregates), which is
+  what lets an agreement key double as a `skipIfAbsent` trigger with both
+  sides of the reference optional.
 - **Delete** is its own transition kind,
   `DocumentIndexOnlyDeleteTransition { base, data }` (`$action:
   "indexOnlyDelete"`), carrying the full value tuple (`$createdAt` under
@@ -173,6 +232,13 @@ Three things change, all bit-compatible with the fallback layout:
   hand the first entry the old price, and their trees — created by the
   fallback — are retained on delete exactly like preallocated ones.
 
+`preallocated` composes with `skipIfAbsent`: every bound key is resolved
+before any operation is emitted, and an absent bound value (an untagged
+post's hashtag, under the absence-aware agreement) bails without emitting
+anything — so a tagged post preallocates the skip index's trees, an
+untagged post preallocates only its id-bound indexes, and an untagged
+like skips exactly the trees that were never built.
+
 The economics: the referenced document's creator pays for the trees
 whether or not anyone ever references it (which is why the flag is an
 explicit opt-in, per index), every entry from the first on costs the
@@ -192,8 +258,9 @@ domain-separated, length-framed hash covering every non-owner component,
 
 Executed-transition proofs (waitForStateTransitionResult) prove a create
 by the presence of the entry its values produce under the **proof index**
-(the first `$ownerId`-bearing index not involving `$createdAt` — contract
-admission guarantees one exists) and a delete by its absence, with the
+(the first `$ownerId`-bearing, non-`skipIfAbsent` index not involving
+`$createdAt` — contract admission guarantees one exists) and a delete by
+its absence, with the
 proved entry's payload checked against the transition-derived row
 commitment (and, when the proof index is summable, the proved sum
 contribution against the created document's amount); prover and verifier

--- a/packages/platform-test-suite/test/functional/platform/IndexOnlyDocument.spec.js
+++ b/packages/platform-test-suite/test/functional/platform/IndexOnlyDocument.spec.js
@@ -54,7 +54,6 @@ describe('Platform', () => {
               position: 1,
             },
           },
-          required: ['hashtag'],
           additionalProperties: false,
         },
         like: {
@@ -70,6 +69,9 @@ describe('Platform', () => {
               countable: 'countable',
               rangeCountable: true,
               rankedCountable: true,
+              // hashtag is this index's skip trigger: a like that omits
+              // it writes no byHashtagPost entry at all
+              skipIfAbsent: true,
             },
             {
               name: 'byPost',
@@ -104,7 +106,7 @@ describe('Platform', () => {
               position: 1,
             },
           },
-          required: ['hashtag', 'postId'],
+          required: ['postId'],
           additionalProperties: false,
         },
       };
@@ -297,9 +299,10 @@ describe('Platform', () => {
 
     it('should fail to query a subset-index projection without proofs', async () => {
       // The subset index [postId] synthesizes a projection without the
-      // required hashtag; a partial document cannot be expressed in the
-      // serialized non-proof response, so it only travels the proved read
-      // surface (where the client synthesizes it from the proof itself)
+      // hashtag — and with hashtag optional, serializing it would assert
+      // an absence the index cannot know; partial documents only travel
+      // the proved read surface (where the client synthesizes them from
+      // the proof itself)
       let fetchError;
 
       try {
@@ -312,7 +315,7 @@ describe('Platform', () => {
       }
 
       expect(fetchError).to.exist();
-      expect(fetchError.message).to.match(/does not cover every required property/);
+      expect(fetchError.message).to.match(/does not cover every property/);
     });
 
     it('should fail to fetch an indexOnly document by id', async () => {
@@ -436,6 +439,143 @@ describe('Platform', () => {
         identity.getId().toString(),
         secondIdentity.getId().toString(),
       ]);
+    });
+
+    describe('skipIfAbsent', () => {
+      let untaggedPost;
+      let untaggedLike;
+
+      it('should create an untagged post and an untagged like under the absence agreement', async () => {
+        // post.hashtag is optional; a post may carry no tag at all
+        untaggedPost = await client.platform.documents.create(
+          'yappr.post',
+          identity,
+          {
+            message: 'a post with no hashtag',
+          },
+        );
+
+        await client.platform.documents.broadcast({
+          create: [untaggedPost],
+        }, identity);
+
+        // Additional wait time to mitigate testnet latency
+        await waitForSTPropagated();
+
+        // Both sides of the propertyAgreement absent: the like may omit
+        // its hashtag exactly because the post has none — and the
+        // skipIfAbsent byHashtagPost index writes nothing for it
+        untaggedLike = await client.platform.documents.create(
+          'yappr.like',
+          identity,
+          {
+            postId: untaggedPost.getId(),
+          },
+        );
+
+        await client.platform.documents.broadcast({
+          create: [untaggedLike],
+        }, identity);
+
+        // Additional wait time to mitigate testnet latency
+        await waitForSTPropagated();
+      });
+
+      it('should refuse a hashtag-less like on a tagged post', async () => {
+        // Referring absent, referenced present: the absence agreement is
+        // strict — a like on a tagged post must carry the tag, or per-tag
+        // aggregates would silently deflate
+        const hashtagLessLike = await client.platform.documents.create(
+          'yappr.like',
+          secondIdentity,
+          {
+            postId: post.getId(),
+          },
+        );
+
+        let broadcastError;
+
+        try {
+          await client.platform.documents.broadcast({
+            create: [hashtagLessLike],
+          }, secondIdentity);
+        } catch (e) {
+          broadcastError = e;
+        }
+
+        expect(broadcastError).to.be.an.instanceOf(StateTransitionBroadcastError);
+        // ReferencedDocumentPropertyMismatchError
+        expect(broadcastError.code).to.equal(40127);
+      });
+
+      it('should refuse a tagged like on an untagged post', async () => {
+        // Referring present, referenced absent: the mirror mismatch
+        const taggedLike = await client.platform.documents.create(
+          'yappr.like',
+          secondIdentity,
+          {
+            hashtag: POST_HASHTAG,
+            postId: untaggedPost.getId(),
+          },
+        );
+
+        let broadcastError;
+
+        try {
+          await client.platform.documents.broadcast({
+            create: [taggedLike],
+          }, secondIdentity);
+        } catch (e) {
+          broadcastError = e;
+        }
+
+        expect(broadcastError).to.be.an.instanceOf(StateTransitionBroadcastError);
+        // ReferencedDocumentPropertyMismatchError
+        expect(broadcastError.code).to.equal(40127);
+      });
+
+      it('should keep untagged likes out of the hashtag index', async () => {
+        // The skip index is a sparse projection: it holds exactly the
+        // likes that carry a hashtag, so the untagged like is invisible
+        // to per-hashtag queries (which must bind the trigger)
+        const likes = await client.platform.documents.get(
+          'yappr.like',
+          {
+            where: [
+              ['hashtag', '==', POST_HASHTAG],
+              ['postId', '==', untaggedPost.getId()],
+            ],
+          },
+        );
+
+        expect(likes).to.have.lengthOf(0);
+      });
+
+      it('should delete an untagged like by its values', async () => {
+        // The locally created document carries the exact value tuple
+        // (postId only) — the delete recomputes the same skip, removing
+        // entries from the non-skip indexes alone
+        await client.platform.documents.broadcast({
+          delete: [untaggedLike],
+        }, identity);
+
+        // Additional wait time to mitigate testnet latency
+        await waitForSTPropagated();
+
+        let broadcastError;
+
+        try {
+          await client.platform.documents.broadcast({
+            delete: [untaggedLike],
+          }, identity);
+        } catch (e) {
+          broadcastError = e;
+        }
+
+        expect(broadcastError).to.be.an.instanceOf(StateTransitionBroadcastError);
+        // DocumentNotFoundError: the first delete was exact
+        expect(broadcastError.code).to.equal(40101);
+      });
     });
   });
 });

--- a/packages/platform-test-suite/test/functional/platform/IndexOnlyDocument.spec.js
+++ b/packages/platform-test-suite/test/functional/platform/IndexOnlyDocument.spec.js
@@ -444,6 +444,7 @@ describe('Platform', () => {
     describe('skipIfAbsent', () => {
       let untaggedPost;
       let untaggedLike;
+      let freshTaggedPost;
 
       it('should create an untagged post and an untagged like under the absence agreement', async () => {
         // post.hashtag is optional; a post may carry no tag at all
@@ -482,6 +483,27 @@ describe('Platform', () => {
       });
 
       it('should refuse a hashtag-less like on a tagged post', async () => {
+        // A FRESH tagged post: both identities already hold likes on the
+        // shared `post`, and the create-side duplicate probe would refuse
+        // the colliding byPost entry (40105) before the agreement check
+        // ever ran — the shape under test needs a post this identity has
+        // no like on
+        freshTaggedPost = await client.platform.documents.create(
+          'yappr.post',
+          identity,
+          {
+            hashtag: POST_HASHTAG,
+            message: 'a second tagged post',
+          },
+        );
+
+        await client.platform.documents.broadcast({
+          create: [freshTaggedPost],
+        }, identity);
+
+        // Additional wait time to mitigate testnet latency
+        await waitForSTPropagated();
+
         // Referring absent, referenced present: the absence agreement is
         // strict — a like on a tagged post must carry the tag, or per-tag
         // aggregates would silently deflate
@@ -489,7 +511,7 @@ describe('Platform', () => {
           'yappr.like',
           secondIdentity,
           {
-            postId: post.getId(),
+            postId: freshTaggedPost.getId(),
           },
         );
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/document/document_reference_validation/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/document/document_reference_validation/v0/mod.rs
@@ -284,6 +284,17 @@ fn validate_document_type_references_v0(
                 // OWN document type's key encoding — one deterministic
                 // normal form per value kind, so an identifier stored as
                 // bytes and one carried as an identifier compare equal.
+                //
+                // Absence is part of the agreement, strictly: both sides
+                // absent agree, one side absent is a mismatch. Anything
+                // laxer breaks the properties agreements exist for — with
+                // referring-absent-always-ok, a document could opt out of
+                // echoing a value its referenced document carries (e.g. a
+                // like on a TAGGED post omitting the tag, silently
+                // deflating every per-tag aggregate), and the referenced
+                // side's absence is what lets a referring doctype whose
+                // agreement key triggers a skipIfAbsent index stay
+                // consistently absent for untagged targets.
                 if let Some(referenced_document) = &referenced_document {
                     use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
                     use dpp::document::DocumentV0Getters;
@@ -299,17 +310,24 @@ fn validate_document_type_references_v0(
                                 .into(),
                             )
                         };
-                        let Ok(Some(referring_value)) =
-                            document_data.get_optional_at_path(referring_property)
-                        else {
-                            return Ok(mismatch());
-                        };
-                        let Ok(Some(referenced_value)) = referenced_document
+                        let referring_value = document_data
+                            .get_optional_at_path(referring_property)
+                            .unwrap_or(None);
+                        let referenced_value = referenced_document
                             .properties()
                             .get_optional_at_path(referenced_property)
-                        else {
-                            return Ok(mismatch());
-                        };
+                            .unwrap_or(None);
+                        let (referring_value, referenced_value) =
+                            match (referring_value, referenced_value) {
+                                (Some(referring_value), Some(referenced_value)) => {
+                                    (referring_value, referenced_value)
+                                }
+                                // Both absent: the sides agree.
+                                (None, None) => continue,
+                                // One side absent: a mismatch, exactly as a
+                                // differing value would be.
+                                (Some(_), None) | (None, Some(_)) => return Ok(mismatch()),
+                            };
                         let Ok(referring_encoded) = document_type.serialize_value_for_key(
                             referring_property,
                             referring_value,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/document/document_reference_validation/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/document/document_reference_validation/v0/mod.rs
@@ -310,13 +310,22 @@ fn validate_document_type_references_v0(
                                 .into(),
                             )
                         };
-                        let referring_value = document_data
-                            .get_optional_at_path(referring_property)
-                            .unwrap_or(None);
-                        let referenced_value = referenced_document
+                        // A lookup ERROR (a non-map value where the dotted
+                        // path expects an intermediate object) is a
+                        // mismatch, never absence — folding it into `None`
+                        // would let two malformed sides "agree" as
+                        // both-absent.
+                        let Ok(referring_value) =
+                            document_data.get_optional_at_path(referring_property)
+                        else {
+                            return Ok(mismatch());
+                        };
+                        let Ok(referenced_value) = referenced_document
                             .properties()
                             .get_optional_at_path(referenced_property)
-                            .unwrap_or(None);
+                        else {
+                            return Ok(mismatch());
+                        };
                         let (referring_value, referenced_value) =
                             match (referring_value, referenced_value) {
                                 (Some(referring_value), Some(referenced_value)) => {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/index_only.rs
@@ -96,10 +96,27 @@ pub(super) mod index_only_tests {
         document
     }
 
+    /// [`build_like`] without the hashtag — the skipIfAbsent form: no
+    /// `byHashtagPost` entry, and the absence agreement demands an
+    /// untagged post.
+    pub(super) fn build_untagged_like(
+        contract: &DataContract,
+        owner: Identifier,
+        post_id: Identifier,
+        entropy: Bytes32,
+        rng: &mut StdRng,
+        platform_version: &PlatformVersion,
+    ) -> Document {
+        let mut document = build_like(contract, owner, post_id, entropy, rng, platform_version);
+        document.remove("hashtag");
+        document
+    }
+
     /// Create a real `post` (the permanent document the likes refer to) and
     /// return it — the like's `postId` carries a `refersTo`, so a like on a
     /// nonexistent post is rejected with ReferencedEntityNotFoundError (as
-    /// this suite's first draft usefully proved).
+    /// this suite's first draft usefully proved). Under `#dash`; see
+    /// [`create_post_with_hashtag`] for the untagged form.
     pub(super) async fn create_post<
         S: dpp::identity::signer::Signer<dpp::identity::IdentityPublicKey>,
     >(
@@ -111,6 +128,39 @@ pub(super) mod index_only_tests {
         nonce: u64,
         signer: &S,
         rng: &mut StdRng,
+        platform_version: &PlatformVersion,
+    ) -> Document {
+        create_post_with_hashtag(
+            platform,
+            platform_state,
+            contract,
+            owner,
+            key,
+            nonce,
+            signer,
+            rng,
+            Some("dash"),
+            platform_version,
+        )
+        .await
+    }
+
+    /// [`create_post`] with the hashtag spelled out — `None` creates an
+    /// UNTAGGED post (`post.hashtag` is optional), the target a
+    /// hashtag-less like's absence agreement must match.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn create_post_with_hashtag<
+        S: dpp::identity::signer::Signer<dpp::identity::IdentityPublicKey>,
+    >(
+        platform: &TempPlatform<MockCoreRPCLike>,
+        platform_state: &PlatformState,
+        contract: &DataContract,
+        owner: Identifier,
+        key: &dpp::identity::IdentityPublicKey,
+        nonce: u64,
+        signer: &S,
+        rng: &mut StdRng,
+        hashtag: Option<&str>,
         platform_version: &PlatformVersion,
     ) -> Document {
         let post_type = contract
@@ -127,7 +177,16 @@ pub(super) mod index_only_tests {
                 platform_version,
             )
             .expect("expected a random post");
-        post.set("hashtag", "dash".into());
+        match hashtag {
+            Some(hashtag) => {
+                post.set("hashtag", hashtag.into());
+            }
+            None => {
+                // The random fill populates optional properties; an
+                // untagged post carries no hashtag at all.
+                post.remove("hashtag");
+            }
+        }
         let create = BatchTransition::new_document_creation_transition_from_document(
             post.clone(),
             post_type,
@@ -516,6 +575,308 @@ pub(super) mod index_only_tests {
                 ..
             }],
             "a like disagreeing with its post's hashtag must be refused"
+        );
+    }
+
+    /// The absence agreement, strictly: a hashtag-less like may only sit
+    /// on a hashtag-less post. A like OMITTING the tag of a TAGGED post is
+    /// a mismatch (anything laxer would deflate per-tag aggregates), and a
+    /// TAGGED like on an UNTAGGED post is the mirror mismatch.
+    #[tokio::test]
+    async fn test_absence_agreement_is_strict_in_both_directions() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let platform_state = platform.state.load();
+        let mut rng = StdRng::seed_from_u64(4244);
+
+        let (alice, alice_signer, alice_key) =
+            setup_identity(&mut platform, 958, dash_to_credits!(1.0));
+        let contract = register_likes(&platform, alice.id(), platform_version);
+        let like_type = contract
+            .document_type_for_name("like")
+            .expect("like doctype exists");
+
+        let tagged_post = create_post(
+            &platform,
+            &platform_state,
+            &contract,
+            alice.id(),
+            &alice_key,
+            2,
+            &alice_signer,
+            &mut rng,
+            platform_version,
+        )
+        .await;
+        let untagged_post = create_post_with_hashtag(
+            &platform,
+            &platform_state,
+            &contract,
+            alice.id(),
+            &alice_key,
+            3,
+            &alice_signer,
+            &mut rng,
+            None,
+            platform_version,
+        )
+        .await;
+
+        // Referring absent, referenced present: refused.
+        let entropy = Bytes32::random_with_rng(&mut rng);
+        let hashtag_less_on_tagged = build_untagged_like(
+            &contract,
+            alice.id(),
+            tagged_post.id(),
+            entropy,
+            &mut rng,
+            platform_version,
+        );
+        let create = BatchTransition::new_document_creation_transition_from_document(
+            hashtag_less_on_tagged,
+            like_type,
+            entropy.0,
+            &alice_key,
+            4,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the create transition");
+        let result = process_and_commit(&platform, &platform_state, &create, platform_version);
+        assert_matches!(
+            result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::PaidConsensusError {
+                error: ConsensusError::StateError(
+                    StateError::ReferencedDocumentPropertyMismatchError(_)
+                ),
+                ..
+            }],
+            "a hashtag-less like on a TAGGED post must be refused"
+        );
+
+        // Referring present, referenced absent: refused.
+        let entropy = Bytes32::random_with_rng(&mut rng);
+        let tagged_on_untagged = build_like(
+            &contract,
+            alice.id(),
+            untagged_post.id(),
+            entropy,
+            &mut rng,
+            platform_version,
+        );
+        let create = BatchTransition::new_document_creation_transition_from_document(
+            tagged_on_untagged,
+            like_type,
+            entropy.0,
+            &alice_key,
+            5,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the create transition");
+        let result = process_and_commit(&platform, &platform_state, &create, platform_version);
+        assert_matches!(
+            result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::PaidConsensusError {
+                error: ConsensusError::StateError(
+                    StateError::ReferencedDocumentPropertyMismatchError(_)
+                ),
+                ..
+            }],
+            "a tagged like on an UNTAGGED post must be refused"
+        );
+    }
+
+    /// The untagged lifecycle end-to-end: both-absent agreement passes,
+    /// the skipIfAbsent index writes nothing, structural uniqueness still
+    /// holds through `byPost`, and unlikes are exact.
+    #[tokio::test]
+    async fn test_untagged_like_lifecycle() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let platform_state = platform.state.load();
+        let mut rng = StdRng::seed_from_u64(4245);
+
+        let (alice, alice_signer, alice_key) =
+            setup_identity(&mut platform, 958, dash_to_credits!(1.0));
+        let contract = register_likes(&platform, alice.id(), platform_version);
+        let like_type = contract
+            .document_type_for_name("like")
+            .expect("like doctype exists");
+
+        let untagged_post = create_post_with_hashtag(
+            &platform,
+            &platform_state,
+            &contract,
+            alice.id(),
+            &alice_key,
+            2,
+            &alice_signer,
+            &mut rng,
+            None,
+            platform_version,
+        )
+        .await;
+
+        // ── the untagged like goes through ─────────────────────────────
+        let entropy = Bytes32::random_with_rng(&mut rng);
+        let untagged_like = build_untagged_like(
+            &contract,
+            alice.id(),
+            untagged_post.id(),
+            entropy,
+            &mut rng,
+            platform_version,
+        );
+        let create = BatchTransition::new_document_creation_transition_from_document(
+            untagged_like.clone(),
+            like_type,
+            entropy.0,
+            &alice_key,
+            3,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the create transition");
+        let result = process_and_commit(&platform, &platform_state, &create, platform_version);
+        assert_eq!(
+            result.valid_count(),
+            1,
+            "the untagged like must be created: {:?}",
+            result.execution_results()
+        );
+
+        // The skip index holds nothing for it: the hashtag property-name
+        // tree stays childless.
+        let like_doctype_path = vec![
+            vec![drive::drive::RootTree::DataContractDocuments as u8],
+            contract.id().to_vec(),
+            vec![1],
+            b"like".to_vec(),
+        ];
+        let path_refs: Vec<&[u8]> = like_doctype_path.iter().map(|v| v.as_slice()).collect();
+        let hashtag_tree = platform
+            .drive
+            .grove_get_raw_optional(
+                path_refs.as_slice().into(),
+                b"hashtag",
+                drive::util::grove_operations::DirectQueryType::StatefulDirectQuery,
+                None,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("read the hashtag property-name tree");
+        assert_matches!(
+            hashtag_tree,
+            Some(drive::grovedb::Element::Tree(None, _)),
+            "the skipIfAbsent index must hold nothing for an untagged like"
+        );
+
+        // ── a second untagged like collides on byPost ──────────────────
+        let entropy_2 = Bytes32::random_with_rng(&mut rng);
+        let again = build_untagged_like(
+            &contract,
+            alice.id(),
+            untagged_post.id(),
+            entropy_2,
+            &mut rng,
+            platform_version,
+        );
+        let create_again = BatchTransition::new_document_creation_transition_from_document(
+            again,
+            like_type,
+            entropy_2.0,
+            &alice_key,
+            4,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the create transition");
+        let result =
+            process_and_commit(&platform, &platform_state, &create_again, platform_version);
+        assert_matches!(
+            result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::PaidConsensusError {
+                error: ConsensusError::StateError(StateError::DuplicateUniqueIndexError(_)),
+                ..
+            }],
+            "structural uniqueness must survive the skipped index"
+        );
+
+        // ── unlike, exactly once ───────────────────────────────────────
+        let delete = BatchTransition::new_document_deletion_transition_from_document(
+            untagged_like.clone(),
+            like_type,
+            &alice_key,
+            5,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the delete transition");
+        let result = process_and_commit(&platform, &platform_state, &delete, platform_version);
+        assert_eq!(
+            result.valid_count(),
+            1,
+            "the untagged unlike must go through: {:?}",
+            result.execution_results()
+        );
+
+        let delete_again = BatchTransition::new_document_deletion_transition_from_document(
+            untagged_like,
+            like_type,
+            &alice_key,
+            6,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the delete transition");
+        let result =
+            process_and_commit(&platform, &platform_state, &delete_again, platform_version);
+        assert_matches!(
+            result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::PaidConsensusError {
+                error: ConsensusError::StateError(StateError::DocumentNotFoundError(_)),
+                ..
+            }],
+            "a second unlike finds nothing"
+        );
+
+        let issues = platform
+            .drive
+            .grove
+            .verify_grovedb(None, true, false, &platform_version.drive.grove_version)
+            .expect("verify_grovedb must run");
+        assert!(
+            issues.is_empty(),
+            "grovedb must stay consistent: {issues:?}"
         );
     }
 
@@ -964,6 +1325,146 @@ mod index_only_executed_proof_tests {
         };
         let (_, absent) = documents.into_iter().next().expect("one entry");
         assert!(absent.is_none(), "the unliked entry must be proven absent");
+    }
+
+    /// Executed proofs for the UNTAGGED form: the proof anchor is a
+    /// non-skip index (the shared selector refuses skipIfAbsent ones), the
+    /// verifier's recomputed commitment matches the skip-absent preimage,
+    /// and the verified document carries no hashtag — absence survives the
+    /// round trip instead of being default-filled.
+    #[tokio::test]
+    async fn test_executed_untagged_like_create_and_delete_proofs() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let platform_state = platform.state.load();
+        let mut rng = StdRng::seed_from_u64(31338);
+
+        let (alice, alice_signer, alice_key) =
+            setup_identity(&mut platform, 958, dash_to_credits!(1.0));
+        let contract = register_likes(&platform, alice.id(), platform_version);
+        let like_type = contract
+            .document_type_for_name("like")
+            .expect("like doctype exists");
+        let contract_arc = Arc::new(contract.clone());
+
+        let untagged_post = create_post_with_hashtag(
+            &platform,
+            &platform_state,
+            &contract,
+            alice.id(),
+            &alice_key,
+            2,
+            &alice_signer,
+            &mut rng,
+            None,
+            platform_version,
+        )
+        .await;
+
+        let entropy = Bytes32::random_with_rng(&mut rng);
+        let untagged_like = build_untagged_like(
+            &contract,
+            alice.id(),
+            untagged_post.id(),
+            entropy,
+            &mut rng,
+            platform_version,
+        );
+        let create = BatchTransition::new_document_creation_transition_from_document(
+            untagged_like.clone(),
+            like_type,
+            entropy.0,
+            &alice_key,
+            3,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the create transition");
+        let result = process_and_commit(&platform, &platform_state, &create, platform_version);
+        assert_eq!(result.valid_count(), 1);
+
+        // ── executed create ────────────────────────────────────────────
+        let proof = platform
+            .drive
+            .prove_state_transition(&create, None, platform_version)
+            .expect("expected to prove the executed untagged create")
+            .into_data()
+            .expect("expected proof bytes");
+        let lookup = |_id: &dpp::identifier::Identifier| Ok(Some(Arc::clone(&contract_arc)));
+        let (root_hash, outcome) = Drive::verify_state_transition_was_executed_with_proof(
+            &create,
+            &BlockInfo::default(),
+            proof.as_slice(),
+            &lookup,
+            platform_version,
+        )
+        .expect("expected the executed untagged create proof to verify");
+        assert_ne!(root_hash, [0u8; 32]);
+        let StateTransitionProofResult::VerifiedDocuments(documents) = outcome.into_result() else {
+            panic!("expected verified documents");
+        };
+        let (_, verified_like) = documents.into_iter().next().expect("one document");
+        let verified_like = verified_like.expect("the created untagged like is present");
+        assert_eq!(
+            verified_like
+                .properties()
+                .get("postId")
+                .expect("postId present")
+                .to_identifier_bytes()
+                .expect("identifier"),
+            untagged_post.id().to_vec()
+        );
+        assert!(
+            !verified_like.properties().contains_key("hashtag"),
+            "absence must survive verification — no default-filling"
+        );
+
+        // ── executed delete ────────────────────────────────────────────
+        let delete = BatchTransition::new_document_deletion_transition_from_document(
+            untagged_like,
+            like_type,
+            &alice_key,
+            4,
+            0,
+            None,
+            &alice_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected the delete transition");
+        let result = process_and_commit(&platform, &platform_state, &delete, platform_version);
+        assert_eq!(result.valid_count(), 1);
+
+        let proof = platform
+            .drive
+            .prove_state_transition(&delete, None, platform_version)
+            .expect("expected to prove the executed untagged delete")
+            .into_data()
+            .expect("expected proof bytes");
+        let (root_hash, outcome) = Drive::verify_state_transition_was_executed_with_proof(
+            &delete,
+            &BlockInfo::default(),
+            proof.as_slice(),
+            &lookup,
+            platform_version,
+        )
+        .expect("expected the executed untagged delete proof to verify");
+        assert_ne!(root_hash, [0u8; 32]);
+        let StateTransitionProofResult::VerifiedDocuments(documents) = outcome.into_result() else {
+            panic!("expected verified documents");
+        };
+        let (_, absent) = documents.into_iter().next().expect("one entry");
+        assert!(
+            absent.is_none(),
+            "the untagged unlike must be proven absent"
+        );
     }
 
     /// A helper for the negative-path tests below: a signed `mark` create

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -2522,7 +2522,9 @@ fn beat_duplicate_and_overlapping_rows() {
 // class where "skip" (absent) and the null-layout empty key (present,
 // empty encoding) sit one byte apart.
 
-fn mark_type_ref(contract: &DataContract) -> dpp::data_contract::document_type::DocumentTypeRef {
+fn mark_type_ref(
+    contract: &DataContract,
+) -> dpp::data_contract::document_type::DocumentTypeRef<'_> {
     contract
         .document_type_for_name("mark")
         .expect("mark doctype exists")
@@ -2859,7 +2861,7 @@ fn skip_estimated_fees_upper_bound_actual_fees() {
 
 // ── pin: the compound skip shape and the empty-encoding trigger ─────────
 
-fn pin_type_ref(contract: &DataContract) -> dpp::data_contract::document_type::DocumentTypeRef {
+fn pin_type_ref(contract: &DataContract) -> dpp::data_contract::document_type::DocumentTypeRef<'_> {
     contract
         .document_type_for_name("pin")
         .expect("pin doctype exists")

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -736,6 +736,29 @@ fn should_serialize_synthesized_documents_on_raw_no_proof_reads() {
         "expected covering guidance, got: {error}"
     );
 
+    // A by-id raw read keeps its DEDICATED guidance: the coverage refusal
+    // must not preempt it (the wire clients' test suite pins the message).
+    let by_id = likes_query(
+        &contract,
+        vec![WhereClause {
+            field: "$id".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Identifier([7u8; 32]),
+        }],
+        Some(1),
+    );
+    let error = by_id
+        .execute_raw_results_no_proof(&drive, None, None, platform_version())
+        .expect_err("a by-id raw read must be refused");
+    assert!(
+        matches!(
+            &error,
+            Error::Query(QuerySyntaxError::Unsupported(message))
+                if message.contains("cannot be fetched by id")
+        ),
+        "expected the by-id guidance, got: {error}"
+    );
+
     assert_grovedb_is_consistent(&drive);
 }
 

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -711,9 +711,10 @@ fn should_serialize_synthesized_documents_on_raw_no_proof_reads() {
     );
     assert_eq!(document.owner_id().to_buffer(), OWNER_1);
 
-    // Subset index ([$ownerId] → postId): the projection has no hashtag,
-    // which is required — it cannot be serialized, so the raw read must
-    // refuse with guidance instead of returning bytes no client can parse.
+    // Subset index ([$ownerId] → postId): the projection has no hashtag —
+    // and with hashtag optional, serializing the projection would assert
+    // an absence the index cannot know (this like HAS a hashtag). The raw
+    // read must refuse with guidance instead of misrepresenting the row.
     let subset = likes_query(
         &contract,
         vec![WhereClause {
@@ -730,7 +731,7 @@ fn should_serialize_synthesized_documents_on_raw_no_proof_reads() {
         matches!(
             &error,
             Error::Query(QuerySyntaxError::Unsupported(message))
-                if message.contains("does not cover every required property")
+                if message.contains("does not cover every property")
         ),
         "expected covering guidance, got: {error}"
     );
@@ -3111,6 +3112,86 @@ fn empty_byte_array_trigger_takes_the_value_lane_not_the_skip_lane() {
         "the empty-lane entry must be gone"
     );
     delete_pin(&drive, &contract, absent_tag, true).expect("delete absent-tag pin");
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+// ── the real payoff shape: the untagged like ────────────────────────────
+
+/// A like carrying no hashtag — `byHashtagPost` is `skipIfAbsent` with
+/// `hashtag` as its trigger, so this form writes only `byPost` and
+/// `byLiker` entries. Shared with the preallocated suite.
+pub(super) fn build_untagged_like(
+    contract: &DataContract,
+    post: [u8; 32],
+    owner: [u8; 32],
+    seed: u64,
+) -> Document {
+    let pv = platform_version();
+    let document_type = contract
+        .document_type_for_name(DOCTYPE)
+        .expect("like doctype exists");
+    let mut doc = document_type
+        .random_document(Some(seed), pv)
+        .expect("random document");
+    let mut props = std::collections::BTreeMap::new();
+    props.insert("postId".to_string(), Value::Identifier(post));
+    doc.set_properties(props);
+    doc.set_owner_id(Identifier::from(owner));
+    doc
+}
+
+/// The measured payoff, end-to-end on the real shape: an untagged like
+/// writes only the two non-skip indexes' entries, costs less than a
+/// tagged like (no ranked hashtag chain), and deletes cleanly.
+#[test]
+fn untagged_like_skips_the_hashtag_index_and_prices_lower() {
+    let (drive, contract) = setup_likes();
+    let base = doctype_path(&contract);
+
+    let untagged = build_untagged_like(&contract, POST_A, OWNER_1, 1);
+    let untagged_fee =
+        insert_like(&drive, &contract, &untagged, true).expect("insert untagged like");
+
+    // byHashtagPost holds nothing: the top-level hashtag tree stays the
+    // empty registration-time tree.
+    assert!(
+        matches!(
+            read_grove_element(&drive, &base, b"hashtag"),
+            Some(Element::Tree(None, _))
+        ),
+        "the skip index must hold nothing for an untagged like"
+    );
+
+    // byPost and byLiker carry the row.
+    let mut by_post = base.clone();
+    by_post.extend([b"postId".to_vec(), POST_A.to_vec(), vec![0]]);
+    assert!(matches!(
+        read_grove_element(&drive, &by_post, &OWNER_1),
+        Some(Element::Item(..))
+    ));
+    let mut by_liker = base.clone();
+    by_liker.extend([b"$ownerId".to_vec(), OWNER_1.to_vec(), vec![0]]);
+    assert!(matches!(
+        read_grove_element(&drive, &by_liker, &POST_A),
+        Some(Element::Item(..))
+    ));
+
+    // A tagged like by another owner on another post pays for the ranked
+    // hashtag chain the untagged one skipped.
+    let tagged = build_like(&contract, "dash", POST_B, OWNER_2, 2);
+    let tagged_fee = insert_like(&drive, &contract, &tagged, true).expect("insert tagged like");
+    assert!(
+        tagged_fee.storage_fee > untagged_fee.storage_fee,
+        "a tagged like ({}) must cost more than an untagged one ({})",
+        tagged_fee.storage_fee,
+        untagged_fee.storage_fee
+    );
+
+    // The untagged like deletes cleanly through the same skip.
+    delete_like(&drive, &contract, untagged, true).expect("delete untagged like");
+    assert!(read_grove_element(&drive, &by_post, &OWNER_1).is_none());
+    assert!(read_grove_element(&drive, &by_liker, &POST_A).is_none());
 
     assert_grovedb_is_consistent(&drive);
 }

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/preallocated_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/preallocated_index_e2e_tests.rs
@@ -767,3 +767,79 @@ fn should_not_emit_partial_paths_when_a_bound_property_is_absent() {
 
     assert_grovedb_is_consistent(&drive);
 }
+
+/// An UNTAGGED post preallocates nothing for the skipIfAbsent
+/// `byHashtagPost` (its hashtag binding has no value to resolve) while
+/// `byPost` — bound purely by the post's id — still preallocates, and an
+/// untagged like then lands in those trees, skipping the hashtag index
+/// entirely. The preallocated + skipIfAbsent composition end-to-end.
+#[test]
+fn should_preallocate_only_reference_bound_trees_for_an_untagged_post() {
+    use super::index_only_e2e_tests::build_untagged_like;
+
+    let (drive, contract) = setup_preallocated_likes();
+    let post_type = contract
+        .document_type_for_name("post")
+        .expect("post doctype exists");
+    let mut post = post_type
+        .random_document(Some(41), platform_version())
+        .expect("random post");
+    post.set_properties(std::collections::BTreeMap::new());
+    post.set_owner_id(Identifier::from(OWNER_POSTER));
+    let post_id = post.id().to_buffer();
+    insert_post(&drive, &contract, &post, true).expect("insert untagged post");
+
+    let base = doctype_path(&contract);
+
+    // byHashtagPost: nothing preallocated — the hashtag binding resolved
+    // to an absent value and bailed before emitting any operation.
+    assert!(
+        matches!(
+            read_grove_element(&drive, &base, b"hashtag"),
+            Some(grovedb::Element::Tree(None, _))
+        ),
+        "no hashtag trees may be preallocated for an untagged post"
+    );
+
+    // byPost: fully preallocated down to the empty member bucket.
+    let mut by_post_level = base.clone();
+    by_post_level.push(b"postId".to_vec());
+    assert!(
+        read_grove_element(&drive, &by_post_level, &post_id).is_some(),
+        "the id-bound byPost trees must still be preallocated"
+    );
+    let mut member_bucket = by_post_level.clone();
+    member_bucket.push(post_id.to_vec());
+    assert!(read_grove_element(&drive, &member_bucket, &[0]).is_some());
+
+    // An untagged like lands in the preallocated byPost trees and skips
+    // the hashtag index.
+    let like = build_untagged_like(&contract, post_id, OWNER_1, 42);
+    insert_like(&drive, &contract, &like, true).expect("insert untagged like");
+    let mut entry_path = member_bucket.clone();
+    entry_path.push(vec![0]);
+    assert!(
+        read_grove_element(&drive, &entry_path, &OWNER_1).is_some(),
+        "the untagged like's byPost entry must sit in the preallocated bucket"
+    );
+    assert!(
+        matches!(
+            read_grove_element(&drive, &base, b"hashtag"),
+            Some(grovedb::Element::Tree(None, _))
+        ),
+        "the like must not have touched the hashtag index"
+    );
+
+    // Unlike keeps the preallocated trees (the no-prune contract).
+    delete_like(&drive, &contract, like, true).expect("delete untagged like");
+    assert!(
+        read_grove_element(&drive, &entry_path, &OWNER_1).is_none(),
+        "the entry itself must be gone"
+    );
+    assert!(
+        read_grove_element(&drive, &member_bucket, &[0]).is_some(),
+        "the preallocated member bucket must survive the unlike"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -149,6 +149,18 @@ impl DriveDocumentQuery<'_> {
             .map(|in_clause| in_clause.field.as_str());
         let order_by_keys: Vec<&str> = self.order_by.keys().map(String::as_str).collect();
 
+        // The union of every field the query binds, for the skip-index
+        // admissibility gate — the by-role slices above are what the
+        // matcher consumes.
+        let mut bound_fields = equal_fields.clone();
+        bound_fields.extend(range_field);
+        bound_fields.extend(in_field);
+        for order_by_key in &order_by_keys {
+            if !bound_fields.contains(order_by_key) {
+                bound_fields.push(order_by_key);
+            }
+        }
+
         let Some((index, _difference, terminal_used)) = self
             .document_type
             .index_for_types_matching_including_terminal(
@@ -161,13 +173,14 @@ impl DriveDocumentQuery<'_> {
                 // opted out above — a raw query name-matching a bucketed
                 // index's properties must not walk its grid-keyed levels.
                 // A skipIfAbsent index additionally requires its trigger
-                // bound — it is a sparse projection, and the matcher alone
-                // would admit a trigger-unbound query within the
-                // difference budget (see
-                // [`index_admissible_for_skip_if_absent`]).
+                // bound — it is a sparse projection, and while the
+                // contiguous matcher already forces position 0 to be bound
+                // whenever any deeper property is used, an all-unused match
+                // inside the difference budget could still slip through
+                // (see [`index_admissible_for_skip_if_absent`]).
                 |index| {
                     index.time_range.is_none()
-                        && index_admissible_for_skip_if_absent(index, &fields)
+                        && index_admissible_for_skip_if_absent(index, &bound_fields)
                 },
                 platform_version,
             )

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -1,4 +1,4 @@
-use dpp::data_contract::document_type::TimeRangeTransform;
+use dpp::data_contract::document_type::{DocumentPropertyType, TimeRangeTransform};
 use std::sync::Arc;
 
 #[cfg(any(feature = "server", feature = "verify"))]
@@ -2537,12 +2537,41 @@ impl<'a> DriveDocumentQuery<'a> {
         // the entries are row commitments, not documents. Synthesize the
         // documents from their (path, key) positions and serialize them into
         // the wire shape this path's callers return. An index that does not
-        // cover every required property cannot produce a serializable
+        // cover EVERY property cannot produce a faithful serialized
         // document: partial projections only travel the proved read surface,
-        // where the client synthesizes them itself from the proof.
+        // where the client synthesizes them itself from the proof. The check
+        // includes optional properties (skipIfAbsent triggers) — the wire
+        // encodes absent-vs-present, and a projection that does not carry an
+        // optional property cannot distinguish "absent on the row" from
+        // "not in this index", so serializing it would assert an absence the
+        // index cannot know.
         {
             use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
             if self.document_type.index_only() {
+                let index = self.index_only_query_index(platform_version)?;
+                let covers_every_property = self
+                    .document_type
+                    .flattened_properties()
+                    .iter()
+                    .filter(|(_, property)| {
+                        !matches!(property.property_type, DocumentPropertyType::Object(_))
+                    })
+                    .all(|(name, _)| {
+                        index.terminal.as_deref() == Some(name.as_str())
+                            || index
+                                .properties
+                                .iter()
+                                .any(|index_property| index_property.name == *name)
+                    });
+                if !covers_every_property {
+                    return Err(Error::Query(QuerySyntaxError::Unsupported(
+                        "this indexOnly query's index does not cover every property, so the \
+                         documents it synthesizes cannot be serialized into a non-proof \
+                         response; query through an index covering all properties, or use a \
+                         proved query"
+                            .to_string(),
+                    )));
+                }
                 let (documents, skipped) = self.execute_index_only_documents_no_proof_internal(
                     drive,
                     transaction,

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -2563,29 +2563,35 @@ impl<'a> DriveDocumentQuery<'a> {
         {
             use dpp::data_contract::document_type::accessors::DocumentTypeV2Getters;
             if self.document_type.index_only() {
-                let index = self.index_only_query_index(platform_version)?;
-                let covers_every_property = self
-                    .document_type
-                    .flattened_properties()
-                    .iter()
-                    .filter(|(_, property)| {
-                        !matches!(property.property_type, DocumentPropertyType::Object(_))
-                    })
-                    .all(|(name, _)| {
-                        index.terminal.as_deref() == Some(name.as_str())
-                            || index
-                                .properties
-                                .iter()
-                                .any(|index_property| index_property.name == *name)
-                    });
-                if !covers_every_property {
-                    return Err(Error::Query(QuerySyntaxError::Unsupported(
-                        "this indexOnly query's index does not cover every property, so the \
-                         documents it synthesizes cannot be serialized into a non-proof \
-                         response; query through an index covering all properties, or use a \
-                         proved query"
-                            .to_string(),
-                    )));
+                // By-id and cursor shapes carry dedicated guidance deeper in
+                // the route (no primary-key tree; keyset pagination) — let
+                // them reach it instead of preempting with the coverage
+                // refusal below, which would misdescribe the problem.
+                if !self.is_for_primary_key() && self.start_at.is_none() {
+                    let index = self.index_only_query_index(platform_version)?;
+                    let covers_every_property = self
+                        .document_type
+                        .flattened_properties()
+                        .iter()
+                        .filter(|(_, property)| {
+                            !matches!(property.property_type, DocumentPropertyType::Object(_))
+                        })
+                        .all(|(name, _)| {
+                            index.terminal.as_deref() == Some(name.as_str())
+                                || index
+                                    .properties
+                                    .iter()
+                                    .any(|index_property| index_property.name == *name)
+                        });
+                    if !covers_every_property {
+                        return Err(Error::Query(QuerySyntaxError::Unsupported(
+                            "this indexOnly query's index does not cover every property, so \
+                             the documents it synthesizes cannot be serialized into a \
+                             non-proof response; query through an index covering all \
+                             properties, or use a proved query"
+                                .to_string(),
+                        )));
+                    }
                 }
                 let (documents, skipped) = self.execute_index_only_documents_no_proof_internal(
                     drive,

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -2209,6 +2209,21 @@ impl<'a> DriveDocumentQuery<'a> {
             .map(|range_clause| range_clause.field.as_str());
         let order_by_keys: Vec<&str> = self.order_by.keys().map(String::as_str).collect();
 
+        // The union of every field the query binds, for the skip-index
+        // admissibility gate — the by-role slices above are what the
+        // matcher consumes. The contiguous matcher already forces a used
+        // index's position 0 to be bound, but an all-unused match inside
+        // the difference budget could still select a sparse index for a
+        // query that never names its trigger.
+        let mut bound_fields = equal_fields.clone();
+        bound_fields.extend(range_field);
+        bound_fields.extend(in_field);
+        for order_by_key in &order_by_keys {
+            if !bound_fields.contains(order_by_key) {
+                bound_fields.push(order_by_key);
+            }
+        }
+
         let Some((index, difference)) = self.document_type.index_for_types_matching(
             equal_fields.as_slice(),
             range_field,
@@ -2216,7 +2231,7 @@ impl<'a> DriveDocumentQuery<'a> {
             order_by_keys.as_slice(),
             |index| {
                 index_admissible_for_resolved_time_range(index, &self.resolved_time_ranges)
-                    && index_admissible_for_skip_if_absent(index, &fields)
+                    && index_admissible_for_skip_if_absent(index, &bound_fields)
             },
             platform_version,
         )?

--- a/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json
@@ -23,7 +23,8 @@
           "terminal": "$ownerId",
           "countable": "countable",
           "rangeCountable": true,
-          "rankedCountable": true
+          "rankedCountable": true,
+          "skipIfAbsent": true
         },
         {
           "name": "byPost",
@@ -70,7 +71,6 @@
         }
       },
       "required": [
-        "hashtag",
         "postId"
       ],
       "additionalProperties": false
@@ -102,9 +102,6 @@
           "position": 1
         }
       },
-      "required": [
-        "hashtag"
-      ],
       "additionalProperties": false
     },
     "beat": {

--- a/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-preallocated-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/yappr-likes/yappr-likes-preallocated-contract.json
@@ -24,7 +24,8 @@
           "countable": "countable",
           "rangeCountable": true,
           "rankedCountable": true,
-          "preallocated": true
+          "preallocated": true,
+          "skipIfAbsent": true
         },
         {
           "name": "byPost",
@@ -72,7 +73,6 @@
         }
       },
       "required": [
-        "hashtag",
         "postId"
       ],
       "additionalProperties": false
@@ -104,9 +104,6 @@
           "position": 1
         }
       },
-      "required": [
-        "hashtag"
-      ],
       "additionalProperties": false
     },
     "beat": {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Third PR of the `skipIfAbsent` stack (#4522 grammar → #4523 storage → this). Write-time `propertyAgreement` validation currently returns 40127 whenever the referring property is absent — which makes a skip trigger that is also an agreement key unusable: a hashtag-less like could never be created against any post.

This PR gives absence first-class agreement semantics, **strictly**: both sides absent agree; one side absent is a mismatch, exactly as a differing value would be. Strict (rather than referring-absent-always-ok) because a like on a *tagged* post that omits the tag would silently deflate every per-tag aggregate — the integrity agreements exist to protect. Strictness also composes with `skipIfAbsent`: the referring property stays consistently absent exactly for untagged targets.

With that in place, the fixture flips to the real payoff shape: `like.hashtag` and `post.hashtag` both leave `required`, `byHashtagPost` becomes `skipIfAbsent` (in the preallocated variant too — the `preallocated` + `skipIfAbsent` composition), the `''`-sentinel wart disappears, and an untagged like measurably prices below a tagged one.

## What was done?

- `document_reference_validation/v0`: the agreement loop now matches on both sides' presence — `(Some, Some)` compares via each doctype's key encoding as before, `(None, None)` agrees, mixed returns 40127. Registration-time rules need no change (there was never a required-membership rule to relax).
- **Raw no-proof read fix the flip surfaced**: subset projections were refused only via the `MissingRequiredKey` serialization failure, so with `hashtag` optional a `byLiker` projection would have *serialized as hashtag-absent* — asserting an absence the index cannot know (the row may well be tagged). The coverage check is now explicit and requires the chosen index to cover EVERY property, optional included; partial projections keep traveling only the proved surface, where the client synthesizes them knowingly.
- Fixtures (both variants): `like.hashtag` optional + `byHashtagPost` `skipIfAbsent`; `post.hashtag` optional.

## How Has This Been Tested?

- **drive e2e** (41 passing): untagged like writes only `byPost`/`byLiker` (the hashtag tree stays literally childless), prices below a tagged like, deletes cleanly; the raw-read coverage refusal updated to the new all-properties rule.
- **preallocated e2e** (11 passing): an untagged post preallocates only its id-bound `byPost` trees — the absent agreement binding bails before emitting any operation — an untagged like lands in them without touching the hashtag index, and unlike honors the no-prune contract.
- **drive-abci** (13 passing): the strict 40127 matrix in both directions (hashtag-less like on a tagged post; tagged like on an untagged post); the full untagged lifecycle — both-absent agreement, duplicate collision through `byPost`, owner-scoped exact unlikes; and executed create/delete proofs for the untagged form, pinning that absence survives verification (no default-filling) and the proof anchors on a non-skip index.

`cargo check --workspace` clean.

## Breaking Changes

None — PV14 unreleased; `propertyAgreement` itself only shipped in the current dev train.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed (book section lands with the final PR of the stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conditional index participation for optional properties through `skipIfAbsent`.
  * Documents missing the configured property are excluded from that index while remaining available through other indexes.
  * Added sparse-projection query support and absence-aware property agreement.
  * Updated index-only commitments and proofs to preserve absent properties distinctly from empty values.
* **Bug Fixes**
  * Improved index selection and raw-result validation for queries involving optional properties.
  * Corrected preallocation and deletion behavior for documents that omit indexed properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->