### PR TITLE
feat(drive): serve ranked and having-range queries at a prefix ranking level

### DIFF
--- a/packages/rs-drive/src/query/drive_document_having_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_having_query/tests.rs
@@ -2354,3 +2354,159 @@ mod pinned_prefix {
         assert_proof_round_trips(&drive, &contract, &pins, &[], &entries);
     }
 }
+
+mod prefix_level {
+    //! `SELECT COUNT(*) … GROUP BY hashtag HAVING COUNT(*) >= n` over a
+    //! prefix-level ranking (`rankedCountable: { "at": "hashtag" }`):
+    //! the having surface reads the same hashtag-level secondary the
+    //! ranked surface walks, through the same shared resolution
+    //! (`find_ranked_index_for_axis` / `encode_prefix_branches` /
+    //! the ranked-level path builder), so a bounded band over subtree
+    //! totals lands on the `at` level. The rank-walk sibling lives in
+    //! `drive_document_ranked_query::tests::prefix_level`.
+
+    use super::super::drive_dispatcher::{DocumentHavingRequest, DocumentHavingResponse};
+    use super::*;
+    use crate::drive::Drive;
+    use crate::query::drive_document_ranked_query::{RankedEntry, RankedEntryValue};
+    use crate::util::object_size_info::DocumentInfo::DocumentRefInfo;
+    use crate::util::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
+    use crate::util::storage_flags::StorageFlags;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::data_contract::accessors::v0::DataContractV0Getters;
+    use dpp::data_contract::document_type::random_document::CreateRandomDocument;
+    use dpp::document::{Document, DocumentV0Setters};
+    use dpp::prelude::DataContract;
+    use dpp::tests::json_document::json_document_to_contract;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    fn platform_version() -> &'static PlatformVersion {
+        PlatformVersion::latest()
+    }
+
+    fn setup_trending_likes() -> (Drive, DataContract) {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let pv = platform_version();
+        let contract = json_document_to_contract(
+            "tests/supporting_files/contract/trending/trending-contract.json",
+            false,
+            pv,
+        )
+        .expect("expected to parse the trending contract");
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                pv,
+            )
+            .expect("expected to apply the trending contract");
+        (drive, contract)
+    }
+
+    fn insert_likes(drive: &Drive, contract: &DataContract, rows: &[(&str, &str)]) {
+        let pv = platform_version();
+        let document_type = contract
+            .document_type_for_name("like")
+            .expect("like doctype exists");
+        for (i, (hashtag, post)) in rows.iter().enumerate() {
+            let mut doc: Document = document_type
+                .random_document(Some(8000 + i as u64), pv)
+                .expect("random document");
+            let mut props = BTreeMap::new();
+            props.insert("hashtag".to_string(), Value::Text(hashtag.to_string()));
+            props.insert("postId".to_string(), Value::Text(post.to_string()));
+            doc.set_properties(props);
+            drive
+                .add_document_for_contract(
+                    DocumentAndContractInfo {
+                        owned_document_info: OwnedDocumentInfo {
+                            document_info: DocumentRefInfo((&doc, None)),
+                            owner_id: None,
+                        },
+                        contract,
+                        document_type,
+                    },
+                    false,
+                    BlockInfo::default(),
+                    true,
+                    None,
+                    pv,
+                    None,
+                )
+                .expect("expected to insert a like");
+        }
+    }
+
+    /// Hashtags whose subtree totals fall in the `COUNT(*) >= n` band,
+    /// ascending by count (the having walk's default direction).
+    #[test]
+    fn count_band_over_subtree_totals_lands_on_the_at_level() {
+        let (drive, contract) = setup_trending_likes();
+        insert_likes(
+            &drive,
+            &contract,
+            &[
+                ("alpha", "p1"),
+                ("alpha", "p1"),
+                ("alpha", "p2"),
+                ("beta", "p1"),
+                ("beta", "p3"),
+                ("gamma", "p2"),
+            ],
+        );
+
+        let group_by = vec!["hashtag".to_string()];
+        let having = vec![clause(
+            HavingAggregateFunction::Count,
+            "",
+            HavingOperator::GreaterThanOrEquals,
+            Value::U64(2),
+        )];
+        let response = drive
+            .execute_document_having_request(
+                DocumentHavingRequest {
+                    contract: &contract,
+                    document_type: contract
+                        .document_type_for_name("like")
+                        .expect("like doctype exists"),
+                    group_by: &group_by,
+                    select: SelectProjection::count_star(),
+                    having: &having,
+                    order_by: &[],
+                    where_clauses: &[],
+                    resolved_time_ranges: &[],
+                    limit: Some(10),
+                    offset: None,
+                    has_start_at: false,
+                    prove: false,
+                },
+                None,
+                platform_version(),
+            )
+            .expect("the having read must succeed");
+        let DocumentHavingResponse::Entries(entries) = response else {
+            panic!("expected entries, got a proof");
+        };
+        assert_eq!(
+            entries,
+            vec![
+                RankedEntry {
+                    key: b"beta".to_vec(),
+                    value: RankedEntryValue::Count(2),
+                    in_key: None,
+                },
+                RankedEntry {
+                    key: b"alpha".to_vec(),
+                    value: RankedEntryValue::Count(3),
+                    in_key: None,
+                },
+            ],
+            "only hashtags with subtree totals in the band qualify, ascending by count"
+        );
+    }
+}

--- a/packages/rs-drive/src/query/drive_document_ranked_query/index_picker.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/index_picker.rs
@@ -21,13 +21,15 @@ use std::collections::BTreeMap;
 ///
 /// An index qualifies when **all** of:
 ///
-/// - its **ranked-level** property for `axis` is `group_by_property`,
+/// - one of its **ranked levels** for `axis` is `group_by_property`,
 ///   with exactly one pin per property before it. For the boolean axes
 ///   the ranked level is the index's **last** property; a prefix-level
-///   `rankedCountable: { at }` hosts the Count axis at the `at`
-///   property instead, ranking its values by whole-subtree count —
-///   there the properties *after* `at` never appear in the request at
-///   all (they are interior to the subtrees being counted);
+///   `rankedCountable: { at }` hosts a Count secondary at the `at`
+///   property as well, ranking its values by whole-subtree count — an
+///   index may declare both, and the (group property, pin count) pair
+///   singles out which level a request addresses. At a prefix level the
+///   properties *after* `at` never appear in the request at all (they
+///   are interior to the subtrees being counted);
 /// - every property **before** the ranked level is pinned: each appears
 ///   (by name) among `equality_pin_fields`. Lengths matching plus the
 ///   pins being distinct (enforced upstream by
@@ -87,39 +89,54 @@ pub fn find_ranked_index_for_axis<'b>(
         if index.time_range.is_some() {
             return false;
         }
-        // The position of the property whose level hosts this axis's
-        // secondary — `None` when the index does not declare the axis (or
-        // aggregates a different field than requested).
-        let ranked_position = match axis {
-            RankedAxis::Count => match index.ranked_countable_at.as_deref() {
-                Some(at) => index.properties.iter().position(|p| p.name == at),
-                None if index.ranked_countable => index.properties.len().checked_sub(1),
-                None => None,
-            },
-            RankedAxis::Sum => (index.ranked_summable
-                && index.summable.as_deref() == Some(aggregate_field))
-            .then(|| index.properties.len().checked_sub(1))
-            .flatten(),
-            RankedAxis::Avg => (index.ranked_averageable
-                && index.summable.as_deref() == Some(aggregate_field))
-            .then(|| index.properties.len().checked_sub(1))
-            .flatten(),
+        // The positions whose levels host this axis's secondaries — up to
+        // TWO for the Count axis, since an index may declare the prefix
+        // (`at`) ranking and the terminal one together; empty when the
+        // index does not declare the axis (or aggregates a different
+        // field than requested).
+        let candidate_positions: [Option<usize>; 2] = match axis {
+            RankedAxis::Count => [
+                index
+                    .ranked_countable_at
+                    .as_deref()
+                    .and_then(|at| index.properties.iter().position(|p| p.name == at)),
+                index
+                    .ranked_countable
+                    .then(|| index.properties.len().checked_sub(1))
+                    .flatten(),
+            ],
+            RankedAxis::Sum => [
+                None,
+                (index.ranked_summable && index.summable.as_deref() == Some(aggregate_field))
+                    .then(|| index.properties.len().checked_sub(1))
+                    .flatten(),
+            ],
+            RankedAxis::Avg => [
+                None,
+                (index.ranked_averageable && index.summable.as_deref() == Some(aggregate_field))
+                    .then(|| index.properties.len().checked_sub(1))
+                    .flatten(),
+            ],
         };
-        let Some(ranked_position) = ranked_position else {
-            return false;
-        };
-        let Some(ranked_property) = index.properties.get(ranked_position) else {
-            return false;
-        };
-        // The ranked-level property is the grouping property; every
-        // property before it is pinned exactly once (length equality +
-        // distinct pins ⇒ set equality).
-        let leading = &index.properties[..ranked_position];
-        ranked_property.name == group_by_property
-            && leading.len() == equality_pin_fields.len()
-            && leading
-                .iter()
-                .all(|property| equality_pin_fields.iter().any(|f| f == &property.name))
+        // A candidate matches when its property is the grouping property
+        // and every property before it is pinned exactly once (length
+        // equality + distinct pins ⇒ set equality). At most one candidate
+        // can match a given request: the two levels are distinct
+        // positions, and the pin count singles one out.
+        candidate_positions
+            .into_iter()
+            .flatten()
+            .any(|ranked_position| {
+                let Some(ranked_property) = index.properties.get(ranked_position) else {
+                    return false;
+                };
+                let leading = &index.properties[..ranked_position];
+                ranked_property.name == group_by_property
+                    && leading.len() == equality_pin_fields.len()
+                    && leading
+                        .iter()
+                        .all(|property| equality_pin_fields.iter().any(|f| f == &property.name))
+            })
     })
 }
 
@@ -272,11 +289,11 @@ pub fn encode_prefix_branches(
     prefix_pins: &[PrefixPin],
     platform_version: &PlatformVersion,
 ) -> Result<Vec<Vec<Vec<u8>>>, Error> {
-    // The pinnable properties end at the index's ranked level — the last
-    // property for the boolean axes, the `at` property for a prefix-level
-    // ranking (whose deeper properties are interior to the counted
-    // subtrees and never pinned).
-    let (leading, _) = super::path::ranked_level_split(index)?;
+    // The pinnable properties end at the ranked level the pin count
+    // addresses (an index may host secondaries at both its `at` property
+    // and its terminal — the pin count singles one out; properties past
+    // it are interior to the counted subtrees and never pinned).
+    let (leading, _) = super::path::ranked_level_split(index, prefix_pins.len())?;
     // Enforced BEFORE any encoding: the ceiling bounds every downstream
     // cost (encode, sort, clone, walk, proof size), so an oversized pin
     // must not buy that work first. The post-product branch count check

--- a/packages/rs-drive/src/query/drive_document_ranked_query/index_picker.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/index_picker.rs
@@ -89,54 +89,52 @@ pub fn find_ranked_index_for_axis<'b>(
         if index.time_range.is_some() {
             return false;
         }
-        // The positions whose levels host this axis's secondaries — up to
-        // TWO for the Count axis, since an index may declare the prefix
-        // (`at`) ranking and the terminal one together; empty when the
-        // index does not declare the axis (or aggregates a different
-        // field than requested).
-        let candidate_positions: [Option<usize>; 2] = match axis {
-            RankedAxis::Count => [
-                index
-                    .ranked_countable_at
-                    .as_deref()
-                    .and_then(|at| index.properties.iter().position(|p| p.name == at)),
-                index
-                    .ranked_countable
-                    .then(|| index.properties.len().checked_sub(1))
-                    .flatten(),
-            ],
-            RankedAxis::Sum => [
-                None,
-                (index.ranked_summable && index.summable.as_deref() == Some(aggregate_field))
-                    .then(|| index.properties.len().checked_sub(1))
-                    .flatten(),
-            ],
-            RankedAxis::Avg => [
-                None,
-                (index.ranked_averageable && index.summable.as_deref() == Some(aggregate_field))
-                    .then(|| index.properties.len().checked_sub(1))
-                    .flatten(),
-            ],
+        // The positions whose levels host this axis's secondaries — for
+        // the Count axis every `at` level plus the terminal when the
+        // boolean is on (any subset of an index's levels may rank); empty
+        // when the index does not declare the axis (or aggregates a
+        // different field than requested).
+        let candidate_positions: Vec<usize> = match axis {
+            RankedAxis::Count => index
+                .ranked_countable_at
+                .iter()
+                .filter_map(|at| index.properties.iter().position(|p| &p.name == at))
+                .chain(
+                    index
+                        .ranked_countable
+                        .then(|| index.properties.len().checked_sub(1))
+                        .flatten(),
+                )
+                .collect(),
+            RankedAxis::Sum => (index.ranked_summable
+                && index.summable.as_deref() == Some(aggregate_field))
+            .then(|| index.properties.len().checked_sub(1))
+            .flatten()
+            .into_iter()
+            .collect(),
+            RankedAxis::Avg => (index.ranked_averageable
+                && index.summable.as_deref() == Some(aggregate_field))
+            .then(|| index.properties.len().checked_sub(1))
+            .flatten()
+            .into_iter()
+            .collect(),
         };
         // A candidate matches when its property is the grouping property
         // and every property before it is pinned exactly once (length
         // equality + distinct pins ⇒ set equality). At most one candidate
         // can match a given request: the two levels are distinct
         // positions, and the pin count singles one out.
-        candidate_positions
-            .into_iter()
-            .flatten()
-            .any(|ranked_position| {
-                let Some(ranked_property) = index.properties.get(ranked_position) else {
-                    return false;
-                };
-                let leading = &index.properties[..ranked_position];
-                ranked_property.name == group_by_property
-                    && leading.len() == equality_pin_fields.len()
-                    && leading
-                        .iter()
-                        .all(|property| equality_pin_fields.iter().any(|f| f == &property.name))
-            })
+        candidate_positions.into_iter().any(|ranked_position| {
+            let Some(ranked_property) = index.properties.get(ranked_position) else {
+                return false;
+            };
+            let leading = &index.properties[..ranked_position];
+            ranked_property.name == group_by_property
+                && leading.len() == equality_pin_fields.len()
+                && leading
+                    .iter()
+                    .all(|property| equality_pin_fields.iter().any(|f| f == &property.name))
+        })
     })
 }
 

--- a/packages/rs-drive/src/query/drive_document_ranked_query/index_picker.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/index_picker.rs
@@ -21,12 +21,16 @@ use std::collections::BTreeMap;
 ///
 /// An index qualifies when **all** of:
 ///
-/// - it has exactly one more property than there are pins, and its
-///   **last** property is `group_by_property` — the ranked secondary's
-///   group keys are the values of an index's last property;
-/// - every **leading** property is pinned: each appears (by name) among
-///   `equality_pin_fields`. Lengths matching plus the pins being
-///   distinct (enforced upstream by
+/// - its **ranked-level** property for `axis` is `group_by_property`,
+///   with exactly one pin per property before it. For the boolean axes
+///   the ranked level is the index's **last** property; a prefix-level
+///   `rankedCountable: { at }` hosts the Count axis at the `at`
+///   property instead, ranking its values by whole-subtree count —
+///   there the properties *after* `at` never appear in the request at
+///   all (they are interior to the subtrees being counted);
+/// - every property **before** the ranked level is pinned: each appears
+///   (by name) among `equality_pin_fields`. Lengths matching plus the
+///   pins being distinct (enforced upstream by
 ///   [`super::mode_detection::prefix_pins_from_where_clauses`]) makes
 ///   this set equality, so no pin is left over either;
 /// - it declares the ranking keyword for `axis`
@@ -35,11 +39,15 @@ use std::collections::BTreeMap;
 ///   property is exactly `aggregate_field`. Both axes are derived from
 ///   the same running sum the index maintains (`Avg` is that sum over the
 ///   group's count), so summing a *different* field than the one the
-///   index accumulates would silently answer about the wrong property;
+///   index accumulates would silently answer about the wrong property.
+///   A prefix-level Count ranking excludes both (the grammar rejects the
+///   combination), so those arms never see an `at` index;
 /// - it carries no time-range transform.
 ///
-/// With no pins this degenerates to the original single-property rule.
-/// A partial pin (some but not all leading properties) matches nothing —
+/// With no pins this degenerates to the original single-property rule —
+/// or, for an index ranked at its FIRST property, to the global group
+/// ranking ("top hashtags by total likes" with nothing pinned). A
+/// partial pin (some but not all leading properties) matches nothing —
 /// the per-prefix secondary lives under one value tree per leading
 /// property, so there is no subtree an unpinned prefix could address —
 /// and callers turn the `None` into a loud
@@ -71,20 +79,6 @@ pub fn find_ranked_index_for_axis<'b>(
     aggregate_field: &str,
 ) -> Option<&'b Index> {
     indexes.values().find(|index| {
-        // Trailing property is the grouping property; every leading
-        // property is pinned exactly once (length equality + distinct
-        // pins ⇒ set equality).
-        let Some((terminal, leading)) = index.properties.split_last() else {
-            return false;
-        };
-        if terminal.name != group_by_property
-            || leading.len() != equality_pin_fields.len()
-            || !leading
-                .iter()
-                .all(|property| equality_pin_fields.iter().any(|f| f == &property.name))
-        {
-            return false;
-        }
         // Ranking over bucket keys is an undesigned surface: a document is
         // stored once per bucket that contains it, so it would contribute to
         // `overlap_factor` groups at once, and a ranked query carries no
@@ -93,15 +87,39 @@ pub fn find_ranked_index_for_axis<'b>(
         if index.time_range.is_some() {
             return false;
         }
-        match axis {
-            RankedAxis::Count => index.ranked_countable,
-            RankedAxis::Sum => {
-                index.ranked_summable && index.summable.as_deref() == Some(aggregate_field)
-            }
-            RankedAxis::Avg => {
-                index.ranked_averageable && index.summable.as_deref() == Some(aggregate_field)
-            }
-        }
+        // The position of the property whose level hosts this axis's
+        // secondary — `None` when the index does not declare the axis (or
+        // aggregates a different field than requested).
+        let ranked_position = match axis {
+            RankedAxis::Count => match index.ranked_countable_at.as_deref() {
+                Some(at) => index.properties.iter().position(|p| p.name == at),
+                None if index.ranked_countable => index.properties.len().checked_sub(1),
+                None => None,
+            },
+            RankedAxis::Sum => (index.ranked_summable
+                && index.summable.as_deref() == Some(aggregate_field))
+            .then(|| index.properties.len().checked_sub(1))
+            .flatten(),
+            RankedAxis::Avg => (index.ranked_averageable
+                && index.summable.as_deref() == Some(aggregate_field))
+            .then(|| index.properties.len().checked_sub(1))
+            .flatten(),
+        };
+        let Some(ranked_position) = ranked_position else {
+            return false;
+        };
+        let Some(ranked_property) = index.properties.get(ranked_position) else {
+            return false;
+        };
+        // The ranked-level property is the grouping property; every
+        // property before it is pinned exactly once (length equality +
+        // distinct pins ⇒ set equality).
+        let leading = &index.properties[..ranked_position];
+        ranked_property.name == group_by_property
+            && leading.len() == equality_pin_fields.len()
+            && leading
+                .iter()
+                .all(|property| equality_pin_fields.iter().any(|f| f == &property.name))
     })
 }
 
@@ -254,7 +272,11 @@ pub fn encode_prefix_branches(
     prefix_pins: &[PrefixPin],
     platform_version: &PlatformVersion,
 ) -> Result<Vec<Vec<Vec<u8>>>, Error> {
-    let leading = &index.properties[..index.properties.len().saturating_sub(1)];
+    // The pinnable properties end at the index's ranked level — the last
+    // property for the boolean axes, the `at` property for a prefix-level
+    // ranking (whose deeper properties are interior to the counted
+    // subtrees and never pinned).
+    let (leading, _) = super::path::ranked_level_split(index)?;
     // Enforced BEFORE any encoding: the ceiling bounds every downstream
     // cost (encode, sort, clone, walk, proof size), so an oversized pin
     // must not buy that work first. The post-product branch count check

--- a/packages/rs-drive/src/query/drive_document_ranked_query/path.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/path.rs
@@ -42,7 +42,10 @@ pub(crate) fn ranked_level_split(
              before the ranked level — the resolved pin set addresses no index property",
         )));
     };
-    let is_at_level = index.ranked_countable_at.as_deref() == Some(ranked_property.name.as_str());
+    let is_at_level = index
+        .ranked_countable_at
+        .iter()
+        .any(|at| at == &ranked_property.name);
     let is_terminal = pin_count + 1 == index.properties.len();
     if !is_at_level && !is_terminal {
         return Err(Error::Drive(DriveError::NotSupported(

--- a/packages/rs-drive/src/query/drive_document_ranked_query/path.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/path.rs
@@ -19,34 +19,39 @@ use crate::error::drive::DriveError;
 use crate::error::Error;
 use dpp::data_contract::document_type::{Index, IndexProperty};
 
-/// The property whose level hosts the index's ranking secondaries, plus
-/// the leading properties a ranked / having-range request must pin: the
-/// `at` property for a prefix-level `rankedCountable` (which excludes
-/// every other ranking axis, so it is the index's ONLY ranked level),
-/// the last property otherwise.
+/// The ranked level a request with `pin_count` pins addresses, split
+/// into the leading properties (one pin each) and the ranked property
+/// itself. An index can host secondaries at up to TWO levels — its
+/// `rankedCountable.at` property and, independently, its terminal
+/// property (the boolean axes) — so the level cannot be derived from
+/// the index alone: the request's pin count names it, since every
+/// property before the ranked level must be pinned and none after it
+/// may appear. Fails closed when the pin count lands on a level that
+/// hosts no secondary.
 ///
 /// Shared by the path builder and the prefix encoder — and, through
 /// them, by the server executors and the SDK verifier — so both sides
-/// agree on where an index's secondary lives without re-deriving it.
+/// agree on where a request's secondary lives without re-deriving it.
 pub(crate) fn ranked_level_split(
     index: &Index,
+    pin_count: usize,
 ) -> Result<(&[IndexProperty], &IndexProperty), Error> {
-    if let Some(at) = index.ranked_countable_at.as_deref() {
-        let Some(position) = index.properties.iter().position(|p| p.name == at) else {
-            return Err(Error::Drive(DriveError::NotSupported(
-                "the index's rankedCountable.at property is not among its properties — the \
-                 contract should never have validated",
-            )));
-        };
-        return Ok((&index.properties[..position], &index.properties[position]));
-    }
-    let Some((terminal_property, leading_properties)) = index.properties.split_last() else {
+    let Some(ranked_property) = index.properties.get(pin_count) else {
         return Err(Error::Drive(DriveError::NotSupported(
-            "ranked and having-range queries require an index with at least one \
-             property",
+            "ranked and having-range queries require exactly one pinned value per property \
+             before the ranked level — the resolved pin set addresses no index property",
         )));
     };
-    Ok((leading_properties, terminal_property))
+    let is_at_level = index.ranked_countable_at.as_deref() == Some(ranked_property.name.as_str());
+    let is_terminal = pin_count + 1 == index.properties.len();
+    if !is_at_level && !is_terminal {
+        return Err(Error::Drive(DriveError::NotSupported(
+            "ranked and having-range queries must land on a level hosting a ranking \
+             secondary — the index's rankedCountable.at property or its terminal property; \
+             the resolved pin set addresses an intermediate level",
+        )));
+    }
+    Ok((&index.properties[..pin_count], ranked_property))
 }
 
 /// Path of an index's **ranked-level** property-name tree — the terminal
@@ -70,16 +75,11 @@ pub(crate) fn indexed_property_name_tree_path_for_index(
     index: &Index,
     equality_prefix_values: &[Vec<u8>],
 ) -> Result<Vec<Vec<u8>>, Error> {
-    let (leading_properties, terminal_property) = ranked_level_split(index)?;
-    if leading_properties.len() != equality_prefix_values.len() {
-        return Err(Error::Drive(DriveError::NotSupported(
-            "ranked and having-range queries over a compound index require exactly one \
-             encoded equality value per leading index property: the axis secondary lives \
-             on the index's terminal property-name tree, which for a compound index sits \
-             under one prefix value tree per leading property, and only a `where` pin (an \
-             equality, or one element of the single permitted `IN`) can name those values",
-        )));
-    }
+    // The pin count names the ranked level (see `ranked_level_split`),
+    // which also makes the leading-property arity match by construction;
+    // the split's fail-closed error replaces the old arity backstop.
+    let (leading_properties, terminal_property) =
+        ranked_level_split(index, equality_prefix_values.len())?;
     let mut path = Vec::with_capacity(5 + 2 * leading_properties.len());
     path.push(vec![RootTree::DataContractDocuments as u8]);
     path.push(contract_id.to_vec());

--- a/packages/rs-drive/src/query/drive_document_ranked_query/path.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/path.rs
@@ -17,17 +17,49 @@ use super::DriveDocumentRankedQuery;
 use crate::drive::RootTree;
 use crate::error::drive::DriveError;
 use crate::error::Error;
-use dpp::data_contract::document_type::Index;
+use dpp::data_contract::document_type::{Index, IndexProperty};
 
-/// Path of an index's terminal property-name tree — shared by the
-/// ranked and having-range query surfaces, which read the same indexed
-/// tree. See [`DriveDocumentRankedQuery::indexed_property_name_tree_path`]
+/// The property whose level hosts the index's ranking secondaries, plus
+/// the leading properties a ranked / having-range request must pin: the
+/// `at` property for a prefix-level `rankedCountable` (which excludes
+/// every other ranking axis, so it is the index's ONLY ranked level),
+/// the last property otherwise.
+///
+/// Shared by the path builder and the prefix encoder — and, through
+/// them, by the server executors and the SDK verifier — so both sides
+/// agree on where an index's secondary lives without re-deriving it.
+pub(crate) fn ranked_level_split(
+    index: &Index,
+) -> Result<(&[IndexProperty], &IndexProperty), Error> {
+    if let Some(at) = index.ranked_countable_at.as_deref() {
+        let Some(position) = index.properties.iter().position(|p| p.name == at) else {
+            return Err(Error::Drive(DriveError::NotSupported(
+                "the index's rankedCountable.at property is not among its properties — the \
+                 contract should never have validated",
+            )));
+        };
+        return Ok((&index.properties[..position], &index.properties[position]));
+    }
+    let Some((terminal_property, leading_properties)) = index.properties.split_last() else {
+        return Err(Error::Drive(DriveError::NotSupported(
+            "ranked and having-range queries require an index with at least one \
+             property",
+        )));
+    };
+    Ok((leading_properties, terminal_property))
+}
+
+/// Path of an index's **ranked-level** property-name tree — the terminal
+/// one for the boolean ranking axes, the `at` level for a prefix-level
+/// `rankedCountable`. Shared by the ranked and having-range query
+/// surfaces, which read the same indexed tree. See
+/// [`DriveDocumentRankedQuery::indexed_property_name_tree_path`]
 /// for the segment layout.
 ///
 /// The branch's prefix segments carry the **encoded index-key bytes** of
 /// each leading property's pinned value, in index-property order — one
-/// per property before the terminal one. Empty for a single-property
-/// index. The arity must match exactly: a compound index's terminal
+/// per property before the ranked one. Empty for an index ranked at its
+/// first property. The arity must match exactly: the ranked level's
 /// tree sits under one prefix value tree per leading property, and only
 /// a `where` pin (an equality, or one element of the single permitted
 /// `IN`) can name those values, so a missing or surplus value means the
@@ -38,12 +70,7 @@ pub(crate) fn indexed_property_name_tree_path_for_index(
     index: &Index,
     equality_prefix_values: &[Vec<u8>],
 ) -> Result<Vec<Vec<u8>>, Error> {
-    let Some((terminal_property, leading_properties)) = index.properties.split_last() else {
-        return Err(Error::Drive(DriveError::NotSupported(
-            "ranked and having-range queries require an index with at least one \
-             property",
-        )));
-    };
+    let (leading_properties, terminal_property) = ranked_level_split(index)?;
     if leading_properties.len() != equality_prefix_values.len() {
         return Err(Error::Drive(DriveError::NotSupported(
             "ranked and having-range queries over a compound index require exactly one \

--- a/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
@@ -4197,3 +4197,66 @@ mod both_levels {
         );
     }
 }
+
+mod every_level {
+    //! The fully ranked chain (`at: ["tag", "region", "postId"]` on the
+    //! trending fixture's `chain` doctype): each of the three levels
+    //! serves its own ranking, addressed purely by the (group property,
+    //! pin count) pair, with every proof verifying against the live
+    //! root hash.
+
+    use super::prefix_level::{
+        assert_proof_round_trips, counts_of, entries_of, insert_rows, named, run, setup_trending,
+    };
+    use crate::query::{WhereClause, WhereOperator};
+    use dpp::platform_value::Value;
+
+    fn pin(field: &str, value: &str) -> WhereClause {
+        WhereClause {
+            field: field.to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Text(value.to_string()),
+        }
+    }
+
+    #[test]
+    fn all_three_levels_serve_and_prove() {
+        let (drive, contract) = setup_trending();
+        insert_rows(
+            &drive,
+            &contract,
+            "chain",
+            &[
+                &[("tag", "alpha"), ("region", "east"), ("postId", "p1")],
+                &[("tag", "alpha"), ("region", "east"), ("postId", "p1")],
+                &[("tag", "alpha"), ("region", "east"), ("postId", "p2")],
+                &[("tag", "alpha"), ("region", "west"), ("postId", "p1")],
+                &[("tag", "beta"), ("region", "east"), ("postId", "p1")],
+            ],
+        );
+
+        // Level 0: top tags, nothing pinned.
+        let tags =
+            entries_of(run(&drive, &contract, "chain", "tag", &[], 10, false).expect("tag read"));
+        assert_eq!(counts_of(&tags), named(&[(4, "alpha"), (1, "beta")]));
+        assert_proof_round_trips(&drive, &contract, "chain", "tag", &[], 10, &tags);
+
+        // Level 1: top regions within a tag.
+        let alpha_pin = vec![pin("tag", "alpha")];
+        let regions = entries_of(
+            run(&drive, &contract, "chain", "region", &alpha_pin, 10, false).expect("region read"),
+        );
+        assert_eq!(counts_of(&regions), named(&[(3, "east"), (1, "west")]));
+        assert_proof_round_trips(
+            &drive, &contract, "chain", "region", &alpha_pin, 10, &regions,
+        );
+
+        // Level 2: top posts within (tag, region).
+        let east_pins = vec![pin("tag", "alpha"), pin("region", "east")];
+        let posts = entries_of(
+            run(&drive, &contract, "chain", "postId", &east_pins, 10, false).expect("post read"),
+        );
+        assert_eq!(counts_of(&posts), named(&[(2, "p1"), (1, "p2")]));
+        assert_proof_round_trips(&drive, &contract, "chain", "postId", &east_pins, 10, &posts);
+    }
+}

--- a/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
@@ -3579,3 +3579,475 @@ mod pinned_prefix {
         );
     }
 }
+
+mod prefix_level {
+    //! `SELECT COUNT(*) … GROUP BY hashtag ORDER BY $count DESC LIMIT k`
+    //! over a prefix-level ranking (`rankedCountable: { "at": "hashtag" }`):
+    //! the Count secondary lives at the **hashtag** level and orders
+    //! hashtags by whole-subtree document count. With `at` on the first
+    //! property nothing is pinned — the global "top hashtags" surface; a
+    //! middle-level `at` pins every property before it and serves one
+    //! ranking per prefix, `IN` fan-out included. The storage side of
+    //! these shapes is pinned by
+    //! `insert_contract::v0::tests::prefix_ranked_index_e2e_tests`; this
+    //! module pins the query resolution, the rank walk and its proof.
+
+    use super::super::drive_dispatcher::{DocumentRankedRequest, DocumentRankedResponse};
+    use super::super::index_picker::resolve_ranked_query_for_mode;
+    use super::super::mode_detection::detect_ranked_mode;
+    use super::super::{
+        DriveDocumentRankedQuery, RankedEntry, RankedEntryValue, RankedPaginationInputs,
+        RANKED_COUNT_ORDER_KEY,
+    };
+    use crate::drive::Drive;
+    use crate::error::query::QuerySyntaxError;
+    use crate::error::Error;
+    use crate::query::projection::SelectProjection;
+    use crate::query::{OrderClause, WhereClause, WhereOperator};
+    use crate::util::object_size_info::DocumentInfo::DocumentRefInfo;
+    use crate::util::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
+    use crate::util::storage_flags::StorageFlags;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::data_contract::accessors::v0::DataContractV0Getters;
+    use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
+    use dpp::data_contract::document_type::random_document::CreateRandomDocument;
+    use dpp::document::{Document, DocumentV0Setters};
+    use dpp::platform_value::Value;
+    use dpp::prelude::DataContract;
+    use dpp::tests::json_document::json_document_to_contract;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    fn platform_version() -> &'static PlatformVersion {
+        PlatformVersion::latest()
+    }
+
+    fn setup_trending() -> (Drive, DataContract) {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let pv = platform_version();
+        let contract = json_document_to_contract(
+            "tests/supporting_files/contract/trending/trending-contract.json",
+            false,
+            pv,
+        )
+        .expect("expected to parse the trending contract");
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                pv,
+            )
+            .expect("expected to apply the trending contract");
+        (drive, contract)
+    }
+
+    fn insert_rows(
+        drive: &Drive,
+        contract: &DataContract,
+        document_type_name: &str,
+        rows: &[&[(&str, &str)]],
+    ) {
+        let pv = platform_version();
+        let document_type = contract
+            .document_type_for_name(document_type_name)
+            .expect("doctype exists");
+        for (i, properties) in rows.iter().enumerate() {
+            let mut doc: Document = document_type
+                .random_document(Some(7000 + i as u64), pv)
+                .expect("random document");
+            let mut props = BTreeMap::new();
+            for (name, value) in *properties {
+                props.insert(name.to_string(), Value::Text(value.to_string()));
+            }
+            doc.set_properties(props);
+            drive
+                .add_document_for_contract(
+                    DocumentAndContractInfo {
+                        owned_document_info: OwnedDocumentInfo {
+                            document_info: DocumentRefInfo((&doc, None)),
+                            owner_id: None,
+                        },
+                        contract,
+                        document_type,
+                    },
+                    false,
+                    BlockInfo::default(),
+                    true,
+                    None,
+                    pv,
+                    None,
+                )
+                .expect("expected to insert a trending document");
+        }
+    }
+
+    fn region_pin(region: &str) -> Vec<WhereClause> {
+        vec![WhereClause {
+            field: "region".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Text(region.to_string()),
+        }]
+    }
+
+    fn run(
+        drive: &Drive,
+        contract: &DataContract,
+        document_type_name: &str,
+        group_by_property: &str,
+        where_clauses: &[WhereClause],
+        limit: u32,
+        prove: bool,
+    ) -> Result<DocumentRankedResponse, Error> {
+        let group_by = vec![group_by_property.to_string()];
+        let order_by = vec![OrderClause {
+            field: RANKED_COUNT_ORDER_KEY.to_string(),
+            ascending: false,
+        }];
+        drive.execute_document_ranked_request(
+            DocumentRankedRequest {
+                contract,
+                document_type: contract
+                    .document_type_for_name(document_type_name)
+                    .expect("doctype exists"),
+                group_by: &group_by,
+                select: SelectProjection::count_star(),
+                having: &[],
+                order_by: &order_by,
+                where_clauses,
+                resolved_time_ranges: &[],
+                limit: Some(limit),
+                offset: None,
+                has_start_at: false,
+                prove,
+            },
+            None,
+            platform_version(),
+        )
+    }
+
+    fn entries_of(response: DocumentRankedResponse) -> Vec<RankedEntry> {
+        match response {
+            DocumentRankedResponse::Entries(page) => page.entries,
+            DocumentRankedResponse::Proof(_) => panic!("expected entries, got a proof"),
+        }
+    }
+
+    fn proof_of(response: DocumentRankedResponse) -> Vec<u8> {
+        match response {
+            DocumentRankedResponse::Proof(proof) => proof,
+            DocumentRankedResponse::Entries(_) => panic!("expected a proof, got entries"),
+        }
+    }
+
+    /// `(count, group)` view of a page for readable assertions.
+    fn counts_of(entries: &[RankedEntry]) -> Vec<(u64, String)> {
+        entries
+            .iter()
+            .map(|entry| {
+                let RankedEntryValue::Count(count) = entry.value else {
+                    panic!("the Count axis must return Count values, got {entry:?}");
+                };
+                (
+                    count,
+                    String::from_utf8(entry.key.clone()).expect("fixture group keys are utf-8"),
+                )
+            })
+            .collect()
+    }
+
+    fn named(pairs: &[(u64, &str)]) -> Vec<(u64, String)> {
+        pairs
+            .iter()
+            .map(|(count, name)| (*count, name.to_string()))
+            .collect()
+    }
+
+    fn client_side_query<'a>(
+        contract: &'a DataContract,
+        document_type_name: &'static str,
+        group_by_property: &str,
+        where_clauses: &[WhereClause],
+        limit: u32,
+    ) -> DriveDocumentRankedQuery<'a> {
+        let group_by = vec![group_by_property.to_string()];
+        let order_by = vec![OrderClause {
+            field: RANKED_COUNT_ORDER_KEY.to_string(),
+            ascending: false,
+        }];
+        let mode = detect_ranked_mode(
+            &SelectProjection::count_star(),
+            &group_by,
+            &[],
+            &order_by,
+            where_clauses,
+            RankedPaginationInputs {
+                limit: Some(limit),
+                offset: None,
+                has_start_at: false,
+            },
+            platform_version(),
+        )
+        .expect("the case is well-formed");
+        let indexes = contract
+            .document_types()
+            .get(document_type_name)
+            .expect("doctype exists")
+            .indexes();
+        resolve_ranked_query_for_mode(
+            contract.id_ref().to_buffer(),
+            contract
+                .document_type_for_name(document_type_name)
+                .expect("doctype exists"),
+            document_type_name.to_string(),
+            indexes,
+            &mode,
+            platform_version(),
+        )
+        .expect("the fixture declares the prefix-level ranking")
+    }
+
+    fn grovedb_root_hash(drive: &Drive) -> [u8; 32] {
+        drive
+            .grove
+            .root_hash(None, &platform_version().drive.grove_version)
+            .unwrap()
+            .expect("root hash must be readable")
+    }
+
+    fn assert_proof_round_trips(
+        drive: &Drive,
+        contract: &DataContract,
+        document_type_name: &'static str,
+        where_clauses: &[WhereClause],
+        limit: u32,
+        expected: &[RankedEntry],
+    ) {
+        let proof = proof_of(
+            run(
+                drive,
+                contract,
+                document_type_name,
+                "hashtag",
+                where_clauses,
+                limit,
+                true,
+            )
+            .expect("prove must succeed"),
+        );
+        let query = client_side_query(
+            contract,
+            document_type_name,
+            "hashtag",
+            where_clauses,
+            limit,
+        );
+        let (root_hash, verified) = query
+            .verify_ranked_top_k_proof(&proof, platform_version())
+            .expect("the proof must verify");
+        assert_eq!(
+            verified.entries, expected,
+            "verified entries must equal what the unproven read returned"
+        );
+        assert_eq!(
+            root_hash,
+            grovedb_root_hash(drive),
+            "the proof must reconstruct the live grovedb root hash"
+        );
+    }
+
+    /// `at` on the first property: nothing pinned, the global "top
+    /// hashtags by total likes" surface — read, prove, verify.
+    #[test]
+    fn global_hashtag_ranking_reads_and_proves_consistently() {
+        let (drive, contract) = setup_trending();
+        insert_rows(
+            &drive,
+            &contract,
+            "like",
+            &[
+                &[("hashtag", "alpha"), ("postId", "p1")],
+                &[("hashtag", "alpha"), ("postId", "p1")],
+                &[("hashtag", "alpha"), ("postId", "p2")],
+                &[("hashtag", "beta"), ("postId", "p1")],
+                &[("hashtag", "beta"), ("postId", "p3")],
+                &[("hashtag", "gamma"), ("postId", "p2")],
+            ],
+        );
+
+        let entries = entries_of(
+            run(&drive, &contract, "like", "hashtag", &[], 10, false).expect("read must succeed"),
+        );
+        assert_eq!(
+            counts_of(&entries),
+            named(&[(3, "alpha"), (2, "beta"), (1, "gamma")]),
+            "the ranking must count across each hashtag's whole subtree"
+        );
+        assert!(entries.iter().all(|entry| entry.in_key.is_none()));
+
+        assert_proof_round_trips(&drive, &contract, "like", &[], 10, &entries);
+    }
+
+    /// A count-propagating level between `at` and the terminal: the
+    /// ranking still reads whole-subtree totals (across regions AND
+    /// posts), and the proof still verifies.
+    #[test]
+    fn propagating_level_totals_serve_the_ranking() {
+        let (drive, contract) = setup_trending();
+        insert_rows(
+            &drive,
+            &contract,
+            "deep",
+            &[
+                &[("hashtag", "alpha"), ("region", "east"), ("postId", "p1")],
+                &[("hashtag", "alpha"), ("region", "east"), ("postId", "p2")],
+                &[("hashtag", "alpha"), ("region", "west"), ("postId", "p1")],
+                &[("hashtag", "beta"), ("region", "east"), ("postId", "p1")],
+            ],
+        );
+
+        let entries = entries_of(
+            run(&drive, &contract, "deep", "hashtag", &[], 10, false).expect("read must succeed"),
+        );
+        assert_eq!(counts_of(&entries), named(&[(3, "alpha"), (1, "beta")]));
+
+        assert_proof_round_trips(&drive, &contract, "deep", &[], 10, &entries);
+    }
+
+    /// A middle-level `at` pins every property before it: each prefix
+    /// serves its own ranking, an unpinned request is rejected naming
+    /// the required shape, and the pinned proof verifies.
+    #[test]
+    fn middle_at_serves_per_prefix_and_requires_the_pin() {
+        let (drive, contract) = setup_trending();
+        insert_rows(
+            &drive,
+            &contract,
+            "mid",
+            &[
+                &[("region", "r1"), ("hashtag", "alpha"), ("postId", "p1")],
+                &[("region", "r1"), ("hashtag", "alpha"), ("postId", "p2")],
+                &[("region", "r1"), ("hashtag", "beta"), ("postId", "p1")],
+                &[("region", "r2"), ("hashtag", "gamma"), ("postId", "p1")],
+            ],
+        );
+
+        let r1 = entries_of(
+            run(
+                &drive,
+                &contract,
+                "mid",
+                "hashtag",
+                &region_pin("r1"),
+                10,
+                false,
+            )
+            .expect("pinned read must succeed"),
+        );
+        assert_eq!(counts_of(&r1), named(&[(2, "alpha"), (1, "beta")]));
+        let r2 = entries_of(
+            run(
+                &drive,
+                &contract,
+                "mid",
+                "hashtag",
+                &region_pin("r2"),
+                10,
+                false,
+            )
+            .expect("pinned read must succeed"),
+        );
+        assert_eq!(
+            counts_of(&r2),
+            named(&[(1, "gamma")]),
+            "each region prefix ranks independently"
+        );
+
+        let error = run(&drive, &contract, "mid", "hashtag", &[], 10, false)
+            .expect_err("an unpinned middle-level ranking must be rejected");
+        assert!(
+            matches!(
+                &error,
+                Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(message))
+                    if message.contains("rankedCountable") && message.contains("hashtag")
+            ),
+            "the rejection must name the missing coverage, got: {error}"
+        );
+
+        assert_proof_round_trips(&drive, &contract, "mid", &region_pin("r1"), 10, &r1);
+    }
+
+    /// An `IN` pin on the property before a middle-level `at` fans out
+    /// into the branched union, `in_key` carrying each entry's branch.
+    #[test]
+    fn an_in_pin_reads_the_branched_union_with_proof() {
+        let (drive, contract) = setup_trending();
+        insert_rows(
+            &drive,
+            &contract,
+            "mid",
+            &[
+                &[("region", "r1"), ("hashtag", "alpha"), ("postId", "p1")],
+                &[("region", "r1"), ("hashtag", "alpha"), ("postId", "p2")],
+                &[("region", "r1"), ("hashtag", "alpha"), ("postId", "p3")],
+                &[("region", "r1"), ("hashtag", "beta"), ("postId", "p1")],
+                &[("region", "r2"), ("hashtag", "gamma"), ("postId", "p1")],
+                &[("region", "r2"), ("hashtag", "gamma"), ("postId", "p2")],
+            ],
+        );
+
+        let in_pin = vec![WhereClause {
+            field: "region".to_string(),
+            operator: WhereOperator::In,
+            value: Value::Array(vec![
+                Value::Text("r1".to_string()),
+                Value::Text("r2".to_string()),
+            ]),
+        }];
+        let entries = entries_of(
+            run(&drive, &contract, "mid", "hashtag", &in_pin, 10, false)
+                .expect("branched read must succeed"),
+        );
+        assert_eq!(
+            counts_of(&entries),
+            named(&[(3, "alpha"), (2, "gamma"), (1, "beta")]),
+            "the union must merge both regions' rankings"
+        );
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.in_key.clone().expect("branched entries carry in_key"))
+                .collect::<Vec<_>>(),
+            vec![b"r1".to_vec(), b"r2".to_vec(), b"r1".to_vec()],
+            "each entry must name the branch it came from"
+        );
+
+        assert_proof_round_trips(&drive, &contract, "mid", &in_pin, 10, &entries);
+    }
+
+    /// An `at` index hosts NO terminal secondary: grouping by the last
+    /// property with the leading ones pinned must be rejected, not
+    /// silently served from a secondary that does not exist.
+    #[test]
+    fn terminal_group_by_on_an_at_index_is_rejected() {
+        let (drive, contract) = setup_trending();
+        let pin = vec![WhereClause {
+            field: "hashtag".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Text("alpha".to_string()),
+        }];
+        let error = run(&drive, &contract, "like", "postId", &pin, 10, false)
+            .expect_err("terminal grouping over an at-index must be rejected");
+        assert!(
+            matches!(
+                &error,
+                Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(message))
+                    if message.contains("postId")
+            ),
+            "the rejection must name the unserved group property, got: {error}"
+        );
+    }
+}

--- a/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
@@ -3623,7 +3623,7 @@ mod prefix_level {
         PlatformVersion::latest()
     }
 
-    fn setup_trending() -> (Drive, DataContract) {
+    pub(super) fn setup_trending() -> (Drive, DataContract) {
         let drive = setup_drive_with_initial_state_structure(None);
         let pv = platform_version();
         let contract = json_document_to_contract(
@@ -3645,7 +3645,7 @@ mod prefix_level {
         (drive, contract)
     }
 
-    fn insert_rows(
+    pub(super) fn insert_rows(
         drive: &Drive,
         contract: &DataContract,
         document_type_name: &str,
@@ -3685,7 +3685,7 @@ mod prefix_level {
         }
     }
 
-    fn region_pin(region: &str) -> Vec<WhereClause> {
+    pub(super) fn region_pin(region: &str) -> Vec<WhereClause> {
         vec![WhereClause {
             field: "region".to_string(),
             operator: WhereOperator::Equal,
@@ -3693,7 +3693,7 @@ mod prefix_level {
         }]
     }
 
-    fn run(
+    pub(super) fn run(
         drive: &Drive,
         contract: &DataContract,
         document_type_name: &str,
@@ -3729,7 +3729,7 @@ mod prefix_level {
         )
     }
 
-    fn entries_of(response: DocumentRankedResponse) -> Vec<RankedEntry> {
+    pub(super) fn entries_of(response: DocumentRankedResponse) -> Vec<RankedEntry> {
         match response {
             DocumentRankedResponse::Entries(page) => page.entries,
             DocumentRankedResponse::Proof(_) => panic!("expected entries, got a proof"),
@@ -3744,7 +3744,7 @@ mod prefix_level {
     }
 
     /// `(count, group)` view of a page for readable assertions.
-    fn counts_of(entries: &[RankedEntry]) -> Vec<(u64, String)> {
+    pub(super) fn counts_of(entries: &[RankedEntry]) -> Vec<(u64, String)> {
         entries
             .iter()
             .map(|entry| {
@@ -3759,7 +3759,7 @@ mod prefix_level {
             .collect()
     }
 
-    fn named(pairs: &[(u64, &str)]) -> Vec<(u64, String)> {
+    pub(super) fn named(pairs: &[(u64, &str)]) -> Vec<(u64, String)> {
         pairs
             .iter()
             .map(|(count, name)| (*count, name.to_string()))
@@ -3818,10 +3818,11 @@ mod prefix_level {
             .expect("root hash must be readable")
     }
 
-    fn assert_proof_round_trips(
+    pub(super) fn assert_proof_round_trips(
         drive: &Drive,
         contract: &DataContract,
         document_type_name: &'static str,
+        group_by_property: &str,
         where_clauses: &[WhereClause],
         limit: u32,
         expected: &[RankedEntry],
@@ -3831,7 +3832,7 @@ mod prefix_level {
                 drive,
                 contract,
                 document_type_name,
-                "hashtag",
+                group_by_property,
                 where_clauses,
                 limit,
                 true,
@@ -3841,7 +3842,7 @@ mod prefix_level {
         let query = client_side_query(
             contract,
             document_type_name,
-            "hashtag",
+            group_by_property,
             where_clauses,
             limit,
         );
@@ -3888,7 +3889,7 @@ mod prefix_level {
         );
         assert!(entries.iter().all(|entry| entry.in_key.is_none()));
 
-        assert_proof_round_trips(&drive, &contract, "like", &[], 10, &entries);
+        assert_proof_round_trips(&drive, &contract, "like", "hashtag", &[], 10, &entries);
     }
 
     /// A count-propagating level between `at` and the terminal: the
@@ -3914,7 +3915,7 @@ mod prefix_level {
         );
         assert_eq!(counts_of(&entries), named(&[(3, "alpha"), (1, "beta")]));
 
-        assert_proof_round_trips(&drive, &contract, "deep", &[], 10, &entries);
+        assert_proof_round_trips(&drive, &contract, "deep", "hashtag", &[], 10, &entries);
     }
 
     /// A middle-level `at` pins every property before it: each prefix
@@ -3977,7 +3978,15 @@ mod prefix_level {
             "the rejection must name the missing coverage, got: {error}"
         );
 
-        assert_proof_round_trips(&drive, &contract, "mid", &region_pin("r1"), 10, &r1);
+        assert_proof_round_trips(
+            &drive,
+            &contract,
+            "mid",
+            "hashtag",
+            &region_pin("r1"),
+            10,
+            &r1,
+        );
     }
 
     /// An `IN` pin on the property before a middle-level `at` fans out
@@ -4025,7 +4034,7 @@ mod prefix_level {
             "each entry must name the branch it came from"
         );
 
-        assert_proof_round_trips(&drive, &contract, "mid", &in_pin, 10, &entries);
+        assert_proof_round_trips(&drive, &contract, "mid", "hashtag", &in_pin, 10, &entries);
     }
 
     /// An `at` index hosts NO terminal secondary: grouping by the last
@@ -4048,6 +4057,143 @@ mod prefix_level {
                     if message.contains("postId")
             ),
             "the rejection must name the unserved group property, got: {error}"
+        );
+    }
+}
+
+mod both_levels {
+    //! One index, two rankings (`rankedCountable: { at: ["hashtag",
+    //! "postId"] }` on the trending fixture's `both` doctype): with
+    //! nothing pinned, `GROUP BY hashtag` reads the grouping secondary
+    //! (subtree totals); with `hashtag` pinned, `GROUP BY postId` reads
+    //! the terminal secondary inside that hashtag's chain. The (group
+    //! property, pin count) pair singles the level out — the resolution
+    //! generalization under test — and both proofs verify against the
+    //! live root hash.
+
+    use super::prefix_level::{
+        assert_proof_round_trips, counts_of, entries_of, insert_rows, named, region_pin, run,
+        setup_trending,
+    };
+    use crate::error::query::QuerySyntaxError;
+    use crate::error::Error;
+    use crate::query::{WhereClause, WhereOperator};
+    use dpp::platform_value::Value;
+
+    fn hashtag_pin(hashtag: &str) -> Vec<WhereClause> {
+        vec![WhereClause {
+            field: "hashtag".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Text(hashtag.to_string()),
+        }]
+    }
+
+    #[test]
+    fn both_rankings_serve_and_prove_on_one_index() {
+        let (drive, contract) = setup_trending();
+        insert_rows(
+            &drive,
+            &contract,
+            "both",
+            &[
+                &[("hashtag", "alpha"), ("postId", "p1")],
+                &[("hashtag", "alpha"), ("postId", "p1")],
+                &[("hashtag", "alpha"), ("postId", "p2")],
+                &[("hashtag", "beta"), ("postId", "p3")],
+            ],
+        );
+
+        // Grouping level: top hashtags by subtree total, nothing pinned.
+        let hashtags = entries_of(
+            run(&drive, &contract, "both", "hashtag", &[], 10, false)
+                .expect("the grouping read must succeed"),
+        );
+        assert_eq!(counts_of(&hashtags), named(&[(3, "alpha"), (1, "beta")]));
+        assert_proof_round_trips(&drive, &contract, "both", "hashtag", &[], 10, &hashtags);
+
+        // Terminal level: top posts within the pinned hashtag.
+        let alpha_posts = entries_of(
+            run(
+                &drive,
+                &contract,
+                "both",
+                "postId",
+                &hashtag_pin("alpha"),
+                10,
+                false,
+            )
+            .expect("the terminal read must succeed"),
+        );
+        assert_eq!(counts_of(&alpha_posts), named(&[(2, "p1"), (1, "p2")]));
+        assert_proof_round_trips(
+            &drive,
+            &contract,
+            "both",
+            "postId",
+            &hashtag_pin("alpha"),
+            10,
+            &alpha_posts,
+        );
+
+        // The pin count disambiguates: an unpinned terminal grouping has
+        // no covering level and must be rejected, not served off the
+        // grouping secondary.
+        let error = run(&drive, &contract, "both", "postId", &[], 10, false)
+            .expect_err("an unpinned terminal grouping must be rejected");
+        assert!(
+            matches!(
+                &error,
+                Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(message))
+                    if message.contains("postId")
+            ),
+            "the rejection must name the unserved shape, got: {error}"
+        );
+    }
+
+    /// The `mid` doctype pins prove the split stays correct when the
+    /// grouping level is not first: the region pin count (1) lands on
+    /// `hashtag`, and two pins would address the (unranked) terminal —
+    /// rejected.
+    #[test]
+    fn pin_count_lands_on_the_declared_level_only() {
+        let (drive, contract) = setup_trending();
+        insert_rows(
+            &drive,
+            &contract,
+            "mid",
+            &[&[("region", "r1"), ("hashtag", "alpha"), ("postId", "p1")]],
+        );
+
+        let entries = entries_of(
+            run(
+                &drive,
+                &contract,
+                "mid",
+                "hashtag",
+                &region_pin("r1"),
+                10,
+                false,
+            )
+            .expect("the pinned grouping read must succeed"),
+        );
+        assert_eq!(counts_of(&entries), named(&[(1, "alpha")]));
+
+        // Two pins address mid's terminal, which hosts no secondary.
+        let two_pins = vec![
+            WhereClause {
+                field: "region".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("r1".to_string()),
+            },
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("alpha".to_string()),
+            },
+        ];
+        assert!(
+            run(&drive, &contract, "mid", "postId", &two_pins, 10, false).is_err(),
+            "mid's unranked terminal must stay unservable"
         );
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Third PR of the #4529 build-out (stacked on #4533, the storage layer). With the prefix-level chain on disk, this PR makes the query surfaces reach it: `documents.ranked({ groupBy: 'hashtag' })` — the issue's "top hashtags by total likes" — resolves, executes and proves against the `at` level's secondary.

## What was done?

The generalization lives entirely in the three functions the ranked and having-range surfaces already share:

- **Index picker** (`find_ranked_index_for_axis`): resolves the ranked-level *position* per axis — the `at` property for the prefix Count form (properties after it never appear in the request; they are interior to the counted subtrees), the last property for the boolean axes. An at-first-property index therefore serves the global group ranking with nothing pinned; a middle-level `at` pins every property before it, `IN` fan-out included.
- **Path builder + prefix encoder**: both split the index at the ranked level through the new `ranked_level_split` (an `at` index has no other ranked level — the grammar excludes the other axes — so the split is unambiguous from the index alone, keeping prover/verifier agreement in one place).

Everything downstream is untouched: executors, branched-axis fan-out, proof generation, the verify side, drive-abci routing and the JS wire surface all operate on the resolved query and paths. Grouping by an at-index's *terminal* property is rejected with the standard no-covering-index message — that secondary does not exist.

## How Has This Been Tested?

New `prefix_level` test modules on both surfaces, against the `trending` fixture from the storage PR:

- global (unpinned) hashtag ranking: read, prove, and **verify the proof client-side against the live grovedb root hash**;
- whole-subtree totals through a count-propagating middle level, with proof round trip;
- middle-level `at`: per-prefix reads for two pinned regions, the unpinned rejection naming the required coverage, and the pinned proof round trip;
- `region IN [r1, r2]`: the branched union merged across prefixes with `in_key` attribution, proved and verified;
- terminal `groupBy` on an at-index rejected;
- having-range: a `COUNT(*) >= n` band over subtree totals landing on the `at` level.

Full ranked + having suites (93 tests) pass; `--all-targets`, the `verify`-feature build and clippy are clean.

## Breaking Changes

None — indexes without `ranked_countable_at` resolve exactly as before (the boolean-axis arms are unchanged), and no wire shape moved.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)