### PR TITLE
feat(drive): storage layout and maintenance for prefix-level ranked count indexes

### DIFF
--- a/packages/rs-drive/src/drive/contract/estimation_costs/add_estimation_costs_for_contract_insertion/v1/mod.rs
+++ b/packages/rs-drive/src/drive/contract/estimation_costs/add_estimation_costs_for_contract_insertion/v1/mod.rs
@@ -139,10 +139,19 @@ impl Drive {
             // deduped.
             let index_structure = document_type_ref.index_structure();
             for level in index_structure.sub_levels().values() {
-                let terminator_tree_type = level
-                    .has_index_with_type()
-                    .map(property_name_tree_type_from_flags)
-                    .unwrap_or(TreeType::NormalTree);
+                // A compound index ranked at its FIRST property
+                // (`rankedCountable: { at }`) makes its top level the
+                // grouping tree — the Count-axis indexed tree
+                // `insert_contract_v0` creates through the level-aware
+                // resolver — even though no index terminates there.
+                let terminator_tree_type = if level.ranked_count_grouping() {
+                    TreeType::ProvableCountIndexedTree
+                } else {
+                    level
+                        .has_index_with_type()
+                        .map(property_name_tree_type_from_flags)
+                        .unwrap_or(TreeType::NormalTree)
+                };
                 tree_weights.tally(terminator_tree_type);
             }
 

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/mod.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/mod.rs
@@ -1,7 +1,7 @@
 use crate::drive::contract::paths;
 
 use crate::drive::document::primary_key_tree_type::DocumentTypePrimaryKeyTreeType;
-use crate::drive::document::ranked_index_tree_type::property_name_tree_type_and_ranked_axes;
+use crate::drive::document::ranked_index_tree_type::property_name_tree_type_and_ranked_axes_for_level;
 use crate::drive::{contract_documents_path, votes, Drive, RootTree};
 use crate::util::object_size_info::DriveKeyInfo::{Key, KeyRef};
 use crate::util::storage_flags::StorageFlags;
@@ -414,15 +414,18 @@ impl Drive {
                     // Meta schema v3 (PV14) layers the ranking axes on top:
                     // any `ranked*` flag upgrades the chosen variant to its
                     // *indexed* mirror, which additionally carries one
-                    // ordered secondary Merk per axis. Note this dispatch
-                    // only ever sees a TERMINAL level — `has_index_with_type`
-                    // is `Some` exactly for single-property indexes, whose
-                    // top-level property-name tree IS the terminal one. A
-                    // compound index's terminal level lives deeper and is
-                    // materialized lazily by the document index walker.
-                    let index_info = level.has_index_with_type();
+                    // ordered secondary Merk per axis. This dispatch sees a
+                    // TERMINAL level for single-property indexes (whose
+                    // top-level property-name tree IS the terminal one) —
+                    // a compound index's terminal level lives deeper and is
+                    // materialized lazily by the document index walker —
+                    // and, since the `rankedCountable: { at }` grammar, a
+                    // GROUPING level when a compound index ranks at its
+                    // first property: the level-aware resolver then yields
+                    // the Count-axis indexed tree, created here so the
+                    // ranking secondary exists from registration.
                     let (tree_type, ranked_axes) =
-                        property_name_tree_type_and_ranked_axes(index_info)?;
+                        property_name_tree_type_and_ranked_axes_for_level(level)?;
                     match tree_type {
                         TreeType::ProvableCountProvableSumTree => self
                             .batch_insert_empty_provable_count_provable_sum_tree(

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/mod.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/mod.rs
@@ -29,6 +29,7 @@
 mod countable_e2e_tests;
 mod index_only_e2e_tests;
 mod preallocated_index_e2e_tests;
+mod prefix_ranked_index_e2e_tests;
 mod range_countable_index_e2e_tests;
 mod range_summable_index_e2e_tests;
 mod ranked_index_e2e_tests;

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/prefix_ranked_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/prefix_ranked_index_e2e_tests.rs
@@ -921,3 +921,158 @@ fn every_level_of_an_index_can_rank() {
 
     assert_grovedb_is_consistent(&drive);
 }
+
+/// The `preallocated` composition the issue calls out: inserting the
+/// referenced `post` preallocates the `plike` chain — the group appears
+/// in the hashtag-level secondary **at zero before any like exists** —
+/// and draining the entries keeps it rankable at zero instead of
+/// pruning it (the non-preallocated drain behaviour is pinned above).
+#[test]
+fn preallocated_groups_stay_rankable_at_zero() {
+    let (drive, contract) = setup_trending();
+    let pv = platform_version();
+
+    // Insert the referenced post; preallocation creates plike's chain.
+    let post_type = contract
+        .document_type_for_name("post")
+        .expect("post doctype exists");
+    let mut post = post_type
+        .random_document(Some(400), pv)
+        .expect("random post");
+    let mut props = std::collections::BTreeMap::new();
+    props.insert("hashtag".to_string(), Value::Text("alpha".to_string()));
+    props.insert("message".to_string(), Value::Text("gm".to_string()));
+    post.set_properties(props);
+    drive
+        .add_document_for_contract(
+            DocumentAndContractInfo {
+                owned_document_info: OwnedDocumentInfo {
+                    document_info: DocumentRefInfo((&post, None)),
+                    owner_id: None,
+                },
+                contract: &contract,
+                document_type: post_type,
+            },
+            false,
+            BlockInfo::default(),
+            true,
+            None,
+            pv,
+            None,
+        )
+        .expect("expected to insert the post");
+
+    let grouping_path = level_path(&contract, "plike", &[b"hashtag"]);
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(0, "alpha")]),
+        "preallocation must surface the group in the secondary at zero, before any like"
+    );
+
+    // Two likes on the post, then drain them both.
+    let plike_type = contract
+        .document_type_for_name("plike")
+        .expect("plike doctype exists");
+    let likes: Vec<Document> = [[1u8; 32], [2u8; 32]]
+        .into_iter()
+        .enumerate()
+        .map(|(i, owner)| {
+            let mut like = plike_type
+                .random_document(Some(500 + i as u64), pv)
+                .expect("random like");
+            let mut props = std::collections::BTreeMap::new();
+            props.insert("hashtag".to_string(), Value::Text("alpha".to_string()));
+            props.insert(
+                "postId".to_string(),
+                Value::Identifier(post.id().to_buffer()),
+            );
+            like.set_properties(props);
+            like.set_owner_id(Identifier::from(owner));
+            drive
+                .add_document_for_contract(
+                    DocumentAndContractInfo {
+                        owned_document_info: OwnedDocumentInfo {
+                            document_info: DocumentRefInfo((&like, None)),
+                            owner_id: None,
+                        },
+                        contract: &contract,
+                        document_type: plike_type,
+                    },
+                    false,
+                    BlockInfo::default(),
+                    true,
+                    None,
+                    pv,
+                    None,
+                )
+                .expect("expected to insert a plike entry");
+            like
+        })
+        .collect();
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(2, "alpha")])
+    );
+
+    for like in likes {
+        drive
+            .delete_index_only_document_for_contract(
+                like,
+                &contract,
+                plike_type,
+                BlockInfo::default(),
+                true,
+                None,
+                pv,
+                None,
+            )
+            .expect("expected to delete the plike entry");
+    }
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(0, "alpha")]),
+        "draining a preallocated group must keep it rankable at zero, not prune it"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// The contract-insert **estimation** path (a dry-run `apply_contract`)
+/// must price the registration of grouping first-level trees — the
+/// branch that tallies the at-level PCIT into the doctype layer's
+/// estimated weights.
+#[test]
+fn dry_run_contract_apply_prices_the_grouping_registration() {
+    let drive = setup_drive_with_initial_state_structure(None);
+    let pv = platform_version();
+    let contract = json_document_to_contract(
+        "tests/supporting_files/contract/trending/trending-contract.json",
+        false,
+        pv,
+    )
+    .expect("expected to parse the trending contract");
+
+    let estimated = drive
+        .apply_contract(
+            &contract,
+            BlockInfo::default(),
+            false,
+            StorageFlags::optional_default_as_cow(),
+            None,
+            pv,
+        )
+        .expect("the dry-run contract apply must traverse the estimation path");
+    assert!(estimated.processing_fee > 0);
+
+    let applied = drive
+        .apply_contract(
+            &contract,
+            BlockInfo::default(),
+            true,
+            StorageFlags::optional_default_as_cow(),
+            None,
+            pv,
+        )
+        .expect("the real apply must succeed after the dry run");
+    assert!(applied.processing_fee > 0);
+}

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/prefix_ranked_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/prefix_ranked_index_e2e_tests.rs
@@ -691,3 +691,138 @@ fn index_only_entries_rank_hashtags_and_drain_on_delete() {
 
     assert_grovedb_is_consistent(&drive);
 }
+
+// ---------------------------------------------------------------------------
+// Behaviour: both rankings on one index (`at: ["hashtag", "postId"]`)
+// ---------------------------------------------------------------------------
+
+/// The `both` doctype declares the grouping level AND the terminal
+/// ranking on one index: the chain nests two indexed trees, the inner
+/// (terminal) one a CONTRIBUTING child inside the grouping level's
+/// count-bearing value trees. Registration lays the outer one down;
+/// document inserts materialize the inner one per hashtag; both
+/// secondaries rank simultaneously and re-key on delete, drains prune
+/// through both, and the dry-run prices the nested layout.
+#[test]
+fn both_levels_rank_on_one_index() {
+    let (drive, contract) = setup_trending();
+    let pv = platform_version();
+
+    // Registration: the grouping first level is the PCIT.
+    let doctype_path = level_path(&contract, "both", &[]);
+    assert!(
+        matches!(
+            read_grove_element(&drive, &doctype_path, b"hashtag"),
+            Some(Element::ProvableCountIndexedTree(..))
+        ),
+        "registration must create the grouping PCIT"
+    );
+
+    // Dry-run estimation traverses the nested layout before any state
+    // exists.
+    let dry_run_doc = build_row(
+        &contract,
+        "both",
+        &[("hashtag", "alpha"), ("postId", "p1")],
+        None,
+        99,
+    );
+    let estimated = insert_row(&drive, &contract, "both", &dry_run_doc, false)
+        .expect("the dry run must traverse the nested layout");
+    assert!(estimated.processing_fee > 0);
+
+    let docs = insert_rows(
+        &drive,
+        &contract,
+        "both",
+        &[
+            &[("hashtag", "alpha"), ("postId", "p1")],
+            &[("hashtag", "alpha"), ("postId", "p1")],
+            &[("hashtag", "alpha"), ("postId", "p2")],
+            &[("hashtag", "beta"), ("postId", "p1")],
+        ],
+    );
+
+    // The inner (terminal) tree is ALSO an indexed tree, contributing
+    // its count to the hashtag value tree above it.
+    let grouping_path = level_path(&contract, "both", &[b"hashtag"]);
+    match read_grove_element(&drive, &grouping_path, b"alpha") {
+        Some(element @ Element::CountTree(..)) => {
+            assert_eq!(
+                element.count_value_or_default(),
+                3,
+                "alpha's value tree must receive the inner PCIT's contribution"
+            );
+        }
+        other => panic!("expected a CountTree value tree for alpha, got {other:?}"),
+    }
+    let alpha_path = level_path(&contract, "both", &[b"hashtag", b"alpha"]);
+    match read_grove_element(&drive, &alpha_path, b"postId") {
+        Some(Element::ProvableCountIndexedTree(_, _, count, _)) => {
+            assert_eq!(
+                count, 3,
+                "the contributing inner PCIT carries alpha's total"
+            );
+        }
+        other => panic!("expected a contributing inner PCIT, got {other:?}"),
+    }
+
+    // Both secondaries serve their rankings.
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(3, "alpha"), (1, "beta")]),
+        "the grouping secondary ranks hashtags by subtree total"
+    );
+    let alpha_posts_path = level_path(&contract, "both", &[b"hashtag", b"alpha", b"postId"]);
+    assert_eq!(
+        count_top_k_named(&drive, &alpha_posts_path, 10, true),
+        named(&[(2, "p1"), (1, "p2")]),
+        "the terminal secondary ranks alpha's posts by member count"
+    );
+
+    // A delete re-keys both secondaries.
+    drive
+        .delete_document_for_contract(
+            docs[0].id(),
+            &contract,
+            "both",
+            BlockInfo::default(),
+            true,
+            None,
+            pv,
+            None,
+        )
+        .expect("expected to delete a like");
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(2, "alpha"), (1, "beta")])
+    );
+    let mut alpha_after = count_top_k_named(&drive, &alpha_posts_path, 10, true);
+    alpha_after.sort();
+    assert_eq!(alpha_after, named(&[(1, "p1"), (1, "p2")]));
+
+    // Draining beta prunes its whole chain — the group leaves the
+    // grouping secondary.
+    drive
+        .delete_document_for_contract(
+            docs[3].id(),
+            &contract,
+            "both",
+            BlockInfo::default(),
+            true,
+            None,
+            pv,
+            None,
+        )
+        .expect("expected to delete beta's only like");
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(2, "alpha")])
+    );
+    assert!(
+        read_grove_element(&drive, &grouping_path, b"beta").is_none(),
+        "beta's drained chain must be pruned"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/prefix_ranked_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/prefix_ranked_index_e2e_tests.rs
@@ -1,0 +1,693 @@
+//! End-to-end coverage for **prefix-level ranked count indexes**
+//! (`rankedCountable: { "at": … }`, meta schema v3 / PV14): the Count-axis
+//! indexed tree placed at a NON-terminal index level, ranking that
+//! property's values by their **whole-subtree** document count instead of
+//! ranking the terminal level's groups by direct member count.
+//!
+//! Everything runs against the `trending` fixture at
+//! `tests/supporting_files/contract/trending/trending-contract.json`:
+//!
+//! | doctype | index                 | properties                    | at        | exercises                                   |
+//! |---------|-----------------------|-------------------------------|-----------|---------------------------------------------|
+//! | `like`  | `byHashtagPost`       | `[hashtag, postId]`           | `hashtag` | the standard two-property shape             |
+//! | `deep`  | `byHashtagRegionPost` | `[hashtag, region, postId]`   | `hashtag` | a count-propagating level between at/terminal |
+//! | `mid`   | `byRegionHashtagPost` | `[region, hashtag, postId]`   | `hashtag` | grouping at a middle level, materialized lazily per prefix |
+//! | `ilike` | `byHashtagPost`       | `[hashtag, postId]` → `$ownerId` | `hashtag` | the indexOnly entries-as-rows shape      |
+//!
+//! The on-disk chain under test, for `like`:
+//!
+//! ```text
+//! "hashtag"  property-name tree   ProvableCountIndexedTree   ← the grouping tree
+//!   <value>  value tree           CountTree (count = subtree total)
+//!     "postId" property-name tree ProvableCountTree (contributes its count!)
+//!       <value> value tree        CountTree
+//!         [0]  member bucket      CountTree of references / Items
+//! ```
+//!
+//! Two layers are checked, mirroring `ranked_index_e2e_tests`: the *shape*
+//! (registration and lazy materialization lay down exactly these tree
+//! types, with the continuation inserted contributing rather than
+//! zero-wrapped) and the *behaviour* (inserts, updates, deletes and
+//! drains keep the hashtag-level secondary ranking by subtree totals,
+//! with grovedb's integrity sweep clean after every test).
+
+use crate::drive::Drive;
+use crate::util::grove_operations::DirectQueryType;
+use crate::util::object_size_info::DocumentInfo::DocumentRefInfo;
+use crate::util::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
+use crate::util::storage_flags::StorageFlags;
+use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+use dpp::block::block_info::BlockInfo;
+use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::data_contract::document_type::random_document::CreateRandomDocument;
+use dpp::document::{Document, DocumentV0Getters, DocumentV0Setters};
+use dpp::fee::fee_result::FeeResult;
+use dpp::platform_value::{Identifier, Value};
+use dpp::prelude::DataContract;
+use dpp::tests::json_document::json_document_to_contract;
+use dpp::version::PlatformVersion;
+use grovedb::Element;
+
+fn platform_version() -> &'static PlatformVersion {
+    PlatformVersion::latest()
+}
+
+fn setup_trending() -> (Drive, DataContract) {
+    let drive = setup_drive_with_initial_state_structure(None);
+    let pv = platform_version();
+    let contract = json_document_to_contract(
+        "tests/supporting_files/contract/trending/trending-contract.json",
+        false,
+        pv,
+    )
+    .expect("expected to parse the trending contract");
+    drive
+        .apply_contract(
+            &contract,
+            BlockInfo::default(),
+            true,
+            StorageFlags::optional_default_as_cow(),
+            None,
+            pv,
+        )
+        .expect("expected to apply the trending contract");
+    (drive, contract)
+}
+
+/// `[DataContractDocuments, contract_id, 1, doctype, segments…]`.
+fn level_path(
+    contract: &DataContract,
+    document_type_name: &str,
+    segments: &[&[u8]],
+) -> Vec<Vec<u8>> {
+    let mut path = vec![
+        vec![crate::drive::RootTree::DataContractDocuments as u8],
+        contract.id().as_bytes().to_vec(),
+        vec![1],
+        document_type_name.as_bytes().to_vec(),
+    ];
+    path.extend(segments.iter().map(|segment| segment.to_vec()));
+    path
+}
+
+fn read_grove_element(drive: &Drive, path: &[Vec<u8>], key: &[u8]) -> Option<Element> {
+    let path_refs: Vec<&[u8]> = path.iter().map(|v| v.as_slice()).collect();
+    drive
+        .grove_get_raw_optional(
+            path_refs.as_slice().into(),
+            key,
+            DirectQueryType::StatefulDirectQuery,
+            None,
+            &mut vec![],
+            &platform_version().drive,
+        )
+        .expect("grove_get_raw_optional should succeed")
+}
+
+/// grovedb's integrity sweep, including the primary↔secondary
+/// content-consistency walk for indexed trees.
+fn assert_grovedb_is_consistent(drive: &Drive) {
+    let issues = drive
+        .grove
+        .verify_grovedb(None, true, false, &platform_version().drive.grove_version)
+        .expect("verify_grovedb must run");
+    assert!(
+        issues.is_empty(),
+        "grovedb integrity verification reported issues: {issues:?}"
+    );
+}
+
+/// A document of `document_type_name` with exactly the given text
+/// properties, owned by `owner` when given (indexOnly entries key their
+/// member rows by `$ownerId`, so those tests need distinct owners).
+fn build_row(
+    contract: &DataContract,
+    document_type_name: &str,
+    properties: &[(&str, &str)],
+    owner: Option<[u8; 32]>,
+    seed: u64,
+) -> Document {
+    let pv = platform_version();
+    let document_type = contract
+        .document_type_for_name(document_type_name)
+        .unwrap_or_else(|_| panic!("{document_type_name} doctype exists"));
+    let mut doc = document_type
+        .random_document(Some(seed), pv)
+        .expect("random document");
+    let mut props = std::collections::BTreeMap::new();
+    for (name, value) in properties {
+        props.insert(name.to_string(), Value::Text(value.to_string()));
+    }
+    doc.set_properties(props);
+    if let Some(owner) = owner {
+        doc.set_owner_id(Identifier::from(owner));
+    }
+    doc
+}
+
+fn insert_row(
+    drive: &Drive,
+    contract: &DataContract,
+    document_type_name: &str,
+    doc: &Document,
+    apply: bool,
+) -> Result<FeeResult, crate::error::Error> {
+    let pv = platform_version();
+    let document_type = contract
+        .document_type_for_name(document_type_name)
+        .unwrap_or_else(|_| panic!("{document_type_name} doctype exists"));
+    drive.add_document_for_contract(
+        DocumentAndContractInfo {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((doc, None)),
+                owner_id: None,
+            },
+            contract,
+            document_type,
+        },
+        false,
+        BlockInfo::default(),
+        apply,
+        None,
+        pv,
+        None,
+    )
+}
+
+fn insert_rows(
+    drive: &Drive,
+    contract: &DataContract,
+    document_type_name: &str,
+    rows: &[&[(&str, &str)]],
+) -> Vec<Document> {
+    rows.iter()
+        .enumerate()
+        .map(|(i, properties)| {
+            let doc = build_row(contract, document_type_name, properties, None, i as u64 + 1);
+            insert_row(drive, contract, document_type_name, &doc, true)
+                .unwrap_or_else(|e| panic!("expected to insert {document_type_name} row: {e}"));
+            doc
+        })
+        .collect()
+}
+
+fn count_top_k(drive: &Drive, path: &[Vec<u8>], k: u16, descending: bool) -> Vec<(u64, Vec<u8>)> {
+    let path_query = grovedb::PathQuery::new_axis(
+        path.to_vec(),
+        grovedb_query::AxisQuery::top_k(grovedb_query::IndexAxis::Count, k, 0, descending)
+            .keys_only(),
+    );
+    match drive
+        .grove
+        .run_path_query(
+            &path_query,
+            true,
+            true,
+            true,
+            grovedb::query_result_type::QueryResultType::QueryKeyElementPairResultType,
+            None,
+            &platform_version().drive.grove_version,
+        )
+        .unwrap()
+        .expect("the keys-only axis read must succeed")
+    {
+        grovedb::PathQueryRun::AxisKeys {
+            keys: grovedb::AxisKeys::Count(pairs),
+            ..
+        } => pairs,
+        other => panic!("expected count keys, got {other:?}"),
+    }
+}
+
+/// `(count, group)` pairs with the group keys decoded for readable
+/// assertions.
+fn count_top_k_named(
+    drive: &Drive,
+    path: &[Vec<u8>],
+    k: u16,
+    descending: bool,
+) -> Vec<(u64, String)> {
+    count_top_k(drive, path, k, descending)
+        .into_iter()
+        .map(|(count, key)| {
+            (
+                count,
+                String::from_utf8(key).expect("group keys are utf-8 in this suite"),
+            )
+        })
+        .collect()
+}
+
+fn named(pairs: &[(u64, &str)]) -> Vec<(u64, String)> {
+    pairs
+        .iter()
+        .map(|(count, name)| (*count, name.to_string()))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+/// A compound index ranked at its FIRST property must get its grouping
+/// tree — the single-axis `ProvableCountIndexedTree` — at contract
+/// registration, exactly where an unranked compound index gets a
+/// `NormalTree`. A middle-level `at` leaves the top level normal (its
+/// grouping tree is materialized lazily, per prefix, by the walkers).
+#[test]
+fn grouping_first_level_is_a_pcit_at_registration() {
+    let (drive, contract) = setup_trending();
+
+    for doctype in ["like", "deep", "ilike"] {
+        let path = level_path(&contract, doctype, &[]);
+        match read_grove_element(&drive, &path, b"hashtag") {
+            Some(Element::ProvableCountIndexedTree(
+                primary_root_key,
+                secondary_root_key,
+                count,
+                _,
+            )) => {
+                assert!(primary_root_key.is_none(), "{doctype}: fresh primary");
+                assert!(secondary_root_key.is_none(), "{doctype}: fresh secondary");
+                assert_eq!(count, 0, "{doctype}: fresh grouping tree counts nothing");
+            }
+            other => panic!("{doctype}: expected ProvableCountIndexedTree, got {other:?}"),
+        }
+    }
+
+    let mid_path = level_path(&contract, "mid", &[]);
+    match read_grove_element(&drive, &mid_path, b"region") {
+        Some(Element::Tree(..)) => {}
+        other => panic!("mid: the level above the grouping stays a NormalTree, got {other:?}"),
+    }
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour: the two-property shape
+// ---------------------------------------------------------------------------
+
+/// Inserting documents through the ordinary document-insert path must key
+/// the hashtag-level secondary by each hashtag's whole-subtree count —
+/// counted across posts — and lay the chain down with the documented tree
+/// types, the continuation contributing its count to the value tree.
+#[test]
+fn likes_rank_hashtags_by_whole_subtree_count() {
+    let (drive, contract) = setup_trending();
+
+    insert_rows(
+        &drive,
+        &contract,
+        "like",
+        &[
+            &[("hashtag", "alpha"), ("postId", "p1")],
+            &[("hashtag", "alpha"), ("postId", "p1")],
+            &[("hashtag", "alpha"), ("postId", "p2")],
+            &[("hashtag", "beta"), ("postId", "p1")],
+            &[("hashtag", "beta"), ("postId", "p3")],
+            &[("hashtag", "gamma"), ("postId", "p2")],
+        ],
+    );
+
+    let grouping_path = level_path(&contract, "like", &[b"hashtag"]);
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(3, "alpha"), (2, "beta"), (1, "gamma")]),
+        "hashtags must rank by total like count across all their posts"
+    );
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 2, false),
+        named(&[(1, "gamma"), (2, "beta")]),
+        "bottom-k reads the same secondary from the other end"
+    );
+
+    // The chain's tree types, level by level under `alpha`.
+    match read_grove_element(&drive, &grouping_path, b"alpha") {
+        Some(element @ Element::CountTree(..)) => {
+            assert_eq!(
+                element.count_value_or_default(),
+                3,
+                "alpha's value tree count must be its subtree total"
+            );
+        }
+        other => panic!("expected a CountTree value tree for alpha, got {other:?}"),
+    }
+    let alpha_path = level_path(&contract, "like", &[b"hashtag", b"alpha"]);
+    match read_grove_element(&drive, &alpha_path, b"postId") {
+        Some(element @ Element::ProvableCountTree(..)) => {
+            assert_eq!(
+                element.count_value_or_default(),
+                3,
+                "the contributing continuation carries the same total upward"
+            );
+        }
+        other => panic!("expected a contributing ProvableCountTree continuation, got {other:?}"),
+    }
+    let alpha_posts_path = level_path(&contract, "like", &[b"hashtag", b"alpha", b"postId"]);
+    match read_grove_element(&drive, &alpha_posts_path, b"p1") {
+        Some(element @ Element::CountTree(..)) => {
+            assert_eq!(element.count_value_or_default(), 2);
+        }
+        other => panic!("expected a CountTree post value tree, got {other:?}"),
+    }
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// Changing a document's hashtag must move its contribution between
+/// groups through the real update path — decrementing (and re-keying) the
+/// old group, incrementing the new one.
+#[test]
+fn updating_a_hashtag_moves_its_document_between_groups() {
+    let (drive, contract) = setup_trending();
+    let pv = platform_version();
+
+    let docs = insert_rows(
+        &drive,
+        &contract,
+        "like",
+        &[
+            &[("hashtag", "alpha"), ("postId", "p1")],
+            &[("hashtag", "alpha"), ("postId", "p2")],
+            &[("hashtag", "beta"), ("postId", "p1")],
+        ],
+    );
+
+    let grouping_path = level_path(&contract, "like", &[b"hashtag"]);
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(2, "alpha"), (1, "beta")])
+    );
+
+    // Move beta's only like to alpha: beta drains, alpha reaches 3.
+    let document_type = contract
+        .document_type_for_name("like")
+        .expect("like doctype exists");
+    let mut updated = docs[2].clone();
+    let mut props = updated.properties().clone();
+    props.insert("hashtag".to_string(), Value::Text("alpha".to_string()));
+    updated.set_properties(props);
+    updated.set_revision(Some(2));
+
+    drive
+        .update_document_for_contract(
+            &updated,
+            &contract,
+            document_type,
+            Some(updated.owner_id().to_buffer()),
+            BlockInfo::default(),
+            true,
+            StorageFlags::optional_default_as_cow(),
+            None,
+            pv,
+            None,
+        )
+        .expect("expected to update the like document");
+
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(3, "alpha")]),
+        "the moved like must drain beta and grow alpha's subtree total"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// Deleting a group's last document must drop the group from the axis
+/// entirely; earlier deletes only decrement it.
+#[test]
+fn draining_a_hashtag_removes_it_from_the_ranking() {
+    let (drive, contract) = setup_trending();
+    let pv = platform_version();
+
+    let docs = insert_rows(
+        &drive,
+        &contract,
+        "like",
+        &[
+            &[("hashtag", "alpha"), ("postId", "p1")],
+            &[("hashtag", "beta"), ("postId", "p1")],
+            &[("hashtag", "beta"), ("postId", "p2")],
+        ],
+    );
+
+    let grouping_path = level_path(&contract, "like", &[b"hashtag"]);
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(2, "beta"), (1, "alpha")])
+    );
+
+    for (doc_index, expected) in [
+        (2usize, named(&[(1, "alpha"), (1, "beta")])),
+        (1usize, named(&[(1, "alpha")])),
+    ] {
+        drive
+            .delete_document_for_contract(
+                docs[doc_index].id(),
+                &contract,
+                "like",
+                BlockInfo::default(),
+                true,
+                None,
+                pv,
+                None,
+            )
+            .expect("expected to delete the like document");
+        let mut after = count_top_k_named(&drive, &grouping_path, 10, true);
+        // Equal counts tie; compare as sets of (count, name).
+        after.sort();
+        let mut expected = expected;
+        expected.sort();
+        assert_eq!(after, expected);
+    }
+
+    assert!(
+        read_grove_element(&drive, &grouping_path, b"beta").is_none(),
+        "the drained group's value tree must be pruned"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// The estimation (dry-run) path must traverse the same layouts without
+/// erroring and price real work — a stateless walker claiming the wrong
+/// tree types would fail or misprice here.
+#[test]
+fn dry_run_insert_estimates_fees_for_the_prefix_ranked_layout() {
+    let (drive, contract) = setup_trending();
+
+    for doctype in ["like", "deep", "mid", "ilike"] {
+        let properties: &[(&str, &str)] = match doctype {
+            "like" | "ilike" => &[("hashtag", "alpha"), ("postId", "p1")],
+            _ => &[("hashtag", "alpha"), ("region", "east"), ("postId", "p1")],
+        };
+        let doc = build_row(&contract, doctype, properties, Some([7u8; 32]), 1);
+        let estimated = insert_row(&drive, &contract, doctype, &doc, false)
+            .unwrap_or_else(|e| panic!("{doctype}: dry-run insert must succeed: {e}"));
+        assert!(
+            estimated.processing_fee > 0,
+            "{doctype}: the dry run must price the write"
+        );
+        let applied = insert_row(&drive, &contract, doctype, &doc, true)
+            .unwrap_or_else(|e| panic!("{doctype}: applied insert must succeed: {e}"));
+        assert!(applied.processing_fee > 0);
+    }
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour: deeper shapes
+// ---------------------------------------------------------------------------
+
+/// With a level between `at` and the terminal, the chain runs through a
+/// count-propagating `CountTree` property-name tree — the grouping
+/// secondary must still see the whole-subtree totals.
+#[test]
+fn deep_chain_propagates_counts_through_the_propagating_level() {
+    let (drive, contract) = setup_trending();
+
+    insert_rows(
+        &drive,
+        &contract,
+        "deep",
+        &[
+            &[("hashtag", "alpha"), ("region", "east"), ("postId", "p1")],
+            &[("hashtag", "alpha"), ("region", "east"), ("postId", "p2")],
+            &[("hashtag", "alpha"), ("region", "west"), ("postId", "p1")],
+            &[("hashtag", "beta"), ("region", "east"), ("postId", "p1")],
+        ],
+    );
+
+    let grouping_path = level_path(&contract, "deep", &[b"hashtag"]);
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(3, "alpha"), (1, "beta")]),
+        "the grouping secondary must rank by totals across regions AND posts"
+    );
+
+    // The propagating level's property-name tree is a contributing
+    // CountTree carrying alpha's total.
+    let alpha_path = level_path(&contract, "deep", &[b"hashtag", b"alpha"]);
+    match read_grove_element(&drive, &alpha_path, b"region") {
+        Some(element @ Element::CountTree(..)) => {
+            assert_eq!(element.count_value_or_default(), 3);
+        }
+        other => panic!("expected a CountTree propagating level, got {other:?}"),
+    }
+    let alpha_regions_path = level_path(&contract, "deep", &[b"hashtag", b"alpha", b"region"]);
+    match read_grove_element(&drive, &alpha_regions_path, b"east") {
+        Some(element @ Element::CountTree(..)) => {
+            assert_eq!(element.count_value_or_default(), 2);
+        }
+        other => panic!("expected a CountTree region value tree, got {other:?}"),
+    }
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+/// A middle-level `at` keeps one grouping tree PER prefix value,
+/// materialized lazily by the walkers, each ranking only its own
+/// prefix's hashtags.
+#[test]
+fn middle_at_ranks_hashtags_within_each_region_prefix() {
+    let (drive, contract) = setup_trending();
+
+    insert_rows(
+        &drive,
+        &contract,
+        "mid",
+        &[
+            &[("region", "r1"), ("hashtag", "alpha"), ("postId", "p1")],
+            &[("region", "r1"), ("hashtag", "alpha"), ("postId", "p2")],
+            &[("region", "r1"), ("hashtag", "beta"), ("postId", "p1")],
+            &[("region", "r2"), ("hashtag", "beta"), ("postId", "p1")],
+        ],
+    );
+
+    // One grouping PCIT per region value.
+    let r1_value_path = level_path(&contract, "mid", &[b"region", b"r1"]);
+    match read_grove_element(&drive, &r1_value_path, b"hashtag") {
+        Some(Element::ProvableCountIndexedTree(_, _, count, _)) => {
+            assert_eq!(count, 3, "r1's grouping tree counts r1's likes only");
+        }
+        other => panic!("expected a lazily-created ProvableCountIndexedTree, got {other:?}"),
+    }
+
+    let r1_grouping_path = level_path(&contract, "mid", &[b"region", b"r1", b"hashtag"]);
+    assert_eq!(
+        count_top_k_named(&drive, &r1_grouping_path, 10, true),
+        named(&[(2, "alpha"), (1, "beta")])
+    );
+    let r2_grouping_path = level_path(&contract, "mid", &[b"region", b"r2", b"hashtag"]);
+    assert_eq!(
+        count_top_k_named(&drive, &r2_grouping_path, 10, true),
+        named(&[(1, "beta")]),
+        "each prefix ranks independently"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour: indexOnly entries
+// ---------------------------------------------------------------------------
+
+/// The indexOnly shape from the motivating issue: entries are the rows,
+/// keyed per owner, and the hashtag level ranks by total like count.
+/// Delete-by-values decrements and drains exactly like references do.
+#[test]
+fn index_only_entries_rank_hashtags_and_drain_on_delete() {
+    let (drive, contract) = setup_trending();
+    let pv = platform_version();
+    let document_type = contract
+        .document_type_for_name("ilike")
+        .expect("ilike doctype exists");
+
+    let rows: [(&str, &str, [u8; 32]); 4] = [
+        ("alpha", "p1", [1u8; 32]),
+        ("alpha", "p1", [2u8; 32]),
+        ("alpha", "p2", [1u8; 32]),
+        ("beta", "p1", [1u8; 32]),
+    ];
+    let docs: Vec<Document> = rows
+        .iter()
+        .enumerate()
+        .map(|(i, (hashtag, post, owner))| {
+            let doc = build_row(
+                &contract,
+                "ilike",
+                &[("hashtag", hashtag), ("postId", post)],
+                Some(*owner),
+                i as u64 + 1,
+            );
+            insert_row(&drive, &contract, "ilike", &doc, true)
+                .unwrap_or_else(|e| panic!("expected to insert ilike entry: {e}"));
+            doc
+        })
+        .collect();
+
+    let grouping_path = level_path(&contract, "ilike", &[b"hashtag"]);
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(3, "alpha"), (1, "beta")])
+    );
+
+    // Structural uniqueness stays per (hashtag, postId, owner): the same
+    // owner liking the same post again is refused, but the same owner
+    // across posts (rows 0 and 2) was fine.
+    let duplicate = build_row(
+        &contract,
+        "ilike",
+        &[("hashtag", "alpha"), ("postId", "p1")],
+        Some([1u8; 32]),
+        9,
+    );
+    assert!(
+        insert_row(&drive, &contract, "ilike", &duplicate, true).is_err(),
+        "a duplicate (hashtag, post, owner) entry must be refused"
+    );
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(3, "alpha"), (1, "beta")]),
+        "the refused duplicate must not have moved any count"
+    );
+
+    // Delete one alpha entry, then drain beta.
+    drive
+        .delete_index_only_document_for_contract(
+            docs[1].clone(),
+            &contract,
+            document_type,
+            BlockInfo::default(),
+            true,
+            None,
+            pv,
+            None,
+        )
+        .expect("expected to delete the ilike entry");
+    let mut after = count_top_k_named(&drive, &grouping_path, 10, true);
+    after.sort();
+    assert_eq!(after, named(&[(1, "beta"), (2, "alpha")]));
+
+    drive
+        .delete_index_only_document_for_contract(
+            docs[3].clone(),
+            &contract,
+            document_type,
+            BlockInfo::default(),
+            true,
+            None,
+            pv,
+            None,
+        )
+        .expect("expected to delete beta's only entry");
+    assert_eq!(
+        count_top_k_named(&drive, &grouping_path, 10, true),
+        named(&[(2, "alpha")]),
+        "beta must drain out of the ranking"
+    );
+
+    assert_grovedb_is_consistent(&drive);
+}

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/prefix_ranked_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/prefix_ranked_index_e2e_tests.rs
@@ -826,3 +826,98 @@ fn both_levels_rank_on_one_index() {
 
     assert_grovedb_is_consistent(&drive);
 }
+
+/// The `chain` doctype ranks EVERY level of `[tag, region, postId]`:
+/// three nested indexed trees, each a contributing child of the level
+/// above. All three secondaries rank simultaneously through the real
+/// walkers, one delete re-keys all three, and the integrity sweep
+/// stays clean — the unbounded-depth composition, end to end.
+#[test]
+fn every_level_of_an_index_can_rank() {
+    let (drive, contract) = setup_trending();
+    let pv = platform_version();
+
+    let dry_run_doc = build_row(
+        &contract,
+        "chain",
+        &[("tag", "alpha"), ("region", "east"), ("postId", "p1")],
+        None,
+        99,
+    );
+    let estimated = insert_row(&drive, &contract, "chain", &dry_run_doc, false)
+        .expect("the dry run must traverse the fully ranked layout");
+    assert!(estimated.processing_fee > 0);
+
+    let docs = insert_rows(
+        &drive,
+        &contract,
+        "chain",
+        &[
+            &[("tag", "alpha"), ("region", "east"), ("postId", "p1")],
+            &[("tag", "alpha"), ("region", "east"), ("postId", "p1")],
+            &[("tag", "alpha"), ("region", "east"), ("postId", "p2")],
+            &[("tag", "alpha"), ("region", "west"), ("postId", "p1")],
+            &[("tag", "beta"), ("region", "east"), ("postId", "p1")],
+        ],
+    );
+
+    // Every level is an indexed tree; every level ranks.
+    let tag_path = level_path(&contract, "chain", &[b"tag"]);
+    assert!(matches!(
+        read_grove_element(&drive, &level_path(&contract, "chain", &[]), b"tag"),
+        Some(Element::ProvableCountIndexedTree(..))
+    ));
+    assert_eq!(
+        count_top_k_named(&drive, &tag_path, 10, true),
+        named(&[(4, "alpha"), (1, "beta")])
+    );
+    let alpha_regions_path = level_path(&contract, "chain", &[b"tag", b"alpha", b"region"]);
+    assert!(matches!(
+        read_grove_element(
+            &drive,
+            &level_path(&contract, "chain", &[b"tag", b"alpha"]),
+            b"region"
+        ),
+        Some(Element::ProvableCountIndexedTree(..))
+    ));
+    assert_eq!(
+        count_top_k_named(&drive, &alpha_regions_path, 10, true),
+        named(&[(3, "east"), (1, "west")])
+    );
+    let alpha_east_posts_path = level_path(
+        &contract,
+        "chain",
+        &[b"tag", b"alpha", b"region", b"east", b"postId"],
+    );
+    assert_eq!(
+        count_top_k_named(&drive, &alpha_east_posts_path, 10, true),
+        named(&[(2, "p1"), (1, "p2")])
+    );
+
+    // One delete re-keys all three secondaries on its path.
+    drive
+        .delete_document_for_contract(
+            docs[0].id(),
+            &contract,
+            "chain",
+            BlockInfo::default(),
+            true,
+            None,
+            pv,
+            None,
+        )
+        .expect("expected to delete a chain document");
+    assert_eq!(
+        count_top_k_named(&drive, &tag_path, 10, true),
+        named(&[(3, "alpha"), (1, "beta")])
+    );
+    assert_eq!(
+        count_top_k_named(&drive, &alpha_regions_path, 10, true),
+        named(&[(2, "east"), (1, "west")])
+    );
+    let mut posts_after = count_top_k_named(&drive, &alpha_east_posts_path, 10, true);
+    posts_after.sort();
+    assert_eq!(posts_after, named(&[(1, "p1"), (1, "p2")]));
+
+    assert_grovedb_is_consistent(&drive);
+}

--- a/packages/rs-drive/src/drive/contract/update/update_contract/v0/mod.rs
+++ b/packages/rs-drive/src/drive/contract/update/update_contract/v0/mod.rs
@@ -1,5 +1,5 @@
 use crate::drive::document::primary_key_tree_type::DocumentTypePrimaryKeyTreeType;
-use crate::drive::document::ranked_index_tree_type::property_name_tree_type_and_ranked_axes;
+use crate::drive::document::ranked_index_tree_type::property_name_tree_type_and_ranked_axes_for_level;
 use crate::drive::{contract_documents_path, Drive};
 use crate::error::drive::DriveError;
 use crate::error::Error;
@@ -324,14 +324,17 @@ impl Drive {
                 // breaking subsequent range-sum / range-count reads.
                 for (level_key, level) in index_structure.sub_levels() {
                     {
-                        let index_info = level.has_index_with_type();
                         // Meta schema v3 (PV14) additionally upgrades the
                         // chosen variant to its indexed mirror when the index
-                        // declares a ranking axis; `ranked_axes` is empty for
-                        // every pre-v3 contract, making this arm bit-identical
-                        // to the previous 4-way dispatch for them.
+                        // declares a ranking axis — including the grouping
+                        // level of a compound index ranked at its first
+                        // property (`rankedCountable: { at }`), which the
+                        // level-aware resolver maps to the Count-axis indexed
+                        // tree; `ranked_axes` is empty for every pre-v3
+                        // contract, making this arm bit-identical to the
+                        // previous 4-way dispatch for them.
                         let (target_tree_type, ranked_axes) =
-                            property_name_tree_type_and_ranked_axes(index_info)?;
+                            property_name_tree_type_and_ranked_axes_for_level(level)?;
                         let apply_type = if estimated_costs_only_with_layer_info.is_none() {
                             BatchInsertTreeApplyType::StatefulBatchInsertTree
                         } else {
@@ -476,9 +479,8 @@ impl Drive {
                         // sum- or range-countable top-level index added via
                         // contract update, diverging on-disk layout from
                         // fresh-insert contracts.
-                        let index_info = level.has_index_with_type();
                         let (tree_type, ranked_axes) =
-                            property_name_tree_type_and_ranked_axes(index_info)?;
+                            property_name_tree_type_and_ranked_axes_for_level(level)?;
                         match tree_type {
                             TreeType::ProvableCountProvableSumTree => self
                                 .batch_insert_empty_provable_count_provable_sum_tree(

--- a/packages/rs-drive/src/drive/document/index_level_tree_types.rs
+++ b/packages/rs-drive/src/drive/document/index_level_tree_types.rs
@@ -576,6 +576,29 @@ mod tests {
             index_level_tree_types_with_continuation_demotion(hashtag_level).is_err(),
             "a grouping level with a terminator stamp must fail closed"
         );
+
+        // Same guard one level down: a COUNT-PROPAGATING level that also
+        // carries a terminator stamp (an index terminating inside another
+        // index's ranked chain — rejected by contract validation, but
+        // constructible by hand) has the same two contradictory layouts.
+        let mut chain = base("byHashtagRegionPost", &["hashtag", "region", "postId"]);
+        chain.ranked_countable_at = vec!["hashtag".to_string()];
+        let terminating_inside = base("byHashtagRegion", &["hashtag", "region"]);
+        let index_structure = IndexLevel::try_from_indices(
+            [&chain, &terminating_inside],
+            "like",
+            PlatformVersion::latest(),
+        )
+        .expect("index level must build — the overlap rule runs at contract parse, not here");
+        let region_level = index_structure
+            .sub_levels()
+            .get("hashtag")
+            .and_then(|level| level.sub_levels().get("region"))
+            .expect("the shared propagating level exists");
+        assert!(
+            index_level_tree_types_with_continuation_demotion(region_level).is_err(),
+            "a count-propagating level with a terminator stamp must fail closed"
+        );
     }
 
     /// The two v14 fixes on one level: a ranked index terminating at

--- a/packages/rs-drive/src/drive/document/index_level_tree_types.rs
+++ b/packages/rs-drive/src/drive/document/index_level_tree_types.rs
@@ -462,7 +462,7 @@ mod tests {
             summable: None,
             range_summable: false,
             ranked_countable: false,
-            ranked_countable_at: Some("hashtag".to_string()),
+            ranked_countable_at: vec!["hashtag".to_string()],
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
@@ -549,7 +549,7 @@ mod tests {
             summable: None,
             range_summable: false,
             ranked_countable: false,
-            ranked_countable_at: None,
+            ranked_countable_at: vec![],
             ranked_summable: false,
             ranked_averageable: false,
             time_range: None,
@@ -558,7 +558,7 @@ mod tests {
             skip_if_absent: false,
         };
         let mut prefix_ranked = base("byHashtagPost", &["hashtag", "postId"]);
-        prefix_ranked.ranked_countable_at = Some("hashtag".to_string());
+        prefix_ranked.ranked_countable_at = vec!["hashtag".to_string()];
         let terminating = base("byHashtag", &["hashtag"]);
 
         let index_structure = IndexLevel::try_from_indices(

--- a/packages/rs-drive/src/drive/document/index_level_tree_types.rs
+++ b/packages/rs-drive/src/drive/document/index_level_tree_types.rs
@@ -73,7 +73,7 @@
 //! provable variant did, so a ranked index's secondaries keep ranking
 //! correctly over a shared-prefix shape.
 
-use crate::drive::document::ranked_index_tree_type::property_name_tree_type_and_ranked_axes;
+use crate::drive::document::ranked_index_tree_type::property_name_tree_type_and_ranked_axes_for_level;
 use crate::error::Error;
 use crate::util::object_size_info::DriveKeyInfo;
 use dpp::data_contract::document_type::{
@@ -116,15 +116,27 @@ pub(crate) struct IndexLevelTreeTypes {
 pub(crate) fn index_level_tree_types_with_continuation_demotion(
     sub_level: &IndexLevel,
 ) -> Result<IndexLevelTreeTypes, Error> {
-    let info = sub_level.has_index_with_type();
-    let (property_name_tree_type, ranked_axes) = property_name_tree_type_and_ranked_axes(info)?;
-    let value_tree_type = derive_value_tree_type(
-        info.map(|i| i.countable.is_countable()).unwrap_or(false),
-        info.map(|i| i.range_countable).unwrap_or(false),
-        info.map(|i| i.summable.is_some()).unwrap_or(false),
-        info.map(|i| i.range_summable).unwrap_or(false),
-        !sub_level.sub_levels().is_empty(),
-    );
+    let (property_name_tree_type, ranked_axes) =
+        property_name_tree_type_and_ranked_axes_for_level(sub_level)?;
+    // A prefix-ranking chain level (the `rankedCountable: { at }` grouping
+    // level or a count-propagating level below it) counts its single
+    // continuation: the value tree's count IS the subtree total the
+    // grouping secondary ranks by, so the continuation is inserted
+    // contributing rather than zero-wrapped (see the walkers). No index
+    // terminates at such a level (the resolver above fails closed on one),
+    // so the terminator-flag derivation below never applies to it.
+    let value_tree_type = if sub_level.ranked_count_grouping() || sub_level.count_propagating() {
+        TreeType::CountTree
+    } else {
+        let info = sub_level.has_index_with_type();
+        derive_value_tree_type(
+            info.map(|i| i.countable.is_countable()).unwrap_or(false),
+            info.map(|i| i.range_countable).unwrap_or(false),
+            info.map(|i| i.summable.is_some()).unwrap_or(false),
+            info.map(|i| i.range_summable).unwrap_or(false),
+            !sub_level.sub_levels().is_empty(),
+        )
+    };
     Ok(IndexLevelTreeTypes {
         property_name_tree_type,
         ranked_axes,
@@ -290,6 +302,7 @@ fn derive_value_tree_type(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::drive::document::ranked_index_tree_type::property_name_tree_type_and_ranked_axes;
     use crate::fees::op::LowLevelDriveOperation;
     use dpp::data_contract::document_type::{IndexCountability, IndexLevelTypeInfo, IndexType};
 
@@ -419,6 +432,150 @@ mod tests {
             assert_eq!(derived_property, expected_property);
             assert_eq!(derived_value, expected_value);
         }
+    }
+
+    /// A `rankedCountable: { at }` index resolves its chain levels to the
+    /// documented tree types: the grouping level to the Count-axis indexed
+    /// tree over `CountTree` value trees, the propagating level to a
+    /// `CountTree` pair, and the terminal level to its unchanged
+    /// terminator-flag derivation.
+    #[test]
+    fn prefix_ranked_chain_levels_resolve_to_the_chain_tree_types() {
+        use dpp::data_contract::document_type::{Index, IndexProperty};
+        use dpp::version::PlatformVersion;
+        use grovedb::element::IndexAxis;
+
+        let prefix_ranked = Index {
+            name: "byHashtagRegionPost".to_string(),
+            properties: ["hashtag", "region", "postId"]
+                .into_iter()
+                .map(|name| IndexProperty {
+                    name: name.to_string(),
+                    ascending: true,
+                })
+                .collect(),
+            unique: false,
+            null_searchable: true,
+            contested_index: None,
+            countable: IndexCountability::Countable,
+            range_countable: true,
+            summable: None,
+            range_summable: false,
+            ranked_countable: false,
+            ranked_countable_at: Some("hashtag".to_string()),
+            ranked_summable: false,
+            ranked_averageable: false,
+            time_range: None,
+            terminal: None,
+            preallocated: false,
+            skip_if_absent: false,
+        };
+
+        let index_structure =
+            IndexLevel::try_from_indices([&prefix_ranked], "like", PlatformVersion::latest())
+                .expect("index level must build");
+
+        let hashtag_level = index_structure
+            .sub_levels()
+            .get("hashtag")
+            .expect("the grouping level exists");
+        let hashtag_types = index_level_tree_types_with_continuation_demotion(hashtag_level)
+            .expect("grouping resolution must succeed");
+        assert_eq!(
+            hashtag_types,
+            IndexLevelTreeTypes {
+                property_name_tree_type: TreeType::ProvableCountIndexedTree,
+                ranked_axes: vec![IndexAxis::Count],
+                value_tree_type: TreeType::CountTree,
+            }
+        );
+
+        let region_level = hashtag_level
+            .sub_levels()
+            .get("region")
+            .expect("the propagating level exists");
+        let region_types = index_level_tree_types_with_continuation_demotion(region_level)
+            .expect("propagating resolution must succeed");
+        assert_eq!(
+            region_types,
+            IndexLevelTreeTypes {
+                property_name_tree_type: TreeType::CountTree,
+                ranked_axes: Vec::new(),
+                value_tree_type: TreeType::CountTree,
+            }
+        );
+
+        let post_level = region_level
+            .sub_levels()
+            .get("postId")
+            .expect("the terminal level exists");
+        let post_types = index_level_tree_types_with_continuation_demotion(post_level)
+            .expect("terminal resolution must succeed");
+        assert_eq!(
+            post_types,
+            IndexLevelTreeTypes {
+                property_name_tree_type: TreeType::ProvableCountTree,
+                ranked_axes: Vec::new(),
+                value_tree_type: TreeType::CountTree,
+            },
+            "the terminal keeps its rangeCountable derivation — the boolean ranked axis is off"
+        );
+    }
+
+    /// A grouping level that also carries a terminator stamp has two
+    /// contradictory layouts; the resolver must fail closed instead of
+    /// picking one. Reachable only through an index set the contract-level
+    /// structural validation rejects (`try_from_indices` alone does not run
+    /// it), which is exactly why the resolver keeps its own guard.
+    #[test]
+    fn a_grouping_level_with_a_terminator_fails_closed() {
+        use dpp::data_contract::document_type::{Index, IndexProperty};
+        use dpp::version::PlatformVersion;
+
+        let base = |name: &str, properties: &[&str]| Index {
+            name: name.to_string(),
+            properties: properties
+                .iter()
+                .map(|property| IndexProperty {
+                    name: property.to_string(),
+                    ascending: true,
+                })
+                .collect(),
+            unique: false,
+            null_searchable: true,
+            contested_index: None,
+            countable: IndexCountability::Countable,
+            range_countable: true,
+            summable: None,
+            range_summable: false,
+            ranked_countable: false,
+            ranked_countable_at: None,
+            ranked_summable: false,
+            ranked_averageable: false,
+            time_range: None,
+            terminal: None,
+            preallocated: false,
+            skip_if_absent: false,
+        };
+        let mut prefix_ranked = base("byHashtagPost", &["hashtag", "postId"]);
+        prefix_ranked.ranked_countable_at = Some("hashtag".to_string());
+        let terminating = base("byHashtag", &["hashtag"]);
+
+        let index_structure = IndexLevel::try_from_indices(
+            [&prefix_ranked, &terminating],
+            "like",
+            PlatformVersion::latest(),
+        )
+        .expect("index level must build — the overlap rule runs at contract parse, not here");
+
+        let hashtag_level = index_structure
+            .sub_levels()
+            .get("hashtag")
+            .expect("the shared level exists");
+        assert!(
+            index_level_tree_types_with_continuation_demotion(hashtag_level).is_err(),
+            "a grouping level with a terminator stamp must fail closed"
+        );
     }
 
     /// The two v14 fixes on one level: a ranked index terminating at

--- a/packages/rs-drive/src/drive/document/insert/add_indices_for_index_level_for_contract_operations/v2/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_indices_for_index_level_for_contract_operations/v2/mod.rs
@@ -131,6 +131,15 @@ impl Drive {
         // sum, or both) — decides whether continuation children go
         // through the zero-contribution helper or the plain one.
         let parent_value_tree_aggregates = !matches!(parent_value_tree_type, TreeType::NormalTree);
+        // A prefix-ranking chain level (`rankedCountable: { at }`) inverts
+        // that choice: its value trees count exactly their single
+        // continuation — the subtree total the grouping secondary ranks by
+        // — so the continuation is inserted unwrapped and CONTRIBUTES its
+        // count instead of being zero-wrapped. Contract validation
+        // guarantees no other continuation or terminator shares such a
+        // level, so nothing else can pollute the total.
+        let continuations_contribute =
+            index_level.ranked_count_grouping() || index_level.count_propagating();
 
         if let Some(estimated_costs_only_with_layer_info) = estimated_costs_only_with_layer_info {
             // On this level we will have a 0 and all the top index paths
@@ -199,7 +208,7 @@ impl Drive {
                 .add_path_info(sub_level_index_path_info.clone());
 
             // here we are inserting an empty tree that will have a subtree of all other index properties
-            if parent_value_tree_aggregates {
+            if parent_value_tree_aggregates && !continuations_contribute {
                 // A ranked terminal level reaching this branch is
                 // rejected inside the helper (it passes `ranked_axes`
                 // straight through): an indexed tree can neither be

--- a/packages/rs-drive/src/drive/document/insert/add_preallocated_index_tree_operations/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_preallocated_index_tree_operations/mod.rs
@@ -258,6 +258,12 @@ impl Drive {
         // property-name tree needs the zero-contribution wrapper — exactly
         // the `parent_value_tree_type` the recursive walker threads through.
         let mut parent_value_tree_type = TreeType::NormalTree;
+        // Whether the level above is a prefix-ranking chain level
+        // (`rankedCountable: { at }` grouping or count-propagating): its
+        // value trees count exactly their single continuation, so the
+        // continuation is inserted unwrapped and contributes — the same
+        // inversion the entry-insert walkers apply.
+        let mut parent_counts_continuations = false;
 
         for (property_name, sub_level, source_property, key_source, value_key) in resolved_levels {
             let tree_types = index_level_tree_types_with_continuation_demotion(sub_level)?;
@@ -296,7 +302,9 @@ impl Drive {
                     };
                     let path_key_info =
                         KeyRef(property_name.as_bytes()).add_path_info(path_info.clone());
-                    if !matches!(parent_value_tree_type, TreeType::NormalTree) {
+                    if !matches!(parent_value_tree_type, TreeType::NormalTree)
+                        && !parent_counts_continuations
+                    {
                         self.batch_insert_empty_tree_contributing_zero_to_aggregating_parent_if_not_exists(
                             path_key_info,
                             parent_value_tree_type,
@@ -406,6 +414,8 @@ impl Drive {
 
             index_path_info = Some(path_info);
             parent_value_tree_type = value_tree_type;
+            parent_counts_continuations =
+                sub_level.ranked_count_grouping() || sub_level.count_propagating();
         }
 
         let mut path_info = index_path_info.ok_or(Error::Drive(

--- a/packages/rs-drive/src/drive/document/ranked_index_tree_type.rs
+++ b/packages/rs-drive/src/drive/document/ranked_index_tree_type.rs
@@ -46,7 +46,7 @@
 
 use crate::error::drive::DriveError;
 use crate::error::Error;
-use dpp::data_contract::document_type::IndexLevelTypeInfo;
+use dpp::data_contract::document_type::{IndexLevel, IndexLevelTypeInfo};
 use grovedb::element::IndexAxis;
 use grovedb::TreeType;
 
@@ -147,6 +147,41 @@ pub(crate) fn property_name_tree_type_and_ranked_axes(
         ranked_property_name_tree_type(base, &ranked_axes)?,
         ranked_axes,
     ))
+}
+
+/// Level-aware form of [`property_name_tree_type_and_ranked_axes`], covering
+/// the prefix-level Count ranking (`rankedCountable: { at }`, meta-schema v3):
+///
+/// - A **grouping** level (`ranked_count_grouping`) hosts the ranking itself:
+///   its property-name tree is the Count-axis indexed tree, whose secondary
+///   ranks the property's values by each value tree's whole-subtree count.
+/// - A **propagating** level (`count_propagating`, strictly between the
+///   grouping level and its index's terminal) gets a `CountTree` property-name
+///   tree so the subtree counts flow through it toward the grouping secondary.
+/// - Every other level resolves through the terminator-info path unchanged.
+///
+/// rs-dpp's structural validation guarantees no index terminates at a
+/// grouping or propagating level; both fail closed here on a stamped
+/// terminator rather than pick one of two contradictory layouts.
+pub(crate) fn property_name_tree_type_and_ranked_axes_for_level(
+    level: &IndexLevel,
+) -> Result<(TreeType, Vec<IndexAxis>), Error> {
+    if level.ranked_count_grouping() || level.count_propagating() {
+        if level.has_index_with_type().is_some() {
+            return Err(Error::Drive(DriveError::CorruptedContractIndexes(
+                "a prefix-ranking (grouping or count-propagating) index level cannot also \
+                 terminate an index; contract validation rejects every shape that shares \
+                 such a level"
+                    .to_string(),
+            )));
+        }
+        return if level.ranked_count_grouping() {
+            Ok((TreeType::ProvableCountIndexedTree, vec![IndexAxis::Count]))
+        } else {
+            Ok((TreeType::CountTree, Vec::new()))
+        };
+    }
+    property_name_tree_type_and_ranked_axes(level.has_index_with_type())
 }
 
 /// The non-indexed tree type an indexed tree mirrors, or `tree_type` itself

--- a/packages/rs-drive/src/drive/document/update/internal/update_document_for_contract_operations/v1/mod.rs
+++ b/packages/rs-drive/src/drive/document/update/internal/update_document_for_contract_operations/v1/mod.rs
@@ -444,6 +444,13 @@ impl Drive {
             let top_level_tree_types =
                 index_level_tree_types_with_continuation_demotion(current_index_level)?;
             let mut parent_value_tree_type = top_level_tree_types.value_tree_type;
+            // A prefix-ranking chain level (`rankedCountable: { at }`)
+            // inverts the zero-contribution choice below: its value trees
+            // count exactly their single continuation, so the continuation
+            // is inserted unwrapped and contributes its subtree count —
+            // matching the v2 insert walker's dispatch.
+            let mut parent_counts_continuations = current_index_level.ranked_count_grouping()
+                || current_index_level.count_propagating();
 
             if change_occurred_on_index {
                 // here we are inserting an empty tree that will have a subtree of all other index properties
@@ -585,7 +592,9 @@ impl Drive {
                         // `INDEXED_INNER_UNWRAPPABLE` in `fees::op`).
                         let property_name_tree_type = sub_level_tree_types.property_name_tree_type;
                         let ranked_axes = sub_level_tree_types.ranked_axes.as_slice();
-                        let inserted = if matches!(parent_value_tree_type, TreeType::NormalTree) {
+                        let inserted = if matches!(parent_value_tree_type, TreeType::NormalTree)
+                            || parent_counts_continuations
+                        {
                             self.batch_insert_empty_index_tree_if_not_exists(
                                 PathKeyInfo::PathKeyRef::<0>((
                                     index_path.clone(),
@@ -671,6 +680,8 @@ impl Drive {
                 // The next-deeper continuation (if any) hangs inside
                 // this level's value tree.
                 parent_value_tree_type = sub_level_tree_types.value_tree_type;
+                parent_counts_continuations = current_index_level.ranked_count_grouping()
+                    || current_index_level.count_propagating();
 
                 // we push the actual value of the index path, both for the new and the old
                 index_path.push(document_index_field);

--- a/packages/rs-drive/tests/supporting_files/contract/trending/trending-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/trending/trending-contract.json
@@ -1,0 +1,198 @@
+{
+  "$formatVersion": "0",
+  "id": "AY6xWncZUFv2GCrS5seqKthUfbW9yYyUXtF8diSuHQ4h",
+  "ownerId": "AtirhSVpAWF7dEt6dLAmesC4Sr1MsJ9bFC1nLAoNnq2S",
+  "version": 1,
+  "documentSchemas": {
+    "like": {
+      "type": "object",
+      "documentsMutable": true,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byHashtagPost",
+          "properties": [
+            {
+              "hashtag": "asc"
+            },
+            {
+              "postId": "asc"
+            }
+          ],
+          "countable": "countable",
+          "rangeCountable": true,
+          "rankedCountable": {
+            "at": "hashtag"
+          }
+        }
+      ],
+      "properties": {
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        },
+        "postId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 1
+        }
+      },
+      "required": [
+        "hashtag",
+        "postId"
+      ],
+      "additionalProperties": false
+    },
+    "deep": {
+      "type": "object",
+      "documentsMutable": true,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byHashtagRegionPost",
+          "properties": [
+            {
+              "hashtag": "asc"
+            },
+            {
+              "region": "asc"
+            },
+            {
+              "postId": "asc"
+            }
+          ],
+          "countable": "countable",
+          "rangeCountable": true,
+          "rankedCountable": {
+            "at": "hashtag"
+          }
+        }
+      ],
+      "properties": {
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        },
+        "region": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 1
+        },
+        "postId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 2
+        }
+      },
+      "required": [
+        "hashtag",
+        "region",
+        "postId"
+      ],
+      "additionalProperties": false
+    },
+    "mid": {
+      "type": "object",
+      "documentsMutable": true,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byRegionHashtagPost",
+          "properties": [
+            {
+              "region": "asc"
+            },
+            {
+              "hashtag": "asc"
+            },
+            {
+              "postId": "asc"
+            }
+          ],
+          "countable": "countable",
+          "rangeCountable": true,
+          "rankedCountable": {
+            "at": "hashtag"
+          }
+        }
+      ],
+      "properties": {
+        "region": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 0
+        },
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 1
+        },
+        "postId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 2
+        }
+      },
+      "required": [
+        "region",
+        "hashtag",
+        "postId"
+      ],
+      "additionalProperties": false
+    },
+    "ilike": {
+      "type": "object",
+      "indexOnly": true,
+      "documentsMutable": false,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byHashtagPost",
+          "properties": [
+            {
+              "hashtag": "asc"
+            },
+            {
+              "postId": "asc"
+            }
+          ],
+          "terminal": "$ownerId",
+          "countable": "countable",
+          "rangeCountable": true,
+          "rankedCountable": {
+            "at": "hashtag"
+          }
+        }
+      ],
+      "properties": {
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        },
+        "postId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 1
+        }
+      },
+      "required": [
+        "hashtag",
+        "postId"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/rs-drive/tests/supporting_files/contract/trending/trending-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/trending/trending-contract.json
@@ -150,6 +150,51 @@
       ],
       "additionalProperties": false
     },
+    "both": {
+      "type": "object",
+      "documentsMutable": true,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byHashtagPost",
+          "properties": [
+            {
+              "hashtag": "asc"
+            },
+            {
+              "postId": "asc"
+            }
+          ],
+          "countable": "countable",
+          "rangeCountable": true,
+          "rankedCountable": {
+            "at": [
+              "hashtag",
+              "postId"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        },
+        "postId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 1
+        }
+      },
+      "required": [
+        "hashtag",
+        "postId"
+      ],
+      "additionalProperties": false
+    },
     "ilike": {
       "type": "object",
       "indexOnly": true,

--- a/packages/rs-drive/tests/supporting_files/contract/trending/trending-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/trending/trending-contract.json
@@ -238,6 +238,62 @@
         "postId"
       ],
       "additionalProperties": false
+    },
+    "chain": {
+      "type": "object",
+      "documentsMutable": true,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byTagRegionPost",
+          "properties": [
+            {
+              "tag": "asc"
+            },
+            {
+              "region": "asc"
+            },
+            {
+              "postId": "asc"
+            }
+          ],
+          "countable": "countable",
+          "rangeCountable": true,
+          "rankedCountable": {
+            "at": [
+              "tag",
+              "region",
+              "postId"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "tag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        },
+        "region": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 1
+        },
+        "postId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 2
+        }
+      },
+      "required": [
+        "tag",
+        "region",
+        "postId"
+      ],
+      "additionalProperties": false
     }
   }
 }

--- a/packages/rs-drive/tests/supporting_files/contract/trending/trending-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/trending/trending-contract.json
@@ -294,6 +294,97 @@
         "postId"
       ],
       "additionalProperties": false
+    },
+    "post": {
+      "type": "object",
+      "documentsMutable": false,
+      "canBeDeleted": false,
+      "indices": [
+        {
+          "name": "byHashtag",
+          "properties": [
+            {
+              "hashtag": "asc"
+            }
+          ]
+        }
+      ],
+      "properties": {
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        },
+        "message": {
+          "type": "string",
+          "maxLength": 280,
+          "position": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "plike": {
+      "type": "object",
+      "indexOnly": true,
+      "documentsMutable": false,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byHashtagPost",
+          "properties": [
+            {
+              "hashtag": "asc"
+            },
+            {
+              "postId": "asc"
+            }
+          ],
+          "terminal": "$ownerId",
+          "countable": "countable",
+          "rangeCountable": true,
+          "rankedCountable": {
+            "at": "hashtag"
+          },
+          "preallocated": true,
+          "skipIfAbsent": true
+        },
+        {
+          "name": "byPost",
+          "properties": [
+            {
+              "postId": "asc"
+            }
+          ]
+        }
+      ],
+      "properties": {
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        },
+        "postId": {
+          "type": "array",
+          "byteArray": true,
+          "minItems": 32,
+          "maxItems": 32,
+          "contentMediaType": "application/x.dash.dpp.identifier",
+          "refersTo": {
+            "type": "permanentDocument",
+            "documentType": "post",
+            "propertyAgreement": {
+              "hashtag": "hashtag"
+            }
+          },
+          "position": 1
+        }
+      },
+      "required": [
+        "postId"
+      ],
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Second PR of the #4529 build-out (stacked on #4531, the dpp grammar). With the grammar in place, this PR makes Drive actually lay out and maintain the prefix-level ranking: a `rankedCountable: { "at": "hashtag" }` index on `[hashtag, postId]` gets its Count-axis indexed tree at the **hashtag** level, ranking hashtags by whole-subtree like count.

## What was done?

**The chain.** The `at` level's property-name tree becomes a `ProvableCountIndexedTree` over `CountTree` value trees; levels strictly between `at` and the terminal become `CountTree` pairs; the terminal keeps its `rangeCountable` derivation. Each value tree's count is exactly its single continuation's subtree total, so grovedb's existing deep-write propagation re-keys the group's secondary entry on every insert/update/delete — Drive emits **no explicit ranking maintenance**, and no grovedb changes are needed.

**The one walker inversion.** Continuations inside a chain level's value trees are inserted **contributing** (unwrapped) instead of zero-wrapped — the value tree's count IS the subtree total. Applied to the insert v2 walker, the update v1 walker and the preallocated path; the delete walkers follow automatically through the shared level-aware derivation, so dry-run and applied fees stay in lockstep.

**Registration.** Contract insert/update resolve top-level trees through a new level-aware resolver (`property_name_tree_type_and_ranked_axes_for_level`), so an index ranked at its *first* property gets its PCIT at registration; deeper groupings materialize lazily per prefix like every dynamic index tree. The contract-insert estimation tally accounts the grouping tree. The resolver fails closed on a grouping/propagating level that also carries a terminator stamp (a shape only unvalidated index sets can produce — contract validation rejects it upstream).

## How Has This Been Tested?

New e2e suite (`prefix_ranked_index_e2e_tests`) against a new `trending` fixture with four shapes — `[hashtag, postId]` at `hashtag`, a three-property chain with a count-propagating middle level, a middle-level `at` (lazy per-prefix grouping trees), and the indexOnly entries-as-rows shape from the issue:

- registration lays down the PCIT exactly at grouping first levels;
- documents inserted through the real document paths rank hashtags by totals across posts (top-k and bottom-k), with every chain level's tree type pinned;
- updating a document's hashtag moves its contribution between groups; deletes decrement; draining a group drops it from the axis and prunes its trees;
- indexOnly entries keep per-(hashtag, post, owner) structural uniqueness and delete-by-values symmetry;
- dry-run inserts traverse the estimation path and price the writes;
- grovedb's integrity sweep (including primary↔secondary content consistency) is clean after every test.

Plus derivation unit tests (chain tree types level by level; the fail-closed guard). Full regression: all contract-insert e2e suites and the drive document module (289 tests) pass; `cargo check --all-targets` and clippy clean.

## Breaking Changes

None — every layout decision keys off the new `IndexLevel` stamps, which no existing contract can produce; all existing shapes derive bit-identically.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for prefix-level ranked count indexes, including compound and multi-level index configurations.
  * Ranking now reflects document counts across nested property groups and updates correctly after inserts, edits, and deletions.
  * Added support for index-only ranked indexes and combined ranking configurations.

* **Bug Fixes**
  * Corrected index tree construction and count propagation for ranked index levels.
  * Preserved existing behavior for legacy contract schemas.

* **Tests**
  * Added comprehensive end-to-end coverage for prefix-ranked indexes and related update, delete, and integrity scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->