### PR TITLE
fix(drive): keep cursor document in descending continuation-page proofs

### DIFF
--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -1873,11 +1873,9 @@ impl<'a> DriveDocumentQuery<'a> {
         if let Some(mut start_at_path_query) = start_at_path_query {
             // The cursor query selects exactly one key, so its walk
             // direction carries no meaning — but grovedb's merge (V4+)
-            // requires every input to agree on direction and propagates
-            // the shared one to the merged root. Align it to the main
-            // query's `orderBy` direction so a descending page merges,
-            // and so the merged root keeps the direction the verifier
-            // will rebuild through this same path.
+            // requires every input to agree on direction, so align it to
+            // the main query's `orderBy` direction so a descending page
+            // merges at all.
             start_at_path_query.query.query.left_to_right =
                 main_path_query.query.query.left_to_right;
             let limit = main_path_query.query.limit.take();
@@ -1887,6 +1885,22 @@ impl<'a> DriveDocumentQuery<'a> {
             )
             .map_err(Error::from)?;
             merged.query.limit = limit.map(|a| a.saturating_add(1));
+            // The merged root must be walked ascending regardless of the
+            // page's `orderBy` direction: the `limit + 1` above reserves
+            // one result slot for the cursor document, and the prover
+            // spends the budget in root traversal order. Ascending, the
+            // cursor branch (key `[0]`) is visited first and takes its
+            // reserved slot; descending, the index branch sorts first,
+            // consumes the whole budget mid-timeline, and the prover then
+            // omits the cursor subtree's lower layer — an unverifiable
+            // proof (the verifier extracts the cursor document from the
+            // proof before rebuilding the main query). Only this
+            // synthesized root flips: each input's own query lands intact
+            // inside a subquery branch, keeping in-branch result order.
+            // The verifier never rebuilds the merged query — it runs the
+            // cursor and main queries as separate subset queries — so the
+            // root's direction is not client-visible.
+            merged.query.query.left_to_right = true;
             Ok(merged)
         } else {
             Ok(main_path_query)

--- a/packages/rs-drive/tests/query_tests.rs
+++ b/packages/rs-drive/tests/query_tests.rs
@@ -8166,6 +8166,253 @@ mod tests {
         assert_eq!(query_result.documents().len(), 1);
     }
 
+    #[cfg(all(feature = "server", feature = "verify"))]
+    #[test]
+    fn test_proved_desc_range_continuation_page_includes_cursor_document() {
+        // Issue #4540: a continuation page over a non-unique
+        // [equality, $createdAt] index — cursor + range clause on the
+        // terminal property + descending order — merged the cursor
+        // fetch into the proved query with a descending root, so the
+        // index branch consumed the whole limit + 1 budget before the
+        // cursor branch was reached and the proof omitted the cursor
+        // document's subtree layer ("V1 proof is missing lower layer"),
+        // which no client could verify. The merged root must be walked
+        // ascending so the cursor branch spends its reserved slot first.
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract_value = platform_value!({
+            "$formatVersion": "0",
+            "id": "BZUodcFoFL6KvnonehrnMVggTvCe8W5MiRnZuqLb6M54",
+            "version": 1,
+            "ownerId": "GZVdTnLFAN2yE9rLeCHBDBCr7YQgmXJuoExkY347j7Z5",
+            "documentSchemas": {
+                "message": {
+                    "type": "object",
+                    "indices": [
+                        {"name":"categoryTimeline", "properties": [{"category":"asc"}, {"$createdAt":"asc"}]},
+                    ],
+                    "properties":{
+                        "category": {
+                            "type": "string",
+                            "maxLength": 63,
+                            "position": 0
+                        }
+                    },
+                    "required": ["category", "$createdAt"],
+                    "additionalProperties": false,
+                },
+            },
+        });
+
+        let contract = DataContract::from_value(contract_value, false, platform_version)
+            .expect("should create a contract from value");
+
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                None,
+                platform_version,
+            )
+            .expect("should apply contract");
+
+        let document_type = contract
+            .document_type_for_name("message")
+            .expect("should have message document type");
+
+        let mut rng = StdRng::seed_from_u64(84594);
+        let base_time: TimestampMillis = 1_700_000_000_000;
+
+        for i in 0u64..12 {
+            let document_value = platform_value!({
+               "category": "en",
+               "$createdAt": base_time + i * 1000,
+            });
+
+            let document = document_type
+                .create_document_from_data(
+                    document_value,
+                    Identifier::random_with_rng(&mut rng),
+                    1,
+                    1,
+                    rng.gen(),
+                    platform_version,
+                )
+                .expect("should create document");
+
+            drive
+                .add_document_for_contract(
+                    DocumentAndContractInfo {
+                        owned_document_info: OwnedDocumentInfo {
+                            document_info: DocumentInfo::DocumentOwnedInfo((document, None)),
+                            owner_id: None,
+                        },
+                        contract: &contract,
+                        document_type,
+                    },
+                    true,
+                    BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                    None,
+                )
+                .expect("should add document");
+        }
+
+        let created_at_values = |results: &[Vec<u8>]| -> Vec<TimestampMillis> {
+            results
+                .iter()
+                .map(|serialized| {
+                    Document::from_bytes(serialized, document_type, platform_version)
+                        .expect("should deserialize document")
+                        .created_at()
+                        .expect("document should have a creation time")
+                })
+                .collect()
+        };
+
+        // Page 1: newest five documents.
+        let page_one_value = json!({
+            "where": [
+                ["category", "==", "en"],
+                ["$createdAt", ">", 0]
+            ],
+            "orderBy": [
+                ["category", "asc"],
+                ["$createdAt", "desc"]
+            ],
+            "limit": 5,
+        });
+        let page_one_cbor = cbor_serializer::serializable_value_to_cbor(&page_one_value, None)
+            .expect("should serialize to cbor");
+        let page_one_query = DriveDocumentQuery::from_cbor(
+            page_one_cbor.as_slice(),
+            &contract,
+            document_type,
+            &drive.config,
+            platform_version,
+        )
+        .expect("query should be built");
+
+        let (page_one_results, _, _) = page_one_query
+            .execute_raw_results_no_proof(&drive, None, None, platform_version)
+            .expect("query should be executed");
+        assert_eq!(
+            created_at_values(&page_one_results),
+            (7..12)
+                .rev()
+                .map(|i| base_time + i * 1000)
+                .collect::<Vec<_>>()
+        );
+
+        let last_document = Document::from_bytes(
+            page_one_results
+                .last()
+                .expect("page one should have results"),
+            document_type,
+            platform_version,
+        )
+        .expect("should deserialize document");
+        let encoded_cursor = bs58::encode(last_document.id().as_slice()).into_string();
+
+        // Page 2 via startAfter: mid-timeline, more matching documents
+        // remain than the limit, so the proved merged query's budget
+        // exhausts before the cursor branch unless the root is walked
+        // ascending.
+        let page_two_value = json!({
+            "where": [
+                ["category", "==", "en"],
+                ["$createdAt", ">", 0]
+            ],
+            "orderBy": [
+                ["category", "asc"],
+                ["$createdAt", "desc"]
+            ],
+            "limit": 5,
+            "startAfter": encoded_cursor.clone(),
+        });
+        let page_two_cbor = cbor_serializer::serializable_value_to_cbor(&page_two_value, None)
+            .expect("should serialize to cbor");
+        let page_two_query = DriveDocumentQuery::from_cbor(
+            page_two_cbor.as_slice(),
+            &contract,
+            document_type,
+            &drive.config,
+            platform_version,
+        )
+        .expect("query should be built");
+
+        let (page_two_results, _, _) = page_two_query
+            .execute_raw_results_no_proof(&drive, None, None, platform_version)
+            .expect("query should be executed");
+        assert_eq!(
+            created_at_values(&page_two_results),
+            (2..7)
+                .rev()
+                .map(|i| base_time + i * 1000)
+                .collect::<Vec<_>>()
+        );
+
+        let root_hash = drive
+            .grove
+            .root_hash(None, &platform_version.drive.grove_version)
+            .unwrap()
+            .expect("there is always a root hash");
+
+        let (proof_root_hash, proof_results, _) = page_two_query
+            .execute_with_proof_only_get_elements(&drive, None, None, platform_version)
+            .expect("proved startAfter continuation page should verify");
+        assert_eq!(root_hash, proof_root_hash);
+        assert_eq!(page_two_results, proof_results);
+
+        // startAt (inclusive) exercises the same merged-query shape.
+        let page_two_inclusive_value = json!({
+            "where": [
+                ["category", "==", "en"],
+                ["$createdAt", ">", 0]
+            ],
+            "orderBy": [
+                ["category", "asc"],
+                ["$createdAt", "desc"]
+            ],
+            "limit": 5,
+            "startAt": encoded_cursor,
+        });
+        let page_two_inclusive_cbor =
+            cbor_serializer::serializable_value_to_cbor(&page_two_inclusive_value, None)
+                .expect("should serialize to cbor");
+        let page_two_inclusive_query = DriveDocumentQuery::from_cbor(
+            page_two_inclusive_cbor.as_slice(),
+            &contract,
+            document_type,
+            &drive.config,
+            platform_version,
+        )
+        .expect("query should be built");
+
+        let (page_two_inclusive_results, _, _) = page_two_inclusive_query
+            .execute_raw_results_no_proof(&drive, None, None, platform_version)
+            .expect("query should be executed");
+        assert_eq!(
+            created_at_values(&page_two_inclusive_results),
+            (3..8)
+                .rev()
+                .map(|i| base_time + i * 1000)
+                .collect::<Vec<_>>()
+        );
+
+        let (proof_root_hash, proof_results, _) = page_two_inclusive_query
+            .execute_with_proof_only_get_elements(&drive, None, None, platform_version)
+            .expect("proved startAt continuation page should verify");
+        assert_eq!(root_hash, proof_root_hash);
+        assert_eq!(page_two_inclusive_results, proof_results);
+    }
+
     #[cfg(feature = "server")]
     #[test]
     fn test_count_regular_index() {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes #4540.

On protocol v14, a documents query combining a `startAfter`/`startAt` cursor, a range clause on the terminal index property, and descending order returned a proof the client cannot verify:

```
grovedb: invalid proof: V1 proof is missing lower layer for non-empty tree at key 00
```

The rejection is correct — the cursor document is genuinely absent from the proof. The cursor fetch is merged into the proved query with `limit + 1` (one slot reserved for the cursor document), and the prover spends that budget in root traversal order. grovedb's V4 merge propagates the inputs' direction onto the merged root, so a descending page visits the index branch before the cursor branch (key `[0]`); mid-timeline the index branch holds more than `limit + 1` matches, exhausts the budget, and the prover omits the cursor subtree's lower layer. `verify_start_at_document_in_proof` then cannot extract the cursor document. This is the shape of every newest-first timeline continuation page, so any client paginating an `[equality, $createdAt]` index descending broke on page 2+.

Not reproducible on protocol ≤ v13: the V3 merge left the synthesized root ascending, which silently protected the cursor-first invariant.

## What was done?

Pin the merged root back to ascending after `PathQuery::merge` in `construct_path_query_operations`, restoring the cursor-first traversal the reserved `limit + 1` slot depends on.

- Only the synthesized merged root flips: each input query lands intact inside a subquery branch of the merged query, so in-branch (newest-first) result order is preserved. Deliberately **not** done by flipping the inputs' roots before the merge — the main query's root *is* the terminal-property level and flipping it would prove the wrong (oldest-first) window.
- The verifier never rebuilds the merged query — it runs the cursor and the main query as two separate subset queries — so the root's direction is not client-visible and no client change is needed. Proof bytes change only for the previously unverifiable shape (ascending pages already had an ascending root; equality-terminal descending pages force one; cursorless queries don't merge). At ≤ v13 the overwrite is a no-op, so no version gate is needed.
- Corrected the comment that claimed the verifier rebuilds the merged query through this path.

Not addressed here (pre-existing, independent, noted in the issue): the cursor lowering excludes the cursor's entire terminal key, so documents tying the cursor's timestamp are skipped across page boundaries even when proofs verify.

## How Has This Been Tested?

New round-trip regression test `test_proved_desc_range_continuation_page_includes_cursor_document`: non-unique `[category, $createdAt]` index, 12 documents under one `category` value, page 2 via `startAfter` (and the inclusive `startAt` variant) with a `$createdAt > 0` range descending, proved with `execute_with_proof_only_get_elements` and checked against the unproved results. Without the fix the test fails with exactly the reported error; with it, both pages verify.

Also ran the full `query_tests` suite (56 tests), `drive` lib `query`/`verify` unit tests (711 + 270), `query_tests_history`, `dashpay`, and `cargo clippy -p drive --all-targets` — all green.

## Breaking Changes

None. Proof generation only; no state, fee, or consensus change. Proof bytes change only for the query shape that currently produces an unverifiable proof.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)