### PR TITLE
fix(drive-abci): sync mainnet blocks 32326-32329 without crash-restarts

### DIFF
--- a/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
+++ b/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
@@ -81,8 +81,26 @@ where
         && config.abci.chain_id == "evo1"
         && block_height < 33000
     {
-        // Old behavior on mainnet below block 33000
-        result?;
+        // Old behaviour on mainnet below block 33000.
+        //
+        // The commit fails here with RocksDB "transaction is busy", because
+        // remove_all_votes_given_by_identities deliberately reproduces the historical
+        // bug by committing its own grovedb transaction mid-block. At the time, the
+        // node kept going: tenderdash#966 meant validators ignored the ABCI error and
+        // moved to the next block with the state partially committed and caches
+        // updated. That tenderdash bug is fixed, so returning the error here aborts
+        // replay instead — which makes mainnet blocks 32326..33000 unreplayable.
+        //
+        // Reproduce the historical *outcome* rather than an error only a buggy
+        // tenderdash could survive.
+        if let Err(error) = result {
+            tracing::warn!(
+                ?error,
+                block_height,
+                "commit failed for a mainnet block below 33000; proceeding as the \
+                 network did at the time (see platform#2309, tenderdash#966)"
+            );
+        }
     } else {
         // In case if transaction commit failed we still have caches in memory that
         // corresponds to the data that we weren't able to commit.

--- a/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
+++ b/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
@@ -69,46 +69,36 @@ where
 
     let result = app.commit_transaction(platform_version);
 
-    // We had a sequence of errors on the mainnet started since block 32326.
-    // We got RocksDB's "transaction is busy" error because of a bug (https://github.com/dashpay/platform/pull/2309).
-    // Due to another bug in Tenderdash (https://github.com/dashpay/tenderdash/pull/966),
-    // validators just proceeded to the next block partially committing the state and updating the cache.
-    // Full nodes are stuck and proceeded after re-sync.
-    // For the mainnet chain, we enable these fixes at the block when we consider the state is consistent.
+    // Mainnet's vote-cleanup incident began at 32326 (platform#2309). Tenderdash#966
+    // let validators continue after the resulting commit conflict with partially committed
+    // state and updated caches. Reproduce that outcome only for the expected Busy error.
+    // The upper bound must match Drive::remove_all_votes_given_by_identities: starting
+    // at 32329, vote deletions stay inside the block transaction again.
     let config = &app.platform().config;
+    let historical_conflict = config.network == Network::Mainnet
+        && config.abci.chain_id == "evo1"
+        && (32326..32329).contains(&block_height)
+        && matches!(
+            &result,
+            Err(Error::Drive(drive::error::Error::GroveDB(error)))
+                if matches!(
+                    error.as_ref(),
+                    drive::grovedb::Error::StorageError(
+                        drive::grovedb_storage::error::Error::RocksDBError(error)
+                    ) if error.kind() == rocksdb::ErrorKind::Busy
+                )
+        );
 
-    if config.network == Network::Mainnet && config.abci.chain_id == "evo1" && block_height < 32329
-    {
-        // Old behaviour on mainnet below block 32329. This window must match the one in
-        // Drive::remove_all_votes_given_by_identities: it is exactly the range where Drive
-        // deliberately commits its own grovedb transaction mid-block, so it is the only
-        // range where a commit failure here is the reproduced historical outcome rather
-        // than a real fault.
-        //
-        // The commit fails here with RocksDB "transaction is busy", because
-        // remove_all_votes_given_by_identities deliberately reproduces the historical
-        // bug by committing its own grovedb transaction mid-block. At the time, the
-        // node kept going: tenderdash#966 meant validators ignored the ABCI error and
-        // moved to the next block with the state partially committed and caches
-        // updated. That tenderdash bug is fixed, so returning the error here aborts
-        // replay instead — which makes mainnet blocks 32326..32329 unreplayable.
-        //
-        // Reproduce the historical *outcome* rather than an error only a buggy
-        // tenderdash could survive.
-        if let Err(error) = result {
-            tracing::warn!(
-                ?error,
-                block_height,
-                "commit failed for a mainnet block below 32329; proceeding as the \
-                 network did at the time (see platform#2309, tenderdash#966)"
-            );
-        }
+    if historical_conflict {
+        tracing::warn!(
+            error = ?result.as_ref().err(),
+            block_height,
+            "historical mainnet vote-cleanup commit conflict; proceeding as the \
+             network did at the time (see platform#2309, tenderdash#966)"
+        );
     } else {
-        // In case if transaction commit failed we still have caches in memory that
-        // corresponds to the data that we weren't able to commit.
-        // The simplified solution is to restart the Drive, so all caches
-        // will be restored from the disk and try to process this block again.
-        // TODO: We need a better handling of the transaction is busy error with retry logic.
+        // A failed commit leaves caches ahead of durable state. Restart Drive so the
+        // caches are restored from disk before retrying the block.
         result.expect("commit transaction");
     }
 
@@ -150,11 +140,11 @@ mod tests {
 
     /// An ABCI application whose `commit_transaction` always fails.
     ///
-    /// Stands in for the RocksDB "transaction is busy" conflict that the mainnet compat window
-    /// exists for, so the tests can prove exactly where the finalize handler tolerates a failed
-    /// commit and where it must not.
+    /// Injects either a real RocksDB error or an unrelated execution error to verify
+    /// that only historical transaction conflicts are tolerated.
     struct FailingCommitApplication<'a> {
         platform: &'a Platform<MockCoreRPCLike>,
+        commit_error: RwLock<Option<Error>>,
         transaction: RwLock<Option<Transaction<'a>>>,
         block_execution_context: RwLock<Option<BlockExecutionContext>>,
     }
@@ -184,9 +174,12 @@ mod tests {
         fn commit_transaction(&self, _platform_version: &PlatformVersion) -> Result<(), Error> {
             // Consume the transaction like the real implementation would, then fail.
             self.transaction.write().unwrap().take();
-            Err(Error::Execution(ExecutionError::CorruptedCodeExecution(
-                "injected commit failure",
-            )))
+            Err(self
+                .commit_error
+                .write()
+                .unwrap()
+                .take()
+                .expect("commit error"))
         }
     }
 
@@ -195,6 +188,7 @@ mod tests {
     fn finalize_block_with_failing_commit(
         config: PlatformConfig,
         height: u64,
+        commit_error: Error,
     ) -> Result<proto::ResponseFinalizeBlock, Error> {
         let platform: TempPlatform<MockCoreRPCLike> = TestPlatformBuilder::new()
             .with_config(config)
@@ -204,6 +198,7 @@ mod tests {
 
         let app = FailingCommitApplication {
             platform: &platform.platform,
+            commit_error: RwLock::new(Some(commit_error)),
             transaction: Default::default(),
             block_execution_context: Default::default(),
         };
@@ -302,34 +297,105 @@ mod tests {
         config
     }
 
+    /// Produce the actual RocksDB error returned when another transaction writes the same key.
+    fn busy_commit_error() -> Error {
+        let directory = tempfile::tempdir().expect("temporary database directory");
+        let db = rocksdb::OptimisticTransactionDB::<rocksdb::SingleThreaded>::open_default(
+            directory.path(),
+        )
+        .expect("open database");
+        let transaction = db.transaction();
+        transaction
+            .put(b"key", b"pending")
+            .expect("transaction write");
+        db.put(b"key", b"committed").expect("independent write");
+        let error = transaction
+            .commit()
+            .expect_err("conflicting commit must fail");
+        assert_eq!(error.kind(), rocksdb::ErrorKind::Busy);
+        drive::grovedb::Error::StorageError(drive::grovedb_storage::error::Error::RocksDBError(
+            error,
+        ))
+        .into()
+    }
+
     #[test]
-    fn finalize_block_tolerates_failed_commit_on_mainnet_evo1_before_32329() {
-        for height in [32326u64, 32328] {
-            let result = finalize_block_with_failing_commit(mainnet_evo1_config(), height);
+    fn finalize_block_tolerates_busy_commit_on_mainnet_evo1_during_incident() {
+        for height in 32326..32329 {
+            let result = finalize_block_with_failing_commit(
+                mainnet_evo1_config(),
+                height,
+                busy_commit_error(),
+            );
             assert!(
                 result.is_ok(),
-                "height {height} is inside the mainnet compat window and must tolerate a failed \
-                 commit, got: {result:?}"
+                "historical conflict at {height}: {result:?}"
             );
         }
     }
 
     #[test]
     #[should_panic(expected = "commit transaction")]
-    fn finalize_block_panics_on_failed_commit_on_mainnet_evo1_at_32329() {
-        // 32329 is the first height where Drive keeps vote deletions inside the block
-        // transaction again, so a failed commit there is a real fault.
-        let _ = finalize_block_with_failing_commit(mainnet_evo1_config(), 32329);
+    fn finalize_block_panics_on_busy_commit_before_incident() {
+        let _ =
+            finalize_block_with_failing_commit(mainnet_evo1_config(), 32325, busy_commit_error());
     }
 
     #[test]
     #[should_panic(expected = "commit transaction")]
-    fn finalize_block_panics_on_failed_commit_outside_mainnet_evo1() {
-        // Same height as the incident, but not the mainnet evo1 chain.
+    fn finalize_block_panics_on_busy_commit_on_mainnet_evo1_at_32329() {
+        // The second crash is prevented by keeping vote deletions inside the transaction
+        // at 32329, not by tolerating another failed commit here.
+        let _ =
+            finalize_block_with_failing_commit(mainnet_evo1_config(), 32329, busy_commit_error());
+    }
+
+    #[test]
+    #[should_panic(expected = "commit transaction")]
+    fn finalize_block_panics_on_busy_commit_outside_mainnet() {
         let mut config = PlatformConfig::default_testnet();
         config.abci.chain_id = "evo1".to_string();
         config.testing_configs.block_commit_signature_verification = false;
-        let _ = finalize_block_with_failing_commit(config, 32326);
+        let _ = finalize_block_with_failing_commit(config, 32326, busy_commit_error());
+    }
+
+    #[test]
+    #[should_panic(expected = "commit transaction")]
+    fn finalize_block_panics_on_busy_commit_with_another_mainnet_chain_id() {
+        let mut config = mainnet_evo1_config();
+        config.abci.chain_id = "another-chain".to_string();
+        let _ = finalize_block_with_failing_commit(config, 32326, busy_commit_error());
+    }
+
+    #[test]
+    #[should_panic(expected = "commit transaction")]
+    fn finalize_block_panics_on_io_error_during_incident() {
+        // A regular file cannot serve as RocksDB's write-ahead log directory.
+        let directory = tempfile::tempdir().expect("temporary database directory");
+        let file = tempfile::NamedTempFile::new().expect("temporary file");
+        let mut options = rocksdb::Options::default();
+        options.create_if_missing(true);
+        options.set_wal_dir(file.path());
+        let error = rocksdb::OptimisticTransactionDB::<rocksdb::SingleThreaded>::open(
+            &options,
+            directory.path(),
+        )
+        .expect_err("WAL path is not a directory");
+        assert_eq!(error.kind(), rocksdb::ErrorKind::IOError);
+        let error = drive::grovedb::Error::StorageError(
+            drive::grovedb_storage::error::Error::RocksDBError(error),
+        )
+        .into();
+        let _ = finalize_block_with_failing_commit(mainnet_evo1_config(), 32328, error);
+    }
+
+    #[test]
+    #[should_panic(expected = "commit transaction")]
+    fn finalize_block_panics_on_execution_error_during_incident() {
+        let error = Error::Execution(ExecutionError::CorruptedCodeExecution(
+            "injected commit failure",
+        ));
+        let _ = finalize_block_with_failing_commit(mainnet_evo1_config(), 32326, error);
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
+++ b/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
@@ -77,11 +77,13 @@ where
     // For the mainnet chain, we enable these fixes at the block when we consider the state is consistent.
     let config = &app.platform().config;
 
-    if app.platform().config.network == Network::Mainnet
-        && config.abci.chain_id == "evo1"
-        && block_height < 33000
+    if config.network == Network::Mainnet && config.abci.chain_id == "evo1" && block_height < 32329
     {
-        // Old behaviour on mainnet below block 33000.
+        // Old behaviour on mainnet below block 32329. This window must match the one in
+        // Drive::remove_all_votes_given_by_identities: it is exactly the range where Drive
+        // deliberately commits its own grovedb transaction mid-block, so it is the only
+        // range where a commit failure here is the reproduced historical outcome rather
+        // than a real fault.
         //
         // The commit fails here with RocksDB "transaction is busy", because
         // remove_all_votes_given_by_identities deliberately reproduces the historical
@@ -89,7 +91,7 @@ where
         // node kept going: tenderdash#966 meant validators ignored the ABCI error and
         // moved to the next block with the state partially committed and caches
         // updated. That tenderdash bug is fixed, so returning the error here aborts
-        // replay instead — which makes mainnet blocks 32326..33000 unreplayable.
+        // replay instead — which makes mainnet blocks 32326..32329 unreplayable.
         //
         // Reproduce the historical *outcome* rather than an error only a buggy
         // tenderdash could survive.
@@ -97,7 +99,7 @@ where
             tracing::warn!(
                 ?error,
                 block_height,
-                "commit failed for a mainnet block below 33000; proceeding as the \
+                "commit failed for a mainnet block below 32329; proceeding as the \
                  network did at the time (see platform#2309, tenderdash#966)"
             );
         }
@@ -126,8 +128,209 @@ where
 mod tests {
     use super::*;
     use crate::abci::app::{FullAbciApplication, TransactionalApplication};
+    use crate::config::PlatformConfig;
+    use crate::execution::types::block_execution_context::v0::BlockExecutionContextV0;
+    use crate::execution::types::block_execution_context::BlockExecutionContext;
+    use crate::execution::types::block_state_info::v0::BlockStateInfoV0;
+    use crate::platform_types::epoch_info::v0::EpochInfoV0;
+    use crate::platform_types::epoch_info::EpochInfo;
+    use crate::platform_types::platform::Platform;
+    use crate::platform_types::withdrawal::unsigned_withdrawal_txs::v0::UnsignedWithdrawalTxs;
     use crate::rpc::core::MockCoreRPCLike;
-    use crate::test::helpers::setup::TestPlatformBuilder;
+    use crate::test::helpers::setup::{TempPlatform, TestPlatformBuilder};
+    use dpp::version::PlatformVersion;
+    use drive::grovedb::Transaction;
+    use std::sync::RwLock;
+    use tenderdash_abci::proto::abci::CommitInfo;
+    use tenderdash_abci::proto::google::protobuf::Timestamp;
+    use tenderdash_abci::proto::types::{
+        Block, BlockId, Data, EvidenceList, Header, PartSetHeader,
+    };
+    use tenderdash_abci::proto::version::Consensus;
+
+    /// An ABCI application whose `commit_transaction` always fails.
+    ///
+    /// Stands in for the RocksDB "transaction is busy" conflict that the mainnet compat window
+    /// exists for, so the tests can prove exactly where the finalize handler tolerates a failed
+    /// commit and where it must not.
+    struct FailingCommitApplication<'a> {
+        platform: &'a Platform<MockCoreRPCLike>,
+        transaction: RwLock<Option<Transaction<'a>>>,
+        block_execution_context: RwLock<Option<BlockExecutionContext>>,
+    }
+
+    impl PlatformApplication<MockCoreRPCLike> for FailingCommitApplication<'_> {
+        fn platform(&self) -> &Platform<MockCoreRPCLike> {
+            self.platform
+        }
+    }
+
+    impl BlockExecutionApplication for FailingCommitApplication<'_> {
+        fn block_execution_context(&self) -> &RwLock<Option<BlockExecutionContext>> {
+            &self.block_execution_context
+        }
+    }
+
+    impl<'a> TransactionalApplication<'a> for FailingCommitApplication<'a> {
+        fn start_transaction(&self) {
+            let transaction = self.platform.drive.grove.start_transaction();
+            self.transaction.write().unwrap().replace(transaction);
+        }
+
+        fn transaction(&self) -> &RwLock<Option<Transaction<'a>>> {
+            &self.transaction
+        }
+
+        fn commit_transaction(&self, _platform_version: &PlatformVersion) -> Result<(), Error> {
+            // Consume the transaction like the real implementation would, then fail.
+            self.transaction.write().unwrap().take();
+            Err(Error::Execution(ExecutionError::CorruptedCodeExecution(
+                "injected commit failure",
+            )))
+        }
+    }
+
+    /// Runs `finalize_block` at `height` against a platform configured with `config`, with a
+    /// commit that is guaranteed to fail.
+    fn finalize_block_with_failing_commit(
+        config: PlatformConfig,
+        height: u64,
+    ) -> Result<proto::ResponseFinalizeBlock, Error> {
+        let platform: TempPlatform<MockCoreRPCLike> = TestPlatformBuilder::new()
+            .with_config(config)
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let app = FailingCommitApplication {
+            platform: &platform.platform,
+            transaction: Default::default(),
+            block_execution_context: Default::default(),
+        };
+
+        app.start_transaction();
+
+        let platform_state = (**platform.state.load()).clone();
+        let quorum_hash: [u8; 32] = platform_state.current_validator_set_quorum_hash().into();
+
+        let block_hash = [1u8; 32];
+        let app_hash = [2u8; 32];
+        let block_time_ms = 1_700_000_000_000u64;
+
+        app.block_execution_context.write().unwrap().replace(
+            BlockExecutionContextV0 {
+                block_state_info: BlockStateInfoV0 {
+                    height,
+                    round: 0,
+                    block_time_ms,
+                    previous_block_time_ms: None,
+                    proposer_pro_tx_hash: [0u8; 32],
+                    core_chain_locked_height: 1,
+                    block_hash: Some(block_hash),
+                    app_hash: Some(app_hash),
+                }
+                .into(),
+                epoch_info: EpochInfo::V0(EpochInfoV0 {
+                    current_epoch_index: 0,
+                    previous_epoch_index: None,
+                    is_epoch_change: false,
+                }),
+                unsigned_withdrawal_transactions: UnsignedWithdrawalTxs::default(),
+                block_address_balance_changes: Default::default(),
+                block_platform_state: platform_state,
+                proposer_results: None,
+            }
+            .into(),
+        );
+
+        let request = proto::RequestFinalizeBlock {
+            commit: Some(CommitInfo {
+                round: 0,
+                quorum_hash: quorum_hash.to_vec(),
+                block_signature: vec![0u8; 96],
+                threshold_vote_extensions: vec![],
+            }),
+            misbehavior: vec![],
+            hash: block_hash.to_vec(),
+            height: height as i64,
+            round: 0,
+            block: Some(Block {
+                header: Some(Header {
+                    version: Some(Consensus { block: 0, app: 1 }),
+                    chain_id: platform.config.abci.chain_id.clone(),
+                    height: height as i64,
+                    time: Some(Timestamp {
+                        seconds: (block_time_ms / 1000) as i64,
+                        nanos: 0,
+                    }),
+                    last_block_id: None,
+                    last_commit_hash: vec![0u8; 32],
+                    data_hash: vec![0u8; 32],
+                    validators_hash: vec![0u8; 32],
+                    next_validators_hash: vec![0u8; 32],
+                    consensus_hash: vec![0u8; 32],
+                    next_consensus_hash: vec![0u8; 32],
+                    app_hash: app_hash.to_vec(),
+                    results_hash: vec![0u8; 32],
+                    evidence_hash: vec![],
+                    proposed_app_version: 1,
+                    proposer_pro_tx_hash: vec![0u8; 32],
+                    core_chain_locked_height: 1,
+                }),
+                data: Some(Data { txs: vec![] }),
+                evidence: Some(EvidenceList { evidence: vec![] }),
+                last_commit: None,
+                core_chain_lock: None,
+            }),
+            block_id: Some(BlockId {
+                hash: block_hash.to_vec(),
+                part_set_header: Some(PartSetHeader {
+                    total: 0,
+                    hash: vec![0u8; 32],
+                }),
+                state_id: vec![0u8; 32],
+            }),
+        };
+
+        finalize_block::<_, MockCoreRPCLike>(&app, request)
+    }
+
+    fn mainnet_evo1_config() -> PlatformConfig {
+        let mut config = PlatformConfig::default_mainnet();
+        config.abci.chain_id = "evo1".to_string();
+        config.testing_configs.block_commit_signature_verification = false;
+        config
+    }
+
+    #[test]
+    fn finalize_block_tolerates_failed_commit_on_mainnet_evo1_before_32329() {
+        for height in [32326u64, 32328] {
+            let result = finalize_block_with_failing_commit(mainnet_evo1_config(), height);
+            assert!(
+                result.is_ok(),
+                "height {height} is inside the mainnet compat window and must tolerate a failed \
+                 commit, got: {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "commit transaction")]
+    fn finalize_block_panics_on_failed_commit_on_mainnet_evo1_at_32329() {
+        // 32329 is the first height where Drive keeps vote deletions inside the block
+        // transaction again, so a failed commit there is a real fault.
+        let _ = finalize_block_with_failing_commit(mainnet_evo1_config(), 32329);
+    }
+
+    #[test]
+    #[should_panic(expected = "commit transaction")]
+    fn finalize_block_panics_on_failed_commit_outside_mainnet_evo1() {
+        // Same height as the incident, but not the mainnet evo1 chain.
+        let mut config = PlatformConfig::default_testnet();
+        config.abci.chain_id = "evo1".to_string();
+        config.testing_configs.block_commit_signature_verification = false;
+        let _ = finalize_block_with_failing_commit(config, 32326);
+    }
 
     #[test]
     fn finalize_block_fails_when_no_transaction() {

--- a/packages/rs-drive/src/drive/votes/cleanup/remove_all_votes_given_by_identities/v0/mod.rs
+++ b/packages/rs-drive/src/drive/votes/cleanup/remove_all_votes_given_by_identities/v0/mod.rs
@@ -124,7 +124,7 @@ impl Drive {
             // Full nodes are stuck and proceeded after re-sync.
             // For the mainnet chain, we enable this fix at the block when we consider the state is consistent.
             let transaction =
-                if network == Network::Mainnet && chain_id == "evo1" && block_height < 33000 {
+                if network == Network::Mainnet && chain_id == "evo1" && block_height < 32329 {
                     // Old behaviour on mainnet
                     None
                 } else {

--- a/packages/rs-drive/src/drive/votes/cleanup/remove_all_votes_given_by_identities/v0/mod.rs
+++ b/packages/rs-drive/src/drive/votes/cleanup/remove_all_votes_given_by_identities/v0/mod.rs
@@ -145,3 +145,206 @@ impl Drive {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::drive::votes::paths::{
+        vote_contested_resource_identity_votes_tree_path_for_identity,
+        vote_contested_resource_identity_votes_tree_path_vec,
+        vote_contested_resource_tree_path_vec,
+    };
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use grovedb::element::reference_path::ReferencePathType;
+    use grovedb::{Element, Transaction};
+
+    const IDENTITY_ID: [u8; 32] = [7u8; 32];
+    const VOTE_ID: [u8; 32] = [9u8; 32];
+    /// Subtree under the contested resource tree that holds the seeded vote element.
+    const VOTE_TREE_KEY: &[u8] = b"t";
+
+    /// Seeds a vote given by `IDENTITY_ID` in the same shape the real registration path uses:
+    /// the vote element lives under the contested resource tree, and the identity votes tree
+    /// holds a reference to it.
+    fn seed_vote(drive: &Drive, platform_version: &PlatformVersion) {
+        let grove_version = &platform_version.drive.grove_version;
+
+        let contested_path = vote_contested_resource_tree_path_vec();
+        let contested_path_ref: Vec<&[u8]> = contested_path.iter().map(|p| p.as_slice()).collect();
+        drive
+            .grove
+            .insert(
+                contested_path_ref.as_slice(),
+                VOTE_TREE_KEY,
+                Element::empty_tree(),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert vote tree");
+
+        let vote_tree_path: Vec<&[u8]> = contested_path_ref
+            .iter()
+            .copied()
+            .chain(std::iter::once(VOTE_TREE_KEY))
+            .collect();
+        // Production stores a sum item here; the element type is irrelevant to deletion, which
+        // only needs to know it is not a subtree.
+        drive
+            .grove
+            .insert(
+                vote_tree_path.as_slice(),
+                &IDENTITY_ID,
+                Element::new_item(vec![1]),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert vote");
+
+        let identity_votes_path = vote_contested_resource_identity_votes_tree_path_vec();
+        let identity_votes_path_ref: Vec<&[u8]> =
+            identity_votes_path.iter().map(|p| p.as_slice()).collect();
+        drive
+            .grove
+            .insert(
+                identity_votes_path_ref.as_slice(),
+                &IDENTITY_ID,
+                Element::empty_tree(),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert identity votes tree");
+
+        let storage_form = ContestedDocumentResourceVoteReferenceStorageForm {
+            reference_path_type:
+                ReferencePathType::UpstreamRootHeightWithParentPathAdditionReference(
+                    2,
+                    vec![VOTE_TREE_KEY.to_vec()],
+                ),
+            identity_vote_times: 1,
+        };
+        let bincode_config = bincode::config::standard()
+            .with_big_endian()
+            .with_no_limit();
+        let encoded_reference =
+            bincode::encode_to_vec(storage_form, bincode_config).expect("encode reference");
+
+        drive
+            .grove
+            .insert(
+                vote_contested_resource_identity_votes_tree_path_for_identity(&IDENTITY_ID)
+                    .as_slice(),
+                &VOTE_ID,
+                Element::new_item(encoded_reference),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert vote reference");
+    }
+
+    fn vote_reference_exists(
+        drive: &Drive,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> bool {
+        match drive
+            .grove
+            .get(
+                vote_contested_resource_identity_votes_tree_path_for_identity(&IDENTITY_ID)
+                    .as_slice(),
+                &VOTE_ID,
+                transaction,
+                &platform_version.drive.grove_version,
+            )
+            .unwrap()
+        {
+            Ok(_) => true,
+            Err(grovedb::Error::PathKeyNotFound(_)) => false,
+            Err(error) => panic!("unexpected error reading vote reference: {error}"),
+        }
+    }
+
+    fn remove_votes(
+        drive: &Drive,
+        block_height: BlockHeight,
+        network: Network,
+        chain_id: &str,
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+    ) {
+        drive
+            .remove_all_votes_given_by_identities_v0(
+                vec![IDENTITY_ID.to_vec()],
+                block_height,
+                network,
+                chain_id,
+                Some(transaction),
+                platform_version,
+            )
+            .expect("remove votes");
+    }
+
+    #[test]
+    fn mainnet_evo1_below_32329_commits_vote_deletion_outside_block_transaction() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        seed_vote(&drive, platform_version);
+
+        let transaction = drive.grove.start_transaction();
+        remove_votes(
+            &drive,
+            32328,
+            Network::Mainnet,
+            "evo1",
+            &transaction,
+            platform_version,
+        );
+
+        // Historical behaviour: the deletion bypasses the block transaction and is already
+        // durable, so rolling the block transaction back does not bring the vote back.
+        assert!(!vote_reference_exists(&drive, None, platform_version));
+        drive
+            .grove
+            .rollback_transaction(&transaction)
+            .expect("rollback");
+        assert!(!vote_reference_exists(&drive, None, platform_version));
+    }
+
+    #[test]
+    fn mainnet_evo1_at_32329_keeps_vote_deletion_inside_block_transaction() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        seed_vote(&drive, platform_version);
+
+        let transaction = drive.grove.start_transaction();
+        remove_votes(
+            &drive,
+            32329,
+            Network::Mainnet,
+            "evo1",
+            &transaction,
+            platform_version,
+        );
+
+        // Fixed behaviour: the deletion is only visible inside the block transaction and is
+        // discarded with it.
+        assert!(!vote_reference_exists(
+            &drive,
+            Some(&transaction),
+            platform_version
+        ));
+        assert!(vote_reference_exists(&drive, None, platform_version));
+        drive
+            .grove
+            .rollback_transaction(&transaction)
+            .expect("rollback");
+        assert!(vote_reference_exists(&drive, None, platform_version));
+    }
+}


### PR DESCRIPTION
## What this fixes

A node syncing mainnet Platform from genesis crashes twice in the 32,326–32,329 window before it gets through. It *does* recover on its own — stock `v4.2-dev` reaches height 100,853 after three tenderdash starts — so this is not a correctness bug and not a stuck chain. It is two forced crash-restarts on every fresh evonode's initial sync, each one a drive-abci ABCI exception plus a container restart.

This PR removes both. Two independent failures with separate fixes.

### 32,326 — `Resource busy`

The vote-cleanup compat path deliberately commits its own GroveDB transaction mid-block (`TxRef::Owned` in `remove_all_votes_given_by_identities`), so the block's own commit hits a RocksDB write conflict. That is intentional: it reproduces the November 2024 incident and yields the state the chain actually recorded.

What is not intentional is returning that error to tenderdash. The network survived it at the time only because dashpay/tenderdash#966 let validators ignore the ABCI error and continue with the state partially committed and caches updated. That tenderdash bug is fixed, so today the same error kills the node instead of being ridden through.

The finalize handler logs the expected RocksDB `Busy` commit conflict and proceeds only on `Mainnet` / `evo1` at heights **32,326–32,328**. The upper cutoff matches the end of Drive's out-of-transaction vote cleanup. All other errors, including I/O failures within that range, fail fast; conflicts before 32,326 and at or after 32,329 also fail fast. The nested Drive/GroveDB/storage errors preserve the RocksDB error, whose `kind()` distinguishes `Busy` from unrelated failures.

The original exception extended below 33,000. Earlier review aligned its upper cutoff to 32,329; the follow-up also adds the incident's lower bound and restricts the exception to the expected error kind.

### 32,329 — app hash mismatch

Drive computes `7510BB0D…`; the chain header records `9E58CEE8…`. (Note the direction: tenderdash's `Expected %X, got %X` at `internal/state/execution.go:437` prints `uncommittedState.AppHash` first and `block.AppHash` second, so "Expected" is *our* value and "got" is chain truth — drive is the party that is wrong here.)

The compat window is one block too wide. Core height across the gap:

```
height=32327  core_height=2165199
height=32328  core_height=2165199
height=32329  core_height=2165700     <- +501 Core blocks
```

501 Dash Core blocks between two consecutive Platform blocks is roughly 21 hours. That is the outage during which the fixes were deployed. The network resumed at 32,329 running corrected code, with the deletions inside the block transaction — so `f017d9071b` ends the window at 32,329 rather than 33,000. 33,000 was a conservative round number; 32,329 is the height at which mainnet state is actually consistent, which is the condition the surrounding comment names ("we enable these fixes at the block when we consider the state is consistent").

## Measurements

dashmate container topology — drive-abci started once and kept alive across tenderdash restarts, exactly as docker does (drive-abci returns an ABCI exception and keeps listening; only tenderdash dies). Genesis → 100,852 on mainnet history served by a local frozen seed, release builds.

| build | tenderdash starts | crashes | 32,326 | 32,329 |
|---|---|---|---|---|
| stock `v4.2-dev` | 3 | 2 | `Resource busy` | app hash |
| \+ `434b83f305` only | 2 | 1 | passes | app hash |
| \+ both commits | **1** | **0** | passes | passes |

Each commit removes exactly one crash; both are needed for a restart-free sync. With both applied, 32,326 commits `87EBC5D5…` and 32,329 commits `9E58CEE8…`, matching the chain.

The original three-arm run completed with identical app hashes at 32,326, 32,329, and 100,852. The build with both original fixes also reached height 424,981 without app-hash mismatches. [Full measurements](https://github.com/dashpay/platform/pull/4536#issuecomment-5471606986). These measurements predate the follow-up error-kind/lower-bound restriction; historical replay has not been rerun for that follow-up.

## Scope

The replay exception applies only to RocksDB `Busy` commit conflicts on `Mainnet` / `evo1` at heights 32,326–32,328. Successful finalization is unchanged elsewhere. Unexpected commit failures fail fast so Drive can restore its caches from disk; they are never acknowledged as successful finalization. The vote-cleanup cutoff remains 32,329, preserving the separate app-hash-crash fix.

## Tests

- `finalize_block`: a real RocksDB transaction conflict is wrapped through the production error types and injected into the handler. It succeeds on Mainnet/evo1 at 32,326, 32,327, and 32,328; it panics at 32,325 and 32,329, on Testnet/evo1, and independently on Mainnet with another chain ID.
- Negative error tests verify that a real RocksDB `IOError` at 32,328 and an unrelated execution error at 32,326 are rejected.
- Existing `remove_all_votes_given_by_identities` tests verify that the vote deletion at 32,328 survives rollback of the supplied block transaction, while at 32,329 it stays inside that transaction and rollback restores it.
- Follow-up local validation: `cargo build --locked -p drive-abci --bin drive-abci`; 59 ABCI handler tests and 81 Drive vote tests; `cargo fmt -p drive-abci -- --check`; `cargo clippy --locked -p drive-abci --lib --tests -- -D warnings`. All passed at `48b5fe498`..
- CI skips the Rust workspace suite for fork PRs (self-hosted runners). The previous full `Tests` mirror run was green at `309372019e`: https://github.com/dashpay/platform/actions/runs/34178556221. That run predates the follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Mainnet `evo1` replay now continues through specific RocksDB busy errors at block heights 32326–32328, while other commit failures remain handled as errors.
  - Vote cleanup behavior is corrected around block height 32329: earlier cleanup can proceed independently of transaction rollback, while cleanup at and after that height follows the block transaction.
  - Added coverage for block replay, commit failures, and transaction rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->