### PR TITLE
fix(sdk): honor explicit regtest addresses in dapi-client; tolerate empty discovery in wasm-sdk trusted context

### DIFF
--- a/packages/js-dapi-client/lib/dapiAddressProvider/ListDAPIAddressProvider.js
+++ b/packages/js-dapi-client/lib/dapiAddressProvider/ListDAPIAddressProvider.js
@@ -32,15 +32,19 @@ class ListDAPIAddressProvider {
     // On macOS, internal docker IP is used to register masternode, and it's
     // not really possible to bind to that address, so that workaround is introduced.
     //
-    // Only addresses carrying such an unreachable docker-internal host are
-    // rewritten. An explicitly configured loopback address already names the
-    // exact gateway to talk to — dashmate e2e suites move the stock ports on
-    // purpose — and clobbering it with the stock local ports silently
-    // redirects every request to whichever network squats those ports on the
-    // machine.
+    // Only addresses discovered from the masternode list (they carry the
+    // masternode's proRegTxHash) can hold such an unreachable docker-internal
+    // host, so only those are rewritten, and only when the host is not
+    // already a reachable loopback. A caller-supplied address — a moved-port
+    // loopback, a secondary loopback like 127.0.0.2, a LAN IP, or a container
+    // hostname — already names the exact gateway to talk to (dashmate e2e
+    // suites move the stock ports on purpose), and clobbering it with the
+    // stock local ports silently redirects every request to whichever network
+    // squats those ports on the machine.
     const network = networks.get(this.options.network);
     const isLoopback = ['127.0.0.1', 'localhost'].includes(liveAddress.getHost());
-    if (network && network.regtestEnabled && !isLoopback) {
+    const isFromMasternodeList = Boolean(liveAddress.getProRegTxHash());
+    if (network && network.regtestEnabled && isFromMasternodeList && !isLoopback) {
       const randomNodeIndex = Math.floor(Math.random() * liveAddresses.length);
 
       liveAddress.protocol = 'https';

--- a/packages/js-dapi-client/lib/dapiAddressProvider/ListDAPIAddressProvider.js
+++ b/packages/js-dapi-client/lib/dapiAddressProvider/ListDAPIAddressProvider.js
@@ -31,8 +31,16 @@ class ListDAPIAddressProvider {
     // This is a temporary fix for a localhost masternode.
     // On macOS, internal docker IP is used to register masternode, and it's
     // not really possible to bind to that address, so that workaround is introduced.
+    //
+    // Only addresses carrying such an unreachable docker-internal host are
+    // rewritten. An explicitly configured loopback address already names the
+    // exact gateway to talk to — dashmate e2e suites move the stock ports on
+    // purpose — and clobbering it with the stock local ports silently
+    // redirects every request to whichever network squats those ports on the
+    // machine.
     const network = networks.get(this.options.network);
-    if (network && network.regtestEnabled) {
+    const isLoopback = ['127.0.0.1', 'localhost'].includes(liveAddress.getHost());
+    if (network && network.regtestEnabled && !isLoopback) {
       const randomNodeIndex = Math.floor(Math.random() * liveAddresses.length);
 
       liveAddress.protocol = 'https';

--- a/packages/js-dapi-client/test/unit/dapiAddressProvider/ListDAPIAddressProvider.spec.js
+++ b/packages/js-dapi-client/test/unit/dapiAddressProvider/ListDAPIAddressProvider.spec.js
@@ -100,13 +100,21 @@ describe('ListDAPIAddressProvider', () => {
       expect(address).to.be.undefined();
     });
 
-    it('should return modified address for localhost node', async () => {
+    it('should return modified address for a masternode-list node on localhost network', async () => {
       options = {
         network: 'local',
       };
 
+      // Addresses discovered from the masternode list carry the masternode's
+      // proRegTxHash and may hold a docker-internal IP that cannot be reached
+      // from the host (macOS), so they are rewritten to the local gateway.
+      const discoveredAddress = new DAPIAddress({
+        host: '172.16.0.2',
+        proRegTxHash: 'a'.repeat(64),
+      });
+
       listDAPIAddressProvider = new ListDAPIAddressProvider(
-        addresses,
+        [discoveredAddress],
         options,
       );
 
@@ -114,6 +122,28 @@ describe('ListDAPIAddressProvider', () => {
 
       expect(liveAddress.host).to.equal('127.0.0.1');
       expect(liveAddress.protocol).to.equal('https');
+      expect(liveAddress.allowSelfSignedCertificate).to.be.true();
+    });
+
+    it('should not modify a caller-supplied non-loopback address', async () => {
+      options = {
+        network: 'local',
+      };
+
+      // A caller-supplied address (no proRegTxHash — it did not come from the
+      // masternode list) names the exact gateway to talk to, even when the
+      // host is a secondary loopback, LAN IP, or container hostname.
+      const explicitAddress = new DAPIAddress('127.0.0.2:45003:self-signed');
+
+      listDAPIAddressProvider = new ListDAPIAddressProvider(
+        [explicitAddress],
+        options,
+      );
+
+      const liveAddress = await listDAPIAddressProvider.getLiveAddress();
+
+      expect(liveAddress.host).to.equal('127.0.0.2');
+      expect(liveAddress.port).to.equal(45003);
       expect(liveAddress.allowSelfSignedCertificate).to.be.true();
     });
 

--- a/packages/js-dapi-client/test/unit/dapiAddressProvider/ListDAPIAddressProvider.spec.js
+++ b/packages/js-dapi-client/test/unit/dapiAddressProvider/ListDAPIAddressProvider.spec.js
@@ -116,6 +116,28 @@ describe('ListDAPIAddressProvider', () => {
       expect(liveAddress.protocol).to.equal('https');
       expect(liveAddress.allowSelfSignedCertificate).to.be.true();
     });
+
+    it('should not modify an explicitly configured loopback address', async () => {
+      options = {
+        network: 'local',
+      };
+
+      // A local network that moved its ports off the stock 2443 range
+      // (dashmate e2e suites do) is addressed explicitly; rewriting the port
+      // would redirect every request to whatever squats the stock ports.
+      const loopbackAddress = new DAPIAddress('127.0.0.1:45003:self-signed');
+
+      listDAPIAddressProvider = new ListDAPIAddressProvider(
+        [loopbackAddress],
+        options,
+      );
+
+      const liveAddress = await listDAPIAddressProvider.getLiveAddress();
+
+      expect(liveAddress.host).to.equal('127.0.0.1');
+      expect(liveAddress.port).to.equal(45003);
+      expect(liveAddress.allowSelfSignedCertificate).to.be.true();
+    });
   });
 
   describe('#hasLiveAddresses', () => {

--- a/packages/js-dapi-client/test/unit/dapiAddressProvider/createDAPIAddressProviderFromOptions.spec.js
+++ b/packages/js-dapi-client/test/unit/dapiAddressProvider/createDAPIAddressProviderFromOptions.spec.js
@@ -81,6 +81,17 @@ describe('createDAPIAddressProviderFromOptions', () => {
       expect(result).to.be.an.instanceOf(ListDAPIAddressProvider);
     });
 
+    it('should not rewrite a caller-supplied non-default regtest address', async () => {
+      options.dapiAddresses = ['127.0.0.2:45003:self-signed'];
+
+      const provider = createDAPIAddressProviderFromOptions(options);
+
+      const liveAddress = await provider.getLiveAddress();
+
+      expect(liveAddress.getHost()).to.equal('127.0.0.2');
+      expect(liveAddress.getPort()).to.equal(45003);
+    });
+
     it('should throw DAPIClientError if `seeds` option is passed too', async () => {
       options.seeds = ['127.0.0.1'];
 

--- a/packages/wasm-sdk/src/context_provider.rs
+++ b/packages/wasm-sdk/src/context_provider.rs
@@ -259,14 +259,16 @@ impl WasmTrustedContext {
 
         // Masternode discovery is an optional convenience: it only feeds the
         // no-explicit-addresses path in `withTrustedContext`, while the quorum
-        // data prefetched above is what proof verification actually needs. It
-        // is also environment-sensitive — the sidecar's per-masternode version
-        // checks fail against a local gateway's self-signed TLS — so a
-        // discovery failure must not make the whole trusted context unusable
-        // for an SDK constructed with explicit addresses.
+        // data prefetched above is what proof verification actually needs. On
+        // a local network the sidecar's per-masternode version checks reject
+        // the gateway's self-signed TLS, so discovery failing there is the
+        // NORMAL case and must not make the whole trusted context unusable
+        // for an SDK constructed with explicit addresses. On public networks
+        // the failure stays fatal: it signals a genuine outage of the trusted
+        // endpoint, and degrading silently would hide it.
         let discovered_addresses = match Self::fetch_addresses_from(&inner).await {
             Ok(addresses) => addresses,
-            Err(e) => {
+            Err(e) if network == dash_sdk::dpp::dashcore::Network::Regtest => {
                 tracing::warn!(
                     error = %e,
                     "trusted context: masternode discovery unavailable, continuing without \
@@ -274,6 +276,7 @@ impl WasmTrustedContext {
                 );
                 Vec::new()
             }
+            Err(e) => return Err(e),
         };
 
         Ok(WasmTrustedContext {

--- a/packages/wasm-sdk/src/context_provider.rs
+++ b/packages/wasm-sdk/src/context_provider.rs
@@ -257,7 +257,24 @@ impl WasmTrustedContext {
             .await
             .map_err(|e| WasmSdkError::generic(format!("Failed to prefetch quorums: {}", e)))?;
 
-        let discovered_addresses = Self::fetch_addresses_from(&inner).await?;
+        // Masternode discovery is an optional convenience: it only feeds the
+        // no-explicit-addresses path in `withTrustedContext`, while the quorum
+        // data prefetched above is what proof verification actually needs. It
+        // is also environment-sensitive — the sidecar's per-masternode version
+        // checks fail against a local gateway's self-signed TLS — so a
+        // discovery failure must not make the whole trusted context unusable
+        // for an SDK constructed with explicit addresses.
+        let discovered_addresses = match Self::fetch_addresses_from(&inner).await {
+            Ok(addresses) => addresses,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "trusted context: masternode discovery unavailable, continuing without \
+                     discovered addresses (explicitly configured addresses are unaffected)"
+                );
+                Vec::new()
+            }
+        };
 
         Ok(WasmTrustedContext {
             inner,


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two client-side bugs surfaced by state-sync e2e work, independent of the feature branches:

* **js-dapi-client silently redirects explicitly-configured addresses on regtest.** `ListDAPIAddressProvider.getLiveAddress()` rewrote EVERY address to `127.0.0.1:2443 + i*100` (the stock local-preset ports) whenever the network is regtest — so a client configured with explicit non-default addresses (e.g. an isolated test network, or any second local network on one machine) silently sent every wallet/DAPI request to whatever occupies the stock ports. On a shared dev machine that was a *different chain entirely*, which produced a long goose chase of "wallet funding is broken" reports: subscriptions landed on the wrong network's rs-dapi, and wallets watched a chain their payments were never on.
* **wasm-sdk trusted-context prefetch dies when masternode discovery returns no eligible entries.** On local networks the quorum sidecar's version checks reject the gateway's self-signed TLS, so empty discovery is the normal case there; discovery only feeds the no-explicit-addresses path and shouldn't be fatal when explicit addresses are configured. Tolerance is scoped to regtest so mainnet/testnet behavior is unchanged.

## What was done?

* `js-dapi-client`: explicit loopback addresses are honored verbatim on regtest; the rewrite only applies where it originally made sense (+ unit test).
* `wasm-sdk`: trusted-context prefetch tolerates empty masternode discovery on regtest instead of failing the whole context build.

## How Has This Been Tested?

js-dapi-client unit suite: 319 passing including the new rewrite regression test. The wasm-sdk change was validated live: it is what allowed the state-sync e2e (dashpay/platform#4530) to seed identities/contracts/documents through an isolated-port local network and re-read them proof-verified — the full suite there runs green with these fixes.

Both commits were code-reviewed (code-review-validator) as part of the e2e branch changeset before being cherry-picked here.

## Breaking Changes

None intended. Behavior change is regtest-only: clients that (perhaps unknowingly) relied on the address rewrite to reach stock-port local networks while configured with different explicit addresses will now use their configured addresses — which is the documented contract.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation if needed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
