### PR TITLE
feat(drive): serve prefix-pinned count queries off the terminal aggregate

### DIFF
--- a/packages/rs-drive/src/query/drive_document_count_query/executors/point_lookup_proof.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/executors/point_lookup_proof.rs
@@ -77,7 +77,8 @@ impl Drive {
         .ok_or_else(|| {
             Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(
                 "prove count requires a `countable: true` index whose properties \
-                 exactly match the where clause fields, or `documentsCountable: \
+                 exactly match the where clause fields, a `rangeCountable: true` \
+                 index they cover up to its last property, or `documentsCountable: \
                  true` on the document type for unfiltered total counts — same \
                  requirement as the no-proof path"
                     .to_string(),

--- a/packages/rs-drive/src/query/drive_document_count_query/executors/total.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/executors/total.rs
@@ -64,8 +64,10 @@ impl Drive {
         .ok_or_else(|| {
             Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(
                 "count query requires a `countable: true` index whose properties \
-                     exactly match the where clause fields, or `documentsCountable: \
-                     true` on the document type for unfiltered total counts"
+                     exactly match the where clause fields, a `rangeCountable: true` \
+                     index they cover up to its last property, or \
+                     `documentsCountable: true` on the document type for unfiltered \
+                     total counts"
                     .to_string(),
             ))
         })?;

--- a/packages/rs-drive/src/query/drive_document_count_query/index_picker.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/index_picker.rs
@@ -14,22 +14,27 @@ use std::collections::{BTreeMap, BTreeSet};
 impl DriveDocumentCountQuery<'_> {
     /// Finds a `countable: true` index whose properties **exactly match** the
     /// indexable (Equal/In) where-clause fields — every index property has a
-    /// corresponding clause AND every clause's field appears in the index.
+    /// corresponding clause AND every clause's field appears in the index —
+    /// or, failing that, a `rangeCountable: true` index whose properties
+    /// match the clause fields **plus one trailing free property**.
     ///
-    /// Exact coverage is the contract for both no-proof and prove count
-    /// paths: a countable index counts exactly what it indexes, and queries
-    /// against partially-covered indexes are rejected with a clear error
-    /// directing the caller at the index-design fix. This avoids the
-    /// product-of-uncovered-branching-factors walk that a prefix-match
-    /// approach would silently fall through to, and keeps the storage's
-    /// "count maintained only at the terminal level" trade-off intact (no
-    /// need to maintain counts at intermediate index levels just to serve
-    /// partial-coverage queries cheaply).
+    /// Exact coverage is the preferred contract for both no-proof and prove
+    /// count paths: a countable index counts exactly what it indexes. The
+    /// prefix-to-last fallback exists because a `rangeCountable` index also
+    /// maintains one aggregate no exact-coverage query can reach — its
+    /// terminal property-name tree is count-bearing, and that tree's own
+    /// element carries the **whole-prefix** total (every last-property value
+    /// tree contributes its count to it). So `count WHERE hashtag == X` on
+    /// `[hashtag, postId]` is one element read at `…/hashtag/X/postId`, not
+    /// a walk — the same shape as the exact form, one level up. Any other
+    /// partial coverage stays rejected: intermediate levels carry no
+    /// aggregates, so there is nothing cheap to read.
     ///
     /// Returns `None` if:
     /// - Any where clause uses an operator other than `Equal` / `In`.
-    /// - The set of indexable where-clause fields doesn't exactly equal the
-    ///   set of properties of any single `countable: true` index.
+    /// - The set of indexable where-clause fields neither exactly equals the
+    ///   property set of a `countable: true` index nor exactly covers all
+    ///   but the last property of a `rangeCountable: true` index.
     ///
     /// For the `documents_countable: true` case (total count with no where
     /// clauses), the dispatcher reads the document-type primary-key tree's
@@ -88,6 +93,46 @@ impl DriveDocumentCountQuery<'_> {
                 .iter()
                 .all(|prop| indexable_fields.contains(prop.name.as_str()));
             if all_covered {
+                return Some(index);
+            }
+        }
+
+        // Prefix-to-last fallback: exactly the first `len - 1` properties
+        // are covered and the last one is free — servable only when the
+        // terminal property-name tree is count-bearing, i.e.
+        // `rangeCountable`. The exact form above stays preferred so a
+        // shorter exact index (one merk layer cheaper) keeps winning when
+        // both exist. Position matters here, unlike the set-equality
+        // form: a clause on the LAST property with an earlier one free is
+        // not a prefix and reads nothing meaningful.
+        for index in indexes.values() {
+            if !index_admissible_for_resolved_time_range(index, resolved_time_ranges) {
+                continue;
+            }
+            if !index.range_countable || !index.countable.is_countable() {
+                continue;
+            }
+            // A ranked axis makes the terminal property-name tree an
+            // INDEXED tree, which grovedb's query dispatch refuses to
+            // return as a result element ("path_queries can not refer to
+            // trees") — the element read this form performs would have
+            // nothing legal to select. Skipped until that dispatch admits
+            // indexed elements; a prefix-level ranking
+            // (`rankedCountable: { at }`) keeps its terminal non-indexed
+            // and stays servable.
+            if index.ranked_countable || index.ranked_summable || index.ranked_averageable {
+                continue;
+            }
+            let Some(leading_len) = index.properties.len().checked_sub(1) else {
+                continue;
+            };
+            if leading_len != indexable_fields.len() || leading_len == 0 {
+                continue;
+            }
+            let leading_covered = index.properties[..leading_len]
+                .iter()
+                .all(|prop| indexable_fields.contains(prop.name.as_str()));
+            if leading_covered {
                 return Some(index);
             }
         }

--- a/packages/rs-drive/src/query/drive_document_count_query/index_picker.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/index_picker.rs
@@ -16,7 +16,10 @@ impl DriveDocumentCountQuery<'_> {
     /// indexable (Equal/In) where-clause fields — every index property has a
     /// corresponding clause AND every clause's field appears in the index —
     /// or, failing that, a `rangeCountable: true` index whose properties
-    /// match the clause fields **plus one trailing free property**.
+    /// match the clause fields **plus one trailing free property** — or,
+    /// failing that, an index with a prefix-level ranking
+    /// (`rankedCountable: { at }`) whose count-bearing chain reaches the
+    /// deepest pinned property, serving contiguous pins of **any** depth.
     ///
     /// Exact coverage is the preferred contract for both no-proof and prove
     /// count paths: a countable index counts exactly what it indexes. The
@@ -130,6 +133,49 @@ impl DriveDocumentCountQuery<'_> {
                 continue;
             }
             let leading_covered = index.properties[..leading_len]
+                .iter()
+                .all(|prop| indexable_fields.contains(prop.name.as_str()));
+            if leading_covered {
+                return Some(index);
+            }
+        }
+
+        // At-chain value-tree fallback: on an index with a prefix-level
+        // ranking (`rankedCountable: { at }`), every level from the
+        // shallowest `at` property down is count-bearing — its value
+        // trees are `CountTree`s whose count IS the whole-subtree total
+        // — so contiguous pins of ANY depth k landing at or below that
+        // level are servable by reading the deepest pin's value tree
+        // element. This also covers what the loop above cannot: a
+        // ranked-terminal (`at` + boolean) index, since the value-tree
+        // read never touches the indexed property-name tree grovedb
+        // refuses to return. Pins landing ABOVE the shallowest `at`
+        // level stay rejected — those levels are plain trees.
+        for index in indexes.values() {
+            if !index_admissible_for_resolved_time_range(index, resolved_time_ranges) {
+                continue;
+            }
+            if !index.countable.is_countable() {
+                continue;
+            }
+            let pin_depth = indexable_fields.len();
+            if pin_depth == 0 || pin_depth >= index.properties.len() {
+                continue;
+            }
+            let Some(min_at_position) = index
+                .ranked_countable_at
+                .iter()
+                .filter_map(|at| index.properties.iter().position(|p| &p.name == at))
+                .min()
+            else {
+                continue;
+            };
+            // The deepest pinned property (position pin_depth - 1) must
+            // sit at or below the shallowest ranked level.
+            if min_at_position > pin_depth - 1 {
+                continue;
+            }
+            let leading_covered = index.properties[..pin_depth]
                 .iter()
                 .all(|prop| indexable_fields.contains(prop.name.as_str()));
             if leading_covered {

--- a/packages/rs-drive/src/query/drive_document_count_query/path_query.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/path_query.rs
@@ -805,10 +805,24 @@ impl DriveDocumentCountQuery<'_> {
     ///       the subquery's single `Key(value)`; `set_subquery_path`
     ///       ends at the terminator's property-name segment.
     ///
+    /// - **Prefix-to-last** (every property except the LAST covered, on
+    ///   a `range_countable` index): the selector is the terminal
+    ///   property-name tree's own element — a count-bearing tree whose
+    ///   aggregate is the whole-prefix total — addressed by its level
+    ///   key one layer below the last pin's value tree:
+    ///   - Equal-only pins: path `[..., pin_field, pin_value]`, single
+    ///     `Key(last_field)`.
+    ///   - With an `In` pin: same compound shape as above, with the
+    ///     post-In Equal `(name, value)` pairs in `set_subquery_path`
+    ///     (all full pairs — nothing is hoisted) and the subquery
+    ///     `Key(last_field)`.
+    ///
     /// ## Errors
     ///
     /// Rejects shapes the builder doesn't support:
-    /// - Partial coverage (uncovered index property)
+    /// - Partial coverage (an uncovered index property, except the
+    ///   trailing free property of the prefix-to-last form on a
+    ///   `range_countable` index)
     /// - More than one `In` clause
     /// - Any non-`Equal` / non-`In` operator (defense-in-depth; mode
     ///   detection already filters these out)
@@ -852,25 +866,34 @@ impl DriveDocumentCountQuery<'_> {
         // the divergence rationale).
         let mut in_outer_keys: Option<Vec<Vec<u8>>> = None;
         let mut subquery_path_extension: Vec<Vec<u8>> = vec![];
+        // Set when the LAST property carries no clause — the
+        // prefix-to-last form on a `range_countable` index. The count is
+        // then the terminal property-name tree's own element aggregate
+        // (the whole-prefix total), addressed by this level key from the
+        // last pin's value tree.
+        let mut prefix_to_last_key: Option<Vec<u8>> = None;
 
         for (position, prop) in self.index.properties.iter().enumerate() {
             // The path segment is the level key — grid-qualified for a
             // time-range index's first property — while the clause lookup
             // and value serialization stay on the bare property name.
             let level_key = self.index.level_key(position, &prop.name);
-            let clause = self
-                .where_clauses
-                .iter()
-                .find(|wc| wc.field == prop.name)
-                .ok_or_else(|| {
-                    Error::Query(QuerySyntaxError::InvalidWhereClauseComponents(
-                        "prove count requires the where clauses to fully cover the \
-                         countable index; one or more index properties have no \
-                         matching `==` or `in` clause — use a more specific index \
-                         (define a `countable: true` index whose properties exactly \
-                         match the clauses) or use `prove=false`",
-                    ))
-                })?;
+            let Some(clause) = self.where_clauses.iter().find(|wc| wc.field == prop.name) else {
+                if position + 1 == self.index.properties.len() && self.index.range_countable {
+                    prefix_to_last_key = Some(level_key.into_bytes());
+                    break;
+                }
+                return Err(Error::Query(
+                    QuerySyntaxError::InvalidWhereClauseComponents(
+                        "prove count requires the where clauses to cover the countable \
+                     index; one or more index properties have no matching `==` or \
+                     `in` clause — only the LAST property of a `rangeCountable: \
+                     true` index may be left free (the prefix-to-last form). Use a \
+                     more specific index (define a `countable: true` index whose \
+                     properties exactly match the clauses) or use `prove=false`",
+                    ),
+                ));
+            };
 
             match clause.operator {
                 WhereOperator::Equal => {
@@ -973,6 +996,37 @@ impl DriveDocumentCountQuery<'_> {
         // tree. See the book's "Count Trees and Provable Counts"
         // chapter for the layout.
         const COUNT_TREE_KEY: u8 = 0;
+
+        // Prefix-to-last selector: the terminal property-name tree —
+        // count-bearing under `rangeCountable`, its aggregate the sum of
+        // every last-property value tree's count, i.e. the whole-prefix
+        // total — read as one element by its level key from the last
+        // pin's value tree. Structurally the `Key([0])` shape with the
+        // terminal level key in place of the bucket key: nothing is
+        // hoisted, so the `In` branches keep their full trailing pairs
+        // in `set_subquery_path`.
+        if let Some(terminal_level_key) = prefix_to_last_key {
+            return Ok(match in_outer_keys {
+                None => {
+                    let mut query = Query::new();
+                    query.insert_key(terminal_level_key);
+                    PathQuery::new(base_path, SizedQuery::new(query, None, None))
+                }
+                Some(keys) => {
+                    let mut outer_query = Query::new();
+                    for key in keys {
+                        outer_query.insert_key(key);
+                    }
+                    let mut subquery = Query::new();
+                    subquery.insert_key(terminal_level_key);
+                    if !subquery_path_extension.is_empty() {
+                        outer_query.set_subquery_path(subquery_path_extension);
+                    }
+                    outer_query.set_subquery(subquery);
+                    PathQuery::new(base_path, SizedQuery::new(outer_query, None, None))
+                }
+            });
+        }
 
         match in_outer_keys {
             None => {

--- a/packages/rs-drive/src/query/drive_document_count_query/path_query.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/path_query.rs
@@ -908,7 +908,7 @@ impl DriveDocumentCountQuery<'_> {
                     .filter_map(|at| self.index.properties.iter().position(|p| &p.name == at))
                     .min();
                 let deepest_pin_is_count_bearing =
-                    position >= 1 && min_at_position.is_some_and(|min_at| min_at <= position - 1);
+                    position >= 1 && min_at_position.is_some_and(|min_at| min_at < position);
                 if deepest_pin_is_count_bearing {
                     // Fail closed on a gapped set reaching the builder
                     // directly: a clause on any deeper property means the

--- a/packages/rs-drive/src/query/drive_document_count_query/path_query.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/path_query.rs
@@ -879,16 +879,62 @@ impl DriveDocumentCountQuery<'_> {
             // and value serialization stay on the bare property name.
             let level_key = self.index.level_key(position, &prop.name);
             let Some(clause) = self.where_clauses.iter().find(|wc| wc.field == prop.name) else {
-                if position + 1 == self.index.properties.len() && self.index.range_countable {
+                // Prefix-to-last: the terminal property-name tree's own
+                // element carries the whole-prefix total — but only when
+                // that tree is a plain (non-indexed) count-bearing tree;
+                // a ranked terminal is an indexed tree grovedb refuses to
+                // return, and those indexes route through the value-tree
+                // arm below instead.
+                let terminal_ranked = self.index.ranked_countable
+                    || self.index.ranked_summable
+                    || self.index.ranked_averageable;
+                if position + 1 == self.index.properties.len()
+                    && self.index.range_countable
+                    && !terminal_ranked
+                {
                     prefix_to_last_key = Some(level_key.into_bytes());
+                    break;
+                }
+                // At-chain value-tree read: when the deepest pinned
+                // property's level sits at or below the index's
+                // shallowest `at` level, its value trees are `CountTree`s
+                // whose count IS the whole-subtree total, and the
+                // fully-covered selector below reads them verbatim — the
+                // loop just stops here instead of at the terminal.
+                let min_at_position = self
+                    .index
+                    .ranked_countable_at
+                    .iter()
+                    .filter_map(|at| self.index.properties.iter().position(|p| &p.name == at))
+                    .min();
+                let deepest_pin_is_count_bearing =
+                    position >= 1 && min_at_position.is_some_and(|min_at| min_at <= position - 1);
+                if deepest_pin_is_count_bearing {
+                    // Fail closed on a gapped set reaching the builder
+                    // directly: a clause on any deeper property means the
+                    // pins are not a contiguous prefix and address nothing.
+                    if self.index.properties[position..]
+                        .iter()
+                        .any(|deeper| self.where_clauses.iter().any(|wc| wc.field == deeper.name))
+                    {
+                        return Err(Error::Query(
+                            QuerySyntaxError::InvalidWhereClauseComponents(
+                                "prove count: the pinned properties must form a \
+                                 contiguous index prefix — a clause on a property \
+                                 deeper than the first free one addresses nothing",
+                            ),
+                        ));
+                    }
                     break;
                 }
                 return Err(Error::Query(
                     QuerySyntaxError::InvalidWhereClauseComponents(
                         "prove count requires the where clauses to cover the countable \
                      index; one or more index properties have no matching `==` or \
-                     `in` clause — only the LAST property of a `rangeCountable: \
-                     true` index may be left free (the prefix-to-last form). Use a \
+                     `in` clause — only a trailing free suffix is servable: the LAST \
+                     property of a `rangeCountable: true` index (the prefix-to-last \
+                     form), or everything below a pinned level of a \
+                     `rankedCountable: { at }` chain (the value-tree form). Use a \
                      more specific index (define a `countable: true` index whose \
                      properties exactly match the clauses) or use `prove=false`",
                     ),

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -3917,7 +3917,7 @@ mod prefix_to_last {
         assert!(
             DriveDocumentCountQuery::find_countable_index_for_where_clauses(
                 person_indexes,
-                &vec![
+                &[
                     WhereClause {
                         field: "firstName".to_string(),
                         operator: WhereOperator::Equal,

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -3714,3 +3714,360 @@ mod time_range_picker_tests {
         );
     }
 }
+
+mod prefix_to_last {
+    //! The prefix-to-last count form: `count WHERE hashtag == X` on a
+    //! `rangeCountable` `[hashtag, postId]` index, with NO clause on the
+    //! last property. The count is the terminal property-name tree's own
+    //! element aggregate — the whole-prefix total — read (and proven) as
+    //! one element at `…/hashtag/X/postId`. Runs against the `tally`
+    //! fixture (the yappr-likes shape minus the ranked axis): grovedb's
+    //! query dispatch refuses to return INDEXED tree elements, so a
+    //! rankedCountable terminal stays unservable by this form — pinned
+    //! below — while a prefix-level ranking (`rankedCountable: { at }`)
+    //! keeps its terminal non-indexed and composes.
+
+    use super::*;
+    use crate::config::DriveConfig;
+    use crate::query::drive_document_count_query::drive_dispatcher::{
+        DocumentCountRequest, DocumentCountResponse,
+    };
+    use dpp::data_contract::document_type::random_document::CreateRandomDocument;
+    use dpp::document::DocumentV0Setters;
+    use dpp::tests::json_document::json_document_to_contract;
+
+    fn setup_tally() -> (Drive, dpp::prelude::DataContract) {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let contract = json_document_to_contract(
+            "tests/supporting_files/contract/tally/tally-contract.json",
+            false,
+            platform_version,
+        )
+        .expect("expected to parse the tally contract");
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply the tally contract");
+        (drive, contract)
+    }
+
+    fn insert_like(
+        drive: &Drive,
+        contract: &dpp::prelude::DataContract,
+        hashtag: &str,
+        post: &str,
+        seed: u64,
+    ) {
+        let platform_version = PlatformVersion::latest();
+        let document_type = contract
+            .document_type_for_name("like")
+            .expect("like doctype exists");
+        let mut doc: Document = document_type
+            .random_document(Some(seed), platform_version)
+            .expect("random document");
+        let mut props = StdBTreeMap::new();
+        props.insert("hashtag".to_string(), Value::Text(hashtag.to_string()));
+        props.insert("postId".to_string(), Value::Text(post.to_string()));
+        doc.set_properties(props);
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&doc, None)),
+                        owner_id: None,
+                    },
+                    contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a like");
+    }
+
+    /// Three likes for `alpha` (across two posts) and one for `beta` —
+    /// the totals the tests below assert.
+    fn seed_likes(drive: &Drive, contract: &dpp::prelude::DataContract) {
+        insert_like(drive, contract, "alpha", "p1", 1);
+        insert_like(drive, contract, "alpha", "p1", 2);
+        insert_like(drive, contract, "alpha", "p2", 3);
+        insert_like(drive, contract, "beta", "p3", 4);
+    }
+
+    fn hashtag_equal(hashtag: &str) -> Vec<WhereClause> {
+        vec![WhereClause {
+            field: "hashtag".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Text(hashtag.to_string()),
+        }]
+    }
+
+    fn like_query<'a>(
+        contract: &'a dpp::prelude::DataContract,
+        where_clauses: Vec<WhereClause>,
+    ) -> DriveDocumentCountQuery<'a> {
+        let document_type = contract
+            .document_type_for_name("like")
+            .expect("like doctype exists");
+        // Off the contract's document-type map rather than the local
+        // `DocumentTypeRef`, so the borrow lives as long as `contract`.
+        let indexes = contract
+            .document_types()
+            .get("like")
+            .expect("like doctype exists")
+            .indexes();
+        let index = DriveDocumentCountQuery::find_countable_index_for_where_clauses(
+            indexes,
+            &where_clauses,
+            &[],
+        )
+        .expect("the prefix-to-last fallback must pick byHashtagPost");
+        assert_eq!(
+            index.properties.len(),
+            2,
+            "the picked index must be the compound byHashtagPost"
+        );
+        DriveDocumentCountQuery {
+            document_type,
+            contract_id: contract.id().to_buffer(),
+            document_type_name: "like".to_string(),
+            index,
+            where_clauses,
+        }
+    }
+
+    /// The picker's coverage rules for the new form, over real contract
+    /// index sets: the fallback fires only for an unranked
+    /// `rangeCountable` index with exactly the leading properties
+    /// covered; a ranked terminal (an indexed tree grovedb refuses to
+    /// return) stays rejected, as does a countable-but-not-rangeCountable
+    /// compound; and an exact match keeps winning where one exists.
+    #[test]
+    fn picker_accepts_leading_coverage_on_unranked_range_countable_only() {
+        let platform_version = PlatformVersion::latest();
+
+        // The tally fixture: {hashtag} covers byHashtagPost's leading
+        // property → the fallback fires.
+        let (_drive, tally) = setup_tally();
+        let like_type_indexes = tally
+            .document_types()
+            .get("like")
+            .expect("like doctype exists")
+            .indexes();
+        let picked = DriveDocumentCountQuery::find_countable_index_for_where_clauses(
+            like_type_indexes,
+            &hashtag_equal("alpha"),
+            &[],
+        )
+        .expect("leading coverage of an unranked rangeCountable index must match");
+        assert_eq!(picked.properties.len(), 2);
+        assert_eq!(picked.properties[0].name, "hashtag");
+
+        // yappr-likes: the same shape but rankedCountable — the terminal
+        // property-name tree is a ProvableCountIndexedTree, which
+        // grovedb's query dispatch refuses to return, so the fallback
+        // must not select it.
+        let yappr = json_document_to_contract(
+            "tests/supporting_files/contract/yappr-likes/yappr-likes-contract.json",
+            false,
+            platform_version,
+        )
+        .expect("yappr fixture parses");
+        let yappr_like_indexes = yappr
+            .document_types()
+            .get("like")
+            .expect("like doctype exists")
+            .indexes();
+        assert!(
+            DriveDocumentCountQuery::find_countable_index_for_where_clauses(
+                yappr_like_indexes,
+                &hashtag_equal("alpha"),
+                &[],
+            )
+            .is_none(),
+            "a ranked terminal must stay rejected — its element is an indexed tree"
+        );
+
+        // family's [firstName, middleName, lastName] is countable but NOT
+        // rangeCountable: leading coverage must stay rejected.
+        let family = json_document_to_contract_with_ids(
+            "tests/supporting_files/contract/family/family-contract-countable.json",
+            None,
+            None,
+            false,
+            platform_version,
+        )
+        .expect("family fixture parses");
+        let person_indexes = family
+            .document_types()
+            .get("person")
+            .expect("person doctype exists")
+            .indexes();
+        assert!(
+            DriveDocumentCountQuery::find_countable_index_for_where_clauses(
+                person_indexes,
+                &vec![
+                    WhereClause {
+                        field: "firstName".to_string(),
+                        operator: WhereOperator::Equal,
+                        value: Value::Text("Alice".to_string()),
+                    },
+                    WhereClause {
+                        field: "middleName".to_string(),
+                        operator: WhereOperator::Equal,
+                        value: Value::Text("M".to_string()),
+                    },
+                ],
+                &[],
+            )
+            .is_none(),
+            "leading coverage without rangeCountable must stay rejected"
+        );
+    }
+
+    /// The motivating query, end to end: the whole-prefix total is one
+    /// element read on the no-proof path and one verified element on the
+    /// prove path, reconstructing the live root hash.
+    #[test]
+    fn equal_prefix_count_reads_and_proves_the_whole_prefix_total() {
+        let (drive, contract) = setup_tally();
+        let platform_version = PlatformVersion::latest();
+        seed_likes(&drive, &contract);
+
+        let query = like_query(&contract, hashtag_equal("alpha"));
+
+        let results = query
+            .execute_no_proof(&drive, None, platform_version)
+            .expect("the prefix count must read");
+        assert_eq!(
+            results[0].count,
+            Some(3),
+            "alpha's total must count across its posts"
+        );
+
+        let proof = query
+            .execute_point_lookup_count_with_proof(&drive, None, platform_version)
+            .expect("the prefix count must prove");
+        let (root_hash, entries) = query
+            .verify_point_lookup_count_proof(&proof, platform_version)
+            .expect("the proof must verify");
+        let summed: u64 = entries.iter().map(|e| e.count.unwrap_or(0)).sum();
+        assert_eq!(summed, 3, "the verified total must match the read");
+        assert_eq!(
+            root_hash,
+            drive
+                .grove
+                .root_hash(None, &platform_version.drive.grove_version)
+                .unwrap()
+                .expect("root hash must be readable"),
+            "the proof must reconstruct the live grovedb root hash"
+        );
+    }
+
+    /// An absent prefix counts zero — with a verifiable absence proof.
+    #[test]
+    fn absent_prefix_counts_zero_with_proof() {
+        let (drive, contract) = setup_tally();
+        let platform_version = PlatformVersion::latest();
+        seed_likes(&drive, &contract);
+
+        let query = like_query(&contract, hashtag_equal("missing"));
+
+        let results = query
+            .execute_no_proof(&drive, None, platform_version)
+            .expect("an absent prefix must read");
+        assert_eq!(results[0].count, Some(0));
+
+        let proof = query
+            .execute_point_lookup_count_with_proof(&drive, None, platform_version)
+            .expect("an absent prefix must prove");
+        let (_root_hash, entries) = query
+            .verify_point_lookup_count_proof(&proof, platform_version)
+            .expect("the absence proof must verify");
+        let summed: u64 = entries.iter().map(|e| e.count.unwrap_or(0)).sum();
+        assert_eq!(summed, 0, "the verified absence must count zero");
+    }
+
+    /// `hashtag IN […]` fans the same element read over the branches:
+    /// the no-proof read sums them; the proof verifies per branch.
+    #[test]
+    fn in_prefix_counts_per_branch() {
+        let (drive, contract) = setup_tally();
+        let platform_version = PlatformVersion::latest();
+        seed_likes(&drive, &contract);
+
+        let query = like_query(
+            &contract,
+            vec![WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::In,
+                value: Value::Array(vec![
+                    Value::Text("alpha".to_string()),
+                    Value::Text("beta".to_string()),
+                ]),
+            }],
+        );
+
+        let results = query
+            .execute_no_proof(&drive, None, platform_version)
+            .expect("the branched prefix count must read");
+        assert_eq!(results[0].count, Some(4), "alpha's 3 plus beta's 1");
+
+        let proof = query
+            .execute_point_lookup_count_with_proof(&drive, None, platform_version)
+            .expect("the branched prefix count must prove");
+        let (_root_hash, entries) = query
+            .verify_point_lookup_count_proof(&proof, platform_version)
+            .expect("the branched proof must verify");
+        let summed: u64 = entries.iter().map(|e| e.count.unwrap_or(0)).sum();
+        assert_eq!(summed, 4, "verified per-branch counts must sum to the read");
+    }
+
+    /// The public dispatcher serves the form end to end — the shape a
+    /// DAPI `GetDocumentsCount` request actually takes.
+    #[test]
+    fn dispatcher_serves_the_prefix_form() {
+        let (drive, contract) = setup_tally();
+        let platform_version = PlatformVersion::latest();
+        seed_likes(&drive, &contract);
+
+        let drive_config = DriveConfig::default();
+        let response = drive
+            .execute_document_count_request(
+                DocumentCountRequest {
+                    contract: &contract,
+                    document_type: contract
+                        .document_type_for_name("like")
+                        .expect("like doctype exists"),
+                    where_clauses: hashtag_equal("alpha"),
+                    resolved_time_ranges: vec![],
+                    order_clauses: Vec::new(),
+                    mode: CountMode::Aggregate,
+                    limit: None,
+                    prove: false,
+                    drive_config: &drive_config,
+                },
+                None,
+                platform_version,
+            )
+            .expect("the dispatcher must serve the prefix form");
+        let DocumentCountResponse::Aggregate(total) = response else {
+            panic!("expected an aggregate response, got a different variant");
+        };
+        assert_eq!(
+            total, 3,
+            "the aggregate total must be alpha's whole-prefix count"
+        );
+    }
+}

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -4071,3 +4071,212 @@ mod prefix_to_last {
         );
     }
 }
+
+mod prefix_to_last_in_with_trailing_equal {
+    //! The one prefix-to-last builder arm the two-property fixture cannot
+    //! reach: an `IN` pin followed by a trailing `Equal` pin with the
+    //! LAST property free. The descent under each `IN` branch rolls the
+    //! trailing pair through `set_subquery_path` and then selects the
+    //! terminal property-name tree by its level key — per-branch
+    //! whole-prefix totals, proved and verified. Also pins the
+    //! no-covering-index rejection text both executors emit for a
+    //! genuinely uncoverable pin set.
+
+    use super::*;
+    use crate::config::DriveConfig;
+    use crate::query::drive_document_count_query::drive_dispatcher::{
+        DocumentCountRequest, DocumentCountResponse,
+    };
+    use dpp::data_contract::document_type::random_document::CreateRandomDocument;
+    use dpp::document::DocumentV0Setters;
+    use dpp::tests::json_document::json_document_to_contract;
+
+    fn setup_geo() -> (Drive, dpp::prelude::DataContract) {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let contract = json_document_to_contract(
+            "tests/supporting_files/contract/tally/tally-contract.json",
+            false,
+            platform_version,
+        )
+        .expect("expected to parse the tally contract");
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply the tally contract");
+        (drive, contract)
+    }
+
+    fn insert_geo(
+        drive: &Drive,
+        contract: &dpp::prelude::DataContract,
+        region: &str,
+        hashtag: &str,
+        post: &str,
+        seed: u64,
+    ) {
+        let platform_version = PlatformVersion::latest();
+        let document_type = contract
+            .document_type_for_name("geo")
+            .expect("geo doctype exists");
+        let mut doc: Document = document_type
+            .random_document(Some(seed), platform_version)
+            .expect("random document");
+        let mut props = StdBTreeMap::new();
+        props.insert("region".to_string(), Value::Text(region.to_string()));
+        props.insert("hashtag".to_string(), Value::Text(hashtag.to_string()));
+        props.insert("postId".to_string(), Value::Text(post.to_string()));
+        doc.set_properties(props);
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&doc, None)),
+                        owner_id: None,
+                    },
+                    contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a geo document");
+    }
+
+    #[test]
+    fn in_pin_with_trailing_equal_counts_per_branch_with_proof() {
+        let (drive, contract) = setup_geo();
+        let platform_version = PlatformVersion::latest();
+
+        // alpha in r1: 3 likes across two posts; alpha in r2: 1; beta
+        // rows must not leak into the alpha totals.
+        insert_geo(&drive, &contract, "r1", "alpha", "p1", 1);
+        insert_geo(&drive, &contract, "r1", "alpha", "p1", 2);
+        insert_geo(&drive, &contract, "r1", "alpha", "p2", 3);
+        insert_geo(&drive, &contract, "r2", "alpha", "p1", 4);
+        insert_geo(&drive, &contract, "r1", "beta", "p1", 5);
+
+        let where_clauses = vec![
+            WhereClause {
+                field: "region".to_string(),
+                operator: WhereOperator::In,
+                value: Value::Array(vec![
+                    Value::Text("r1".to_string()),
+                    Value::Text("r2".to_string()),
+                ]),
+            },
+            WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("alpha".to_string()),
+            },
+        ];
+        let document_type = contract
+            .document_type_for_name("geo")
+            .expect("geo doctype exists");
+        let indexes = contract
+            .document_types()
+            .get("geo")
+            .expect("geo doctype exists")
+            .indexes();
+        let index = DriveDocumentCountQuery::find_countable_index_for_where_clauses(
+            indexes,
+            &where_clauses,
+            &[],
+        )
+        .expect("the fallback must accept the two leading pins of the 3-property index");
+        assert_eq!(index.properties.len(), 3);
+        let query = DriveDocumentCountQuery {
+            document_type,
+            contract_id: contract.id().to_buffer(),
+            document_type_name: "geo".to_string(),
+            index,
+            where_clauses,
+        };
+
+        let results = query
+            .execute_no_proof(&drive, None, platform_version)
+            .expect("the branched trailing-equal prefix count must read");
+        assert_eq!(results[0].count, Some(4), "r1 alpha's 3 plus r2 alpha's 1");
+
+        let proof = query
+            .execute_point_lookup_count_with_proof(&drive, None, platform_version)
+            .expect("the branched trailing-equal prefix count must prove");
+        let (root_hash, entries) = query
+            .verify_point_lookup_count_proof(&proof, platform_version)
+            .expect("the proof must verify");
+        let summed: u64 = entries.iter().map(|e| e.count.unwrap_or(0)).sum();
+        assert_eq!(summed, 4, "verified per-branch totals must sum to the read");
+        assert_eq!(
+            root_hash,
+            drive
+                .grove
+                .root_hash(None, &platform_version.drive.grove_version)
+                .unwrap()
+                .expect("root hash must be readable"),
+        );
+    }
+
+    /// A pin set no index covers — a MIDDLE property left free is not the
+    /// prefix-to-last shape — must surface both executors' rejection text
+    /// naming every acceptable coverage.
+    #[test]
+    fn uncoverable_pins_name_the_acceptable_coverages() {
+        let (drive, contract) = setup_geo();
+        let platform_version = PlatformVersion::latest();
+        insert_geo(&drive, &contract, "r1", "alpha", "p1", 1);
+
+        // region pinned, hashtag free, postId pinned: covers neither the
+        // exact form nor the leading prefix.
+        let gapped = vec![
+            WhereClause {
+                field: "region".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("r1".to_string()),
+            },
+            WhereClause {
+                field: "postId".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("p1".to_string()),
+            },
+        ];
+        let drive_config = DriveConfig::default();
+        for prove in [false, true] {
+            let error = drive
+                .execute_document_count_request(
+                    DocumentCountRequest {
+                        contract: &contract,
+                        document_type: contract
+                            .document_type_for_name("geo")
+                            .expect("geo doctype exists"),
+                        where_clauses: gapped.clone(),
+                        resolved_time_ranges: vec![],
+                        order_clauses: Vec::new(),
+                        mode: CountMode::Aggregate,
+                        limit: None,
+                        prove,
+                        drive_config: &drive_config,
+                    },
+                    None,
+                    platform_version,
+                )
+                .expect_err("a gapped pin set must be rejected (prove: {prove})");
+            let message = format!("{error}");
+            assert!(
+                message.contains("rangeCountable") && message.contains("exactly match"),
+                "the rejection must name both acceptable coverages (prove: {prove}); \
+                 got {message}"
+            );
+        }
+    }
+}

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -4380,3 +4380,286 @@ mod prefix_to_last_in_with_trailing_equal {
         }
     }
 }
+
+mod at_chain_value_tree_counts {
+    //! Short-prefix counts on `rankedCountable: { at }` chains: every
+    //! level from the shallowest `at` property down keeps its subtree
+    //! total in a plain `CountTree` value tree, so contiguous pins of
+    //! ANY depth landing at or below that level are one proven element
+    //! read — including on ranked-terminal indexes, which the
+    //! prefix-to-last form cannot serve (their terminal property-name
+    //! tree is an indexed element grovedb refuses to return). Runs
+    //! against the trending fixture's `chain` ([tag, region, postId],
+    //! every level ranked), `both` ([hashtag, postId], prefix AND
+    //! terminal ranked), `deep` (at: hashtag with a propagating region
+    //! level) and `mid` (at: hashtag at position 1) doctypes.
+
+    use super::*;
+    use dpp::data_contract::document_type::random_document::CreateRandomDocument;
+    use dpp::document::DocumentV0Setters;
+    use dpp::tests::json_document::json_document_to_contract;
+
+    fn setup_trending() -> (Drive, dpp::prelude::DataContract) {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let contract = json_document_to_contract(
+            "tests/supporting_files/contract/trending/trending-contract.json",
+            false,
+            platform_version,
+        )
+        .expect("expected to parse the trending contract");
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply the trending contract");
+        (drive, contract)
+    }
+
+    fn insert_doc(
+        drive: &Drive,
+        contract: &dpp::prelude::DataContract,
+        document_type_name: &str,
+        properties: &[(&str, &str)],
+        seed: u64,
+    ) {
+        let platform_version = PlatformVersion::latest();
+        let document_type = contract
+            .document_type_for_name(document_type_name)
+            .expect("doctype exists");
+        let mut doc: Document = document_type
+            .random_document(Some(seed), platform_version)
+            .expect("random document");
+        let mut props = StdBTreeMap::new();
+        for (name, value) in properties {
+            props.insert(name.to_string(), Value::Text(value.to_string()));
+        }
+        doc.set_properties(props);
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&doc, None)),
+                        owner_id: None,
+                    },
+                    contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to insert the document");
+    }
+
+    fn count_query<'a>(
+        contract: &'a dpp::prelude::DataContract,
+        document_type_name: &'static str,
+        where_clauses: Vec<WhereClause>,
+    ) -> DriveDocumentCountQuery<'a> {
+        let document_type = contract
+            .document_type_for_name(document_type_name)
+            .expect("doctype exists");
+        let indexes = contract
+            .document_types()
+            .get(document_type_name)
+            .expect("doctype exists")
+            .indexes();
+        let index = DriveDocumentCountQuery::find_countable_index_for_where_clauses(
+            indexes,
+            &where_clauses,
+            &[],
+        )
+        .expect("the at-chain fallback must pick the ranked index");
+        DriveDocumentCountQuery {
+            document_type,
+            contract_id: contract.id().to_buffer(),
+            document_type_name: document_type_name.to_string(),
+            index,
+            where_clauses,
+        }
+    }
+
+    fn equal(field: &str, value: &str) -> WhereClause {
+        WhereClause {
+            field: field.to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Text(value.to_string()),
+        }
+    }
+
+    fn assert_counts(
+        drive: &Drive,
+        query: &DriveDocumentCountQuery,
+        expected_total: u64,
+        context: &str,
+    ) {
+        let platform_version = PlatformVersion::latest();
+        let results = query
+            .execute_no_proof(drive, None, platform_version)
+            .unwrap_or_else(|e| panic!("{context}: the read must succeed: {e}"));
+        assert_eq!(results[0].count, Some(expected_total), "{context}");
+
+        let proof = query
+            .execute_point_lookup_count_with_proof(drive, None, platform_version)
+            .unwrap_or_else(|e| panic!("{context}: the prove must succeed: {e}"));
+        let (root_hash, entries) = query
+            .verify_point_lookup_count_proof(&proof, platform_version)
+            .unwrap_or_else(|e| panic!("{context}: the proof must verify: {e}"));
+        let summed: u64 = entries.iter().map(|e| e.count.unwrap_or(0)).sum();
+        assert_eq!(summed, expected_total, "{context}: verified total");
+        assert_eq!(
+            root_hash,
+            drive
+                .grove
+                .root_hash(None, &platform_version.drive.grove_version)
+                .unwrap()
+                .expect("root hash must be readable"),
+            "{context}: the proof must reconstruct the live root hash"
+        );
+    }
+
+    /// The fully ranked chain serves a count at EVERY pin depth — one
+    /// pin, two pins — each read off the deepest pin's value tree,
+    /// even though its terminal property-name tree is an indexed
+    /// element the prefix-to-last form cannot touch.
+    #[test]
+    fn every_chain_depth_serves_a_proven_count() {
+        let (drive, contract) = setup_trending();
+        for (i, (tag, region, post)) in [
+            ("alpha", "east", "p1"),
+            ("alpha", "east", "p1"),
+            ("alpha", "east", "p2"),
+            ("alpha", "west", "p1"),
+            ("beta", "east", "p1"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            insert_doc(
+                &drive,
+                &contract,
+                "chain",
+                &[("tag", tag), ("region", region), ("postId", post)],
+                700 + i as u64,
+            );
+        }
+
+        // Depth 1: everything under a tag.
+        let query = count_query(&contract, "chain", vec![equal("tag", "alpha")]);
+        assert_counts(&drive, &query, 4, "chain depth 1");
+
+        // Depth 2 (== n−1, but the ranked terminal forces the
+        // value-tree read): everything under (tag, region).
+        let query = count_query(
+            &contract,
+            "chain",
+            vec![equal("tag", "alpha"), equal("region", "east")],
+        );
+        assert_counts(&drive, &query, 3, "chain depth 2");
+
+        // An IN pin at depth 1 fans the same read over the branches.
+        let query = count_query(
+            &contract,
+            "chain",
+            vec![WhereClause {
+                field: "tag".to_string(),
+                operator: WhereOperator::In,
+                value: Value::Array(vec![
+                    Value::Text("alpha".to_string()),
+                    Value::Text("beta".to_string()),
+                ]),
+            }],
+        );
+        assert_counts(&drive, &query, 5, "chain depth 1 IN");
+    }
+
+    /// A `both` index (prefix AND terminal ranked) was entirely
+    /// unservable by the prefix-to-last form; the value-tree read
+    /// serves its hashtag totals.
+    #[test]
+    fn a_ranked_terminal_index_serves_prefix_counts_through_its_chain() {
+        let (drive, contract) = setup_trending();
+        for (i, (hashtag, post)) in [("dash", "p1"), ("dash", "p2"), ("btc", "p1")]
+            .into_iter()
+            .enumerate()
+        {
+            insert_doc(
+                &drive,
+                &contract,
+                "both",
+                &[("hashtag", hashtag), ("postId", post)],
+                800 + i as u64,
+            );
+        }
+        let query = count_query(&contract, "both", vec![equal("hashtag", "dash")]);
+        assert_counts(&drive, &query, 2, "both hashtag total");
+    }
+
+    /// A count-propagating level (deep's `region`, between the at level
+    /// and the terminal) is count-bearing too and serves its subtree.
+    #[test]
+    fn a_propagating_level_serves_its_subtree_count() {
+        let (drive, contract) = setup_trending();
+        for (i, (hashtag, region, post)) in [
+            ("dash", "east", "p1"),
+            ("dash", "east", "p2"),
+            ("dash", "west", "p1"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            insert_doc(
+                &drive,
+                &contract,
+                "deep",
+                &[("hashtag", hashtag), ("region", region), ("postId", post)],
+                900 + i as u64,
+            );
+        }
+        let query = count_query(
+            &contract,
+            "deep",
+            vec![equal("hashtag", "dash"), equal("region", "east")],
+        );
+        assert_counts(&drive, &query, 2, "deep (hashtag, region) subtree");
+    }
+
+    /// Pins landing ABOVE the shallowest at level stay rejected: mid's
+    /// `region` level (position 0, at = hashtag at position 1) is a
+    /// plain tree with nothing cheap to read.
+    #[test]
+    fn pins_above_the_shallowest_at_level_stay_rejected() {
+        let (drive, contract) = setup_trending();
+        insert_doc(
+            &drive,
+            &contract,
+            "mid",
+            &[("region", "r1"), ("hashtag", "dash"), ("postId", "p1")],
+            950,
+        );
+        let indexes = contract
+            .document_types()
+            .get("mid")
+            .expect("mid doctype exists")
+            .indexes();
+        assert!(
+            DriveDocumentCountQuery::find_countable_index_for_where_clauses(
+                indexes,
+                &[equal("region", "r1")],
+                &[],
+            )
+            .is_none(),
+            "a pin above the shallowest at level addresses a plain tree"
+        );
+        drop(drive);
+    }
+}

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -4351,25 +4351,26 @@ mod prefix_to_last_in_with_trailing_equal {
         ];
         let drive_config = DriveConfig::default();
         for prove in [false, true] {
-            let error = drive
-                .execute_document_count_request(
-                    DocumentCountRequest {
-                        contract: &contract,
-                        document_type: contract
-                            .document_type_for_name("geo")
-                            .expect("geo doctype exists"),
-                        where_clauses: gapped.clone(),
-                        resolved_time_ranges: vec![],
-                        order_clauses: Vec::new(),
-                        mode: CountMode::Aggregate,
-                        limit: None,
-                        prove,
-                        drive_config: &drive_config,
-                    },
-                    None,
-                    platform_version,
-                )
-                .expect_err("a gapped pin set must be rejected (prove: {prove})");
+            let result = drive.execute_document_count_request(
+                DocumentCountRequest {
+                    contract: &contract,
+                    document_type: contract
+                        .document_type_for_name("geo")
+                        .expect("geo doctype exists"),
+                    where_clauses: gapped.clone(),
+                    resolved_time_ranges: vec![],
+                    order_clauses: Vec::new(),
+                    mode: CountMode::Aggregate,
+                    limit: None,
+                    prove,
+                    drive_config: &drive_config,
+                },
+                None,
+                platform_version,
+            );
+            let Err(error) = result else {
+                panic!("a gapped pin set must be rejected (prove: {prove})");
+            };
             let message = format!("{error}");
             assert!(
                 message.contains("rangeCountable") && message.contains("exactly match"),

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -4185,9 +4185,7 @@ mod prefix_to_last_in_with_trailing_equal {
 
     use super::*;
     use crate::config::DriveConfig;
-    use crate::query::drive_document_count_query::drive_dispatcher::{
-        DocumentCountRequest, DocumentCountResponse,
-    };
+    use crate::query::drive_document_count_query::drive_dispatcher::DocumentCountRequest;
     use dpp::data_contract::document_type::random_document::CreateRandomDocument;
     use dpp::document::DocumentV0Setters;
     use dpp::tests::json_document::json_document_to_contract;

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -3936,6 +3936,107 @@ mod prefix_to_last {
         );
     }
 
+    /// The composition with the prefix-level ranking stack: an `at`-form
+    /// index (`rankedCountable: { "at": "hashtag" }` on the trending
+    /// fixture's `like` doctype) keeps its TERMINAL property-name tree
+    /// non-indexed, so — unlike a terminal-ranked index — the
+    /// prefix-to-last fallback serves it: one index answers both "top
+    /// hashtags by total likes" (the ranking) and "how many likes does
+    /// this hashtag have" (this proven point read).
+    #[test]
+    fn an_at_form_index_serves_prefix_counts_alongside_its_ranking() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let contract = json_document_to_contract(
+            "tests/supporting_files/contract/trending/trending-contract.json",
+            false,
+            platform_version,
+        )
+        .expect("expected to parse the trending contract");
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply the trending contract");
+
+        let document_type = contract
+            .document_type_for_name("like")
+            .expect("like doctype exists");
+        for (i, (hashtag, post)) in [("alpha", "p1"), ("alpha", "p2"), ("beta", "p1")]
+            .into_iter()
+            .enumerate()
+        {
+            let mut doc: Document = document_type
+                .random_document(Some(600 + i as u64), platform_version)
+                .expect("random document");
+            let mut props = StdBTreeMap::new();
+            props.insert("hashtag".to_string(), Value::Text(hashtag.to_string()));
+            props.insert("postId".to_string(), Value::Text(post.to_string()));
+            doc.set_properties(props);
+            drive
+                .add_document_for_contract(
+                    DocumentAndContractInfo {
+                        owned_document_info: OwnedDocumentInfo {
+                            document_info: DocumentRefInfo((&doc, None)),
+                            owner_id: None,
+                        },
+                        contract: &contract,
+                        document_type,
+                    },
+                    false,
+                    BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                    None,
+                )
+                .expect("expected to insert a like");
+        }
+
+        let where_clauses = hashtag_equal("alpha");
+        let indexes = contract
+            .document_types()
+            .get("like")
+            .expect("like doctype exists")
+            .indexes();
+        let index = DriveDocumentCountQuery::find_countable_index_for_where_clauses(
+            indexes,
+            &where_clauses,
+            &[],
+        )
+        .expect("the at-form index's non-indexed terminal must be servable");
+        assert!(
+            !index.ranked_countable_at.is_empty(),
+            "the picked index must be the prefix-ranked byHashtagPost"
+        );
+        let query = DriveDocumentCountQuery {
+            document_type,
+            contract_id: contract.id().to_buffer(),
+            document_type_name: "like".to_string(),
+            index,
+            where_clauses,
+        };
+
+        let results = query
+            .execute_no_proof(&drive, None, platform_version)
+            .expect("the prefix count must read on an at-form index");
+        assert_eq!(results[0].count, Some(2), "alpha's total across its posts");
+
+        let proof = query
+            .execute_point_lookup_count_with_proof(&drive, None, platform_version)
+            .expect("the prefix count must prove on an at-form index");
+        let (_root_hash, entries) = query
+            .verify_point_lookup_count_proof(&proof, platform_version)
+            .expect("the proof must verify");
+        let summed: u64 = entries.iter().map(|e| e.count.unwrap_or(0)).sum();
+        assert_eq!(summed, 2);
+    }
+
     /// The motivating query, end to end: the whole-prefix total is one
     /// element read on the no-proof path and one verified element on the
     /// prove path, reconstructing the live root hash.

--- a/packages/rs-drive/tests/supporting_files/contract/tally/tally-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/tally/tally-contract.json
@@ -42,6 +42,55 @@
         "postId"
       ],
       "additionalProperties": false
+    },
+    "geo": {
+      "type": "object",
+      "documentsMutable": true,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byRegionHashtagPost",
+          "properties": [
+            {
+              "region": "asc"
+            },
+            {
+              "hashtag": "asc"
+            },
+            {
+              "postId": "asc"
+            }
+          ],
+          "countable": "countable",
+          "rangeCountable": true
+        }
+      ],
+      "properties": {
+        "region": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 0
+        },
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 1
+        },
+        "postId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 2
+        }
+      },
+      "required": [
+        "region",
+        "hashtag",
+        "postId"
+      ],
+      "additionalProperties": false
     }
   }
 }

--- a/packages/rs-drive/tests/supporting_files/contract/tally/tally-contract.json
+++ b/packages/rs-drive/tests/supporting_files/contract/tally/tally-contract.json
@@ -1,0 +1,47 @@
+{
+  "$formatVersion": "0",
+  "id": "AY6xWncZUFv2GCrS5seqKthUfbW9yYyUXtF8diSuHQ5j",
+  "ownerId": "AtirhSVpAWF7dEt6dLAmesC4Sr1MsJ9bFC1nLAoNnq2S",
+  "version": 1,
+  "documentSchemas": {
+    "like": {
+      "type": "object",
+      "documentsMutable": true,
+      "canBeDeleted": true,
+      "indices": [
+        {
+          "name": "byHashtagPost",
+          "properties": [
+            {
+              "hashtag": "asc"
+            },
+            {
+              "postId": "asc"
+            }
+          ],
+          "countable": "countable",
+          "rangeCountable": true
+        }
+      ],
+      "properties": {
+        "hashtag": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 63,
+          "position": 0
+        },
+        "postId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32,
+          "position": 1
+        }
+      },
+      "required": [
+        "hashtag",
+        "postId"
+      ],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

The smaller independent sibling from #4529: **prefix-pinned count queries**. Before this PR, a count query had to pin *every* property of a countable index — asking for a whole-prefix total was rejected even though the answer already sits on chain, maintained by every write. This PR relaxes the exact-index-match rule for those shapes, with proofs, **working on already-registered `rangeCountable` contracts** (no migration, no new writes), and — for indexes using the prefix-level ranking from the merged #4529 stack — at **any** contiguous pin depth.

## What works now that didn't before

Take the likes shape from the issue — an index on `[hashtag, postId]` with `countable` + `rangeCountable`:

| Query | Before | After |
|---|---|---|
| `count WHERE hashtag == "dash"` — *"how many likes does #dash have in total?"* | ❌ `count query requires a countable index whose properties exactly match the where clause fields` | ✅ one proven element read |
| `count WHERE hashtag IN ["dash", "btc"]` | ❌ rejected | ✅ per-hashtag totals, one proof |
| `count WHERE region IN ["eu", "us"] AND hashtag == "dash"` on `[region, hashtag, postId]` | ❌ rejected | ✅ per-region totals for the hashtag |
| `count WHERE hashtag == "dash" AND postId == p` (exact match) | ✅ | ✅ unchanged — exact coverage still wins when both could serve |
| `count WHERE region == "eu" AND postId == p` (a **gapped** pin set — the free property sits *between* the pins) | ❌ rejected | ❌ still rejected — with a gap there is no addressable path to any aggregate, whatever the layout maintains |

And on indexes using `rankedCountable: { "at": … }` (merged via #4531/#4533/#4535), whose chain keeps a whole-subtree total in a plain `CountTree` at **every** level from the shallowest ranked one down:

| Query | Before | After |
|---|---|---|
| `count WHERE tag == "dash"` on a fully ranked `[tag, region, postId]` (two properties free!) | ❌ rejected | ✅ one proven read of the tag's value tree |
| `count WHERE tag == "dash" AND region == "eu"` on the same index (ranked terminal) | ❌ rejected | ✅ value-tree read — the ranked terminal is never touched |
| `count WHERE hashtag == "dash"` on `{ "at": ["hashtag", "postId"] }` (both rankings on one index) | ❌ rejected | ✅ — one index now serves the ranking **and** its totals |
| `count WHERE region == "eu"` on `[region, hashtag, postId]` with `at: "hashtag"` (pin **above** the chain) | ❌ rejected | ❌ still rejected — levels above the shallowest ranked one are plain trees |

The user-visible win: a "likes received" profile stat, a per-hashtag total, or any *"how big is this group?"* question is a single **O(log n)** point read with an **O(log n)** proof — not a walk, and not a schema change.

## Where the answers live

Under `rangeCountable`, the write path already maintains a count the exact-match rule could never read; a prefix-level ranking maintains one at *every* chain level:

```text
[0x01] / <contract id> / [0x01] / "like"          (rankedCountable: { "at": "hashtag" })
└─ "hashtag"                          grouping tree (indexed)
   └─ "dash"                          value tree — CountTree, count = 3
      │                            ◄─ ★ at-chain read: everything under #dash
      └─ "postId"                     ProvableCountTree — element count = 3
         │                         ◄─ ★ prefix-to-last read (plain rangeCountable
         │                              indexes use this one)
         ├─ "post-a"                  value tree — count = 2
         │  └─ [0] ── owner1, owner2  ◄─ the exact-match read (unchanged)
         └─ "post-b"                  value tree — count = 1
            └─ [0] ── owner1
```

Every level contributes its count upward, so a value tree's element *is* its whole-subtree total. Each read is the same shape — one element behind the pins — just at a different depth.

## How resolution decides

```mermaid
flowchart TD
    Q["count WHERE … (==/IN pins)"] --> E{"every property of a countable\nindex pinned? (exact match)"}
    E -- yes --> V["read the pinned VALUE tree's\ncount element — unchanged,\nstill preferred"]
    E -- no --> P{"pins cover exactly the first\nn−1 properties of a rangeCountable\nindex with a plain terminal?"}
    P -- yes --> T["★ read the terminal PROPERTY-NAME\ntree's count element\n(whole-prefix total)"]
    P -- no --> A{"contiguous pins reaching at or\nbelow the shallowest\nrankedCountable.at level?"}
    A -- yes --> C["★ read the deepest pin's\nVALUE tree count element\n(whole-subtree total)"]
    A -- no --> X["rejected:\nno covering index"]
```

The picker (`find_countable_index_for_where_clauses`, now with the two fallbacks) and the path builder (`point_lookup_count_path_query`) are shared by the executors *and* the SDK verifier, so read / prove / verify agree by construction. The at-chain arm reuses the existing fully-covered selector verbatim — the property loop just stops at the first free property — and the existing `IN` fan-out and trailing-Equal machinery composes unchanged at every depth. Gapped pin sets fail closed in both layers.

The one shape that stays out: reading a **ranked property-name tree's own element** (e.g. the grouping tree's grand total with nothing pinned) — indexed elements are refused by grovedb's query dispatch (`path_queries can not refer to trees`). On at-form indexes that never bites (the value-tree reads sidestep it); it only limits plain-`rangeCountable` indexes whose *terminal* is boolean-ranked, which have no chain to fall back on.

## How Has This Been Tested?

- Picker coverage rules over real fixtures: unranked `rangeCountable` accepted; terminal-ranked without a chain (yappr-likes) and countable-but-not-`rangeCountable` (family) rejected; a last-property-only pin resolves to the exact single-property index instead.
- E2e on the `tally` fixture: whole-prefix total read, proven and **verified against the live grovedb root hash**; absence proof counting zero; `IN` per-branch fan-out; the public `execute_document_count_request` dispatcher end to end.
- The `IN` + trailing-Equal + free-last shape (the `set_subquery_path` arm) on a 3-property `geo` doctype, proved and verified per branch.
- At-chain reads at **every depth** of the fully ranked `chain` doctype (one pin, two pins, `IN` fan-out), the `both` index's hashtag totals (previously entirely unservable), a propagating level's subtree, and the above-chain rejection — each proof verified against the live root hash.
- Rejection text for gapped pin sets on both executors.
- Full count + sum query suites pass; clippy and both feature builds clean.

## Breaking Changes

None — strictly additive: previously-rejected queries now succeed, and every previously-served query resolves identically (exact match runs first, unchanged).

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)