### PR TITLE
fix(dapi): truthful state sync status, health height field collision, client crash on absent sections

### DIFF
--- a/packages/js-dapi-client/lib/methods/platform/getStatus/GetStatusResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getStatus/GetStatusResponse.js
@@ -23,16 +23,6 @@ function readOptional(message, read) {
   return message ? read(message) : undefined;
 }
 
-/**
- * Convert an optional numeric protobuf field to BigInt, preserving absence.
- *
- * @param {string|number|undefined} value
- * @returns {bigint|undefined}
- */
-function toOptionalBigInt(value) {
-  return value === undefined || value === null ? undefined : BigInt(value);
-}
-
 class GetStatusResponse {
   /**
    * @param {VersionStatus} version - status versions
@@ -40,7 +30,7 @@ class GetStatusResponse {
    * @param {ChainStatus|null} chain - chain status, null if unavailable
    * @param {NetworkStatus|null} network - network status, null if unavailable
    * @param {StateSyncStatus|null} stateSync - state sync status, null if not state syncing
-   * @param {TimeStatus} time - time status
+   * @param {TimeStatus|null} time - time status, null if unavailable
    */
   constructor(version, node, chain, network, stateSync, time) {
     this.version = version;
@@ -87,7 +77,7 @@ class GetStatusResponse {
   }
 
   /**
-   * @returns {TimeStatus} time status
+   * @returns {TimeStatus|null} time status, null if unavailable
    */
   getTimeStatus() {
     return this.time;
@@ -163,12 +153,12 @@ class GetStatusResponse {
 
     const timeProto = v0.getTime();
 
-    const time = new TimeStatus(
-      toOptionalBigInt(readOptional(timeProto, (t) => t.getLocal())),
-      toOptionalBigInt(readOptional(timeProto, (t) => t.getBlock())),
-      toOptionalBigInt(readOptional(timeProto, (t) => t.getGenesis())),
-      readOptional(timeProto, (t) => t.getEpoch()),
-    );
+    const time = timeProto ? new TimeStatus(
+      BigInt(timeProto.getLocal()),
+      BigInt(timeProto.getBlock()),
+      BigInt(timeProto.getGenesis()),
+      timeProto.getEpoch(),
+    ) : null;
 
     return new GetStatusResponse(
       version,

--- a/packages/js-dapi-client/lib/methods/platform/getStatus/GetStatusResponse.js
+++ b/packages/js-dapi-client/lib/methods/platform/getStatus/GetStatusResponse.js
@@ -5,13 +5,41 @@ const TimeStatus = require('./TimeStatus');
 const StateSyncStatus = require('./StateSyncStatus');
 const NetworkStatus = require('./NetworkStatus');
 
+/**
+ * Read a value out of an optional protobuf sub-message.
+ *
+ * Every message-typed field in `GetStatusResponseV0` is optional on the wire, and DAPI
+ * omits whole sections when the underlying data is unavailable: `state_sync` is absent
+ * unless the node is state syncing, `chain`/`node`/`network` are absent when Tenderdash
+ * is unreachable, and `protocol.drive` is absent when Drive is unreachable. The generated
+ * getters return `undefined` for an absent sub-message, so they must never be chained
+ * without a guard.
+ *
+ * @param {object|undefined} message - protobuf sub-message, possibly absent
+ * @param {function(object): *} read - reader invoked when the sub-message is present
+ * @returns {*} the read value, or `undefined` when the sub-message is absent
+ */
+function readOptional(message, read) {
+  return message ? read(message) : undefined;
+}
+
+/**
+ * Convert an optional numeric protobuf field to BigInt, preserving absence.
+ *
+ * @param {string|number|undefined} value
+ * @returns {bigint|undefined}
+ */
+function toOptionalBigInt(value) {
+  return value === undefined || value === null ? undefined : BigInt(value);
+}
+
 class GetStatusResponse {
   /**
    * @param {VersionStatus} version - status versions
-   * @param {NodeStatus} node - node status
-   * @param {ChainStatus} chain - chain status
-   * @param {NetworkStatus} network - network status
-   * @param {StateSyncStatus} stateSync - state sync status
+   * @param {NodeStatus|null} node - node status, null if unavailable
+   * @param {ChainStatus|null} chain - chain status, null if unavailable
+   * @param {NetworkStatus|null} network - network status, null if unavailable
+   * @param {StateSyncStatus|null} stateSync - state sync status, null if not state syncing
    * @param {TimeStatus} time - time status
    */
   constructor(version, node, chain, network, stateSync, time) {
@@ -31,28 +59,28 @@ class GetStatusResponse {
   }
 
   /**
-   * @returns {NodeStatus} node info status
+   * @returns {NodeStatus|null} node info status, null if unavailable
    */
   getNodeStatus() {
     return this.node;
   }
 
   /**
-   * @returns {ChainStatus} chain status
+   * @returns {ChainStatus|null} chain status, null if unavailable
    */
   getChainStatus() {
     return this.chain;
   }
 
   /**
-   * @returns {NetworkStatus} network status
+   * @returns {NetworkStatus|null} network status, null if unavailable
    */
   getNetworkStatus() {
     return this.network;
   }
 
   /**
-   * @returns {StateSyncStatus} state sync status
+   * @returns {StateSyncStatus|null} state sync status, null if not state syncing
    */
   getStateSyncStatus() {
     return this.stateSync;
@@ -72,85 +100,75 @@ class GetStatusResponse {
   static createFromProto(proto) {
     const v0 = proto.getV0();
 
-    const dapiVersion = v0.getVersion().getSoftware().getDapi();
-    const driveVersion = v0.getVersion().getSoftware().getDrive();
-    const tenderdashVersion = v0.getVersion().getSoftware().getTenderdash();
-    const tenderdashP2pProtocol = v0.getVersion().getProtocol().getTenderdash().getP2p();
-    const tenderdashBlockProtocol = v0.getVersion().getProtocol().getTenderdash().getBlock();
-    const driveCurrentProtocol = v0.getVersion().getProtocol().getDrive().getCurrent();
-    const driveLatestProtocol = v0.getVersion().getProtocol().getDrive().getLatest();
-    const driveNextEpochProtocol = v0.getVersion().getProtocol().getDrive().getNextEpoch();
+    const versionProto = v0.getVersion();
+    const softwareProto = readOptional(versionProto, (v) => v.getSoftware());
+    const protocolProto = readOptional(versionProto, (v) => v.getProtocol());
+    const tenderdashProtocolProto = readOptional(protocolProto, (p) => p.getTenderdash());
+    const driveProtocolProto = readOptional(protocolProto, (p) => p.getDrive());
 
     const version = new VersionStatus(
-      dapiVersion,
-      driveVersion,
-      tenderdashVersion,
-      tenderdashP2pProtocol,
-      tenderdashBlockProtocol,
-      driveCurrentProtocol,
-      driveLatestProtocol,
-      driveNextEpochProtocol,
+      readOptional(softwareProto, (s) => s.getDapi()),
+      readOptional(softwareProto, (s) => s.getDrive()),
+      readOptional(softwareProto, (s) => s.getTenderdash()),
+      readOptional(tenderdashProtocolProto, (t) => t.getP2p()),
+      readOptional(tenderdashProtocolProto, (t) => t.getBlock()),
+      readOptional(driveProtocolProto, (d) => d.getCurrent()),
+      readOptional(driveProtocolProto, (d) => d.getLatest()),
+      readOptional(driveProtocolProto, (d) => d.getNextEpoch()),
     );
 
-    const nodeId = Buffer.from(v0.getNode().getId()).toString('hex');
-    const proTxHash = Buffer.from(v0.getNode().getProTxHash()).toString('hex');
+    const nodeProto = v0.getNode();
 
-    const node = new NodeStatus(nodeId, proTxHash);
+    const node = nodeProto ? new NodeStatus(
+      Buffer.from(nodeProto.getId()).toString('hex'),
+      Buffer.from(nodeProto.getProTxHash()).toString('hex'),
+    ) : null;
 
-    const catchingUp = v0.getChain().getCatchingUp();
-    const latestBlockHash = Buffer.from(v0.getChain().getLatestBlockHash()).toString('hex');
-    const latestAppHash = Buffer.from(v0.getChain().getLatestAppHash()).toString('hex');
-    const latestBlockHeight = BigInt(v0.getChain().getLatestBlockHeight());
-    const earliestBlockHash = Buffer.from(v0.getChain().getEarliestBlockHash()).toString('hex');
-    const earliestAppHash = Buffer.from(v0.getChain().getEarliestAppHash()).toString('hex');
-    const earliestBlockHeight = BigInt(v0.getChain().getEarliestBlockHeight());
-    const maxPeerBlockHeight = BigInt(v0.getChain().getMaxPeerBlockHeight());
-    const coreChainLockedHeight = v0.getChain().getCoreChainLockedHeight();
+    const chainProto = v0.getChain();
 
-    const chain = new ChainStatus(
-      catchingUp,
-      latestBlockHash,
-      latestAppHash,
-      latestBlockHeight,
-      earliestBlockHash,
-      earliestAppHash,
-      earliestBlockHeight,
-      maxPeerBlockHeight,
-      coreChainLockedHeight,
+    const chain = chainProto ? new ChainStatus(
+      chainProto.getCatchingUp(),
+      Buffer.from(chainProto.getLatestBlockHash()).toString('hex'),
+      Buffer.from(chainProto.getLatestAppHash()).toString('hex'),
+      BigInt(chainProto.getLatestBlockHeight()),
+      Buffer.from(chainProto.getEarliestBlockHash()).toString('hex'),
+      Buffer.from(chainProto.getEarliestAppHash()).toString('hex'),
+      BigInt(chainProto.getEarliestBlockHeight()),
+      BigInt(chainProto.getMaxPeerBlockHeight()),
+      chainProto.getCoreChainLockedHeight(),
+    ) : null;
+
+    const networkProto = v0.getNetwork();
+
+    const network = networkProto ? new NetworkStatus(
+      networkProto.getChainId(),
+      networkProto.getPeersCount(),
+      networkProto.getListening(),
+    ) : null;
+
+    // DAPI omits the whole state sync section on nodes that are not state syncing,
+    // so an absent section means "no state sync information", not "all zeroes".
+    const stateSyncProto = v0.getStateSync();
+
+    const stateSync = stateSyncProto ? new StateSyncStatus(
+      BigInt(stateSyncProto.getTotalSyncedTime()),
+      BigInt(stateSyncProto.getRemainingTime()),
+      stateSyncProto.getTotalSnapshots(),
+      BigInt(stateSyncProto.getChunkProcessAvgTime()),
+      BigInt(stateSyncProto.getSnapshotHeight()),
+      BigInt(stateSyncProto.getSnapshotChunksCount()),
+      BigInt(stateSyncProto.getBackfilledBlocks()),
+      BigInt(stateSyncProto.getBackfillBlocksTotal()),
+    ) : null;
+
+    const timeProto = v0.getTime();
+
+    const time = new TimeStatus(
+      toOptionalBigInt(readOptional(timeProto, (t) => t.getLocal())),
+      toOptionalBigInt(readOptional(timeProto, (t) => t.getBlock())),
+      toOptionalBigInt(readOptional(timeProto, (t) => t.getGenesis())),
+      readOptional(timeProto, (t) => t.getEpoch()),
     );
-
-    const chainId = v0.getNetwork().getChainId();
-    const peersCount = v0.getNetwork().getPeersCount();
-    const isListening = v0.getNetwork().getListening();
-
-    const network = new NetworkStatus(chainId, peersCount, isListening);
-
-    const totalSyncedTime = BigInt(v0.getStateSync().getTotalSyncedTime());
-    const remainingTime = BigInt(v0.getStateSync().getRemainingTime());
-    const totalSnapshots = v0.getStateSync().getTotalSnapshots();
-    const chunkProcessAverageTime = BigInt(v0.getStateSync().getChunkProcessAvgTime());
-    const snapshotHeight = BigInt(v0.getStateSync().getSnapshotHeight());
-    const snapshotChunksCount = BigInt(v0.getStateSync().getSnapshotChunksCount());
-    const backfilledBlocks = BigInt(v0.getStateSync().getBackfilledBlocks());
-    const backfillBlocksTotal = BigInt(v0.getStateSync().getBackfillBlocksTotal());
-
-    const stateSync = new StateSyncStatus(
-      totalSyncedTime,
-      remainingTime,
-      totalSnapshots,
-      chunkProcessAverageTime,
-      snapshotHeight,
-      snapshotChunksCount,
-      backfilledBlocks,
-      backfillBlocksTotal,
-    );
-
-    const local = BigInt(v0.getTime().getLocal());
-    const block = BigInt(v0.getTime().getBlock());
-    const genesis = BigInt(v0.getTime().getGenesis());
-    const epoch = v0.getTime().getEpoch();
-
-    const time = new TimeStatus(local, block, genesis, epoch);
 
     return new GetStatusResponse(
       version,

--- a/packages/js-dapi-client/test/unit/methods/platform/getStatus/GetStatusResponse.spec.js
+++ b/packages/js-dapi-client/test/unit/methods/platform/getStatus/GetStatusResponse.spec.js
@@ -349,4 +349,51 @@ describe('GetStatusResponse', () => {
     expect(timeStatus.getGenesisTime()).to.equal(BigInt(statusFixture.time.genesis));
     expect(timeStatus.getEpochNumber()).to.equal(statusFixture.time.epoch);
   });
+
+  it('should create an instance from proto without state sync section', () => {
+    // DAPI omits the state sync section on nodes that never state synced
+    proto.getV0().clearStateSync();
+
+    getStatusResponse = GetStatusResponseClass.createFromProto(proto);
+
+    expect(getStatusResponse.getStateSyncStatus()).to.equal(null);
+
+    // the rest of the response must still be parsed
+    expect(getStatusResponse.getChainStatus()).to.be.an.instanceOf(ChainStatus);
+    expect(getStatusResponse.getChainStatus().getLatestBlockHeight())
+      .to.equal(BigInt(statusFixture.chain.latestBlockHeight));
+    expect(getStatusResponse.getVersionStatus()).to.be.an.instanceOf(VersionStatus);
+    expect(getStatusResponse.getTimeStatus()).to.be.an.instanceOf(TimeStatus);
+  });
+
+  it('should create an instance from proto with every optional section absent', () => {
+    const v0 = proto.getV0();
+
+    v0.clearNode();
+    v0.clearChain();
+    v0.clearNetwork();
+    v0.clearStateSync();
+    v0.getVersion().getProtocol().clearDrive();
+    v0.getVersion().getProtocol().clearTenderdash();
+    v0.getVersion().clearSoftware();
+
+    getStatusResponse = GetStatusResponseClass.createFromProto(proto);
+
+    expect(getStatusResponse.getNodeStatus()).to.equal(null);
+    expect(getStatusResponse.getChainStatus()).to.equal(null);
+    expect(getStatusResponse.getNetworkStatus()).to.equal(null);
+    expect(getStatusResponse.getStateSyncStatus()).to.equal(null);
+
+    const versionStatus = getStatusResponse.getVersionStatus();
+    expect(versionStatus).to.be.an.instanceOf(VersionStatus);
+    expect(versionStatus.getDapiVersion()).to.equal(undefined);
+    expect(versionStatus.getDriveVersion()).to.be.null();
+    expect(versionStatus.getTenderdashVersion()).to.be.null();
+    expect(versionStatus.getDriveCurrentProtocol()).to.equal(undefined);
+    expect(versionStatus.getTenderdashP2pProtocol()).to.equal(undefined);
+
+    const timeStatus = getStatusResponse.getTimeStatus();
+    expect(timeStatus).to.be.an.instanceOf(TimeStatus);
+    expect(timeStatus.getLocalTime()).to.equal(BigInt(statusFixture.time.local));
+  });
 });

--- a/packages/rs-dapi/src/server/metrics.rs
+++ b/packages/rs-dapi/src/server/metrics.rs
@@ -112,7 +112,7 @@ async fn handle_health(State(state): State<MetricsAppState>) -> impl axum::respo
             true,
             CoreRpcCheck {
                 status: "ok".into(),
-                latest_block_height: Some(height),
+                core_block_height: Some(height),
                 error: None,
             },
         ),
@@ -122,7 +122,7 @@ async fn handle_health(State(state): State<MetricsAppState>) -> impl axum::respo
                 false,
                 CoreRpcCheck {
                     status: "error".into(),
-                    latest_block_height: None,
+                    core_block_height: None,
                     error: Some(health_error_label(&err).to_string()),
                 },
             )
@@ -131,7 +131,7 @@ async fn handle_health(State(state): State<MetricsAppState>) -> impl axum::respo
             false,
             CoreRpcCheck {
                 status: "error".into(),
-                latest_block_height: None,
+                core_block_height: None,
                 error: Some("timeout".into()),
             },
         ),
@@ -213,8 +213,13 @@ struct PlatformChecks {
 #[derive(Serialize)]
 struct CoreRpcCheck {
     status: String,
-    #[serde(rename = "latestBlockHeight", skip_serializing_if = "Option::is_none")]
-    latest_block_height: Option<u32>,
+    /// Dash Core chain height from `getblockcount`.
+    ///
+    /// Deliberately not called `latestBlockHeight`: that name is the *Platform* chain height
+    /// in `getStatus`'s `chain` section, and reporting a Core height under the same name here
+    /// has been mistaken for a wildly-ahead Platform height on freshly joined nodes.
+    #[serde(rename = "coreBlockHeight", skip_serializing_if = "Option::is_none")]
+    core_block_height: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
 }
@@ -302,5 +307,26 @@ impl From<bool> for ComponentCheck {
                 error: Some("failed".into()),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The Core RPC health check reports a Dash Core height. Naming it `latestBlockHeight`
+    /// collides with the Platform height of the same name in `getStatus`'s `chain` section,
+    /// and operators have read the Core height as a Platform height because of it.
+    #[test]
+    fn core_rpc_health_check_does_not_reuse_the_platform_height_field_name() {
+        let json = serde_json::to_string(&CoreRpcCheck {
+            status: "ok".into(),
+            core_block_height: Some(8036),
+            error: None,
+        })
+        .expect("serialize core rpc check");
+
+        assert!(json.contains(r#""coreBlockHeight":8036"#), "{json}");
+        assert!(!json.contains("latestBlockHeight"), "{json}");
     }
 }

--- a/packages/rs-dapi/src/services/platform_service/get_status.rs
+++ b/packages/rs-dapi/src/services/platform_service/get_status.rs
@@ -335,7 +335,9 @@ fn build_chain_info(
 ///
 /// Emitting an all-zero message therefore asserts "state sync happened and did nothing",
 /// which an operator cannot distinguish from "this node never state synced". Report the
-/// message only when Tenderdash actually gave us something, and omit it otherwise.
+/// message only when one of the six genuinely state-sync-specific counters is non-zero, which
+/// on Tenderdash 1.7 means never - block-sync progress alone must not raise a section named
+/// after state sync.
 ///
 /// To tell after the fact that a node was state synced, use `chain.earliest_block_height`:
 /// on a state-synced node the block store starts at the backfill floor rather than at the
@@ -364,11 +366,17 @@ fn build_state_sync_info(
         backfill_blocks_total: parse_or_default(&sync_info.backfill_blocks_total),
     };
 
-    if state_sync == get_status_response_v0::StateSync::default() {
-        None
-    } else {
-        Some(state_sync)
-    }
+    // `total_synced_time` / `remaining_time` are deliberately excluded: they are block sync
+    // values and are set on any node merely replaying blocks, which says nothing about a
+    // snapshot restore.
+    let has_state_sync_data = state_sync.total_snapshots != 0
+        || state_sync.chunk_process_avg_time != 0
+        || state_sync.snapshot_height != 0
+        || state_sync.snapshot_chunks_count != 0
+        || state_sync.backfilled_blocks != 0
+        || state_sync.backfill_blocks_total != 0;
+
+    has_state_sync_data.then_some(state_sync)
 }
 
 /// Build network-related stats such as peers and listening state.
@@ -499,8 +507,27 @@ mod tests {
         assert!(build_state_sync_info(&TenderdashStatusResponse::default()).is_none());
     }
 
+    /// A node replaying blocks sets `total_synced_time` / `remaining_time` through the block
+    /// sync reactor without ever touching a snapshot, so those two alone must not raise a
+    /// section named after state sync.
     #[test]
-    fn state_sync_is_reported_while_the_node_is_syncing() {
+    fn state_sync_is_omitted_when_only_block_sync_progress_is_reported() {
+        let tenderdash_status: TenderdashStatusResponse = serde_json::from_str(&status_json(
+            r#"
+            "total_synced_time": "123456789",
+            "remaining_time": "9876543",
+            "total_snapshots": "0",
+            "snapshot_height": "0",
+            "backfilled_blocks": "0",
+            "#,
+        ))
+        .expect("parse tenderdash status");
+
+        assert!(build_state_sync_info(&tenderdash_status).is_none());
+    }
+
+    #[test]
+    fn state_sync_is_reported_while_the_node_is_state_syncing() {
         let tenderdash_status: TenderdashStatusResponse = serde_json::from_str(&status_json(
             r#"
             "total_synced_time": "123456789",

--- a/packages/rs-dapi/src/services/platform_service/get_status.rs
+++ b/packages/rs-dapi/src/services/platform_service/get_status.rs
@@ -322,39 +322,51 @@ fn build_chain_info(
 }
 
 /// Produce state sync metrics derived from Tenderdash status response.
+///
+/// Tenderdash serialises every one of these as a quoted integer that is always present, so
+/// their absence can never be used to decide whether the node state synced. Worse, most of
+/// them are hardcoded to zero in Tenderdash 1.7: `/status` only copies the state sync
+/// counters when `Environment.StateSyncMetricer` is set (`internal/rpc/core/status.go:91`),
+/// and no node ever assigns it (`internal/rpc/core/env.go:86` has no writer), so
+/// `total_snapshots`, `chunk_process_avg_time`, `snapshot_height`, `snapshot_chunks_count`,
+/// `backfilled_blocks` and `backfill_blocks_total` read `"0"` during and after a state sync
+/// alike. Only `total_synced_time` and `remaining_time` are ever non-zero, and those come
+/// from the *block sync* reactor (`internal/blocksync/reactor.go:308-328`), not state sync.
+///
+/// Emitting an all-zero message therefore asserts "state sync happened and did nothing",
+/// which an operator cannot distinguish from "this node never state synced". Report the
+/// message only when Tenderdash actually gave us something, and omit it otherwise.
+///
+/// To tell after the fact that a node was state synced, use `chain.earliest_block_height`:
+/// on a state-synced node the block store starts at the backfill floor rather than at the
+/// genesis height.
 fn build_state_sync_info(
     tenderdash_status: &TenderdashStatusResponse,
 ) -> Option<get_status_response_v0::StateSync> {
     let sync_info = &tenderdash_status.sync_info;
 
-    let has_state_sync_data = !sync_info.total_synced_time.is_empty()
-        || !sync_info.remaining_time.is_empty()
-        || !sync_info.total_snapshots.is_empty()
-        || !sync_info.snapshot_height.is_empty();
+    let parse_or_default = |value: &str| -> u64 {
+        if value.is_empty() {
+            0
+        } else {
+            value.parse::<i64>().map(|v| v.max(0) as u64).unwrap_or(0)
+        }
+    };
 
-    if !has_state_sync_data {
+    let state_sync = get_status_response_v0::StateSync {
+        total_synced_time: parse_or_default(&sync_info.total_synced_time),
+        remaining_time: parse_or_default(&sync_info.remaining_time),
+        total_snapshots: parse_or_default(&sync_info.total_snapshots).min(u32::MAX as u64) as u32,
+        chunk_process_avg_time: parse_or_default(&sync_info.chunk_process_avg_time),
+        snapshot_height: parse_or_default(&sync_info.snapshot_height),
+        snapshot_chunks_count: parse_or_default(&sync_info.snapshot_chunks_count),
+        backfilled_blocks: parse_or_default(&sync_info.backfilled_blocks),
+        backfill_blocks_total: parse_or_default(&sync_info.backfill_blocks_total),
+    };
+
+    if state_sync == get_status_response_v0::StateSync::default() {
         None
     } else {
-        let parse_or_default = |value: &str| -> u64 {
-            if value.is_empty() {
-                0
-            } else {
-                value.parse::<i64>().map(|v| v.max(0) as u64).unwrap_or(0)
-            }
-        };
-
-        let state_sync = get_status_response_v0::StateSync {
-            total_synced_time: parse_or_default(&sync_info.total_synced_time),
-            remaining_time: parse_or_default(&sync_info.remaining_time),
-            total_snapshots: parse_or_default(&sync_info.total_snapshots).min(u32::MAX as u64)
-                as u32,
-            chunk_process_avg_time: parse_or_default(&sync_info.chunk_process_avg_time),
-            snapshot_height: parse_or_default(&sync_info.snapshot_height),
-            snapshot_chunks_count: parse_or_default(&sync_info.snapshot_chunks_count),
-            backfilled_blocks: parse_or_default(&sync_info.backfilled_blocks),
-            backfill_blocks_total: parse_or_default(&sync_info.backfill_blocks_total),
-        };
-
         Some(state_sync)
     }
 }
@@ -445,11 +457,111 @@ mod tests {
         let network = inner.network.expect("network present");
         assert_eq!(network.chain_id, "dash-testnet-51");
 
-        let state_sync = inner.state_sync.expect("state sync present");
-        assert_eq!(state_sync.total_synced_time, 0);
+        // Tenderdash always serialises the state sync counters, all zeroed on a node that is
+        // not syncing. Reporting them would be indistinguishable from a state sync that did
+        // nothing, so the section must be omitted instead.
+        assert!(
+            inner.state_sync.is_none(),
+            "all-zero state sync counters must be omitted"
+        );
 
         let time = inner.time.expect("time present");
         assert!(time.local > 0);
+    }
+
+    /// Regression guard for bug 2: `chain.latest_block_height` is the Platform height read
+    /// from Tenderdash's `sync_info`, never a Dash Core height. Tenderdash's `/status` has no
+    /// Core chain fields at all, and the only Core height in this response is
+    /// `core_chain_locked_height`, which comes from Drive.
+    #[test]
+    fn chain_latest_block_height_is_the_platform_height_not_a_core_height() {
+        let tenderdash_status: TenderdashStatusResponse =
+            serde_json::from_str(&status_json(r#""latest_block_height": "28","#))
+                .expect("parse tenderdash status");
+
+        let drive_status = DriveStatusResponse {
+            chain: Some(get_status_response_v0::Chain {
+                core_chain_locked_height: Some(8036),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let chain = build_chain_info(&drive_status, &tenderdash_status).expect("chain present");
+
+        assert_eq!(chain.latest_block_height, 28);
+        assert_eq!(chain.core_chain_locked_height, Some(8036));
+    }
+
+    #[test]
+    fn state_sync_is_omitted_when_tenderdash_is_unreachable() {
+        // Every field defaults to an empty string, which must not be read as "zero counters".
+        assert!(build_state_sync_info(&TenderdashStatusResponse::default()).is_none());
+    }
+
+    #[test]
+    fn state_sync_is_reported_while_the_node_is_syncing() {
+        let tenderdash_status: TenderdashStatusResponse = serde_json::from_str(&status_json(
+            r#"
+            "total_synced_time": "123456789",
+            "remaining_time": "9876543",
+            "total_snapshots": "3",
+            "chunk_process_avg_time": "4242",
+            "snapshot_height": "198000",
+            "snapshot_chunks_count": "12",
+            "backfilled_blocks": "500",
+            "backfill_blocks_total": "1000",
+            "#,
+        ))
+        .expect("parse tenderdash status");
+
+        let state_sync = build_state_sync_info(&tenderdash_status).expect("state sync present");
+
+        assert_eq!(state_sync.total_synced_time, 123456789);
+        assert_eq!(state_sync.remaining_time, 9876543);
+        assert_eq!(state_sync.total_snapshots, 3);
+        assert_eq!(state_sync.chunk_process_avg_time, 4242);
+        assert_eq!(state_sync.snapshot_height, 198000);
+        assert_eq!(state_sync.snapshot_chunks_count, 12);
+        assert_eq!(state_sync.backfilled_blocks, 500);
+        assert_eq!(state_sync.backfill_blocks_total, 1000);
+    }
+
+    /// Tenderdash 1.7 never populates the state sync counters (`StateSyncMetricer` is nil), so
+    /// a node that state synced reports the same zeroes as one that never did. Only
+    /// `total_synced_time` / `remaining_time` — which the *block sync* reactor owns — can be
+    /// non-zero, and they are back to zero once the node has caught up.
+    #[test]
+    fn state_sync_is_omitted_after_a_completed_state_sync() {
+        let tenderdash_status: TenderdashStatusResponse = serde_json::from_str(&status_json(
+            r#"
+            "total_synced_time": "0",
+            "remaining_time": "0",
+            "total_snapshots": "0",
+            "chunk_process_avg_time": "0",
+            "snapshot_height": "0",
+            "snapshot_chunks_count": "0",
+            "backfilled_blocks": "0",
+            "backfill_blocks_total": "0",
+            "#,
+        ))
+        .expect("parse tenderdash status");
+
+        assert!(build_state_sync_info(&tenderdash_status).is_none());
+    }
+
+    /// Build a minimal `/status` payload whose `sync_info` also carries `extra_sync_info`.
+    fn status_json(extra_sync_info: &str) -> String {
+        format!(
+            r#"{{
+              "node_info": {{ "id": "972a33056d57359de8acfa4fb8b29dc1c14f76b8" }},
+              "sync_info": {{
+                {extra_sync_info}
+                "latest_block_hash": "B15CB7BD25D5334587B591D46FADEDA3AFCE2C57B7BC99E512F79422AB710343",
+                "catching_up": false
+              }}
+            }}"#
+        )
     }
 
     const TENDERMASH_STATUS_JSON: &str = r#"


### PR DESCRIPTION
## Issue being fixed or feature implemented

Three status-reporting bugs found during state-sync QA (all observed live on a state-synced local node). Independent of the state-sync feature PRs — these affect today's v4.2-dev.

## What was done?

* **rs-dapi: stop emitting misleading all-zero `stateSync` counters.** Tenderdash 1.7 never populates the six state-sync counters in `/status` — `env.StateSyncMetricer` has **no assignment site anywhere in tenderdash** (the reactor is dropped into `node.services` with no reference kept, and `*statesync.Reactor` doesn't even implement the `Metricer` interface), so the fields are always `"0"`. rs-dapi's emit gate was additionally inverted (`json:",string"` means the fields are never absent, so the "is any data present" check always passed). getStatus now emits the `stateSync` section only when one of the six state-sync-specific counters is non-zero — absent rather than "state sync ran and did nothing" — and block-sync progress fields no longer leak into the state-sync section. The precise tenderdash-side fix (wire the reactor into `rpcEnv`, implement the two missing `Metricer` methods, snapshot syncer values before `syncComplete()` nils them, persist across restart) is documented in the code and being addressed separately.
* **rs-dapi: `/health` no longer reports a Core height under the name `latestBlockHeight`.** getStatus's `chain.latestBlockHeight` was always correct (tenderdash platform height); the collision was `checks.coreRpc.latestBlockHeight` on the unversioned `/health` endpoint, sourced from Core `getblockcount` — the exact number QA observed. Renamed to `coreBlockHeight` (no in-repo consumers of the old key), with a regression test pinning that `chain.latest_block_height` is the platform height.
* **js-dapi-client: getStatus no longer throws on nodes missing optional sections.** `getStateSync()`, `getNode()`, `getChain()`, `getNetwork()`, `getTime()`, and the nested version getters were all called unguarded; any of them absent (never-synced node, Drive or tenderdash unreachable) threw a TypeError. All optional sub-messages are now guarded, with unit tests for the absent-section shapes.

## How Has This Been Tested?

rs-dapi: 307 unit tests passing including 7 new/changed (mid-sync, post-sync, never-synced, block-sync-only fixtures; height-collision regression). js-dapi-client: 320 passing including new absent-section cases. fmt/clippy clean. code-review-validator gate run; both valid findings fixed.

## Breaking Changes

`/health`'s `checks.coreRpc.latestBlockHeight` key is renamed to `coreBlockHeight` (unversioned diagnostics endpoint; no in-repo consumers — external scrapers of that exact key would need the one-word update). getStatus omits the `stateSync` section when there is no state-sync data instead of emitting zeros.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation if needed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Platform status responses now handle missing optional sections without failing.
  * State sync information is shown only when state-sync activity is present, avoiding misleading status data.
  * Platform and Core block heights are now reported from the correct sources.

* **Changes**
  * Health endpoint output renames `latestBlockHeight` to `coreBlockHeight` to distinguish it from the Platform chain height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->