### PR TITLE
fix(drive): rename the skip-if-absent matcher argument to the merged binding

### DIFF
--- a/packages/rs-drive/src/query/index_only_synthesis.rs
+++ b/packages/rs-drive/src/query/index_only_synthesis.rs
@@ -167,7 +167,7 @@ impl DriveDocumentQuery<'_> {
                 // [`index_admissible_for_skip_if_absent`]).
                 |index| {
                     index.time_range.is_none()
-                        && index_admissible_for_skip_if_absent(index, &fields)
+                        && index_admissible_for_skip_if_absent(index, &equal_fields)
                 },
                 platform_version,
             )

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -2216,7 +2216,7 @@ impl<'a> DriveDocumentQuery<'a> {
             order_by_keys.as_slice(),
             |index| {
                 index_admissible_for_resolved_time_range(index, &self.resolved_time_ranges)
-                    && index_admissible_for_skip_if_absent(index, &fields)
+                    && index_admissible_for_skip_if_absent(index, &equal_fields)
             },
             platform_version,
         )?


### PR DESCRIPTION
v4.2-dev does not compile since #4526 merged over #4523: #4526 renamed `fields` → `equal_fields`, and the merge kept #4523's two skip-if-absent matcher closures referencing the old name (`query/mod.rs:2219`, `query/index_only_synthesis.rs:170`) — E0425 ×2, breaking Clippy/Tests and the JS build (wasm compile) on the branch. Pure identifier rename to the merged binding — same list #4523 passed, same semantics. `cargo clippy -p drive --all-features --no-deps` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected index selection for queries using equality conditions.
  - Improved handling of indexes that skip records when a field is absent.
  - Queries now more reliably select applicable indexes based on their bound fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->