### PR TITLE
build: bump grovedb to develop 0a3b3f9b (re-key churn as replaced bytes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "grovedb"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "axum 0.8.9",
  "bincode",
@@ -3014,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "grovedb-bulk-append-tree"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "bincode",
  "blake3",
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "grovedb-commitment-tree"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "blake3",
  "grovedb-bulk-append-tree",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "grovedb-dense-fixed-sized-merkle-tree"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "bincode",
  "blake3",
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "grovedb-element"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "grovedb-costs",
  "hex",
@@ -3101,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -3127,7 +3127,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merkle-mountain-range"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "bincode",
  "blake3",
@@ -3140,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "hex",
 ]
@@ -3148,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "grovedb-private-document-store"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "blake3",
  "grovedb-bulk-append-tree",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "grovedb-query"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3177,7 +3177,7 @@ dependencies = [
 [[package]]
 name = "grovedb-storage"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -3196,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "grovedbg-types"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=6c882c3ee7d2c331f1feda2eb4223add9a6f0e45#6c882c3ee7d2c331f1feda2eb4223add9a6f0e45"
+source = "git+https://github.com/dashpay/grovedb?rev=0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03#0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03"
 dependencies = [
  "serde",
  "serde_with 3.21.0",

--- a/packages/rs-dpp/Cargo.toml
+++ b/packages/rs-dpp/Cargo.toml
@@ -71,7 +71,7 @@ strum = { version = "0.26", features = ["derive"] }
 json-schema-compatibility-validator = { path = '../rs-json-schema-compatibility-validator', optional = true }
 once_cell = "1.19.0"
 tracing = { version = "0.1.41" }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45", optional = true }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.40", features = ["full"] }

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -82,7 +82,7 @@ derive_more = { version = "1.0", features = ["from", "deref", "deref_mut"] }
 async-trait = "0.1.77"
 console-subscriber = { version = "0.4", optional = true }
 bls-signatures = { git = "https://github.com/dashpay/bls-signatures", rev = "0842b17583888e8f46c252a4ee84cdfd58e0546f", optional = true }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45" }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03" }
 nonempty = "0.11"
 # Shielded-pool snapshot needs raw RocksDB SstFileWriter + ingest_external_file_cf
 # bindings, and blake3 for the snapshot-file checksum.
@@ -108,7 +108,7 @@ dpp = { path = "../rs-dpp", default-features = false, features = [
 drive = { path = "../rs-drive", features = ["fixtures-and-mocks"] }
 drive-proof-verifier = { path = "../rs-drive-proof-verifier" }
 strategy-tests = { path = "../strategy-tests" }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45", features = ["client"] }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03", features = ["client"] }
 assert_matches = "1.5.0"
 drive-abci = { path = ".", features = ["testing-config", "mocks", "shielded_test_data"] }
 bls-signatures = { git = "https://github.com/dashpay/bls-signatures", rev = "0842b17583888e8f46c252a4ee84cdfd58e0546f" }
@@ -122,8 +122,8 @@ integer-encoding = { version = "4.0.0" }
 
 # For dump_only_default_and_aux_cfs_under_shielded_subtree_prefix — same
 # subtree-prefix algorithm grovedb uses internally.
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45" }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03" }
 
 [features]
 default = ["bls-signatures"]

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -52,13 +52,13 @@ enum-map = { version = "2.0.3", optional = true }
 intmap = { version = "3.0.1", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.13", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45", optional = true, default-features = false }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45" }
-grovedb-query = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45", optional = true }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45" }
-grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45" }
+grovedb = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03", optional = true, default-features = false }
+grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03", optional = true }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03" }
+grovedb-query = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03", optional = true }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03" }
+grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 thiserror = { version = "2.0.12" }
 bincode = { version = "=2.0.1" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45" }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03" }
 
 [features]
 mock-versions = []

--- a/packages/rs-platform-wallet/Cargo.toml
+++ b/packages/rs-platform-wallet/Cargo.toml
@@ -69,7 +69,7 @@ zeroize = "1"
 log = "0.4"
 
 # Shielded pool (optional, behind `shielded` feature)
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45", optional = true }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03", optional = true }
 # Direct `rusqlite` access so `FileBackedShieldedStore::open_path` can set
 # WAL + synchronous=NORMAL pragmas before handing the connection to
 # `ClientPersistentCommitmentTree`. Version locked to match the rev grovedb

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -18,7 +18,7 @@ drive = { path = "../rs-drive", default-features = false, features = [
 ] }
 
 drive-proof-verifier = { path = "../rs-drive-proof-verifier", default-features = false }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "6c882c3ee7d2c331f1feda2eb4223add9a6f0e45", features = [
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "0a3b3f9b8b44a18ff7f53a3bd88b93d20485fe03", features = [
   "client",
   "sqlite",
 ], optional = true }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Picks up [dashpay/grovedb#841](https://github.com/dashpay/grovedb/pull/841): a ranked secondary's re-key — a group's count/sum change moving its mirror row from `(n‖key)` to `(n+1‖key)` — now bills its churn as `replaced_bytes` (400 credits/byte processing) instead of removed + added (27,000 credits/byte perpetual storage plus an unattributable removal that refunded nobody, since mirror rows carry no element flags). Aggregate updates stop paying storage rates for bytes that never grow the store.

## What was done?

Pin bump `6c882c3e` → `0a3b3f9b` across the 7 Cargo.toml files + lockfile. No platform code changes required — the accounting change is entirely inside grovedb's batch commit cost assembly, with root hashes and stored state byte-identical.

**Measured fee impact** (yappr fixtures, same probe either side of the bump):

| Write | Before | After |
| --- | ---: | ---: |
| Steady tagged like | 44.7M (1,586 B storage) | **29.1M** (1,014 B) |
| Steady untagged like | 30.0M (1,050 B) | **22.2M** (764 B) |
| Unlike (steady) | 15.4M storage + processing | **0 storage**, 2.06M processing |
| First like on a preallocated post | 29.1M | 29.1M — now **byte-identical** to the nth |

The deltas are exactly the ranked-secondary re-keys (2 × 286 B on a tagged like, 1 × 286 B untagged). A side effect worth noting: preallocated first-like == nth-like storage equality, previously approximate because merk link noise leaked into `added_bytes`, is now exact — the preallocated fee tests could be tightened to assert it in a follow-up.

## How Has This Been Tested?

Full `drive` suite (3,682 passing), `drive-abci` indexOnly battery (13) and fee suites (211), plus the ranked / time-range / preallocated / fees filters — all green with zero assertion changes: the `estimated ≥ actual` invariants hold because estimation deliberately keeps the raw delete+insert shape as an upper bound. `cargo check --workspace` clean.

## Breaking Changes

None — PV14 unreleased; state and root hashes are unchanged, only the reported fee split.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grovedb components to a newer pinned revision across platform, wallet, SDK, and Drive packages.
  * Maintained existing dependency options and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->