### PR TITLE
fix(drive): reject index-gapped document queries at protocol version 14

### DIFF
--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
@@ -518,6 +518,7 @@ fn terminal_aware_matching_prefers_generic_and_scores_candidates() {
         .index_for_types_matching_including_terminal(
             &["postId"],
             None,
+            None,
             &[],
             |_| true,
             PlatformVersion::latest(),
@@ -535,6 +536,7 @@ fn terminal_aware_matching_prefers_generic_and_scores_candidates() {
         .index_for_types_matching_including_terminal(
             &["$ownerId", "postId"],
             None,
+            None,
             &[],
             |_| true,
             PlatformVersion::latest(),
@@ -550,6 +552,7 @@ fn terminal_aware_matching_prefers_generic_and_scores_candidates() {
     let (index, difference, terminal_used) = document_type_ref
         .index_for_types_matching_including_terminal(
             &["hashtag", "postId", "$ownerId"],
+            None,
             None,
             &[],
             |_| true,

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -743,18 +743,26 @@ impl TryFrom<BTreeMap<String, String>> for IndexProperty {
 }
 
 impl Index {
-    // The matches function will take a slice of an array of strings and an optional sort on value.
-    // An index matches if all the index_names in the slice are consecutively the index's properties
-    // with leftovers permitted.
-    // If a sort_on value is provided it must match the last index property.
-    // The number returned is the number of unused index properties
-
+    // The v0 (protocol versions <= 13, frozen on chain) matching rule:
+    // every index_name must appear SOMEWHERE in the index's properties
+    // (set membership, any order, any position), the order_by fields must
+    // be a contiguous in-index-order run (not necessarily at the end),
+    // and an in field must be the last or before-last property. The
+    // number returned is the number of unused index properties.
+    //
     // A case for example if we have an index on person's name and age
     // where we say name == 'Sam' sort by age
     // there is no field operator on age
     // The return value for name == 'Sam' sort by age would be 0
-    // The return value for name == 'Sam and age > 5 sort by age would be 0
+    // The return value for name == 'Sam' and age > 5 sort by age would be 0
     // the return value for sort by age would be 1
+    //
+    // Because membership is positionless, a query binding only LATER
+    // index properties (leaving a leading/middle property unbound) still
+    // matches here even though the positional path lowering cannot
+    // represent the gap — [`Self::matches_contiguous`] (protocol version
+    // 14+) closes that hole. This function must keep its defective
+    // semantics byte-for-byte for on-chain replay.
     pub fn matches(
         &self,
         index_names: &[&str],
@@ -883,6 +891,173 @@ impl Index {
         }
 
         Some(d as u16)
+    }
+
+    /// [`Self::matches`] with the contiguous-prefix requirement the
+    /// positional path lowering depends on (protocol version 14+): the
+    /// equality-bound fields must exactly cover the index's leading
+    /// properties, a range or `in` clause must sit immediately after them
+    /// (in either order when both are present — the lowering nests the
+    /// earlier index property outside), and no unused property may precede
+    /// a field the query names (so order-by-only fields cannot skip over
+    /// an unbound level). Unused TRAILING properties are still permitted
+    /// and still count toward the returned difference.
+    ///
+    /// Fields arrive by role rather than as one flat set because a gapped
+    /// shape can be role-invisible: on the index [a, b, c], the query
+    /// `a == 1 AND c == 3 AND b > 0` names exactly {a, b, c}, yet its
+    /// lowering keys c's equality at b's level and applies b's range at
+    /// c's level.
+    pub fn matches_contiguous(
+        &self,
+        equality_fields: &[&str],
+        range_field: Option<&str>,
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+    ) -> Option<u16> {
+        Self::matches_over_components_contiguous(
+            &self.properties,
+            equality_fields,
+            range_field,
+            in_field_name,
+            order_by,
+        )
+    }
+
+    /// [`Self::matches_contiguous`] with the index's terminal (an
+    /// indexOnly index's member-key property) as a matchable component,
+    /// mirroring [`Self::matches_including_terminal`]: the terminal is
+    /// the entry level itself — ALWAYS the index's deepest component — so
+    /// it is stripped from every role before the prefix properties match
+    /// through the contiguous algorithm. A terminal named in `order_by`
+    /// must be its last (deepest) entry; a terminal range or `in`
+    /// constraint leaves the prefix without one.
+    ///
+    /// Returns `(difference, terminal_used)` with the difference counting
+    /// unused PREFIX properties only, exactly like the v0 variant.
+    pub fn matches_including_terminal_contiguous(
+        &self,
+        equality_fields: &[&str],
+        range_field: Option<&str>,
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+    ) -> Option<(u16, bool)> {
+        let Some(terminal) = self.terminal.as_deref() else {
+            return self
+                .matches_contiguous(equality_fields, range_field, in_field_name, order_by)
+                .map(|difference| (difference, false));
+        };
+
+        let terminal_used = equality_fields.contains(&terminal)
+            || range_field == Some(terminal)
+            || in_field_name == Some(terminal)
+            || order_by.contains(&terminal);
+        let prefix_equality_fields: Vec<&str> = equality_fields
+            .iter()
+            .copied()
+            .filter(|field| *field != terminal)
+            .collect();
+        let prefix_range_field = range_field.filter(|field| *field != terminal);
+        let prefix_in_field = in_field_name.filter(|field| *field != terminal);
+        let prefix_order_by: &[&str] = match order_by.iter().position(|field| *field == terminal) {
+            // Ordering by the terminal is ordering the deepest level —
+            // admissible only as the ordering's last entry.
+            Some(position) if position + 1 == order_by.len() => &order_by[..position],
+            Some(_) => return None,
+            None => order_by,
+        };
+
+        let difference = Self::matches_over_components_contiguous(
+            &self.properties,
+            &prefix_equality_fields,
+            prefix_range_field,
+            prefix_in_field,
+            prefix_order_by,
+        )?;
+        Some((difference, terminal_used))
+    }
+
+    fn matches_over_components_contiguous(
+        properties: &[IndexProperty],
+        equality_fields: &[&str],
+        range_field: Option<&str>,
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+    ) -> Option<u16> {
+        // The flat field set the v0 checks (order-by suffix run, in-field
+        // placement, membership, difference count) run over — assembled
+        // the way `select_best_index` always has, deduplicated.
+        let mut index_names: Vec<&str> = equality_fields.to_vec();
+        for field in [range_field, in_field_name].into_iter().flatten() {
+            if !index_names.contains(&field) {
+                index_names.push(field);
+            }
+        }
+        for field in order_by {
+            if !index_names.contains(field) {
+                index_names.push(field);
+            }
+        }
+
+        let difference =
+            Self::matches_over_components(properties, &index_names, in_field_name, order_by)?;
+
+        // The equality clauses must exactly cover the index's leading
+        // properties: the lowering pairs their serialized values with
+        // `properties[..equality_fields.len()]` positionally.
+        if properties.len() < equality_fields.len() {
+            return None;
+        }
+        if !properties[..equality_fields.len()]
+            .iter()
+            .all(|property| equality_fields.contains(&property.name.as_str()))
+        {
+            return None;
+        }
+
+        // A range or `in` clause becomes the level right below the
+        // equality path, so its field must sit immediately after the
+        // equality prefix; with both present they occupy the next two
+        // positions (the lowering nests whichever is earlier outside).
+        let position_of = |field: &str| {
+            properties
+                .iter()
+                .position(|property| property.name == field)
+        };
+        let equality_len = equality_fields.len();
+        match (range_field, in_field_name) {
+            (Some(range_field), Some(in_field)) => {
+                let range_position = position_of(range_field)?;
+                let in_position = position_of(in_field)?;
+                if range_position.min(in_position) != equality_len
+                    || range_position.max(in_position) != equality_len + 1
+                {
+                    return None;
+                }
+            }
+            (Some(field), None) | (None, Some(field)) => {
+                if position_of(field)? != equality_len {
+                    return None;
+                }
+            }
+            (None, None) => {}
+        }
+
+        // No unused property may precede a named one: every field the
+        // query names (order-by-only fields included) must fall inside
+        // the index prefix of their combined cardinality, leaving unused
+        // properties only as a trailing run.
+        if properties.len() < index_names.len() {
+            return None;
+        }
+        if !properties[..index_names.len()]
+            .iter()
+            .all(|property| index_names.contains(&property.name.as_str()))
+        {
+            return None;
+        }
+
+        Some(difference)
     }
 }
 
@@ -3001,6 +3176,211 @@ mod tests {
         let index = make_index("idx", vec![("name", true), ("age", true)], false);
         let result = index.matches(&["name"], Some("email"), &[]);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_matches_accepts_gapped_binding_frozen_v0_semantics() {
+        // The frozen v0 rule is positionless set membership: binding only
+        // the LAST property of [name, age] still matches with difference
+        // 1, even though the positional lowering cannot represent the
+        // gap. On-chain replay for protocol versions <= 13 depends on
+        // this staying true.
+        let index = make_index("idx", vec![("name", true), ("age", true)], false);
+        assert_eq!(index.matches(&["age"], None, &[]), Some(1));
+    }
+
+    // -----------------------------------------------------------------------
+    // Index::matches_contiguous() tests (protocol version 14+)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_matches_contiguous_agrees_with_v0_on_contiguous_shapes() {
+        let index = make_index(
+            "idx",
+            vec![("name", true), ("age", true), ("city", true)],
+            false,
+        );
+        // Full equality cover.
+        assert_eq!(
+            index.matches_contiguous(&["name", "age", "city"], None, None, &[]),
+            Some(0)
+        );
+        // Equality prefix with trailing unused properties.
+        assert_eq!(
+            index.matches_contiguous(&["name"], None, None, &[]),
+            Some(2)
+        );
+        assert_eq!(
+            index.matches_contiguous(&["name", "age"], None, None, &[]),
+            Some(1)
+        );
+        // Equality prefix + adjacent order-by.
+        assert_eq!(
+            index.matches_contiguous(&["name"], None, None, &["age"]),
+            Some(1)
+        );
+        // Equality fields given in any order still cover the prefix.
+        assert_eq!(
+            index.matches_contiguous(&["age", "name"], None, None, &[]),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn test_matches_contiguous_rejects_gapped_equality() {
+        let index = make_index(
+            "idx",
+            vec![("name", true), ("age", true), ("city", true)],
+            false,
+        );
+        // Last property alone.
+        assert_eq!(index.matches_contiguous(&["city"], None, None, &[]), None);
+        // Middle property alone.
+        assert_eq!(index.matches_contiguous(&["age"], None, None, &[]), None);
+        // First and last, hole in the middle.
+        assert_eq!(
+            index.matches_contiguous(&["name", "city"], None, None, &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_matches_contiguous_rejects_role_permutation() {
+        // name == ? AND city == ? AND age > ? names exactly {name, age,
+        // city}, but the range fills the equality hole: the lowering
+        // would key city's equality at age's level. Role-aware matching
+        // must reject it even though the flat set covers the index.
+        let index = make_index(
+            "idx",
+            vec![("name", true), ("age", true), ("city", true)],
+            false,
+        );
+        assert_eq!(
+            index.matches_contiguous(&["name", "city"], Some("age"), None, &["age", "city"]),
+            None
+        );
+        // The well-formed variant of the same flat set passes.
+        assert_eq!(
+            index.matches_contiguous(&["name", "age"], Some("city"), None, &["city"]),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn test_matches_contiguous_range_and_in_adjacency() {
+        let index = make_index(
+            "idx",
+            vec![("name", true), ("age", true), ("city", true)],
+            false,
+        );
+        // Range immediately after the equality prefix.
+        assert_eq!(
+            index.matches_contiguous(&["name"], Some("age"), None, &["age"]),
+            Some(1)
+        );
+        // Range skipping over the unbound middle property.
+        assert_eq!(
+            index.matches_contiguous(&["name"], Some("city"), None, &["city"]),
+            None
+        );
+        // In immediately after the equality prefix (before-last position).
+        assert_eq!(
+            index.matches_contiguous(&["name"], None, Some("age"), &[]),
+            Some(1)
+        );
+        // In on the last property with the middle property unbound.
+        assert_eq!(
+            index.matches_contiguous(&["name"], None, Some("city"), &[]),
+            None
+        );
+        // Range + in filling the two positions after the prefix, in
+        // either index order.
+        assert_eq!(
+            index.matches_contiguous(&["name"], Some("age"), Some("city"), &["age", "city"]),
+            Some(0)
+        );
+        assert_eq!(
+            index.matches_contiguous(&["name"], Some("city"), Some("age"), &["age", "city"]),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn test_matches_contiguous_rejects_order_by_gap() {
+        // An order-by-only field beyond an unbound property claims an
+        // ordering the leftover walk does not deliver.
+        let index = make_index(
+            "idx",
+            vec![("name", true), ("age", true), ("city", true)],
+            false,
+        );
+        assert_eq!(
+            index.matches_contiguous(&["name"], None, None, &["city"]),
+            None
+        );
+        // Ordering by the property right after the prefix is fine, and
+        // may continue into deeper properties.
+        assert_eq!(
+            index.matches_contiguous(&["name"], None, None, &["age", "city"]),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn test_matches_including_terminal_contiguous() {
+        let mut index = make_index("idx", vec![("hashtag", true), ("post", true)], false);
+        index.terminal = Some("owner".to_string());
+
+        // Fully determined prefix + terminal equality.
+        assert_eq!(
+            index.matches_including_terminal_contiguous(
+                &["hashtag", "post", "owner"],
+                None,
+                None,
+                &[]
+            ),
+            Some((0, true))
+        );
+        // Prefix-only cover leaves the terminal unused and costs nothing.
+        assert_eq!(
+            index.matches_including_terminal_contiguous(&["hashtag", "post"], None, None, &[]),
+            Some((0, false))
+        );
+        // An `in` on the terminal strips to a pure prefix match.
+        assert_eq!(
+            index.matches_including_terminal_contiguous(
+                &["hashtag", "post"],
+                None,
+                Some("owner"),
+                &[]
+            ),
+            Some((0, true))
+        );
+        // Ordering by the terminal is only admissible as the deepest
+        // (last) order-by entry.
+        assert_eq!(
+            index.matches_including_terminal_contiguous(
+                &["hashtag"],
+                None,
+                None,
+                &["post", "owner"]
+            ),
+            Some((0, true))
+        );
+        assert_eq!(
+            index.matches_including_terminal_contiguous(
+                &["hashtag"],
+                None,
+                None,
+                &["owner", "post"]
+            ),
+            None
+        );
+        // A gapped prefix is rejected even when the terminal is bound.
+        assert_eq!(
+            index.matches_including_terminal_contiguous(&["post", "owner"], None, None, &[]),
+            None
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/packages/rs-dpp/src/data_contract/document_type/methods/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/methods/mod.rs
@@ -70,11 +70,43 @@ pub trait DocumentTypeBasicMethods: DocumentTypeV0Getters {
     }
 }
 
+/// The flat field list the v0 (protocol versions <= 13, frozen on chain)
+/// matchers run over, assembled the way `select_best_index` always has:
+/// equality fields first, then the range and `in` fields, then any
+/// order-by fields not already present. The v0 selection loops must keep
+/// receiving exactly this list for on-chain replay.
+fn flatten_query_fields<'a>(
+    equality_fields: &[&'a str],
+    range_field: Option<&'a str>,
+    in_field_name: Option<&'a str>,
+    order_by: &[&'a str],
+) -> Vec<&'a str> {
+    let mut fields = equality_fields.to_vec();
+    if let Some(range_field) = range_field {
+        fields.push(range_field);
+    }
+    if let Some(in_field_name) = in_field_name {
+        fields.push(in_field_name);
+    }
+    for field in order_by {
+        if !fields.contains(field) {
+            fields.push(field);
+        }
+    }
+    fields
+}
+
 // TODO: Some of those methods are only for tests. Hide under feature
 pub trait DocumentTypeV0Methods: DocumentTypeV0Getters + DocumentTypeV0MethodsVersioned {
+    /// Best index for a query's bound fields, given by role. Version 0
+    /// (protocol versions <= 13, frozen on chain) flattens the roles into
+    /// one positionless field set; version 1 (protocol version 14+)
+    /// additionally requires the fields to cover a contiguous prefix of
+    /// the index — the shape the positional path lowering depends on.
     fn index_for_types(
         &self,
-        index_names: &[&str],
+        equality_fields: &[&str],
+        range_field: Option<&str>,
         in_field_name: Option<&str>,
         order_by: &[&str],
         platform_version: &PlatformVersion,
@@ -86,10 +118,15 @@ pub trait DocumentTypeV0Methods: DocumentTypeV0Getters + DocumentTypeV0MethodsVe
             .methods
             .index_for_types
         {
-            0 => Ok(self.index_for_types_v0(index_names, in_field_name, order_by)),
+            0 => Ok(self.index_for_types_v0(
+                &flatten_query_fields(equality_fields, range_field, in_field_name, order_by),
+                in_field_name,
+                order_by,
+            )),
+            1 => Ok(self.index_for_types_v1(equality_fields, range_field, in_field_name, order_by)),
             version => Err(ProtocolError::UnknownVersionMismatch {
-                method: "store_ephemeral_state".to_string(),
-                known_versions: vec![0],
+                method: "index_for_types".to_string(),
+                known_versions: vec![0, 1],
                 received: version,
             }),
         }
@@ -108,7 +145,8 @@ pub trait DocumentTypeV0Methods: DocumentTypeV0Getters + DocumentTypeV0MethodsVe
     /// the candidate set, it does not change how a candidate is scored.
     fn index_for_types_matching(
         &self,
-        index_names: &[&str],
+        equality_fields: &[&str],
+        range_field: Option<&str>,
         in_field_name: Option<&str>,
         order_by: &[&str],
         filter: impl Fn(&Index) -> bool,
@@ -121,10 +159,22 @@ pub trait DocumentTypeV0Methods: DocumentTypeV0Getters + DocumentTypeV0MethodsVe
             .methods
             .index_for_types
         {
-            0 => Ok(self.index_for_types_matching_v0(index_names, in_field_name, order_by, filter)),
+            0 => Ok(self.index_for_types_matching_v0(
+                &flatten_query_fields(equality_fields, range_field, in_field_name, order_by),
+                in_field_name,
+                order_by,
+                filter,
+            )),
+            1 => Ok(self.index_for_types_matching_v1(
+                equality_fields,
+                range_field,
+                in_field_name,
+                order_by,
+                filter,
+            )),
             version => Err(ProtocolError::UnknownVersionMismatch {
                 method: "index_for_types_matching".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             }),
         }
@@ -141,7 +191,8 @@ pub trait DocumentTypeV0Methods: DocumentTypeV0Getters + DocumentTypeV0MethodsVe
     /// version 14.
     fn index_for_types_matching_including_terminal(
         &self,
-        index_names: &[&str],
+        equality_fields: &[&str],
+        range_field: Option<&str>,
         in_field_name: Option<&str>,
         order_by: &[&str],
         filter: impl Fn(&Index) -> bool,
@@ -155,14 +206,21 @@ pub trait DocumentTypeV0Methods: DocumentTypeV0Getters + DocumentTypeV0MethodsVe
             .index_for_types
         {
             0 => Ok(self.index_for_types_matching_including_terminal_v0(
-                index_names,
+                &flatten_query_fields(equality_fields, range_field, in_field_name, order_by),
+                in_field_name,
+                order_by,
+                filter,
+            )),
+            1 => Ok(self.index_for_types_matching_including_terminal_v1(
+                equality_fields,
+                range_field,
                 in_field_name,
                 order_by,
                 filter,
             )),
             version => Err(ProtocolError::UnknownVersionMismatch {
                 method: "index_for_types_matching_including_terminal".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             }),
         }

--- a/packages/rs-dpp/src/data_contract/document_type/methods/versioned_methods.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/methods/versioned_methods.rs
@@ -491,6 +491,107 @@ pub trait DocumentTypeV0MethodsVersioned: DocumentTypeV0Getters + DocumentTypeBa
         best_index
     }
 
+    fn index_for_types_v1(
+        &self,
+        equality_fields: &[&str],
+        range_field: Option<&str>,
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+    ) -> Option<(&Index, u16)> {
+        self.index_for_types_matching_v1(
+            equality_fields,
+            range_field,
+            in_field_name,
+            order_by,
+            |_| true,
+        )
+    }
+
+    /// [`Self::index_for_types_matching_v0`]'s selection loop over
+    /// [`Index::matches_contiguous`] (protocol version 14+): candidates
+    /// whose bound fields do not cover a contiguous prefix of the index
+    /// are skipped before they are scored, so a well-shaped index can win
+    /// where the v0 matcher would have handed the query to a candidate
+    /// the positional path lowering misaligns on. Scoring and the
+    /// index-map-order tie-break are unchanged.
+    fn index_for_types_matching_v1(
+        &self,
+        equality_fields: &[&str],
+        range_field: Option<&str>,
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+        filter: impl Fn(&Index) -> bool,
+    ) -> Option<(&Index, u16)> {
+        let mut best_index: Option<(&Index, u16)> = None;
+        let mut best_difference = u16::MAX;
+        for (_, index) in self.indexes().iter() {
+            if !filter(index) {
+                continue;
+            }
+            let difference_option =
+                index.matches_contiguous(equality_fields, range_field, in_field_name, order_by);
+            if let Some(difference) = difference_option {
+                if difference == 0 {
+                    return Some((index, 0));
+                } else if difference < best_difference {
+                    best_difference = difference;
+                    best_index = Some((index, best_difference));
+                }
+            }
+        }
+        best_index
+    }
+
+    /// [`Self::index_for_types_matching_including_terminal_v0`]'s
+    /// class-precedence loop over
+    /// [`Index::matches_including_terminal_contiguous`] (protocol version
+    /// 14+): generic (non-terminal) matches keep absolute precedence over
+    /// terminal-using ones, with the contiguous-prefix requirement
+    /// applied to each candidate's prefix properties.
+    fn index_for_types_matching_including_terminal_v1(
+        &self,
+        equality_fields: &[&str],
+        range_field: Option<&str>,
+        in_field_name: Option<&str>,
+        order_by: &[&str],
+        filter: impl Fn(&Index) -> bool,
+    ) -> Option<(&Index, u16, bool)> {
+        let mut best_generic: Option<(&Index, u16)> = None;
+        let mut best_generic_difference = u16::MAX;
+        let mut best_terminal: Option<(&Index, u16)> = None;
+        let mut best_terminal_difference = u16::MAX;
+        for (_, index) in self.indexes().iter() {
+            if !filter(index) {
+                continue;
+            }
+            let Some((difference, terminal_used)) = index.matches_including_terminal_contiguous(
+                equality_fields,
+                range_field,
+                in_field_name,
+                order_by,
+            ) else {
+                continue;
+            };
+            if terminal_used {
+                if difference < best_terminal_difference {
+                    best_terminal_difference = difference;
+                    best_terminal = Some((index, difference));
+                }
+            } else {
+                if difference == 0 {
+                    return Some((index, 0, false));
+                }
+                if difference < best_generic_difference {
+                    best_generic_difference = difference;
+                    best_generic = Some((index, difference));
+                }
+            }
+        }
+        best_generic
+            .map(|(index, difference)| (index, difference, false))
+            .or(best_terminal.map(|(index, difference)| (index, difference, true)))
+    }
+
     /// The estimated size uses the middle ceil size of all attributes
     fn estimated_size_v0(&self, platform_version: &PlatformVersion) -> Result<u16, ProtocolError> {
         let mut total_size = 0u16;

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/index_only_e2e_tests.rs
@@ -1123,7 +1123,11 @@ fn should_refuse_pivot_with_terminal_range() {
 }
 
 /// An equality BELOW the pivot is not yet supported and must be refused
-/// rather than silently scanned.
+/// rather than silently scanned. Since protocol version 14's contiguous
+/// matching, the candidate is rejected at index-selection time (the
+/// equality does not cover the index prefix the range pivots on), so
+/// the refusal is the generic no-index error rather than the synthesis
+/// route's targeted shape error.
 #[test]
 fn should_refuse_equality_below_pivot() {
     use crate::error::query::QuerySyntaxError;
@@ -1167,8 +1171,7 @@ fn should_refuse_equality_below_pivot() {
         .expect_err("an equality below the pivot must be refused");
     assert_matches!(
         &error,
-        crate::error::Error::Query(QuerySyntaxError::Unsupported(message))
-            if message.contains("BELOW a pivot"),
+        crate::error::Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(_)),
         "unexpected error: {error}"
     );
 }

--- a/packages/rs-drive/src/drive/identity/withdrawals/document/fetch_oldest_withdrawal_documents_by_status/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/withdrawals/document/fetch_oldest_withdrawal_documents_by_status/v0/mod.rs
@@ -41,13 +41,30 @@ impl Drive {
 
         let mut order_by = IndexMap::new();
 
-        order_by.insert(
-            withdrawal::properties::UPDATED_AT.to_string(),
-            OrderClause {
-                field: withdrawal::properties::UPDATED_AT.to_string(),
-                ascending: true,
-            },
-        );
+        // The full tail of the `pooling` index ([status, pooling,
+        // coreFeePerByte, $updatedAt]), in index order. This is the
+        // ordering the left-over walk has always delivered — before
+        // protocol version 14 the query named only $updatedAt and the
+        // matcher tolerated the two unbound middle properties, so
+        // documents still came back grouped by (pooling, coreFeePerByte)
+        // ascending, then oldest-first within a group. Naming the whole
+        // tail keeps the query accepted under v14's contiguous matching
+        // and produces the identical path query (all directions match
+        // the walk's ascending defaults), so results are unchanged on
+        // every protocol version.
+        for field in [
+            withdrawal::properties::POOLING,
+            withdrawal::properties::CORE_FEE_PER_BYTE,
+            withdrawal::properties::UPDATED_AT,
+        ] {
+            order_by.insert(
+                field.to_string(),
+                OrderClause {
+                    field: field.to_string(),
+                    ascending: true,
+                },
+            );
+        }
 
         let drive_query = DriveDocumentQuery {
             contract: &withdrawals_contract,
@@ -537,5 +554,91 @@ mod tests {
         //     "Successfully fetched {} QUEUED documents sorted by updatedAt",
         //     queued_documents.len()
         // );
+    }
+
+    /// The pooling fetch names the `pooling` index's full tail
+    /// ([pooling, coreFeePerByte, $updatedAt]) in `order_by`; before the
+    /// protocol-version-14 contiguous matching it named only $updatedAt
+    /// and relied on the matcher tolerating the two unbound middle
+    /// properties. Withdrawal pooling runs during block execution, so
+    /// the shapes must lower to the byte-identical path query at
+    /// protocol version 13 for replay — and only the full-tail shape
+    /// may survive at protocol version 14.
+    #[test]
+    fn full_tail_order_by_lowers_identically_to_the_legacy_shape_at_protocol_v13() {
+        let platform_version = PlatformVersion::latest();
+        let protocol_v13 = PlatformVersion::get(13).expect("protocol version 13 exists");
+
+        let data_contract =
+            load_system_data_contract(SystemDataContract::Withdrawals, platform_version)
+                .expect("to load system data contract");
+        let document_type = data_contract
+            .document_type_for_name(withdrawal::NAME)
+            .expect("expected to get document type");
+
+        let make_query = |order_fields: &[&str]| {
+            let mut where_clauses = BTreeMap::new();
+            where_clauses.insert(
+                withdrawal::properties::STATUS.to_string(),
+                WhereClause {
+                    field: withdrawal::properties::STATUS.to_string(),
+                    operator: crate::query::WhereOperator::Equal,
+                    value: Value::U8(withdrawals_contract::WithdrawalStatus::QUEUED as u8),
+                },
+            );
+            let mut order_by = IndexMap::new();
+            for field in order_fields {
+                order_by.insert(
+                    field.to_string(),
+                    OrderClause {
+                        field: field.to_string(),
+                        ascending: true,
+                    },
+                );
+            }
+            DriveDocumentQuery {
+                contract: &data_contract,
+                document_type,
+                internal_clauses: InternalClauses {
+                    primary_key_in_clause: None,
+                    primary_key_equal_clause: None,
+                    in_clauses: Vec::new(),
+                    range_clause: None,
+                    equal_clauses: where_clauses,
+                },
+                offset: None,
+                limit: Some(DEFAULT_QUERY_LIMIT),
+                order_by,
+                start_at: None,
+                start_at_included: false,
+                block_time_ms: None,
+                resolved_time_ranges: vec![],
+            }
+        };
+
+        let legacy_shape = make_query(&[withdrawal::properties::UPDATED_AT]);
+        let full_tail_shape = make_query(&[
+            withdrawal::properties::POOLING,
+            withdrawal::properties::CORE_FEE_PER_BYTE,
+            withdrawal::properties::UPDATED_AT,
+        ]);
+
+        let legacy_v13 = legacy_shape
+            .construct_path_query(None, protocol_v13)
+            .expect("legacy shape lowers at protocol v13");
+        let full_tail_v13 = full_tail_shape
+            .construct_path_query(None, protocol_v13)
+            .expect("full-tail shape lowers at protocol v13");
+        assert_eq!(
+            legacy_v13, full_tail_v13,
+            "the two order-by shapes must lower to the identical path query at protocol v13"
+        );
+
+        full_tail_shape
+            .construct_path_query(None, platform_version)
+            .expect("full-tail shape lowers at protocol v14");
+        legacy_shape
+            .construct_path_query(None, platform_version)
+            .expect_err("the gapped legacy shape is rejected at protocol v14");
     }
 }

--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -130,40 +130,30 @@ impl DriveDocumentQuery<'_> {
             return Ok(None);
         }
 
-        // The same field assembly the generic matcher receives.
-        let mut fields = self
+        // The same by-role field assembly the generic matcher receives.
+        let equal_fields = self
             .internal_clauses
             .equal_clauses
             .keys()
             .map(|field| field.as_str())
             .collect::<Vec<&str>>();
-        if let Some(range_clause) = &self.internal_clauses.range_clause {
-            fields.push(range_clause.field.as_str());
-        }
+        let range_field = self
+            .internal_clauses
+            .range_clause
+            .as_ref()
+            .map(|range_clause| range_clause.field.as_str());
         let in_field = self
             .internal_clauses
             .in_clauses
             .first()
             .map(|in_clause| in_clause.field.as_str());
-        if let Some(in_field) = in_field {
-            fields.push(in_field);
-        }
-        let order_by_keys: Vec<&str> = self
-            .order_by
-            .keys()
-            .map(|key: &String| {
-                let field = key.as_str();
-                if !fields.contains(&field) {
-                    fields.push(field);
-                }
-                field
-            })
-            .collect();
+        let order_by_keys: Vec<&str> = self.order_by.keys().map(String::as_str).collect();
 
         let Some((index, _difference, terminal_used)) = self
             .document_type
             .index_for_types_matching_including_terminal(
-                fields.as_slice(),
+                equal_fields.as_slice(),
+                range_field,
                 in_field,
                 order_by_keys.as_slice(),
                 // Bucketed indexes never serve the terminal route: only

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -2179,29 +2179,11 @@ impl<'a> DriveDocumentQuery<'a> {
             .range_clause
             .as_ref()
             .map(|range_clause| range_clause.field.as_str());
-        let mut fields = equal_fields;
-        if let Some(range_field) = range_field {
-            fields.push(range_field);
-        }
-        if let Some(in_field) = in_field {
-            fields.push(in_field);
-            //if there is an in_field, it always takes precedence
-        }
-
-        let order_by_keys: Vec<&str> = self
-            .order_by
-            .keys()
-            .map(|key: &String| {
-                let str = key.as_str();
-                if !fields.contains(&str) {
-                    fields.push(str);
-                }
-                str
-            })
-            .collect();
+        let order_by_keys: Vec<&str> = self.order_by.keys().map(String::as_str).collect();
 
         let Some((index, difference)) = self.document_type.index_for_types_matching(
-            fields.as_slice(),
+            equal_fields.as_slice(),
+            range_field,
             in_field,
             order_by_keys.as_slice(),
             |index| index_admissible_for_resolved_time_range(index, &self.resolved_time_ranges),

--- a/packages/rs-drive/src/query/non_primary_key_path_query/single_in_path_query/v0/mod.rs
+++ b/packages/rs-drive/src/query/non_primary_key_path_query/single_in_path_query/v0/mod.rs
@@ -403,6 +403,29 @@ impl<'a> DriveDocumentQuery<'a> {
             .collect::<Result<Vec<Vec<u8>>, ProtocolError>>()
             .map_err(Error::from)?;
 
+        // Defensive re-check of the protocol-version-14 matcher's
+        // contiguity guarantee (`Index::matches_contiguous`): the
+        // positional split below pairs `intermediate_values` with the
+        // index's leading properties in order, so a gap in the equality
+        // cover — or a range/`in` clause not sitting right after it —
+        // would misalign every level below the hole.
+        if !query_covers_index_prefix_contiguously(
+            &index.properties,
+            &|field| self.internal_clauses.equal_clauses.contains_key(field),
+            last_clause,
+            subquery_clause,
+            intermediate_values.len(),
+        ) {
+            return Err(Error::Query(
+                QuerySyntaxError::WhereClauseOnNonIndexedProperty(format!(
+                    "query fields do not contiguously cover the index's properties from the \
+                     first: equality clauses must cover the index prefix and any range or in \
+                     clause must immediately follow it; index: {:?}",
+                    index
+                )),
+            ));
+        }
+
         let final_query = match last_clause {
             None => {
                 // There is no last_clause which means we are using an index most likely because of an order_by, however we have no
@@ -705,5 +728,146 @@ impl<'a> DriveDocumentQuery<'a> {
             path,
             SizedQuery::new(final_query, self.limit, self.offset),
         ))
+    }
+}
+
+/// True when the query's clauses line up with the positional path
+/// construction: the first `equality_prefix_len` index properties all
+/// carry equality clauses (they are the levels `intermediate_values`
+/// keys), the terminal clause (equality, range, or `in`) sits on the
+/// property right after that prefix, and a subquery clause (the later
+/// of an `in`/range pair) on the property after it. Unreachable-false
+/// once index selection ran through the protocol-version-14 contiguous
+/// matcher; kept as defense in depth for this file's `split_at`.
+#[cfg(any(feature = "server", feature = "verify"))]
+fn query_covers_index_prefix_contiguously(
+    index_properties: &[IndexProperty],
+    is_equality_field: &dyn Fn(&str) -> bool,
+    last_clause: Option<&WhereClause>,
+    subquery_clause: Option<&WhereClause>,
+    equality_prefix_len: usize,
+) -> bool {
+    if index_properties.len() < equality_prefix_len {
+        return false;
+    }
+    let prefix_covered = index_properties[..equality_prefix_len]
+        .iter()
+        .all(|property| is_equality_field(property.name.as_str()));
+    let clause_sits_at = |clause: Option<&WhereClause>, position: usize| match clause {
+        Some(clause) => index_properties
+            .get(position)
+            .is_some_and(|property| property.name == clause.field),
+        None => true,
+    };
+    prefix_covered
+        && clause_sits_at(last_clause, equality_prefix_len)
+        && clause_sits_at(subquery_clause, equality_prefix_len + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::conditions::WhereOperator;
+    use dpp::platform_value::Value;
+
+    fn properties(names: &[&str]) -> Vec<IndexProperty> {
+        names
+            .iter()
+            .map(|name| IndexProperty {
+                name: name.to_string(),
+                ascending: true,
+            })
+            .collect()
+    }
+
+    fn clause(field: &str, operator: WhereOperator) -> WhereClause {
+        WhereClause {
+            field: field.to_string(),
+            operator,
+            value: Value::U64(0),
+        }
+    }
+
+    #[test]
+    fn aligned_shapes_pass() {
+        let index_properties = properties(&["a", "b", "c"]);
+        let is_equality = |field: &str| field == "a" || field == "b";
+
+        // Pure equalities: the deepest one is the terminal clause and is
+        // not among the intermediate values.
+        let terminal = clause("b", WhereOperator::Equal);
+        assert!(query_covers_index_prefix_contiguously(
+            &index_properties,
+            &is_equality,
+            Some(&terminal),
+            None,
+            1,
+        ));
+
+        // Equality prefix + adjacent range.
+        let range = clause("c", WhereOperator::GreaterThan);
+        assert!(query_covers_index_prefix_contiguously(
+            &index_properties,
+            &is_equality,
+            Some(&range),
+            None,
+            2,
+        ));
+
+        // Equality + in + range on consecutive properties.
+        let in_clause = clause("b", WhereOperator::In);
+        assert!(query_covers_index_prefix_contiguously(
+            &index_properties,
+            &|field| field == "a",
+            Some(&in_clause),
+            Some(&range),
+            1,
+        ));
+
+        // No clauses at all (order-by-only use of the index).
+        assert!(query_covers_index_prefix_contiguously(
+            &index_properties,
+            &|_| false,
+            None,
+            None,
+            0,
+        ));
+    }
+
+    #[test]
+    fn misaligned_shapes_fail() {
+        let index_properties = properties(&["a", "b", "c"]);
+
+        // Equality gap: values collected for a and c would be keyed at
+        // a's and b's levels.
+        let terminal = clause("c", WhereOperator::Equal);
+        assert!(!query_covers_index_prefix_contiguously(
+            &index_properties,
+            &|field| field == "a" || field == "c",
+            Some(&terminal),
+            None,
+            1,
+        ));
+
+        // Range skipping the unbound middle property: its items would be
+        // applied at b's level.
+        let range = clause("c", WhereOperator::GreaterThan);
+        assert!(!query_covers_index_prefix_contiguously(
+            &index_properties,
+            &|field| field == "a",
+            Some(&range),
+            None,
+            1,
+        ));
+
+        // Equality on a property the index does not lead with.
+        let terminal = clause("b", WhereOperator::Equal);
+        assert!(!query_covers_index_prefix_contiguously(
+            &index_properties,
+            &|field| field == "b",
+            Some(&terminal),
+            None,
+            0,
+        ));
     }
 }

--- a/packages/rs-drive/src/query/test_index.rs
+++ b/packages/rs-drive/src/query/test_index.rs
@@ -150,6 +150,64 @@ mod tests {
     }
 
     #[test]
+    fn test_find_best_index_gapped_equality() {
+        // `d == "2"` binds only the LAST property of the [b, a, d] index.
+        // The v0 matcher (protocol versions <= 13, frozen on chain) scores
+        // it as a set-membership match with difference 2, even though the
+        // positional lowering cannot represent the two-property gap. From
+        // protocol version 14 the bound fields must cover a contiguous
+        // index prefix, so no index matches.
+        let document_type = construct_indexed_document_type();
+        let contract = get_dpns_data_contract_fixture(None, 0, 1).data_contract_owned();
+
+        let query_value = json!({
+            "where": [
+                ["d", "==", "2"]
+            ]
+        });
+        let where_cbor = cbor_serializer::serializable_value_to_cbor(&query_value, None)
+            .expect("expected to serialize to cbor");
+
+        let protocol_v13 = PlatformVersion::get(13).expect("protocol version 13 exists");
+        let query = DriveDocumentQuery::from_cbor(
+            where_cbor.as_slice(),
+            &contract,
+            document_type.as_ref(),
+            &DriveConfig::default(),
+            protocol_v13,
+        )
+        .expect("query should be valid");
+        let index = query
+            .find_best_index(protocol_v13)
+            .expect("v13 must keep matching the gapped candidate");
+        assert_eq!(
+            index,
+            document_type.indexes().iter().nth(3).unwrap().1,
+            "v13 selects the [b, a, d] index on its last property alone"
+        );
+
+        let platform_version = PlatformVersion::latest();
+        let query = DriveDocumentQuery::from_cbor(
+            where_cbor.as_slice(),
+            &contract,
+            document_type.as_ref(),
+            &DriveConfig::default(),
+            platform_version,
+        )
+        .expect("query should be valid");
+        let error = query
+            .find_best_index(platform_version)
+            .expect_err("a gapped binding must not match any index");
+        assert!(
+            matches!(
+                &error,
+                Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(_))
+            ),
+            "expected WhereClauseOnNonIndexedProperty, got {error:?}"
+        );
+    }
+
+    #[test]
     fn test_find_best_index_error() {
         let document_type = construct_indexed_document_type();
         let contract = get_dpns_data_contract_fixture(None, 0, 1).data_contract_owned();

--- a/packages/rs-drive/tests/query_tests.rs
+++ b/packages/rs-drive/tests/query_tests.rs
@@ -9097,3 +9097,373 @@ mod withdrawal_in_clause_placement_equivalence {
         }
     }
 }
+
+#[cfg(feature = "server")]
+#[cfg(test)]
+mod gapped_index_query_tests {
+    //! Queries whose bound fields do not cover a contiguous prefix of the
+    //! chosen index. Index matching accepted such queries since 2022
+    //! (`33f2a764a4` dropped the original prefix requirement), but the
+    //! positional lowering (`index.properties.split_at(...)`) pairs the
+    //! collected equality values with the index's LEADING properties, so a
+    //! gap misaligns every level below it: results are silently empty or —
+    //! when a range clause fills the hole — satisfy a permutation of the
+    //! requested clauses. Both come back identically on the proof path, so
+    //! the wrong answer verifies against the root hash.
+    //!
+    //! Protocol versions <= 13 are on chain and must replay this defective
+    //! behavior byte-for-byte (the `_frozen_at_protocol_v13` tests — never
+    //! edit their expectations). Protocol version 14 requires the bound
+    //! fields to cover a contiguous index prefix at match time, so a gapped
+    //! candidate is skipped: a well-shaped index wins instead, or the query
+    //! is rejected with `WhereClauseOnNonIndexedProperty`.
+
+    use super::*;
+    use dpp::data_contract::document_type::DocumentTypeRef;
+
+    /// One document type, five integer properties, and two indexes:
+    /// `gapped` = `[a, b, c]` (the index the defective matcher picks) and
+    /// `wide` = `[a, c, d, e]` (a well-shaped fallback for `a`/`c`-bound
+    /// queries).
+    fn setup_gapped_contract() -> (Drive, DataContract) {
+        let drive: Drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let owner_id = Identifier::new([2u8; 32]);
+
+        let documents = platform_value!({
+            "testDocument": {
+                "type": "object",
+                "properties": {
+                    "a": { "type": "integer", "position": 0 },
+                    "b": { "type": "integer", "position": 1 },
+                    "c": { "type": "integer", "position": 2 },
+                    "d": { "type": "integer", "position": 3 },
+                    "e": { "type": "integer", "position": 4 }
+                },
+                "additionalProperties": false,
+                "indices": [
+                    {
+                        "name": "gapped",
+                        "properties": [
+                            { "a": "asc" },
+                            { "b": "asc" },
+                            { "c": "asc" }
+                        ]
+                    },
+                    {
+                        "name": "wide",
+                        "properties": [
+                            { "a": "asc" },
+                            { "c": "asc" },
+                            { "d": "asc" },
+                            { "e": "asc" }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        let factory = DataContractFactory::new(platform_version.protocol_version)
+            .expect("should create factory");
+        let contract = factory
+            .create_with_value_config(owner_id, 0, documents, None, None)
+            .expect("data in fixture should be correct")
+            .data_contract_owned();
+
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("should apply contract");
+
+        let document_type = contract
+            .document_type_for_name("testDocument")
+            .expect("should have testDocument type");
+
+        for (entropy_seed, a, b, c, d, e) in [
+            // Satisfies the MISREAD of the wrong-documents query
+            // (a == 1 AND b == 3 AND c > 0) but not the query itself.
+            (1u8, 1i64, 3i64, 5i64, 1i64, 1i64),
+            // Satisfies the wrong-documents query as written
+            // (a == 1 AND c == 3 AND b > 0) and a == 1 AND c == 3.
+            (2, 1, 7, 3, 2, 2),
+            // Third a == 1 document, for the order-by case.
+            (3, 1, 2, 9, 3, 3),
+            // Control: matches nothing (a != 1).
+            (4, 2, 3, 3, 4, 4),
+        ] {
+            let document = document_type
+                .create_document_from_data(
+                    platform_value!({ "a": a, "b": b, "c": c, "d": d, "e": e }),
+                    owner_id,
+                    0,
+                    0,
+                    [entropy_seed; 32],
+                    platform_version,
+                )
+                .expect("should create document");
+
+            drive
+                .add_document_for_contract(
+                    DocumentAndContractInfo {
+                        owned_document_info: OwnedDocumentInfo {
+                            document_info: DocumentInfo::DocumentOwnedInfo((document, None)),
+                            owner_id: None,
+                        },
+                        contract: &contract,
+                        document_type,
+                    },
+                    true,
+                    BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                    None,
+                )
+                .expect("should add document");
+        }
+
+        (drive, contract)
+    }
+
+    fn abcde_tuples(
+        results: &[Vec<u8>],
+        document_type: DocumentTypeRef,
+        platform_version: &PlatformVersion,
+    ) -> Vec<(i64, i64, i64, i64, i64)> {
+        results
+            .iter()
+            .map(|bytes| {
+                let document =
+                    Document::from_bytes(bytes.as_slice(), document_type, platform_version)
+                        .expect("should deserialize document");
+                let get = |field: &str| -> i64 {
+                    document
+                        .get(field)
+                        .unwrap_or_else(|| panic!("document should have {field}"))
+                        .to_integer::<i64>()
+                        .expect("field is an integer")
+                };
+                (get("a"), get("b"), get("c"), get("d"), get("e"))
+            })
+            .collect()
+    }
+
+    /// Runs the query at the given protocol version on both the no-proof
+    /// and proof paths, asserts they agree and the proof verifies against
+    /// the live root hash, and returns the (a, b, c, d, e) tuples.
+    fn run_query(
+        drive: &Drive,
+        contract: &DataContract,
+        query_value: &serde_json::Value,
+        platform_version: &PlatformVersion,
+    ) -> Result<Vec<(i64, i64, i64, i64, i64)>, Error> {
+        let document_type = contract
+            .document_type_for_name("testDocument")
+            .expect("should have testDocument type");
+        let where_cbor = cbor_serializer::serializable_value_to_cbor(query_value, None)
+            .expect("expected to serialize to cbor");
+        let query = DriveDocumentQuery::from_cbor(
+            where_cbor.as_slice(),
+            contract,
+            document_type,
+            &drive.config,
+            platform_version,
+        )
+        .expect("query should be built");
+
+        let (results, _, _) =
+            query.execute_raw_results_no_proof(drive, None, None, platform_version)?;
+
+        let root_hash = drive
+            .grove
+            .root_hash(None, &platform_version.drive.grove_version)
+            .unwrap()
+            .expect("there is always a root hash");
+        let (proof_root_hash, proof_results, _) = query
+            .execute_with_proof_only_get_elements(drive, None, None, platform_version)
+            .expect("we should be able to get a proof");
+        assert_eq!(root_hash, proof_root_hash);
+        assert_eq!(
+            results, proof_results,
+            "proof and no-proof paths must return the same documents"
+        );
+
+        Ok(abcde_tuples(&results, document_type, platform_version))
+    }
+
+    fn protocol_v13() -> &'static PlatformVersion {
+        let protocol_v13 = PlatformVersion::get(13).expect("protocol version 13 exists");
+        assert_eq!(
+            protocol_v13
+                .dpp
+                .contract_versions
+                .document_type_versions
+                .methods
+                .index_for_types,
+            0,
+            "protocol v13 must keep the v0 (gap-tolerant) index matching"
+        );
+        protocol_v13
+    }
+
+    // a == 1 AND c == 3 AND b > 0, order by [b, c]. The `gapped` index
+    // [a, b, c] scores difference 0, and the lowering keys c's value at
+    // b's level and applies b's range at c's level — delivering
+    // a == 1 AND b == 3 AND c > 0 instead.
+    fn wrong_documents_query() -> serde_json::Value {
+        json!({
+            "where": [
+                ["a", "==", 1],
+                ["c", "==", 3],
+                ["b", ">", 0],
+            ],
+            "orderBy": [
+                ["b", "asc"],
+                ["c", "asc"]
+            ]
+        })
+    }
+
+    #[test]
+    fn range_filling_an_equality_gap_returns_permuted_clause_results_frozen_at_protocol_v13() {
+        let (drive, contract) = setup_gapped_contract();
+
+        let results = run_query(&drive, &contract, &wrong_documents_query(), protocol_v13())
+            .expect("v13 executes the misaligned query");
+
+        // The document actually satisfying a == 1 AND c == 3 AND b > 0 is
+        // (1, 7, 3, 2, 2). v0 returns the document satisfying the
+        // permuted clauses instead — cryptographically proven above.
+        assert_eq!(
+            results,
+            vec![(1, 3, 5, 1, 1)],
+            "v0 must keep returning the permuted-clause document"
+        );
+    }
+
+    #[test]
+    fn range_filling_an_equality_gap_is_rejected_at_latest_protocol_version() {
+        let (drive, contract) = setup_gapped_contract();
+
+        let error = run_query(
+            &drive,
+            &contract,
+            &wrong_documents_query(),
+            PlatformVersion::latest(),
+        )
+        .expect_err("a gapped equality set must not match any index");
+
+        assert!(
+            matches!(
+                &error,
+                Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(_))
+            ),
+            "expected WhereClauseOnNonIndexedProperty, got {error:?}"
+        );
+    }
+
+    // a == 1 AND c == 3, no order by. `gapped` [a, b, c] scores
+    // difference 1 and wins over the well-shaped `wide` [a, c, d, e]
+    // (difference 2); its misaligned path keys c's value at b's level
+    // above a subtree that does not exist there.
+    fn equality_gap_query() -> serde_json::Value {
+        json!({
+            "where": [
+                ["a", "==", 1],
+                ["c", "==", 3],
+            ]
+        })
+    }
+
+    #[test]
+    fn equality_gap_returns_proven_empty_result_frozen_at_protocol_v13() {
+        let (drive, contract) = setup_gapped_contract();
+
+        let results = run_query(&drive, &contract, &equality_gap_query(), protocol_v13())
+            .expect("v13 executes the misaligned query");
+
+        // (1, 7, 3, 2, 2) satisfies the query; v0 returns nothing, with a
+        // valid absence proof (checked in run_query).
+        assert_eq!(
+            results,
+            vec![],
+            "v0 must keep returning the proven-empty result"
+        );
+    }
+
+    #[test]
+    fn equality_gap_selects_the_well_shaped_index_at_latest_protocol_version() {
+        let (drive, contract) = setup_gapped_contract();
+
+        // The gapped candidate is skipped at match time, so `wide`
+        // [a, c, d, e] (a contiguous [a, c] prefix, difference 2) wins and
+        // the query returns its actual match.
+        let results = run_query(
+            &drive,
+            &contract,
+            &equality_gap_query(),
+            PlatformVersion::latest(),
+        )
+        .expect("the well-shaped index should serve the query");
+
+        assert_eq!(results, vec![(1, 7, 3, 2, 2)]);
+    }
+
+    // a == 1 order by [c]. `gapped` [a, b, c] scores difference 1 and
+    // wins; the leftover walk emits (b, c) tree order while the response
+    // claims order by c.
+    fn order_by_gap_query() -> serde_json::Value {
+        json!({
+            "where": [
+                ["a", "==", 1],
+            ],
+            "orderBy": [
+                ["c", "asc"]
+            ]
+        })
+    }
+
+    #[test]
+    fn order_by_beyond_an_unbound_property_lies_about_order_frozen_at_protocol_v13() {
+        let (drive, contract) = setup_gapped_contract();
+
+        let results = run_query(&drive, &contract, &order_by_gap_query(), protocol_v13())
+            .expect("v13 executes the misaligned query");
+
+        // All three a == 1 documents come back, but in (b, c) tree order —
+        // c descends 9, 5, 3 while the query claims c ascending.
+        assert_eq!(
+            results,
+            vec![(1, 2, 9, 3, 3), (1, 3, 5, 1, 1), (1, 7, 3, 2, 2)],
+            "v0 must keep returning (b, c) tree order under an order-by [c] claim"
+        );
+    }
+
+    #[test]
+    fn order_by_beyond_an_unbound_property_selects_the_well_shaped_index_at_latest_protocol_version(
+    ) {
+        let (drive, contract) = setup_gapped_contract();
+
+        // `gapped` is skipped (its order-by field c sits beyond the unbound
+        // b), so `wide` [a, c, d, e] wins and delivers the claimed order.
+        let results = run_query(
+            &drive,
+            &contract,
+            &order_by_gap_query(),
+            PlatformVersion::latest(),
+        )
+        .expect("the well-shaped index should serve the query");
+
+        assert_eq!(
+            results,
+            vec![(1, 7, 3, 2, 2), (1, 3, 5, 1, 1), (1, 2, 9, 3, 3)],
+            "results must actually be ordered by c ascending"
+        );
+    }
+}

--- a/packages/rs-drive/tests/query_tests.rs
+++ b/packages/rs-drive/tests/query_tests.rs
@@ -9121,6 +9121,9 @@ mod gapped_index_query_tests {
     use super::*;
     use dpp::data_contract::document_type::DocumentTypeRef;
 
+    /// A returned document's (a, b, c, d, e) values.
+    type AbcdeTuple = (i64, i64, i64, i64, i64);
+
     /// One document type, five integer properties, and two indexes:
     /// `gapped` = `[a, b, c]` (the index the defective matcher picks) and
     /// `wide` = `[a, c, d, e]` (a well-shaped fallback for `a`/`c`-bound
@@ -9235,7 +9238,7 @@ mod gapped_index_query_tests {
         results: &[Vec<u8>],
         document_type: DocumentTypeRef,
         platform_version: &PlatformVersion,
-    ) -> Vec<(i64, i64, i64, i64, i64)> {
+    ) -> Vec<AbcdeTuple> {
         results
             .iter()
             .map(|bytes| {
@@ -9262,7 +9265,7 @@ mod gapped_index_query_tests {
         contract: &DataContract,
         query_value: &serde_json::Value,
         platform_version: &PlatformVersion,
-    ) -> Result<Vec<(i64, i64, i64, i64, i64)>, Error> {
+    ) -> Result<Vec<AbcdeTuple>, Error> {
         let document_type = contract
             .document_type_for_name("testDocument")
             .expect("should have testDocument type");

--- a/packages/rs-platform-version/src/version/dpp_versions/dpp_contract_versions/v6.rs
+++ b/packages/rs-platform-version/src/version/dpp_versions/dpp_contract_versions/v6.rs
@@ -88,7 +88,18 @@ pub const CONTRACT_VERSIONS_V6: DPPContractVersions = DPPContractVersions {
             prefunded_voting_balance_for_document: 0,
             contested_vote_poll_for_document: 0,
             estimated_size: 1, // changed: adds the document serialization format 3 contract-version stamp varint (worst case 5 bytes) to the estimate
-            index_for_types: 0,
+            // Changed: v1 requires a query's bound fields to cover a
+            // contiguous prefix of the candidate index (equalities exactly
+            // covering the leading properties, range/in immediately after,
+            // no unused property before an order-by field). v0 matched by
+            // positionless set membership, so a query binding only later
+            // index properties selected an index the positional path
+            // lowering misaligns on — returning cryptographically proven
+            // wrong or empty results. Gapped candidates are now skipped
+            // per-candidate, letting a well-shaped index win or the query
+            // fail with WhereClauseOnNonIndexedProperty. v0 stays frozen
+            // for replay at protocol versions <= 13.
+            index_for_types: 1,
             max_size: 0,
             serialize_value_for_key: 0,
             deserialize_value_for_key: 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Index matching accepts queries whose bound fields do not cover a contiguous prefix of the chosen index: `Index::matches_over_components` tests positionless set membership (since 2022, when the original prefix requirement was dropped while making field order irrelevant for `in` support), but the single-`In`/no-`In` lowering builds the grove path positionally via `index.properties.split_at(intermediate_values.len())`. A gap misaligns every level below it, and the proof path constructs the identical wrong path query, so the wrong answer is cryptographically authenticated. Confirmed at runtime on both execution paths:

- **Permuted results**: on index `[a, b, c]`, the query `a == 1 AND c == 3 AND b > 0 orderBy [b, c]` matches at difference 0 and returns the documents satisfying `a == 1 AND b == 3 AND c > 0` — c's equality is keyed at b's level and b's range applied at c's level.
- **Proven-empty results**: `a == 1 AND c == 3` lowers to a path that does not exist in the tree and returns empty with a valid absence proof, even when matching documents exist.
- **Order lies**: `a == 1 orderBy [c]` returns `(b, c)` tree order while claiming c-ascending.

The multi-`In`, count, ranked, and indexOnly pickers all enforce contiguity independently; the generic `find_best_index` route was the sole outlier.

## What was done?
<!--- Describe your changes in detail -->

- **`rs-dpp` `index/mod.rs`**: new `Index::matches_contiguous` / `matches_including_terminal_contiguous` taking fields by role (`equality_fields`, `range_field`, `in_field_name`, `order_by`) — a flat field set cannot catch the permuted-results case since the range fills the equality hole. The predicate runs the frozen v0 checks, then requires: equalities exactly cover the index's leading properties; a range/`in` clause sits immediately after them (either order for the pair, matching the issue #2409 nesting rule); no unused property precedes any named field. `matches`/`matches_over_components` stay byte-identical for replay, with the stale "consecutively" doc comment corrected.
- **`rs-dpp` `methods/mod.rs` / `versioned_methods.rs`**: the three `index_for_types*` dispatchers take role-structured fields; version 0 arms reassemble the historical flat list via `flatten_query_fields` bit-for-bit, new `_v1` selection loops match through the contiguous matcher so gapped candidates are skipped **per-candidate** — a well-shaped index wins where one exists, otherwise the existing `WhereClauseOnNonIndexedProperty` fires (no new error variant). Also fixed the copy-pasted `store_ephemeral_state` string in `index_for_types`' version-mismatch error.
- **`rs-platform-version` `dpp_contract_versions/v6.rs`**: `index_for_types: 0 → 1` (protocol version 14 only; v13's table untouched).
- **`rs-drive` `query/mod.rs`, `index_only_synthesis.rs`**: `select_best_index` and the terminal route pass roles directly instead of a merged field vec.
- **`rs-drive` `single_in_path_query/v0/mod.rs`** (protocol-version-14-only, never shipped): defensive `query_covers_index_prefix_contiguously` re-check right before the positional `split_at`, returning a clean `QuerySyntaxError` instead of building a misaligned path.

- **`rs-drive` `fetch_oldest_withdrawal_documents_by_status/v0`**: the withdrawal-pooling fetch (runs during block execution) queried `status == X orderBy [$updatedAt]`, itself relying on gap-tolerant matching against the `pooling` index `[status, pooling, coreFeePerByte, $updatedAt]` — under contiguous matching it would have errored at protocol version 14. It now names the index's full tail in `order_by`, which is the ordering the left-over walk always delivered; a test pins that both shapes lower to the byte-identical path query at protocol version 13, so results are unchanged on every protocol version. (Worth noting: this fetch has always returned documents grouped by `(pooling, coreFeePerByte)` first, oldest-first only within a group — the "fee band" ordering — despite the "oldest" name.)
- **`rs-drive` `index_only_e2e_tests`**: `should_refuse_equality_below_pivot` now expects the generic no-index error — the gapped pivot shape is rejected at index-selection time and no longer reaches the synthesis route's targeted shape error. The refusal invariant is unchanged.

The pre-v14 lowering (`non_primary_key_path_query/v0`) and matcher are untouched: protocol versions <= 13 replay the defective behavior byte-for-byte.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

- `tests/query_tests.rs` `mod gapped_index_query_tests`: three paired tests per failure shape — the `_frozen_at_protocol_v13` twin pins the defective output (permuted documents / proven-empty / wrong order, proof and no-proof agreeing against the live root hash), the latest-version twin asserts the rejection or the reroute to the well-shaped index. Written repro-first: the v13 twins passed and the v14 twins failed before the fix.
- `src/query/test_index.rs` `test_find_best_index_gapped_equality`: last-property-only binding selects `[b, a, d]` at v13, errors at latest.
- `index/mod.rs` unit tests: gapped equality, role permutation, order-by gaps, range/`in` adjacency in both orders, terminal stripping, difference-agreement with `matches` on contiguous shapes; plus a freeze test pinning v0's gap tolerance.
- `single_in_path_query/v0` unit tests for the lowering guard.
- `fetch_oldest_withdrawal_documents_by_status/v0` tests pass with unchanged expectations (results identical at latest protocol version), plus a new v13 path-query equivalence test for the two order-by shapes.
- `cargo test -p drive --lib` (3492/3492), `cargo test -p drive --test query_tests` (55/55), dpp matcher + `index_only_tests` suites, `cargo check --all-targets -p dpp -p drive`, `cargo check -p drive --no-default-features --features verify`, `cargo check -p drive-abci`.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None to released consensus: the acceptance change is gated to protocol version 14 (unreleased), and protocol versions <= 13 are byte-identical. Consensus-internal queries were audited: index-uniqueness validation, data triggers, and the fee-pool reward fetch are contiguous shapes unaffected by the new requirement; the one gapped internal shape — the withdrawal-pooling fetch — now names its index's full tail with a v13 path-query-equivalence test proving results are unchanged on every protocol version. At protocol version 14, queries that previously returned provably wrong or empty results are rejected with `WhereClauseOnNonIndexedProperty` (or served correctly by another index).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
