### PR TITLE
feat(swift-sdk): include critical Swift diagnostics in log exports

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/SDKLogger.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/SDKLogger.swift
@@ -1,4 +1,253 @@
+import CryptoKit
 import Foundation
+
+// MARK: - Structured Diagnostic Logging
+
+/// Categories intentionally kept small for the first diagnostic-log rollout.
+/// They identify the subsystem without putting user-controlled data in the
+/// logger name.
+public enum SDKLogCategory: String, Sendable {
+    case lifecycle
+    case persistence
+    case shielded
+}
+
+public enum SDKLogSeverity: String, Sendable {
+    case debug = "DEBUG"
+    case info = "INFO"
+    case warning = "WARN"
+    case error = "ERROR"
+}
+
+/// A value that is safe to include in a diagnostic event.
+///
+/// Use ``reference(_:)`` for identifiers. References are written as the first
+/// 12 hexadecimal characters of their SHA-256 digest; the original value is
+/// never passed to the sink.
+public enum SDKLogValue: Sendable {
+    case publicText(String)
+    case integer(Int64)
+    case unsignedInteger(UInt64)
+    case double(Double)
+    case boolean(Bool)
+    case reference(Data)
+    case referenceString(String)
+}
+
+/// Serial file sink used by the structured logger. All writes, including
+/// callbacks entering Swift concurrently from FFI threads, are protected by a
+/// single lock so a diagnostic line is appended atomically.
+final class SDKLogFileSink: @unchecked Sendable {
+    let fileURL: URL
+
+    private let lock = NSLock()
+    private let handle: FileHandle
+
+    init(sessionDirectory: URL, fileManager: FileManager = .default) throws {
+        let swiftDirectory = sessionDirectory.appendingPathComponent("swift", isDirectory: true)
+        try fileManager.createDirectory(at: swiftDirectory, withIntermediateDirectories: true)
+
+        fileURL = swiftDirectory.appendingPathComponent("run.log", isDirectory: false)
+        if !fileManager.fileExists(atPath: fileURL.path) {
+            guard fileManager.createFile(atPath: fileURL.path, contents: nil) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+        }
+
+        handle = try FileHandle(forWritingTo: fileURL)
+        try handle.seekToEnd()
+    }
+
+    deinit {
+        try? handle.close()
+    }
+
+    func write(_ line: String) {
+        guard let data = (line + "\n").data(using: .utf8) else { return }
+        lock.withLock {
+            try? handle.write(contentsOf: data)
+        }
+    }
+
+    func flush() {
+        lock.withLock {
+            try? handle.synchronize()
+        }
+    }
+}
+
+enum SDKLogFormatter {
+    static let maximumErrorDescriptionLength = 1_024
+
+    static func format(
+        timestamp: Date = Date(),
+        event: String,
+        category: SDKLogCategory,
+        severity: SDKLogSeverity,
+        fields: [String: SDKLogValue] = [:],
+        error: Error? = nil,
+        redacting sensitiveValues: [String] = []
+    ) -> String {
+        var renderedFields = fields.mapValues(render)
+
+        if let error {
+            let nsError = error as NSError
+            renderedFields["error_code"] = String(nsError.code)
+            renderedFields["error_domain"] = quoted(redact(nsError.domain, values: sensitiveValues))
+            renderedFields["error_message"] = quoted(
+                String(
+                    redact(nsError.localizedDescription, values: sensitiveValues)
+                        .prefix(maximumErrorDescriptionLength)
+                )
+            )
+            renderedFields["error_type"] = quoted(String(reflecting: type(of: error)))
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+
+        var components = [
+            formatter.string(from: timestamp),
+            severity.rawValue,
+            "swift.\(category.rawValue)",
+            "event=\(token(event))",
+        ]
+        components.append(contentsOf: renderedFields.keys.sorted().map { key in
+            "\(token(key))=\(renderedFields[key]!)"
+        })
+        return components.joined(separator: " ")
+    }
+
+    static func reference(_ data: Data) -> String {
+        SHA256.hash(data: data).prefix(6).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func reference(_ string: String) -> String {
+        reference(Data(string.utf8))
+    }
+
+    private static func render(_ value: SDKLogValue) -> String {
+        switch value {
+        case .publicText(let value):
+            return quoted(value)
+        case .integer(let value):
+            return String(value)
+        case .unsignedInteger(let value):
+            return String(value)
+        case .double(let value):
+            return String(value)
+        case .boolean(let value):
+            return value ? "true" : "false"
+        case .reference(let value):
+            return reference(value)
+        case .referenceString(let value):
+            return reference(value)
+        }
+    }
+
+    /// Identifiers and paths often arrive embedded in a dependency's
+    /// localized error text. Callers can provide exact sensitive values; the
+    /// generic patterns are a second line of defence for paths and the long
+    /// hex/base58 forms used by wallet, identity and outpoint identifiers.
+    private static func redact(_ value: String, values: [String]) -> String {
+        var result = value
+        for sensitive in values.filter({ !$0.isEmpty }).sorted(by: { $0.count > $1.count }) {
+            let isShortToken = sensitive.count < 8
+                && sensitive.unicodeScalars.allSatisfy(CharacterSet.alphanumerics.contains)
+            if isShortToken {
+                let escaped = NSRegularExpression.escapedPattern(for: sensitive)
+                let pattern = "(?<![A-Za-z0-9])\(escaped)(?![A-Za-z0-9])"
+                guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+                let range = NSRange(result.startIndex..<result.endIndex, in: result)
+                result = regex.stringByReplacingMatches(
+                    in: result,
+                    range: range,
+                    withTemplate: "<redacted>"
+                )
+            } else {
+                result = result.replacingOccurrences(of: sensitive, with: "<redacted>")
+            }
+        }
+
+        let patterns = [
+            #"(?<![A-Za-z0-9])(?:file://)?/(?:[^\s\"']+/)*[^\s\"']*"#,
+            #"\b[0-9a-fA-F]{32,}\b"#,
+            #"\b[1-9A-HJ-NP-Za-km-z]{32,}\b"#,
+        ]
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let range = NSRange(result.startIndex..<result.endIndex, in: result)
+            result = regex.stringByReplacingMatches(
+                in: result,
+                range: range,
+                withTemplate: "<redacted>"
+            )
+        }
+        return result
+    }
+
+    private static func token(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        let scalars = value.unicodeScalars.map { allowed.contains($0) ? String($0) : "_" }
+        let result = scalars.joined()
+        return result.isEmpty ? "unknown" : result
+    }
+
+    private static func quoted(_ value: String) -> String {
+        var escaped = ""
+        for scalar in value.unicodeScalars {
+            switch scalar.value {
+            case 0x22: escaped += "\\\""
+            case 0x5c: escaped += "\\\\"
+            case 0x0a: escaped += "\\n"
+            case 0x0d: escaped += "\\r"
+            case 0x09: escaped += "\\t"
+            case 0x00...0x1f, 0x7f:
+                escaped += String(format: "\\u%04x", scalar.value)
+            default:
+                escaped.unicodeScalars.append(scalar)
+            }
+        }
+        return "\"\(escaped)\""
+    }
+}
+
+private final class SDKLoggerState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var sink: SDKLogFileSink?
+    private var includeDebug = false
+
+    func installSink(at sessionDirectory: URL, includeDebug: Bool) -> Bool {
+        do {
+            let newSink = try SDKLogFileSink(sessionDirectory: sessionDirectory)
+            lock.withLock {
+                sink = newSink
+                self.includeDebug = includeDebug
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func updateDebugSetting(_ includeDebug: Bool) {
+        lock.withLock {
+            self.includeDebug = includeDebug
+        }
+    }
+
+    func destination(for severity: SDKLogSeverity) -> SDKLogFileSink? {
+        lock.withLock {
+            guard severity != .debug || includeDebug else { return nil }
+            return sink
+        }
+    }
+
+    func flush() {
+        lock.withLock { sink }?.flush()
+    }
+}
 
 // MARK: - Logging Preferences
 
@@ -48,8 +297,8 @@ public enum LoggingPreferences {
     }
 
     /// Session directory of the current launch, set once `configure()`
-    /// installs the file subscriber. `nil` when file logging is off
-    /// (subscriber already installed, or the path wasn't writable).
+    /// installs at least one of the independent Swift or Rust sinks.
+    /// `nil` only when neither sink could be installed.
     @MainActor
     public private(set) static var currentSessionDirectory: URL?
 
@@ -67,26 +316,41 @@ public enum LoggingPreferences {
     @MainActor
     public static func configure() -> LoggingPreset {
         let preset = loadPreset()
-        let enableSwiftVerbose: Bool
+        let enableSwiftVerbose = preset == .high
 
         if !didInstallLogging {
             didInstallLogging = true
-            if let sessionRoot = launchLogPaths(),
-               SDK.enableFileLogging(level: .info, sessionRoot: sessionRoot.path) {
-                currentSessionDirectory = sessionRoot
-                pruneOldSessions(keeping: sessionRoot)
-            } else {
+            let sessionRoot = launchLogPaths()
+            let swiftSinkInstalled = sessionRoot.map {
+                SDKLogger.installFileSink(at: $0, includeDebug: enableSwiftVerbose)
+            } ?? false
+            let rustSinkInstalled = sessionRoot.map {
+                SDK.enableFileLogging(level: .info, sessionRoot: $0.path)
+            } ?? false
+
+            if !rustSinkInstalled {
+                // Rust tracing is process-global and first-init-wins, but a
+                // failed file destination must not silence console logging.
                 SDK.enableLogging(level: .info)
             }
-        }
 
-        switch preset {
-        case .high:
-            enableSwiftVerbose = true
-        case .medium:
-            enableSwiftVerbose = false
-        case .low:
-            enableSwiftVerbose = false
+            if let sessionRoot, swiftSinkInstalled || rustSinkInstalled {
+                currentSessionDirectory = sessionRoot
+                pruneOldSessions(keeping: sessionRoot)
+            }
+
+            SDKLogger.event(
+                "logging_configured",
+                category: .lifecycle,
+                severity: .info,
+                fields: [
+                    "preset": .publicText(preset.rawValue),
+                    "rust_sink_active": .boolean(rustSinkInstalled),
+                    "swift_sink_active": .boolean(swiftSinkInstalled),
+                ]
+            )
+        } else {
+            SDKLogger.updateDebugSetting(enableSwiftVerbose)
         }
 
         setenv("SPV_SWIFT_LOG", enableSwiftVerbose ? "1" : "0", 1)
@@ -187,6 +451,58 @@ public enum LoggingPreferences {
 }
 
 public enum SDKLogger {
+    private static let state = SDKLoggerState()
+
+    /// Record a structured diagnostic event. Only this API writes to
+    /// `swift/run.log`; the legacy free-form methods below remain console-only
+    /// until their call sites have been explicitly reviewed for privacy.
+    public static func event(
+        _ event: String,
+        category: SDKLogCategory,
+        severity: SDKLogSeverity = .info,
+        fields: [String: SDKLogValue] = [:],
+        error: Error? = nil,
+        redacting sensitiveValues: [String] = []
+    ) {
+        let line = SDKLogFormatter.format(
+            event: event,
+            category: category,
+            severity: severity,
+            fields: fields,
+            error: error,
+            redacting: sensitiveValues
+        )
+
+        state.destination(for: severity)?.write(line)
+
+        let shouldMirrorToConsole: Bool
+        switch severity {
+        case .debug:
+            shouldMirrorToConsole = LoggingPreferences.allows(.high)
+        case .info:
+            shouldMirrorToConsole = LoggingPreferences.allows(.medium)
+        case .warning, .error:
+            shouldMirrorToConsole = true
+        }
+        if shouldMirrorToConsole {
+            NSLog("%@", line)
+            Swift.print(line)
+        }
+    }
+
+    /// Synchronize the Swift file handle before diagnostics copy the session.
+    public static func flush() {
+        state.flush()
+    }
+
+    static func installFileSink(at sessionDirectory: URL, includeDebug: Bool) -> Bool {
+        state.installSink(at: sessionDirectory, includeDebug: includeDebug)
+    }
+
+    static func updateDebugSetting(_ includeDebug: Bool) {
+        state.updateDebugSetting(includeDebug)
+    }
+
     public static func log(_ message: String, minimumLevel level: LoggingPreset = .medium) {
         guard LoggingPreferences.allows(level) else { return }
         // Mirror to NSLog (unified logging) in addition to stdout so

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/SDKLogger.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/SDKLogger.swift
@@ -203,7 +203,7 @@ enum SDKLogFormatter {
             case 0x0a: escaped += "\\n"
             case 0x0d: escaped += "\\r"
             case 0x09: escaped += "\\t"
-            case 0x00...0x1f, 0x7f:
+            case 0x00...0x1f, 0x7f, 0x85, 0x2028, 0x2029:
                 escaped += String(format: "\\u%04x", scalar.value)
             default:
                 escaped.unicodeScalars.append(scalar)

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
@@ -562,8 +562,11 @@ public class PlatformWalletManager: ObservableObject {
         if handle != NULL_HANDLE {
             let h = handle
             let calls = nativeTeardownCalls
-            Self.log.warning(
-                "PlatformWalletManager deallocated without shutdown(); scheduling fallback native teardown off-main for handle \(h, privacy: .public)"
+            SDKLogger.event(
+                "manager_deinit_without_shutdown",
+                category: .lifecycle,
+                severity: .warning,
+                fields: ["fallback_teardown_scheduled": .boolean(true)]
             )
             Self.destroyQueue.async {
                 _ = Self.performNativeTeardown(h, calls: calls)
@@ -632,6 +635,11 @@ public class PlatformWalletManager: ObservableObject {
         // and the generation bumps drop any trailing sync event the main
         // actor delivers after this turn.
         let h = handle
+        SDKLogger.event(
+            "manager_shutdown_started",
+            category: .lifecycle,
+            fields: ["wallet_count": .integer(Int64(wallets.count))]
+        )
         handle = NULL_HANDLE
         isConfigured = false
         progressPollTask?.cancel()
@@ -648,7 +656,17 @@ public class PlatformWalletManager: ObservableObject {
             }
         }
         shutdownTask = task
-        return await task.value
+        let metrics = await task.value
+        SDKLogger.event(
+            "manager_shutdown_completed",
+            category: .lifecycle,
+            fields: [
+                "duration_ms": .integer(Int64(metrics.totalMilliseconds)),
+                "off_main_thread": .boolean(metrics.ranOffMainThread),
+                "step_count": .integer(Int64(metrics.steps.count)),
+            ]
+        )
+        return metrics
     }
 
     /// The blocking native teardown body, shared by [`shutdown()`] and the
@@ -676,8 +694,16 @@ public class PlatformWalletManager: ObservableObject {
             let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
             steps.append(.init(name: name, ffiCode: result.code.rawValue, milliseconds: ms))
             if !result.isSuccess {
-                Self.log.error(
-                    "native teardown step \(name, privacy: .public) failed with \(String(describing: result.code), privacy: .public): \(result.message ?? "<no detail from Rust>", privacy: .public)"
+                SDKLogger.event(
+                    "manager_shutdown_step_failed",
+                    category: .lifecycle,
+                    severity: .error,
+                    fields: [
+                        "duration_ms": .integer(Int64(ms)),
+                        "ffi_code": .integer(Int64(result.code.rawValue)),
+                        "step": .publicText(name),
+                    ],
+                    error: PlatformWalletError(code: result.code, message: result.message)
                 )
             }
         }
@@ -702,11 +728,15 @@ public class PlatformWalletManager: ObservableObject {
             totalMilliseconds: Int((CFAbsoluteTimeGetCurrent() - totalStart) * 1000),
             ranOffMainThread: offMain
         )
-        let stepSummary = steps
-            .map { "\($0.name)=\($0.milliseconds)ms(code \($0.ffiCode))" }
-            .joined(separator: " ")
-        Self.log.info(
-            "native teardown finished in \(metrics.totalMilliseconds, privacy: .public)ms offMain=\(offMain, privacy: .public): \(stepSummary, privacy: .public)"
+        SDKLogger.event(
+            "manager_native_teardown_completed",
+            category: .lifecycle,
+            fields: [
+                "duration_ms": .integer(Int64(metrics.totalMilliseconds)),
+                "failed_steps": .integer(Int64(steps.filter { $0.ffiCode != 0 }.count)),
+                "off_main_thread": .boolean(offMain),
+                "step_count": .integer(Int64(steps.count)),
+            ]
         )
         return metrics
     }
@@ -775,6 +805,14 @@ public class PlatformWalletManager: ObservableObject {
         network: Network? = nil
     ) throws {
         try ensureConfigurationAllowed()
+        SDKLogger.event(
+            "manager_configuration_started",
+            category: .lifecycle,
+            fields: [
+                "network": .publicText(network.map { String(describing: $0) } ?? "unknown"),
+                "persistence_enabled": .boolean(modelContainer != nil),
+            ]
+        )
         var handle: Handle = NULL_HANDLE
 
         let handler: PlatformWalletPersistenceHandler?
@@ -828,6 +866,13 @@ public class PlatformWalletManager: ObservableObject {
             if let context = eventHandlerCallbacks.context {
                 Unmanaged<PlatformWalletEventHandler>.fromOpaque(context).release()
             }
+            SDKLogger.event(
+                "manager_configuration_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: ["phase": .publicText("native_create")],
+                error: error
+            )
             throw error
         }
 
@@ -843,6 +888,13 @@ public class PlatformWalletManager: ObservableObject {
             ).check()
         } catch {
             _ = platform_wallet_manager_destroy(handle)
+            SDKLogger.event(
+                "manager_configuration_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: ["phase": .publicText("persistence_capabilities")],
+                error: error
+            )
             throw error
         }
 
@@ -858,6 +910,14 @@ public class PlatformWalletManager: ObservableObject {
         self.isConfigured = true
 
         startProgressPolling()
+        SDKLogger.event(
+            "manager_configuration_completed",
+            category: .lifecycle,
+            fields: [
+                "capabilities_version": .unsignedInteger(UInt64(effectiveCapabilities.version)),
+                "persistence_enabled": .boolean(handler != nil),
+            ]
+        )
     }
 
     /// A manager owns at most one configured native lifetime. A no-op shutdown
@@ -933,23 +993,47 @@ public class PlatformWalletManager: ObservableObject {
         birthHeight: UInt32? = nil
     ) throws -> ManagedPlatformWallet {
         try ensureSyncNativeOpAllowed("createWallet")
+        SDKLogger.event(
+            "wallet_create_started",
+            category: .lifecycle,
+            fields: [
+                "birth_height_provided": .boolean(birthHeight != nil),
+                "network": .publicText(String(describing: network)),
+                "source": .publicText("mnemonic"),
+            ]
+        )
         var walletHandle: Handle = NULL_HANDLE
         var walletId: FFIByteTuple32 =
             (0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)
 
         let accountOptions: UInt32 = createDefaultAccounts ? 1 : 0
 
-        try mnemonic.withCString { mnemonicPtr in
-            try platform_wallet_manager_create_wallet_from_mnemonic_with_birth_height(
-                handle,
-                mnemonicPtr,
-                network.ffiValue,
-                accountOptions,
-                birthHeight != nil,
-                birthHeight ?? 0,
-                &walletHandle,
-                &walletId
-            ).check()
+        do {
+            try mnemonic.withCString { mnemonicPtr in
+                try platform_wallet_manager_create_wallet_from_mnemonic_with_birth_height(
+                    handle,
+                    mnemonicPtr,
+                    network.ffiValue,
+                    accountOptions,
+                    birthHeight != nil,
+                    birthHeight ?? 0,
+                    &walletHandle,
+                    &walletId
+                ).check()
+            }
+        } catch {
+            SDKLogger.event(
+                "wallet_create_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: [
+                    "network": .publicText(String(describing: network)),
+                    "source": .publicText("mnemonic"),
+                ],
+                error: error,
+                redacting: [mnemonic]
+            )
+            throw error
         }
 
         let idData = withUnsafeBytes(of: &walletId) { Data($0) }
@@ -958,6 +1042,14 @@ public class PlatformWalletManager: ObservableObject {
         }
         let w = ManagedPlatformWallet(handle: walletHandle, walletId: idData)
         self.wallets[idData] = w
+        SDKLogger.event(
+            "wallet_create_completed",
+            category: .lifecycle,
+            fields: [
+                "source": .publicText("mnemonic"),
+                "wallet_reference": .reference(idData),
+            ]
+        )
         return w
     }
 
@@ -1046,17 +1138,44 @@ public class PlatformWalletManager: ObservableObject {
     ) -> Result<ManagedPlatformWallet, PlatformWalletError> {
         let offMain = !Thread.isMainThread
         let start = CFAbsoluteTimeGetCurrent()
+        SDKLogger.event(
+            "wallet_create_started",
+            category: .lifecycle,
+            fields: [
+                "birth_height_provided": .boolean(params.birthHeight != nil),
+                "network": .publicText(String(describing: params.network)),
+                "off_main_thread": .boolean(offMain),
+                "source": .publicText("mnemonic"),
+            ]
+        )
         let outcome = calls.createFromMnemonic(handle, params)
         let result = PlatformWalletResult(outcome.result)
         let ms = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
         guard result.isSuccess else {
-            Self.log.error(
-                "native create failed in \(ms, privacy: .public)ms offMain=\(offMain, privacy: .public) network=\(params.network.rawValue, privacy: .public): \(String(describing: result.code), privacy: .public): \(result.message ?? "<no detail from Rust>", privacy: .public)"
+            SDKLogger.event(
+                "wallet_create_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: [
+                    "duration_ms": .integer(Int64(ms)),
+                    "network": .publicText(String(describing: params.network)),
+                    "off_main_thread": .boolean(offMain),
+                    "source": .publicText("mnemonic"),
+                ],
+                error: PlatformWalletError(code: result.code, message: result.message),
+                redacting: [params.mnemonic]
             )
             return .failure(PlatformWalletError(code: result.code, message: result.message))
         }
-        Self.log.info(
-            "native create finished in \(ms, privacy: .public)ms offMain=\(offMain, privacy: .public) network=\(params.network.rawValue, privacy: .public)"
+        SDKLogger.event(
+            "wallet_create_completed",
+            category: .lifecycle,
+            fields: [
+                "duration_ms": .integer(Int64(ms)),
+                "off_main_thread": .boolean(offMain),
+                "source": .publicText("mnemonic"),
+                "wallet_reference": .reference(outcome.walletId),
+            ]
         )
         return .success(
             ManagedPlatformWallet(handle: outcome.walletHandle, walletId: outcome.walletId))
@@ -1081,6 +1200,15 @@ public class PlatformWalletManager: ObservableObject {
                 "seed must be 64 bytes, got \(seed.count)"
             )
         }
+        SDKLogger.event(
+            "wallet_create_started",
+            category: .lifecycle,
+            fields: [
+                "birth_height_provided": .boolean(birthHeight != nil),
+                "network": .publicText(String(describing: network)),
+                "source": .publicText("seed"),
+            ]
+        )
 
         var walletHandle: Handle = NULL_HANDLE
         var walletId: FFIByteTuple32 =
@@ -1088,18 +1216,32 @@ public class PlatformWalletManager: ObservableObject {
 
         let accountOptions: UInt32 = createDefaultAccounts ? 1 : 0
 
-        try seed.withUnsafeBytes { seedPtr in
-            try platform_wallet_manager_create_wallet_from_seed_with_birth_height(
-                handle,
-                network.ffiValue,
-                seedPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                UInt(seed.count),
-                accountOptions,
-                birthHeight != nil,
-                birthHeight ?? 0,
-                &walletHandle,
-                &walletId
-            ).check()
+        do {
+            try seed.withUnsafeBytes { seedPtr in
+                try platform_wallet_manager_create_wallet_from_seed_with_birth_height(
+                    handle,
+                    network.ffiValue,
+                    seedPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                    UInt(seed.count),
+                    accountOptions,
+                    birthHeight != nil,
+                    birthHeight ?? 0,
+                    &walletHandle,
+                    &walletId
+                ).check()
+            }
+        } catch {
+            SDKLogger.event(
+                "wallet_create_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: [
+                    "network": .publicText(String(describing: network)),
+                    "source": .publicText("seed"),
+                ],
+                error: error
+            )
+            throw error
         }
 
         let idData = withUnsafeBytes(of: &walletId) { Data($0) }
@@ -1108,6 +1250,14 @@ public class PlatformWalletManager: ObservableObject {
         }
         let w = ManagedPlatformWallet(handle: walletHandle, walletId: idData)
         self.wallets[idData] = w
+        SDKLogger.event(
+            "wallet_create_completed",
+            category: .lifecycle,
+            fields: [
+                "source": .publicText("seed"),
+                "wallet_reference": .reference(idData),
+            ]
+        )
         return w
     }
 
@@ -1142,14 +1292,35 @@ public class PlatformWalletManager: ObservableObject {
         // flight — a second Rust loader running concurrently with the one
         // on the destroy queue races load.rs's two-step hydration.
         try ensureSyncNativeOpAllowed("loadFromPersistor")
+        SDKLogger.event(
+            "wallet_restore_started",
+            category: .lifecycle,
+            fields: ["off_main_thread": .boolean(!Thread.isMainThread)]
+        )
 
-        try platform_wallet_manager_load_from_persistor(handle).check()
+        do {
+            try platform_wallet_manager_load_from_persistor(handle).check()
+        } catch {
+            SDKLogger.event(
+                "wallet_restore_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: ["phase": .publicText("bulk_load")],
+                error: error
+            )
+            throw error
+        }
 
         // Ask SwiftData for the list of wallet ids we just told Rust
         // to load. We reuse the same container rather than shipping a
         // separate FFI "list ids" entry, because SwiftData already is
         // the source of truth.
         guard let persistenceHandler = persistenceHandler else {
+            SDKLogger.event(
+                "wallet_restore_completed",
+                category: .lifecycle,
+                fields: ["wallet_count": .integer(0)]
+            )
             return []
         }
         let walletIds = persistenceHandler.restorableWalletIds()
@@ -1188,6 +1359,13 @@ public class PlatformWalletManager: ObservableObject {
                 // whole restore. Usually means wallet_id / xpub
                 // disagreement (SwiftData drift vs. Rust recompute).
                 self.lastError = error
+                SDKLogger.event(
+                    "wallet_restore_item_failed",
+                    category: .lifecycle,
+                    severity: .error,
+                    fields: ["wallet_reference": .reference(walletId)],
+                    error: error
+                )
             }
         }
 
@@ -1203,6 +1381,12 @@ public class PlatformWalletManager: ObservableObject {
         // `statusRaw = 3 + proofBytes` back to SwiftData. UI updates
         // reactively via `@Query`.
         catchUpStuckAssetLocks(wallets: restored)
+
+        SDKLogger.event(
+            "wallet_restore_completed",
+            category: .lifecycle,
+            fields: ["wallet_count": .integer(Int64(restored.count))]
+        )
 
         return restored
     }
@@ -1239,12 +1423,25 @@ public class PlatformWalletManager: ObservableObject {
     ) -> OffMainLoadOutcome {
         let started = CFAbsoluteTimeGetCurrent()
         let offMain = !Thread.isMainThread
+        SDKLogger.event(
+            "wallet_restore_started",
+            category: .lifecycle,
+            fields: ["off_main_thread": .boolean(offMain)]
+        )
 
         let bulk = PlatformWalletResult(calls.loadFromPersistor(handle))
         guard bulk.isSuccess else {
             let ms = Int((CFAbsoluteTimeGetCurrent() - started) * 1000)
-            Self.log.error(
-                "native load failed in \(ms, privacy: .public)ms offMain=\(offMain, privacy: .public): \(String(describing: bulk.code), privacy: .public): \(bulk.message ?? "<no detail from Rust>", privacy: .public)"
+            SDKLogger.event(
+                "wallet_restore_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: [
+                    "duration_ms": .integer(Int64(ms)),
+                    "off_main_thread": .boolean(offMain),
+                    "phase": .publicText("bulk_load"),
+                ],
+                error: PlatformWalletError(code: bulk.code, message: bulk.message)
             )
             return OffMainLoadOutcome(
                 bulkResult: .failure(PlatformWalletError(code: bulk.code, message: bulk.message)),
@@ -1263,9 +1460,17 @@ public class PlatformWalletManager: ObservableObject {
                 // doesn't fail the whole restore. Recorded IN SEQUENCE so
                 // the epilogue's `lastError` replay matches the sync
                 // overload's per-wallet ordering.
-                lookups.append(.skipped(PlatformWalletError(
+                let error = PlatformWalletError(
                     code: lookupResult.code,
-                    message: lookupResult.message)))
+                    message: lookupResult.message)
+                SDKLogger.event(
+                    "wallet_restore_item_failed",
+                    category: .lifecycle,
+                    severity: .error,
+                    fields: ["wallet_reference": .reference(walletId)],
+                    error: error
+                )
+                lookups.append(.skipped(error))
                 continue
             }
             lookups.append(.restored(walletId: walletId, walletHandle: lookup.walletHandle))
@@ -1275,8 +1480,14 @@ public class PlatformWalletManager: ObservableObject {
             if case .restored = entry { count += 1 }
         }
         let ms = Int((CFAbsoluteTimeGetCurrent() - started) * 1000)
-        Self.log.info(
-            "native load finished in \(ms, privacy: .public)ms offMain=\(offMain, privacy: .public) wallets=\(restoredCount, privacy: .public)"
+        SDKLogger.event(
+            "wallet_restore_native_completed",
+            category: .lifecycle,
+            fields: [
+                "duration_ms": .integer(Int64(ms)),
+                "off_main_thread": .boolean(offMain),
+                "wallet_count": .integer(Int64(restoredCount)),
+            ]
         )
         return OffMainLoadOutcome(bulkResult: .success(()), lookups: lookups)
     }
@@ -1368,8 +1579,13 @@ public class PlatformWalletManager: ObservableObject {
             }
         }
         let unlockMs = Int(unlockSeconds * 1000)
-        Self.log.info(
-            "load unlock loop finished in \(unlockMs, privacy: .public)ms wallets=\(restored.count, privacy: .public)"
+        SDKLogger.event(
+            "wallet_restore_completed",
+            category: .lifecycle,
+            fields: [
+                "unlock_duration_ms": .integer(Int64(unlockMs)),
+                "wallet_count": .integer(Int64(restored.count)),
+            ]
         )
 
         catchUpStuckAssetLocks(wallets: restored)
@@ -1386,13 +1602,13 @@ public class PlatformWalletManager: ObservableObject {
         let walletId = managedWallet.walletId
         do {
             let unlocked = try unlockWalletFromKeychain(managedWallet)
-            // NSLog (not print) so the unlock outcome is observable
-            // off-Xcode — it pairs with the resolver audit line in
-            // MnemonicResolver.resolve for "what touched the seed".
-            NSLog(
-                "🔓 wallet unlock %@: %@",
-                String(walletId.toHexString().prefix(8)),
-                unlocked ? "seed verified" : "no mnemonic — stays watch-only"
+            SDKLogger.event(
+                "wallet_unlock_completed",
+                category: .lifecycle,
+                fields: [
+                    "result": .publicText(unlocked ? "seed_verified" : "watch_only"),
+                    "wallet_reference": .reference(walletId),
+                ]
             )
         } catch let error as PlatformWalletError {
             // Distinguish a wrong-seed binding (Rust `SeedMismatch` →
@@ -1404,18 +1620,39 @@ public class PlatformWalletManager: ObservableObject {
             // Either way the wallet stays external-signable (cannot sign),
             // so no wrong-seed signing can occur.
             if case .invalidParameter = error {
-                print(
-                    "🚫 wallet unlock REJECTED \(walletId.toHexString().prefix(8)): "
-                        + "seed does not bind (mis-mapped Keychain slot?) — stays watch-only"
+                SDKLogger.event(
+                    "wallet_unlock_rejected",
+                    category: .lifecycle,
+                    severity: .error,
+                    fields: [
+                        "reason": .publicText("seed_binding_mismatch"),
+                        "wallet_reference": .reference(walletId),
+                    ],
+                    error: error
                 )
             } else {
                 // Transient (resolver/Keychain unavailable, …) — not
                 // retried this pass; a later signer-present action re-tries.
-                print("⚠️ wallet unlock failed \(walletId.toHexString().prefix(8)) (transient): \(error)")
+                SDKLogger.event(
+                    "wallet_unlock_failed",
+                    category: .lifecycle,
+                    severity: .warning,
+                    fields: [
+                        "transient": .boolean(true),
+                        "wallet_reference": .reference(walletId),
+                    ],
+                    error: error
+                )
             }
             self.lastError = error
         } catch {
-            print("❌ wallet unlock failed \(walletId.toHexString().prefix(8)): \(error)")
+            SDKLogger.event(
+                "wallet_unlock_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: ["wallet_reference": .reference(walletId)],
+                error: error
+            )
             self.lastError = error
         }
     }
@@ -1604,10 +1841,13 @@ public class PlatformWalletManager: ObservableObject {
                     walletId: walletId,
                     marker: String(cString: ptr)
                 )
-                NSLog(
-                    "🔐 seed binding verified via resolver for %@ — marker "
-                        + "persisted; later launches skip the derivation",
-                    String(walletId.toHexString().prefix(8))
+                SDKLogger.event(
+                    "seed_binding_verified",
+                    category: .lifecycle,
+                    fields: [
+                        "marker_persisted": .boolean(true),
+                        "wallet_reference": .reference(walletId),
+                    ]
                 )
             }
             setDashPaySeedMismatch(walletId, false)
@@ -1655,15 +1895,24 @@ public class PlatformWalletManager: ObservableObject {
             walletHandle, &pendingOps
         )
         if PlatformWalletResultCode(ffi: countResult.code) == .success && pendingOps == 0 {
-            NSLog(
-                "🧵 contact-crypto drain skipped for %@ — no pending ops",
-                String(walletId.toHexString().prefix(8))
+            SDKLogger.event(
+                "contact_crypto_drain_skipped",
+                category: .lifecycle,
+                severity: .debug,
+                fields: [
+                    "reason": .publicText("empty_queue"),
+                    "wallet_reference": .reference(walletId),
+                ]
             )
             return true
         }
-        NSLog(
-            "🧵 contact-crypto drain scheduling for %@ — %u pending op(s)",
-            String(walletId.toHexString().prefix(8)), pendingOps
+        SDKLogger.event(
+            "contact_crypto_drain_scheduled",
+            category: .lifecycle,
+            fields: [
+                "pending_count": .unsignedInteger(UInt64(pendingOps)),
+                "wallet_reference": .reference(walletId),
+            ]
         )
 
         // Don't stack a second drain on an in-flight one: a banner Unlock tap
@@ -1730,17 +1979,24 @@ public class PlatformWalletManager: ObservableObject {
         setDashPayDraining(walletId, false)
         if let drainError {
             lastError = drainError
-            print(
-                "⚠️ contact-crypto drain failed for "
-                    + "\(walletId.toHexString().prefix(8)): \(drainError)"
+            SDKLogger.event(
+                "contact_crypto_drain_failed",
+                category: .lifecycle,
+                severity: .warning,
+                fields: ["wallet_reference": .reference(walletId)],
+                error: drainError
             )
         } else if drained > 0 {
             // `drained` counts cleared queue entries — both completed
             // and permanently-failed (channel-broken) ops — so report
             // it neutrally rather than implying all succeeded.
-            print(
-                "🔑 processed \(drained) deferred contact-crypto op(s) for "
-                    + "\(walletId.toHexString().prefix(8))"
+            SDKLogger.event(
+                "contact_crypto_drain_completed",
+                category: .lifecycle,
+                fields: [
+                    "processed_count": .unsignedInteger(UInt64(drained)),
+                    "wallet_reference": .reference(walletId),
+                ]
             )
         }
     }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerStartup.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerStartup.swift
@@ -167,6 +167,15 @@ extension PlatformWalletManager {
                 "walletId must be 32 bytes, got \(walletId.count)"
             )
         }
+        SDKLogger.event(
+            "wallet_startup_started",
+            category: .lifecycle,
+            fields: [
+                "budget_provided": .boolean(budget != nil),
+                "gap_limit_provided": .boolean(gapLimit != nil),
+                "wallet_reference": .reference(walletId),
+            ]
+        )
 
         // Nothing below may run on a seed that does not own this wallet.
         // Everything this call does with key material is unauthenticated —
@@ -211,10 +220,15 @@ extension PlatformWalletManager {
         case .present:
             coreSigner = MnemonicResolver(storage: storage)
         case .unavailable(let status):
-            SDKLogger.log(
-                "startup: mnemonic availability unknown (OSStatus \(status)); "
-                    + "passing a resolver so the scan can defer rather than fail",
-                minimumLevel: .medium)
+            SDKLogger.event(
+                "wallet_startup_mnemonic_unavailable",
+                category: .lifecycle,
+                severity: .warning,
+                fields: [
+                    "os_status": .integer(Int64(status)),
+                    "wallet_reference": .reference(walletId),
+                ]
+            )
             coreSigner = MnemonicResolver(storage: storage)
         }
         // Identity signer for the DIP-15 auto-accept pass. Nil without a
@@ -251,23 +265,51 @@ extension PlatformWalletManager {
             budgetSecs = max(1, converted)
         }
 
-        return try await Task.detached(priority: .userInitiated) { () -> WalletStartupOutcome in
-            try withExtendedLifetime((coreSigner, identitySigner)) {
-                var out = WalletStartupOutcomeFFI()
-                try walletId.withUnsafeBytes { raw in
-                    try platform_wallet_manager_start_wallet_subsystems(
-                        handle,
-                        raw.bindMemory(to: UInt8.self).baseAddress,
-                        coreSigner?.handle,
-                        identitySigner?.handle,
-                        budgetSecs,
-                        gapLimit ?? 0,
-                        &out
-                    ).check()
+        do {
+            let outcome = try await Task.detached(priority: .userInitiated) { () -> WalletStartupOutcome in
+                try withExtendedLifetime((coreSigner, identitySigner)) {
+                    var out = WalletStartupOutcomeFFI()
+                    try walletId.withUnsafeBytes { raw in
+                        try platform_wallet_manager_start_wallet_subsystems(
+                            handle,
+                            raw.bindMemory(to: UInt8.self).baseAddress,
+                            coreSigner?.handle,
+                            identitySigner?.handle,
+                            budgetSecs,
+                            gapLimit ?? 0,
+                            &out
+                        ).check()
+                    }
+                    return WalletStartupOutcome(out)
                 }
-                return WalletStartupOutcome(out)
+            }.value
+            var fields: [String: SDKLogValue] = [
+                "contact_accounts_drained": .unsignedInteger(UInt64(outcome.contactAccountsDrained)),
+                "contact_accounts_pending": .unsignedInteger(UInt64(outcome.contactAccountsPending)),
+                "discovery_attempts": .unsignedInteger(UInt64(outcome.discoveryAttempts)),
+                "duration_ms": .integer(Int64(outcome.elapsed * 1_000)),
+                "status": .publicText(String(describing: outcome.status)),
+                "wallet_reference": .reference(walletId),
+            ]
+            if let identityId = outcome.identityId {
+                fields["identity_reference"] = .reference(identityId)
             }
-        }.value
+            SDKLogger.event(
+                "wallet_startup_completed",
+                category: .lifecycle,
+                fields: fields
+            )
+            return outcome
+        } catch {
+            SDKLogger.event(
+                "wallet_startup_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: ["wallet_reference": .reference(walletId)],
+                error: error
+            )
+            throw error
+        }
     }
 }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -191,6 +191,33 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
         }
     }
 
+    /// Best-effort save used by callback helpers that may also be invoked
+    /// outside a Rust changeset. The legacy behavior remains non-throwing,
+    /// but failures are no longer invisible in exported diagnostics.
+    private func saveBackgroundContextIfNeeded(
+        operation: String,
+        walletId: Data? = nil
+    ) {
+        guard !inChangeset else { return }
+        do {
+            try backgroundContext.save()
+        } catch {
+            var fields: [String: SDKLogValue] = [
+                "operation": .publicText(operation)
+            ]
+            if let walletId {
+                fields["wallet_reference"] = .reference(walletId)
+            }
+            SDKLogger.event(
+                "persistence_save_failed",
+                category: .persistence,
+                severity: .error,
+                fields: fields,
+                error: error
+            )
+        }
+    }
+
     // MARK: - Platform Address Balances
 
     /// Apply an incremental BLAST balance changeset to SwiftData.
@@ -379,7 +406,18 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 do {
                     existing = try backgroundContext.fetch(descriptor).first
                 } catch {
-                    print("⚠️ persistInvitations: fetch failed for outpoint \(outPointHex) — skipping upsert; this invitation may be missing from the Sent list: \(error)")
+                    SDKLogger.event(
+                        "persistence_invitation_fetch_failed",
+                        category: .persistence,
+                        severity: .error,
+                        fields: [
+                            "operation": .publicText("upsert"),
+                            "outpoint_reference": .referenceString(outPointHex),
+                            "wallet_reference": .reference(walletId),
+                        ],
+                        error: error,
+                        redacting: [outPointHex]
+                    )
                     allPersisted = false
                     continue
                 }
@@ -419,7 +457,18 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                         backgroundContext.delete(existing)
                     }
                 } catch {
-                    print("⚠️ persistInvitations: fetch failed for removal of outpoint \(hex) — stale invitation may linger in the Sent list: \(error)")
+                    SDKLogger.event(
+                        "persistence_invitation_fetch_failed",
+                        category: .persistence,
+                        severity: .error,
+                        fields: [
+                            "operation": .publicText("remove"),
+                            "outpoint_reference": .referenceString(hex),
+                            "wallet_reference": .reference(walletId),
+                        ],
+                        error: error,
+                        redacting: [hex]
+                    )
                     allPersisted = false
                 }
             }
@@ -477,14 +526,35 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 do {
                     identityRow = try backgroundContext.fetch(identityDescriptor).first
                 } catch {
-                    print("⚠️ persistDpnsNameStates: identity fetch failed for \(identityId.toBase58String()) — skipping marketplace row for \"\(entry.label)\": \(error)")
+                    SDKLogger.event(
+                        "persistence_dpns_identity_fetch_failed",
+                        category: .persistence,
+                        severity: .error,
+                        fields: [
+                            "identity_reference": .reference(identityId),
+                            "label_reference": .referenceString(entry.label),
+                            "wallet_reference": .reference(walletId),
+                        ],
+                        error: error,
+                        redacting: [identityId.toBase58String(), entry.label]
+                    )
                     allPersisted = false
                     continue
                 }
                 guard let identityRow else {
                     // Not an error: the identity row simply isn't staged
                     // yet. The next marketplace sync pass re-emits this row.
-                    print("ℹ️ persistDpnsNameStates: no identity row for \(identityId.toBase58String()) yet — marketplace state for \"\(entry.label)\" will land on the next sync pass")
+                    SDKLogger.event(
+                        "persistence_dpns_deferred",
+                        category: .persistence,
+                        severity: .warning,
+                        fields: [
+                            "identity_reference": .reference(identityId),
+                            "label_reference": .referenceString(entry.label),
+                            "reason": .publicText("identity_missing"),
+                            "wallet_reference": .reference(walletId),
+                        ]
+                    )
                     continue
                 }
 
@@ -502,7 +572,18 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 do {
                     existing = try backgroundContext.fetch(descriptor).first
                 } catch {
-                    print("⚠️ persistDpnsNameStates: fetch failed for \"\(normalizedLabel)\" — its price/sale state may be stale in the UI: \(error)")
+                    SDKLogger.event(
+                        "persistence_dpns_state_fetch_failed",
+                        category: .persistence,
+                        severity: .error,
+                        fields: [
+                            "label_reference": .referenceString(normalizedLabel),
+                            "operation": .publicText("upsert"),
+                            "wallet_reference": .reference(walletId),
+                        ],
+                        error: error,
+                        redacting: [normalizedLabel]
+                    )
                     allPersisted = false
                     continue
                 }
@@ -573,7 +654,18 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                         row.lastUpdated = Date()
                     }
                 } catch {
-                    print("⚠️ persistDpnsNameStates: fetch failed for removal of document \(documentId) — stale price/sale state may linger: \(error)")
+                    SDKLogger.event(
+                        "persistence_dpns_state_fetch_failed",
+                        category: .persistence,
+                        severity: .error,
+                        fields: [
+                            "document_reference": .referenceString(documentId),
+                            "operation": .publicText("remove"),
+                            "wallet_reference": .reference(walletId),
+                        ],
+                        error: error,
+                        redacting: [documentId]
+                    )
                     allPersisted = false
                 }
             }
@@ -1665,8 +1757,12 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
     /// instrumented timing, etc.) has an obvious seam.
     func beginChangeset(walletId: Data) {
         onQueue {
-            _ = walletId
             self.inChangeset = true
+            SDKLogger.event(
+                "persistence_changeset_started",
+                category: .persistence,
+                fields: ["wallet_reference": .reference(walletId)]
+            )
         }
     }
 
@@ -1689,7 +1785,6 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
     @discardableResult
     func endChangeset(walletId: Data, success: Bool) -> Bool {
         onQueue {
-            _ = walletId
             // Clear the flag before draining deferred backfills so each one's
             // save() lands cleanly outside the round; `drainDeferredBackfills`
             // is guarded on `!inChangeset`, so the ordering inside this `defer`
@@ -1715,18 +1810,27 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     ownerIdentityId: entry.ownerIdentityId,
                     payments: entry.payments
                 ) {
-                    print(
-                        "⚠️ endChangeset: no PersistentIdentity for owner "
-                            + "\(entry.ownerIdentityId.prefix(8).toHexString())… after the "
-                            + "round's identity applies; failing the round so Rust rolls "
-                            + "back \(entry.payments.count) payment row(s) instead of "
-                            + "losing them"
+                    SDKLogger.event(
+                        "persistence_changeset_failed",
+                        category: .persistence,
+                        severity: .error,
+                        fields: [
+                            "identity_reference": .reference(entry.ownerIdentityId),
+                            "payment_count": .integer(Int64(entry.payments.count)),
+                            "reason": .publicText("payment_owner_missing"),
+                            "wallet_reference": .reference(walletId),
+                        ]
                     )
                     backgroundContext.rollback()
                     return false
                 }
                 do {
                     try backgroundContext.save()
+                    SDKLogger.event(
+                        "persistence_changeset_committed",
+                        category: .persistence,
+                        fields: ["wallet_reference": .reference(walletId)]
+                    )
                     return true
                 } catch {
                     // The context still has the pending changes on
@@ -1735,7 +1839,16 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     // only have committed data prior to this save, so
                     // the user-visible store is consistent — but the
                     // round did NOT commit, so report failure upward.
-                    print("⚠️ endChangeset: save failed: \(error.localizedDescription)")
+                    SDKLogger.event(
+                        "persistence_changeset_failed",
+                        category: .persistence,
+                        severity: .error,
+                        fields: [
+                            "reason": .publicText("save_failed"),
+                            "wallet_reference": .reference(walletId),
+                        ],
+                        error: error
+                    )
                     backgroundContext.rollback()
                     return false
                 }
@@ -1745,6 +1858,15 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 // side rolled its in-memory entries back too, so persisting
                 // them later would fabricate history.
                 deferredPaymentUpserts.removeAll()
+                SDKLogger.event(
+                    "persistence_changeset_rolled_back",
+                    category: .persistence,
+                    severity: .warning,
+                    fields: [
+                        "reason": .publicText("upstream_callback_failed"),
+                        "wallet_reference": .reference(walletId),
+                    ]
+                )
                 return false
             }
         }
@@ -2542,7 +2664,16 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     // out-of-wallet owner with no PersistentIdentity)
                     // is at least observable rather than vanishing
                     // silently.
-                    print("⚠️ persistContacts: skipped contact upsert — no PersistentIdentity for owner \(entry.ownerIdentityId.prefix(8).toHexString())…; will retry next sync round")
+                    SDKLogger.event(
+                        "persistence_contact_deferred",
+                        category: .persistence,
+                        severity: .warning,
+                        fields: [
+                            "identity_reference": .reference(entry.ownerIdentityId),
+                            "operation": .publicText("contact_upsert"),
+                            "reason": .publicText("identity_missing"),
+                        ]
+                    )
                     continue
                 }
 
@@ -2718,7 +2849,16 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             predicate: #Predicate { $0.identityId == ownerId }
         )
         guard let owner = try? backgroundContext.fetch(ownerDescriptor).first else {
-            print("⚠️ persistContacts: skipped ignored-sender — no PersistentIdentity for owner \(row.ownerIdentityId.prefix(8).toHexString())…; will retry next sync round")
+            SDKLogger.event(
+                "persistence_contact_deferred",
+                category: .persistence,
+                severity: .warning,
+                fields: [
+                    "identity_reference": .reference(row.ownerIdentityId),
+                    "operation": .publicText("ignored_sender"),
+                    "reason": .publicText("identity_missing"),
+                ]
+            )
             return
         }
 
@@ -2853,7 +2993,13 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 do {
                     try backgroundContext.save()
                 } catch {
-                    print("⚠️ persistDashpayPayments: SwiftData save failed — payment history may be incomplete: \(error)")
+                    SDKLogger.event(
+                        "persistence_dashpay_payments_save_failed",
+                        category: .persistence,
+                        severity: .error,
+                        fields: ["identity_reference": .reference(ownerIdentityId)],
+                        error: error
+                    )
                 }
             }
         }
@@ -3054,6 +3200,15 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
         // from the synchronous, out-of-round entry point.
         if inChangeset {
             deferredBackfills.append((walletId: walletId, items: items))
+            SDKLogger.event(
+                "persistence_backfill_deferred",
+                category: .persistence,
+                severity: .debug,
+                fields: [
+                    "item_count": .integer(Int64(items.count)),
+                    "wallet_reference": .reference(walletId),
+                ]
+            )
             return (0, 0, 0)
         }
 
@@ -3093,7 +3248,16 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 ),
                 expectedPath == meta.derivationPath
             else {
-                print("⚠️ backfill: path self-check failed for \(meta.publicKey.prefix(8))… — left unmigrated")
+                SDKLogger.event(
+                    "persistence_backfill_item_failed",
+                    category: .persistence,
+                    severity: .warning,
+                    fields: [
+                        "public_key_reference": .referenceString(meta.publicKey),
+                        "reason": .publicText("derivation_path_mismatch"),
+                        "wallet_reference": .reference(walletId),
+                    ]
+                )
                 failed += 1
                 continue
             }
@@ -3105,10 +3269,35 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
         // Save only when a row actually changed; `failed`/`skipped` paths never
         // mutate the context.
         if written > 0 {
-            try? backgroundContext.save()
+            do {
+                try backgroundContext.save()
+            } catch {
+                SDKLogger.event(
+                    "persistence_backfill_save_failed",
+                    category: .persistence,
+                    severity: .error,
+                    fields: [
+                        "attempted_count": .integer(Int64(written)),
+                        "wallet_reference": .reference(walletId),
+                    ],
+                    error: error
+                )
+                backgroundContext.rollback()
+                failed += written
+                written = 0
+            }
         }
         if written > 0 || failed > 0 {
-            print("ℹ️ backfill(\(walletId.toHexString().prefix(8))…): wrote \(written), skipped \(skipped), failed \(failed)")
+            SDKLogger.event(
+                "persistence_backfill_completed",
+                category: .persistence,
+                fields: [
+                    "failed_count": .integer(Int64(failed)),
+                    "skipped_count": .integer(Int64(skipped)),
+                    "wallet_reference": .reference(walletId),
+                    "written_count": .integer(Int64(written)),
+                ]
+            )
         }
         return (written, skipped, failed)
     }
@@ -3335,7 +3524,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             }
         }
 
-        if !self.inChangeset { try? backgroundContext.save() }
+        saveBackgroundContextIfNeeded(operation: "account_addresses", walletId: walletId)
         return true
         }  // onQueue
     }
@@ -3410,7 +3599,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             row.lastUpdated = Date()
         }
 
-        if !self.inChangeset { try? backgroundContext.save() }
+        saveBackgroundContextIfNeeded(operation: "platform_payment_addresses", walletId: walletId)
     }
 
     /// Split a DIP-0018 bech32m platform address back into
@@ -3547,7 +3736,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     backgroundContext.insert(row)
                 }
             }
-            if !self.inChangeset { try? backgroundContext.save() }
+            saveBackgroundContextIfNeeded(operation: "shielded_notes", walletId: walletId)
         }
     }
 
@@ -3603,7 +3792,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     backgroundContext.insert(row)
                 }
             }
-            if !self.inChangeset { try? backgroundContext.save() }
+            saveBackgroundContextIfNeeded(operation: "shielded_outgoing_notes", walletId: walletId)
         }
     }
 
@@ -3696,7 +3885,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     backgroundContext.insert(row)
                 }
             }
-            if !self.inChangeset { try? backgroundContext.save() }
+            saveBackgroundContextIfNeeded(operation: "shielded_activity", walletId: walletId)
         }
     }
 
@@ -3718,7 +3907,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     }
                 }
             }
-            if !self.inChangeset { try? backgroundContext.save() }
+            saveBackgroundContextIfNeeded(operation: "shielded_spent_nullifiers", walletId: walletId)
         }
     }
 
@@ -3738,7 +3927,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 }
                 row.lastUpdated = Date()
             }
-            if !self.inChangeset { try? backgroundContext.save() }
+            saveBackgroundContextIfNeeded(operation: "shielded_sync_indices", walletId: walletId)
         }
     }
 
@@ -3777,7 +3966,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     )
                 }
             }
-            if !self.inChangeset { try? backgroundContext.save() }
+            saveBackgroundContextIfNeeded(operation: "shielded_viewing_keys", walletId: walletId)
         }
     }
 
@@ -3983,7 +4172,16 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 // address. Mirrors the Rust persist side, which rejects
                 // non-43-byte recipients before they reach SwiftData.
                 guard row.recipient.count == 43 else {
-                    print("⚠️ loadShieldedOutgoingNotes: skipping row with malformed recipient length \(row.recipient.count) (expected 43)")
+                    SDKLogger.event(
+                        "persistence_shielded_outgoing_row_skipped",
+                        category: .persistence,
+                        severity: .warning,
+                        fields: [
+                            "actual_length": .integer(Int64(row.recipient.count)),
+                            "expected_length": .integer(43),
+                            "reason": .publicText("malformed_recipient"),
+                        ]
+                    )
                     continue
                 }
                 let memoBuf = UnsafeMutablePointer<UInt8>.allocate(capacity: row.memo.count)
@@ -4274,10 +4472,15 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             if let bad = rows.first(where: {
                 $0.walletId.count != 32 || $0.fvkBytes.count != 96
             }) {
-                SDKLogger.error(
-                    "loadShieldedViewingKeys: corrupt row "
-                        + "(walletId \(bad.walletId.count)B, fvk \(bad.fvkBytes.count)B) — "
-                        + "failing the load rather than masking it as a missing key"
+                SDKLogger.event(
+                    "persistence_shielded_viewing_key_load_failed",
+                    category: .persistence,
+                    severity: .error,
+                    fields: [
+                        "fvk_length": .integer(Int64(bad.fvkBytes.count)),
+                        "reason": .publicText("corrupt_row"),
+                        "wallet_id_length": .integer(Int64(bad.walletId.count)),
+                    ]
                 )
                 resultErrored = true
                 return
@@ -4355,7 +4558,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             }
             wallet.birthHeight = birthHeight
             wallet.lastUpdated = Date()
-            if !self.inChangeset { try? backgroundContext.save() }
+            saveBackgroundContextIfNeeded(operation: "wallet_metadata", walletId: walletId)
         }
     }
 
@@ -4369,7 +4572,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             guard let wallet = findWalletRecord(walletId: walletId) else { return }
             wallet.name = name
             wallet.lastUpdated = Date()
-            try? backgroundContext.save()
+            saveBackgroundContextIfNeeded(operation: "wallet_name", walletId: walletId)
         }
     }
 
@@ -4393,7 +4596,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             guard let wallet = findWalletRecord(walletId: walletId) else { return }
             wallet.seedBindingVerifiedMarker = marker
             wallet.lastUpdated = Date()
-            try? backgroundContext.save()
+            saveBackgroundContextIfNeeded(operation: "seed_binding_marker", walletId: walletId)
         }
     }
 
@@ -4425,6 +4628,11 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
 
     /// Wipe a wallet's SwiftData footprint.
     public func deleteWalletData(walletId: Data) throws {
+        SDKLogger.event(
+            "persistence_wallet_delete_started",
+            category: .persistence,
+            fields: ["wallet_reference": .reference(walletId)]
+        )
         try onQueue {
             do {
                 let walletDescriptor = FetchDescriptor<PersistentWallet>(
@@ -4667,8 +4875,20 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 }
 
                 try backgroundContext.save()
+                SDKLogger.event(
+                    "persistence_wallet_delete_completed",
+                    category: .persistence,
+                    fields: ["wallet_reference": .reference(walletId)]
+                )
             } catch {
                 backgroundContext.rollback()
+                SDKLogger.event(
+                    "persistence_wallet_delete_failed",
+                    category: .persistence,
+                    severity: .error,
+                    fields: ["wallet_reference": .reference(walletId)],
+                    error: error
+                )
                 throw error
             }
         }
@@ -4752,7 +4972,7 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             account.friendIdentityId = friendIdentityId
             account.accountExtendedPubKeyBytes = xpubBytes
             account.lastUpdated = Date()
-            if !self.inChangeset { try? backgroundContext.save() }
+            saveBackgroundContextIfNeeded(operation: "account_registration", walletId: walletId)
         }
     }
 
@@ -4793,24 +5013,35 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
         guard healed > 0 else { return }
         do {
             try backgroundContext.save()
-            NSLog(
-                "[persistor-load:swift] healed isLocal on %d identity row(s)",
-                healed
+            SDKLogger.event(
+                "persistence_identity_flags_healed",
+                category: .persistence,
+                fields: ["row_count": .integer(Int64(healed))]
             )
         } catch {
             // Non-fatal: the next launch retries. Roll back so the
             // failed heal can't bleed into the restore fetches below.
             backgroundContext.rollback()
-            NSLog(
-                "[persistor-load:swift] isLocal heal save failed: %@",
-                String(describing: error)
+            SDKLogger.event(
+                "persistence_identity_flags_heal_failed",
+                category: .persistence,
+                severity: .error,
+                fields: ["row_count": .integer(Int64(healed))],
+                error: error
             )
         }
     }
 
     /// Returns `(nil, 0)` if nothing is restorable.
     func loadWalletList() -> (entries: UnsafePointer<WalletRestoreEntryFFI>?, count: Int, errored: Bool) {
-        onQueue {
+        SDKLogger.event(
+            "persistence_wallet_load_started",
+            category: .persistence,
+            fields: [
+                "network": .publicText(network.map { String(describing: $0) } ?? "all")
+            ]
+        )
+        return onQueue {
         healIdentityIsLocalFlags()
         // Scope the fetch to the handler's bound network so a
         // per-network manager only sees its own wallets. If
@@ -4837,9 +5068,12 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             // appear to "succeed" with zero wallets, hiding a real
             // database fault from the user. The callback returns
             // non-zero on `errored == true`.
-            NSLog(
-                "[persistor-load:swift] PersistentWallet fetch failed: %@",
-                String(describing: error)
+            SDKLogger.event(
+                "persistence_wallet_load_failed",
+                category: .persistence,
+                severity: .error,
+                fields: ["phase": .publicText("wallet_fetch")],
+                error: error
             )
             return (nil, 0, true)
         }
@@ -4847,6 +5081,11 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             wallet.accounts.contains { ($0.accountExtendedPubKeyBytes?.isEmpty == false) }
         }
         if restorable.isEmpty {
+            SDKLogger.event(
+                "persistence_wallet_load_completed",
+                category: .persistence,
+                fields: ["wallet_count": .integer(0)]
+            )
             return (nil, 0, false)
         }
 
@@ -4879,9 +5118,12 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             do {
                 unspent = try backgroundContext.fetch(unspentDescriptor)
             } catch {
-                NSLog(
-                    "[persistor-load:swift] PersistentTxo unspent fetch failed: %@",
-                    String(describing: error)
+                SDKLogger.event(
+                    "persistence_wallet_load_failed",
+                    category: .persistence,
+                    severity: .error,
+                    fields: ["phase": .publicText("unspent_txo_fetch")],
+                    error: error
                 )
                 return (nil, 0, true)
             }
@@ -4949,9 +5191,15 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     // loader treats `errored = true` as a hard fail
                     // and won't construct a half-loaded manager.
                     guard let typeTagByte = UInt8(exactly: acc.accountType) else {
-                        NSLog(
-                            "[persistor-load:swift] aborting load: account row has accountType %u out of UInt8 range — refusing to silently drop it",
-                            acc.accountType
+                        SDKLogger.event(
+                            "persistence_wallet_load_validation_failed",
+                            category: .persistence,
+                            severity: .error,
+                            fields: [
+                                "account_type": .unsignedInteger(UInt64(acc.accountType)),
+                                "reason": .publicText("account_type_out_of_range"),
+                                "wallet_reference": .reference(w.walletId),
+                            ]
                         )
                         buf.deallocate()
                         allocation.release()
@@ -5206,6 +5454,11 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
 
         let typed = UnsafePointer(entriesPtr)
         loadAllocations[UnsafeRawPointer(typed)] = allocation
+        SDKLogger.event(
+            "persistence_wallet_load_completed",
+            category: .persistence,
+            fields: ["wallet_count": .integer(Int64(restorable.count))]
+        )
         return (typed, restorable.count, false)
         }  // onQueue
     }
@@ -5275,9 +5528,15 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             // keeps the restore contract uniform.
             let txid = record.txid
             guard txid.count == 32 else {
-                NSLog(
-                    "[persistor-load:swift] aborting load: UTXO has txid of %d bytes (expected 32) — refusing to silently drop it",
-                    txid.count
+                SDKLogger.event(
+                    "persistence_wallet_load_validation_failed",
+                    category: .persistence,
+                    severity: .error,
+                    fields: [
+                        "actual_length": .integer(Int64(txid.count)),
+                        "expected_length": .integer(32),
+                        "reason": .publicText("utxo_txid_length"),
+                    ]
                 )
                 buf.deallocate()
                 return (nil, 0, true)
@@ -5290,9 +5549,14 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             // signal `errored = true` and let `loadWalletList` fail
             // the whole callback — the persisted snapshot is corrupt.
             guard let typeTagByte = UInt8(exactly: account.accountType) else {
-                NSLog(
-                    "[persistor-load:swift] aborting load: UTXO has parent accountType %u out of UInt8 range — refusing to silently drop it",
-                    account.accountType
+                SDKLogger.event(
+                    "persistence_wallet_load_validation_failed",
+                    category: .persistence,
+                    severity: .error,
+                    fields: [
+                        "account_type": .unsignedInteger(UInt64(account.accountType)),
+                        "reason": .publicText("utxo_account_type_out_of_range"),
+                    ]
                 )
                 buf.deallocate()
                 return (nil, 0, true)
@@ -5370,9 +5634,14 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
         for group in groups {
             let account = group.account
             guard let typeTagByte = UInt8(exactly: account.accountType) else {
-                NSLog(
-                    "[persistor-load:swift] aborting load: address-pool account row has accountType %u out of UInt8 range",
-                    account.accountType
+                SDKLogger.event(
+                    "persistence_wallet_load_validation_failed",
+                    category: .persistence,
+                    severity: .error,
+                    fields: [
+                        "account_type": .unsignedInteger(UInt64(account.accountType)),
+                        "reason": .publicText("address_pool_account_type_out_of_range"),
+                    ]
                 )
                 buf.deallocate()
                 return (nil, 0, true)
@@ -5461,9 +5730,14 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             // — we can't manufacture a valid outpoint and a malformed
             // row indicates an old / corrupt snapshot.
             guard let outPoint = decodeOutPointHex(record.outPointHex) else {
-                NSLog(
-                    "[persistor-load:swift] dropping asset-lock row with malformed outPointHex: %@",
-                    record.outPointHex
+                SDKLogger.event(
+                    "persistence_asset_lock_row_skipped",
+                    category: .persistence,
+                    severity: .warning,
+                    fields: [
+                        "outpoint_reference": .referenceString(record.outPointHex),
+                        "reason": .publicText("malformed_outpoint"),
+                    ]
                 )
                 continue
             }
@@ -5481,9 +5755,14 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             } else {
                 // A row with no transaction bytes is broken — Rust's
                 // load path will reject it; drop here.
-                NSLog(
-                    "[persistor-load:swift] dropping asset-lock row with empty transactionBytes: %@",
-                    record.outPointHex
+                SDKLogger.event(
+                    "persistence_asset_lock_row_skipped",
+                    category: .persistence,
+                    severity: .warning,
+                    fields: [
+                        "outpoint_reference": .referenceString(record.outPointHex),
+                        "reason": .publicText("empty_transaction"),
+                    ]
                 )
                 continue
             }
@@ -5524,18 +5803,28 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             // asset-lock's effective state. Skip the row instead,
             // logged loudly so an operator can see and fix the bad row.
             guard let fundingType = UInt8(exactly: record.fundingTypeRaw) else {
-                NSLog(
-                    "[persistor-load] dropping asset-lock row %@ — fundingTypeRaw out of u8 range: %d",
-                    record.outPointHex,
-                    record.fundingTypeRaw
+                SDKLogger.event(
+                    "persistence_asset_lock_row_skipped",
+                    category: .persistence,
+                    severity: .warning,
+                    fields: [
+                        "funding_type": .integer(Int64(record.fundingTypeRaw)),
+                        "outpoint_reference": .referenceString(record.outPointHex),
+                        "reason": .publicText("funding_type_out_of_range"),
+                    ]
                 )
                 continue
             }
             guard let status = UInt8(exactly: record.statusRaw) else {
-                NSLog(
-                    "[persistor-load] dropping asset-lock row %@ — statusRaw out of u8 range: %d",
-                    record.outPointHex,
-                    record.statusRaw
+                SDKLogger.event(
+                    "persistence_asset_lock_row_skipped",
+                    category: .persistence,
+                    severity: .warning,
+                    fields: [
+                        "outpoint_reference": .referenceString(record.outPointHex),
+                        "reason": .publicText("status_out_of_range"),
+                        "status": .integer(Int64(record.statusRaw)),
+                    ]
                 )
                 continue
             }
@@ -6332,7 +6621,13 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 try trackedMasternodeContext.save()
                 return true
             } catch {
-                print("⚠️ persistTrackedMasternodes: \(error)")
+                SDKLogger.event(
+                    "persistence_tracked_masternodes_save_failed",
+                    category: .persistence,
+                    severity: .error,
+                    fields: ["network": .publicText(String(describing: network))],
+                    error: error
+                )
                 // A failed save leaves pending inserts/deletes registered on
                 // the context. Discard them before returning failure so a
                 // later load or successful mutation cannot expose/commit a
@@ -6360,7 +6655,13 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 ]
                 rows = try trackedMasternodeContext.fetch(descriptor)
             } catch {
-                print("⚠️ loadTrackedMasternodes: \(error)")
+                SDKLogger.event(
+                    "persistence_tracked_masternodes_load_failed",
+                    category: .persistence,
+                    severity: .error,
+                    fields: ["network": .publicText(String(describing: network))],
+                    error: error
+                )
                 return (nil, 0, true)
             }
             guard !rows.isEmpty else {
@@ -6375,7 +6676,16 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 // skip the row (same convention as the shielded loaders)
                 // rather than keying a phantom masternode on zeros.
                 guard row.proTxHash.count == 32 else {
-                    print("⚠️ loadTrackedMasternodes: skipping a row with a \(row.proTxHash.count)-byte proTxHash")
+                    SDKLogger.event(
+                        "persistence_tracked_masternode_row_skipped",
+                        category: .persistence,
+                        severity: .warning,
+                        fields: [
+                            "actual_length": .integer(Int64(row.proTxHash.count)),
+                            "expected_length": .integer(32),
+                            "network": .publicText(String(describing: network)),
+                        ]
+                    )
                     continue
                 }
                 var entry = TrackedMasternodeFFI()
@@ -6612,9 +6922,12 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             do {
                 rows = try backgroundContext.fetch(descriptor)
             } catch {
-                NSLog(
-                    "[persistor-txids:swift] PersistentTransaction fetch failed: %@",
-                    String(describing: error)
+                SDKLogger.event(
+                    "persistence_core_txids_load_failed",
+                    category: .persistence,
+                    severity: .error,
+                    fields: ["wallet_reference": .reference(walletId)],
+                    error: error
                 )
                 return ([], true)
             }
@@ -7782,7 +8095,16 @@ private func persistDpnsNameStatesCallback(
     // Drop it here rather than corrupting the cache.
     let usable = upserts.filter { !$0.normalizedLabel.isEmpty }
     if usable.count != upserts.count {
-        print("⚠️ persistDpnsNameStates: dropped \(upserts.count - usable.count) marketplace row(s) with an unreadable normalized label")
+        SDKLogger.event(
+            "persistence_dpns_rows_dropped",
+            category: .persistence,
+            severity: .warning,
+            fields: [
+                "dropped_count": .integer(Int64(upserts.count - usable.count)),
+                "reason": .publicText("unreadable_normalized_label"),
+                "wallet_reference": .reference(walletId),
+            ]
+        )
     }
     if usable.isEmpty && removed.isEmpty {
         return 0

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/ShieldedService.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/ShieldedService.swift
@@ -252,6 +252,15 @@ class ShieldedService: ObservableObject {
 
         let dbPath = Self.dbPath(for: network)
         let sortedAccounts = Array(Set(accounts)).sorted()
+        SDKLogger.event(
+            "shielded_bind_started",
+            category: .shielded,
+            fields: [
+                "account_count": .integer(Int64(sortedAccounts.count)),
+                "network": .publicText(network.networkName),
+                "wallet_reference": .reference(walletId),
+            ]
+        )
         do {
             // The per-network SQLite tree handle now lives on the
             // manager (one shared `NetworkShieldedCoordinator`),
@@ -292,13 +301,28 @@ class ShieldedService: ObservableObject {
             let primary = sortedAccounts.contains(0) ? 0 : (sortedAccounts.first ?? 0)
             orchardDisplayAddress = addressesByAccount[primary]
 
-            SDKLogger.log(
-                "Shielded bound: walletId=\(walletId.prefix(4).map { String(format: "%02x", $0) }.joined())… network=\(network.networkName) accounts=\(sortedAccounts) tree=\(dbPath)",
-                minimumLevel: .medium
+            SDKLogger.event(
+                "shielded_bind_completed",
+                category: .shielded,
+                fields: [
+                    "account_count": .integer(Int64(sortedAccounts.count)),
+                    "network": .publicText(network.networkName),
+                    "wallet_reference": .reference(walletId),
+                ]
             )
         } catch {
             lastError = "Shielded bind failed: \(error.localizedDescription)"
-            SDKLogger.log(lastError ?? "", minimumLevel: .medium)
+            SDKLogger.event(
+                "shielded_bind_failed",
+                category: .shielded,
+                severity: .error,
+                fields: [
+                    "network": .publicText(network.networkName),
+                    "wallet_reference": .reference(walletId),
+                ],
+                error: error,
+                redacting: [dbPath]
+            )
         }
 
         syncStateCancellable = walletManager.$shieldedSyncIsSyncing
@@ -315,9 +339,14 @@ class ShieldedService: ObservableObject {
                 // for a pass that completes before this publisher flips.
                 if newValue && !wasSyncing {
                     self.beginSyncTimingIfNeeded()
-                    SDKLogger.log(
-                        "Shielded sync started",
-                        minimumLevel: .medium
+                    var fields: [String: SDKLogValue] = [:]
+                    if let walletId = self.boundWalletId {
+                        fields["wallet_reference"] = .reference(walletId)
+                    }
+                    SDKLogger.event(
+                        "shielded_sync_started",
+                        category: .shielded,
+                        fields: fields
                     )
                 }
                 // Detect true → false edge. Tear down the ticker and
@@ -418,15 +447,27 @@ class ShieldedService: ObservableObject {
                 resolver: resolver,
                 accounts: sortedAccounts
             )
-            SDKLogger.log(
-                "Shielded engine-bound: walletId=\(walletId.prefix(4).map { String(format: "%02x", $0) }.joined())… network=\(network.networkName) accounts=\(sortedAccounts)",
-                minimumLevel: .medium
+            SDKLogger.event(
+                "shielded_engine_bind_completed",
+                category: .shielded,
+                fields: [
+                    "account_count": .integer(Int64(sortedAccounts.count)),
+                    "network": .publicText(network.networkName),
+                    "wallet_reference": .reference(walletId),
+                ]
             )
             return true
         } catch {
-            SDKLogger.log(
-                "Shielded engine-bind failed for walletId=\(walletId.prefix(4).map { String(format: "%02x", $0) }.joined())…: \(error.localizedDescription)",
-                minimumLevel: .medium
+            SDKLogger.event(
+                "shielded_engine_bind_failed",
+                category: .shielded,
+                severity: .error,
+                fields: [
+                    "network": .publicText(network.networkName),
+                    "wallet_reference": .reference(walletId),
+                ],
+                error: error,
+                redacting: [dbPath]
             )
             return false
         }
@@ -452,9 +493,14 @@ class ShieldedService: ObservableObject {
             let resolver,
             let network
         else {
-            SDKLogger.log(
-                "ShieldedService.switchTo called before initial bind — ignoring",
-                minimumLevel: .medium
+            SDKLogger.event(
+                "shielded_switch_skipped",
+                category: .shielded,
+                severity: .warning,
+                fields: [
+                    "reason": .publicText("not_initialized"),
+                    "wallet_reference": .reference(walletId),
+                ]
             )
             return
         }
@@ -478,6 +524,18 @@ class ShieldedService: ObservableObject {
     func manualSync() async {
         guard !isSyncing else { return }
         guard let walletManager else { return }
+        var startFields: [String: SDKLogValue] = [
+            "bound": .boolean(isBound),
+            "wallet_count": .integer(Int64(walletManager.wallets.count)),
+        ]
+        if let walletId = boundWalletId {
+            startFields["wallet_reference"] = .reference(walletId)
+        }
+        SDKLogger.event(
+            "shielded_manual_sync_started",
+            category: .shielded,
+            fields: startFields
+        )
 
         // If we're unbound (typically because the user pressed
         // Clear earlier) but still have the bind credentials,
@@ -540,7 +598,15 @@ class ShieldedService: ObservableObject {
         // bail rather than chain a sync that would skip every wallet —
         // preserves the pre-existing "don't chain a sync that will fail the
         // same way" intent, per-wallet-ized.
-        guard anyWalletRegistered else { return }
+        guard anyWalletRegistered else {
+            SDKLogger.event(
+                "shielded_manual_sync_skipped",
+                category: .shielded,
+                severity: .warning,
+                fields: ["reason": .publicText("no_registered_wallet")]
+            )
+            return
+        }
 
         isSyncing = true
         lastError = nil
@@ -557,7 +623,17 @@ class ShieldedService: ObservableObject {
             try await walletManager.syncShieldedNow()
         } catch {
             lastError = "Shielded sync error: \(error.localizedDescription)"
-            SDKLogger.log(lastError ?? "", minimumLevel: .medium)
+            var fields: [String: SDKLogValue] = [:]
+            if let walletId = boundWalletId {
+                fields["wallet_reference"] = .reference(walletId)
+            }
+            SDKLogger.event(
+                "shielded_manual_sync_failed",
+                category: .shielded,
+                severity: .error,
+                fields: fields,
+                error: error
+            )
         }
 
         // Restart the manager-wide shielded sync loop AFTER the
@@ -576,8 +652,11 @@ class ShieldedService: ObservableObject {
                 try walletManager.startShieldedSync()
             }
         } catch {
-            SDKLogger.error(
-                "ShieldedService.manualSync: failed to (re)start shielded sync loop: \(error.localizedDescription)"
+            SDKLogger.event(
+                "shielded_sync_loop_restart_failed",
+                category: .shielded,
+                severity: .error,
+                error: error
             )
         }
     }
@@ -601,6 +680,15 @@ class ShieldedService: ObservableObject {
     /// caller's responsibility (see
     /// [`PlatformWalletManager.stopShieldedSync`]).
     func reset() {
+        var fields: [String: SDKLogValue] = ["had_binding": .boolean(isBound)]
+        if let walletId = boundWalletId {
+            fields["wallet_reference"] = .reference(walletId)
+        }
+        SDKLogger.event(
+            "shielded_service_reset",
+            category: .shielded,
+            fields: fields
+        )
         syncStateCancellable?.cancel()
         syncEventCancellable?.cancel()
         progressCancellable?.cancel()
@@ -673,6 +761,11 @@ class ShieldedService: ObservableObject {
         // per-network SQLite delete; that step is gone — see
         // doc above for why.)
         let managerForStop = walletManager
+        SDKLogger.event(
+            "shielded_reset_started",
+            category: .shielded,
+            fields: ["wallet_count": .integer(Int64(walletManager?.wallets.count ?? 0))]
+        )
 
         // 1) Reset the Rust-side shielded state BEFORE touching
         //    state on disk. The Swift `ShieldedService` is
@@ -728,7 +821,12 @@ class ShieldedService: ObservableObject {
         prepareForShieldedRebind()
         guard let managerForStop else {
             lastError = "Failed to reset shielded state: no wallet manager is bound."
-            SDKLogger.error(lastError ?? "")
+            SDKLogger.event(
+                "shielded_reset_failed",
+                category: .shielded,
+                severity: .error,
+                fields: ["reason": .publicText("manager_unavailable")]
+            )
             return
         }
 
@@ -753,16 +851,28 @@ class ShieldedService: ObservableObject {
                 }
             )
         } catch {
+            let phase: String
+            let underlyingError: Error
             switch error {
-            case .rustReset(let underlyingError):
+            case .rustReset(let error):
+                phase = "rust_state"
+                underlyingError = error
                 lastError =
-                    "Failed to reset shielded state: \(underlyingError.localizedDescription)"
-            case .hostPersistence(let underlyingError):
+                    "Failed to reset shielded state: \(error.localizedDescription)"
+            case .hostPersistence(let error):
+                phase = "host_persistence"
+                underlyingError = error
                 lastError =
                     "Failed to wipe persisted shielded state: "
-                    + underlyingError.localizedDescription
+                    + error.localizedDescription
             }
-            SDKLogger.error(lastError ?? "")
+            SDKLogger.event(
+                "shielded_reset_failed",
+                category: .shielded,
+                severity: .error,
+                fields: ["phase": .publicText(phase)],
+                error: underlyingError
+            )
             return
         }
 
@@ -778,6 +888,10 @@ class ShieldedService: ObservableObject {
         lastSyncTime = nil
         lastError = nil
         orchardDisplayAddress = nil
+        SDKLogger.event(
+            "shielded_reset_completed",
+            category: .shielded
+        )
         addressesByAccount = [:]
         syncCountSinceLaunch = 0
         totalScanned = 0
@@ -946,31 +1060,39 @@ class ShieldedService: ObservableObject {
                     } else {
                         longestSyncDuration = elapsed
                     }
-                    let rateString: String
+                    var fields: [String: SDKLogValue] = [
+                        "duration_ms": .integer(Int64(elapsed * 1_000)),
+                        "new_notes": .unsignedInteger(UInt64(result.newNotes)),
+                        "pass": .integer(Int64(syncCountSinceLaunch)),
+                        "scanned": .unsignedInteger(result.totalScanned),
+                        "spent_notes": .unsignedInteger(UInt64(result.newlySpent)),
+                    ]
                     if elapsed > 0.05 && result.totalScanned > 0 {
                         let rate = Double(result.totalScanned) / elapsed
-                        rateString = String(format: " rate=%.0f/s", rate)
-                    } else {
-                        rateString = ""
+                        fields["rate_per_second"] = .double(rate.rounded())
                     }
-                    SDKLogger.log(
-                        String(
-                            format: "Shielded sync done  pass=%d  elapsed=%.2fs%@  scanned=%llu  new=%u  spent=%u  balance=%llu",
-                            syncCountSinceLaunch,
-                            elapsed,
-                            rateString,
-                            result.totalScanned,
-                            result.newNotes,
-                            result.newlySpent,
-                            result.balance
-                        ),
-                        minimumLevel: .medium
+                    if let walletId = boundWalletId {
+                        fields["wallet_reference"] = .reference(walletId)
+                    }
+                    SDKLogger.event(
+                        "shielded_sync_completed",
+                        category: .shielded,
+                        fields: fields
                     )
                 } else {
                     lastSyncDuration = nil
-                    SDKLogger.log(
-                        "Shielded sync done (no paired start) pass=\(syncCountSinceLaunch) scanned=\(result.totalScanned) balance=\(result.balance)",
-                        minimumLevel: .medium
+                    var fields: [String: SDKLogValue] = [
+                        "paired_start": .boolean(false),
+                        "pass": .integer(Int64(syncCountSinceLaunch)),
+                        "scanned": .unsignedInteger(result.totalScanned),
+                    ]
+                    if let walletId = boundWalletId {
+                        fields["wallet_reference"] = .reference(walletId)
+                    }
+                    SDKLogger.event(
+                        "shielded_sync_completed",
+                        category: .shielded,
+                        fields: fields
                     )
                 }
                 // Close the timing bracket AFTER reading
@@ -991,11 +1113,28 @@ class ShieldedService: ObservableObject {
             // stamp survives to the next pass.
             isBound = false
             endSyncTiming()
+            SDKLogger.event(
+                "shielded_sync_skipped",
+                category: .shielded,
+                severity: .warning,
+                fields: ["reason": .publicText("wallet_not_bound")]
+            )
         } else {
             // Failure terminal: surface the error and close the timing
             // bracket so the stale start stamp isn't reused next pass.
             lastError = result.errorMessage ?? "Shielded sync failed"
             endSyncTiming()
+            let error = NSError(
+                domain: "SwiftExampleApp.ShieldedService",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: lastError ?? "Shielded sync failed"]
+            )
+            SDKLogger.event(
+                "shielded_sync_failed",
+                category: .shielded,
+                severity: .error,
+                error: error
+            )
         }
     }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Services/LogExporter.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Services/LogExporter.swift
@@ -19,8 +19,9 @@ enum LogExportError: LocalizedError {
 
 /// Bundles recent SwiftDashSDK log sessions into a shareable zip.
 ///
-/// Each app launch writes one session directory of per-crate
-/// `run.log` files under `Library/Logs/SwiftDashSDK/<timestamp>/`
+/// Each app launch writes one session directory containing the Swift
+/// `swift/run.log` plus per-crate Rust `run.log` files under
+/// `Library/Logs/SwiftDashSDK/<timestamp>/`
 /// (see `LoggingPreferences`). This exporter stages the launch's own
 /// session (passed in by the caller — never inferred from timestamp
 /// order, which a clock rollback or stale future-dated directory
@@ -60,6 +61,10 @@ struct LogExporter {
         appVersion: String,
         currentSession: URL?
     ) throws -> URL {
+        // FileHandle buffers must be synchronized before the detached copy
+        // starts, otherwise the newest events can be missing from the zip.
+        SDKLogger.flush()
+
         let fm = FileManager.default
 
         guard let root = LoggingPreferences.logsRootDirectory,
@@ -98,13 +103,7 @@ struct LogExporter {
         let staging = scratch.appendingPathComponent(archiveName, isDirectory: true)
         defer { try? fm.removeItem(at: scratch) }
 
-        try fm.createDirectory(at: staging, withIntermediateDirectories: true)
-        for session in selected {
-            try fm.copyItem(
-                at: session.url,
-                to: staging.appendingPathComponent(session.url.lastPathComponent, isDirectory: true)
-            )
-        }
+        try stageSessions(selected, at: staging, fileManager: fm)
 
         let summary = summaryText(
             network: network,
@@ -125,6 +124,23 @@ struct LogExporter {
         }
         try zipDirectory(at: staging, to: zipURL)
         return zipURL
+    }
+
+    /// Copy complete session directories into export staging. Keeping this as
+    /// one shared operation is important: the Swift and Rust logs are siblings
+    /// in the same session, so neither side should need a separate allow-list.
+    static func stageSessions(
+        _ sessions: [SessionCandidate],
+        at staging: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        try fileManager.createDirectory(at: staging, withIntermediateDirectories: true)
+        for session in sessions {
+            try fileManager.copyItem(
+                at: session.url,
+                to: staging.appendingPathComponent(session.url.lastPathComponent, isDirectory: true)
+            )
+        }
     }
 
     /// Pure selection policy, split out for unit testing.
@@ -236,6 +252,9 @@ struct LogExporter {
             "OS: \(ProcessInfo.processInfo.operatingSystemVersionString)",
             "Hardware: \(model) (\(environment))",
             "Network: \(network)",
+            "",
+            "Each session includes structured Swift diagnostics in swift/run.log",
+            "and Rust diagnostics in their component run.log files.",
             "",
             "Each session directory's build_info.txt records the exact",
             "platform-wallet git commit that run was built from.",

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/SwiftExampleAppApp.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/SwiftExampleAppApp.swift
@@ -155,9 +155,7 @@ struct SwiftExampleAppApp: App {
                     appUIState.pendingInviteURL = url.absoluteString
                 }
                 .task {
-                    SDKLogger.log("🚀 SwiftExampleApp: Starting initialization...", minimumLevel: .medium)
                     await bootstrap()
-                    SDKLogger.log("🚀 SwiftExampleApp: Initialization complete", minimumLevel: .medium)
                 }
                 // Rebind wallet-scoped services whenever the set of
                 // managed wallets changes — wallet creation, restore
@@ -206,18 +204,31 @@ struct SwiftExampleAppApp: App {
     @MainActor
     private func activateManager(for network: Network) {
         guard let sdk = platformState.sdk else {
-            SDKLogger.error(
-                "Cannot activate wallet manager for \(network.displayName): "
-                    + "no SDK available (still bootstrapping?)"
+            SDKLogger.event(
+                "manager_activation_skipped",
+                category: .lifecycle,
+                severity: .warning,
+                fields: [
+                    "network": .publicText(network.displayName),
+                    "reason": .publicText("sdk_unavailable"),
+                ]
             )
             return
         }
         do {
             try walletManagerStore.activate(network: network, sdk: sdk)
+            SDKLogger.event(
+                "manager_activated",
+                category: .lifecycle,
+                fields: ["network": .publicText(network.displayName)]
+            )
         } catch {
-            SDKLogger.error(
-                "Failed to activate wallet manager for "
-                    + "\(network.displayName): \(error.localizedDescription)"
+            SDKLogger.event(
+                "manager_activation_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: ["network": .publicText(network.displayName)],
+                error: error
             )
         }
     }
@@ -413,6 +424,11 @@ struct SwiftExampleAppApp: App {
     private func bootstrap() async {
         do {
             LoggingPreferences.configure()
+            SDKLogger.event(
+                "app_initialization_started",
+                category: .lifecycle,
+                fields: ["network": .publicText(platformState.currentNetwork.displayName)]
+            )
 
             // Kick off Halo 2 proving-key build on a background
             // thread so the first shielded send doesn't pay the
@@ -477,8 +493,23 @@ struct SwiftExampleAppApp: App {
             // bumps last wins and the other bails (never a double-start).
             isInitialized = true
             await autoStartCoreSpvIfNeeded()
+            SDKLogger.event(
+                "app_initialization_completed",
+                category: .lifecycle,
+                fields: [
+                    "network": .publicText(platformState.currentNetwork.displayName),
+                    "wallet_count": .integer(Int64(walletManager.wallets.count)),
+                ]
+            )
         } catch {
             bootstrapError = error
+            SDKLogger.event(
+                "app_initialization_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: ["network": .publicText(platformState.currentNetwork.displayName)],
+                error: error
+            )
         }
     }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/WalletManagerStore.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/WalletManagerStore.swift
@@ -173,10 +173,13 @@ final class WalletManagerStore: ObservableObject {
                 }
                 return
             }
-            SDKLogger.log(
-                "WalletManagerStore: SDK changed for \(network.displayName); "
-                    + "rebuilding cached manager",
-                minimumLevel: .medium
+            SDKLogger.event(
+                "manager_cache_invalidated",
+                category: .lifecycle,
+                fields: [
+                    "network": .publicText(network.displayName),
+                    "reason": .publicText("sdk_changed"),
+                ]
             )
             // No `activeManager = nil` — the field isn't optional. The
             // rebuild below will overwrite it via `if makeActive {
@@ -198,9 +201,12 @@ final class WalletManagerStore: ObservableObject {
         do {
             _ = try manager.loadFromPersistor()
         } catch {
-            SDKLogger.error(
-                "WalletManagerStore: load-from-persistor failed for "
-                    + "\(network.displayName): \(error.localizedDescription)"
+            SDKLogger.event(
+                "manager_restore_failed",
+                category: .lifecycle,
+                severity: .error,
+                fields: ["network": .publicText(network.displayName)],
+                error: error
             )
         }
         managers[network] = manager
@@ -213,6 +219,15 @@ final class WalletManagerStore: ObservableObject {
             invalidatePendingSpvStarts()
             activeManager = manager
         }
+        SDKLogger.event(
+            "manager_materialized",
+            category: .lifecycle,
+            fields: [
+                "active": .boolean(makeActive),
+                "network": .publicText(network.displayName),
+                "wallet_count": .integer(Int64(manager.wallets.count)),
+            ]
+        )
     }
 
     /// Manager for `network` if one has been activated this session;

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/LogExporterSelectionTests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/LogExporterSelectionTests.swift
@@ -122,4 +122,40 @@ final class LogExporterSelectionTests: XCTestCase {
     func testNoSessionsSelectsNothing() {
         XCTAssertEqual(LogExporter.selectSessions(current: nil, others: []), [])
     }
+
+    func testStagingCopiesSwiftAndRustLogsFromTheSameSession() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("LogExporterTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let session = root.appendingPathComponent("2026-08-31T12-00-00Z", isDirectory: true)
+        let swiftDirectory = session.appendingPathComponent("swift", isDirectory: true)
+        let rustDirectory = session.appendingPathComponent("platform_wallet", isDirectory: true)
+        try fm.createDirectory(at: swiftDirectory, withIntermediateDirectories: true)
+        try fm.createDirectory(at: rustDirectory, withIntermediateDirectories: true)
+        try "swift event\n".write(
+            to: swiftDirectory.appendingPathComponent("run.log"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "rust event\n".write(
+            to: rustDirectory.appendingPathComponent("run.log"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let staging = root.appendingPathComponent("staging", isDirectory: true)
+        try LogExporter.stageSessions(
+            [.init(url: session, bytes: 24)],
+            at: staging,
+            fileManager: fm
+        )
+
+        let stagedSession = staging.appendingPathComponent(session.lastPathComponent)
+        XCTAssertTrue(fm.fileExists(atPath: stagedSession.appendingPathComponent("swift/run.log").path))
+        XCTAssertTrue(
+            fm.fileExists(atPath: stagedSession.appendingPathComponent("platform_wallet/run.log").path)
+        )
+    }
 }

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/SDKLoggerTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/SDKLoggerTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import XCTest
+@testable import SwiftDashSDK
+
+final class SDKLoggerTests: XCTestCase {
+    private func temporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SDKLoggerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        return directory
+    }
+
+    func testConcurrentWritesProduceCompleteNonInterleavedLines() throws {
+        let session = try temporaryDirectory()
+        let sink = try SDKLogFileSink(sessionDirectory: session)
+        let count = 500
+
+        DispatchQueue.concurrentPerform(iterations: count) { index in
+            let line = SDKLogFormatter.format(
+                event: "parallel_write",
+                category: .persistence,
+                severity: .info,
+                fields: ["index": .integer(Int64(index))]
+            )
+            sink.write(line)
+        }
+        sink.flush()
+
+        let contents = try String(contentsOf: sink.fileURL, encoding: .utf8)
+        let lines = contents.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+
+        XCTAssertEqual(lines.count, count)
+        XCTAssertEqual(Set(lines).count, count)
+        for line in lines {
+            XCTAssertNotNil(
+                line.range(
+                    of: #"^\S+ INFO swift\.persistence event=parallel_write index=\d+$"#,
+                    options: .regularExpression
+                ),
+                "Malformed or interleaved line: \(line)"
+            )
+        }
+    }
+
+    func testFormattingHasStableFieldOrderEscapingAndLevels() {
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let fields: [String: SDKLogValue] = [
+            "zeta": .boolean(true),
+            "alpha": .publicText("first\nsecond"),
+            "middle": .integer(-2),
+        ]
+
+        let info = SDKLogFormatter.format(
+            timestamp: timestamp,
+            event: "format_test",
+            category: .lifecycle,
+            severity: .info,
+            fields: fields
+        )
+
+        XCTAssertTrue(info.hasPrefix("2023-11-14T22:13:20.000Z INFO swift.lifecycle event=format_test "))
+        XCTAssertTrue(info.hasSuffix(#"alpha="first\nsecond" middle=-2 zeta=true"#))
+        XCTAssertFalse(info.contains("first\nsecond"))
+
+        for severity in [SDKLogSeverity.debug, .warning, .error] {
+            let line = SDKLogFormatter.format(
+                timestamp: timestamp,
+                event: "level",
+                category: .lifecycle,
+                severity: severity
+            )
+            XCTAssertTrue(line.contains(" \(severity.rawValue) swift.lifecycle "))
+        }
+    }
+
+    func testErrorIsStructuredRedactedAndLimited() {
+        let sensitive = "identity-fixture-that-must-not-leak"
+        let longDescription = sensitive + " /private/user/wallet.sqlite " + String(repeating: "x", count: 2_000)
+        let error = NSError(
+            domain: "wallet.persistence",
+            code: 41,
+            userInfo: [NSLocalizedDescriptionKey: longDescription]
+        )
+
+        let line = SDKLogFormatter.format(
+            event: "save_failed",
+            category: .persistence,
+            severity: .error,
+            error: error,
+            redacting: [sensitive]
+        )
+
+        XCTAssertTrue(line.contains("error_code=41"))
+        XCTAssertTrue(line.contains(#"error_domain="wallet.persistence""#))
+        XCTAssertTrue(line.contains("error_type="))
+        XCTAssertTrue(line.contains("<redacted>"))
+        XCTAssertFalse(line.contains(sensitive))
+        XCTAssertFalse(line.contains("wallet.sqlite"))
+        XCTAssertFalse(line.contains("\n"))
+
+        let marker = #"error_message=""#
+        let start = try! XCTUnwrap(line.range(of: marker)?.upperBound)
+        let remainder = line[start...]
+        let end = try! XCTUnwrap(remainder.firstIndex(of: "\""))
+        XCTAssertLessThanOrEqual(remainder[..<end].count, SDKLogFormatter.maximumErrorDescriptionLength)
+    }
+
+    func testShortSensitiveValueRedactsOnlyAWholeToken() {
+        let error = NSError(
+            domain: "SwiftDashSDK.PlatformWalletError",
+            code: 19,
+            userInfo: [NSLocalizedDescriptionKey: "invalid mnemonic: m"]
+        )
+
+        let line = SDKLogFormatter.format(
+            event: "wallet_create_failed",
+            category: .lifecycle,
+            severity: .error,
+            error: error,
+            redacting: ["m"]
+        )
+
+        XCTAssertTrue(line.contains("error_domain=\"SwiftDashSDK.PlatformWalletError\""))
+        XCTAssertTrue(line.contains("error_message=\"invalid mnemonic: <redacted>\""))
+    }
+
+    func testReferenceIsDeterministicAndRawValueNeverReachesLine() throws {
+        let fixture = "wallet-identity-fixture-123456789"
+        let first = SDKLogFormatter.reference(fixture)
+        let second = SDKLogFormatter.reference(fixture)
+
+        XCTAssertEqual(first, "40e17fb042f5")
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(first.count, 12)
+
+        let session = try temporaryDirectory()
+        let sink = try SDKLogFileSink(sessionDirectory: session)
+        sink.write(
+            SDKLogFormatter.format(
+                event: "reference_test",
+                category: .lifecycle,
+                severity: .info,
+                fields: [
+                    "data_reference": .reference(Data(fixture.utf8)),
+                    "string_reference": .referenceString(fixture),
+                ]
+            )
+        )
+        sink.flush()
+
+        let contents = try String(contentsOf: sink.fileURL, encoding: .utf8)
+        XCTAssertFalse(contents.contains(fixture))
+        XCTAssertEqual(contents.components(separatedBy: first).count - 1, 2)
+    }
+
+    func testFailedSinkCreationDoesNotAffectIndependentWorkingSink() throws {
+        let root = try temporaryDirectory()
+        let goodSession = root.appendingPathComponent("good", isDirectory: true)
+        let goodSink = try SDKLogFileSink(sessionDirectory: goodSession)
+
+        let invalidSession = root.appendingPathComponent("not-a-directory")
+        XCTAssertTrue(FileManager.default.createFile(atPath: invalidSession.path, contents: Data()))
+        XCTAssertThrowsError(try SDKLogFileSink(sessionDirectory: invalidSession))
+
+        goodSink.write("still-active")
+        goodSink.flush()
+        XCTAssertEqual(
+            try String(contentsOf: goodSink.fileURL, encoding: .utf8),
+            "still-active\n"
+        )
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/SDKLoggerTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/SDKLoggerTests.swift
@@ -47,7 +47,7 @@ final class SDKLoggerTests: XCTestCase {
         let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
         let fields: [String: SDKLogValue] = [
             "zeta": .boolean(true),
-            "alpha": .publicText("first\nsecond"),
+            "alpha": .publicText("first\nsecond\u{0085}third\u{2028}fourth\u{2029}fifth"),
             "middle": .integer(-2),
         ]
 
@@ -60,8 +60,13 @@ final class SDKLoggerTests: XCTestCase {
         )
 
         XCTAssertTrue(info.hasPrefix("2023-11-14T22:13:20.000Z INFO swift.lifecycle event=format_test "))
-        XCTAssertTrue(info.hasSuffix(#"alpha="first\nsecond" middle=-2 zeta=true"#))
+        XCTAssertTrue(
+            info.hasSuffix(
+                #"alpha="first\nsecond\u0085third\u2028fourth\u2029fifth" middle=-2 zeta=true"#
+            )
+        )
         XCTAssertFalse(info.contains("first\nsecond"))
+        XCTAssertFalse(info.contains { $0.isNewline })
 
         for severity in [SDKLogSeverity.debug, .warning, .error] {
             let line = SDKLogFormatter.format(

--- a/packages/swift-sdk/get_logs.sh
+++ b/packages/swift-sdk/get_logs.sh
@@ -3,15 +3,15 @@ set -euo pipefail
 
 # Extract a single SwiftDashSDK session's logs from an iOS Simulator
 #
-# `LoggingPreferences.configure()` (SDKLogger.swift) calls
-# `platform_wallet_enable_file_logging` at app startup, which lays
-# out one file per `tracing` bucket under a session-stamped root:
+# `LoggingPreferences.configure()` (SDKLogger.swift) independently starts
+# Swift and Rust file sinks under a session-stamped root:
 #
 #     <sandbox>/Library/Logs/SwiftDashSDK/<YYYY-MM-DDTHH-mm-ss>/
-#         dash-sdk/run.log
-#         platform-wallet/run.log
-#         dash-spv/run.log
-#         key-wallet/run.log
+#         swift/run.log
+#         dash_sdk/run.log
+#         platform_wallet/run.log
+#         dash_spv/run.log
+#         key_wallet/run.log
 #         grpc/run.log
 #
 # This script picks a simulator + app container, then lets the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Critical Swift wallet diagnostics were only emitted to the console, so exported support bundles could not explain failures in wallet lifecycle, persistence, or shielded synchronization.

## What was done?
<!--- Describe your changes in detail -->

- Added structured Swift diagnostic events with lifecycle, persistence, and shielded categories; typed fields; stable formatting; newline escaping; and bounded error descriptions.
- Added privacy-safe references using the first 12 hexadecimal characters of SHA-256 instead of raw wallet, identity, outpoint, or DPNS identifiers.
- Added a thread-safe Swift file sink at `Library/Logs/SwiftDashSDK/<session>/swift/run.log`, with independent Swift/Rust sink setup and explicit flushing before export.
- Migrated critical manager lifecycle, persistence callback/save/load/backfill, and shielded bind/sync/reset paths to structured diagnostics.
- Included the Swift log automatically in the existing session export while keeping legacy free-form logs outside the selected paths unchanged.
- Added logger concurrency, formatting, redaction, fallback, and export staging coverage, and updated the log collection helper documentation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Rebuilt the simulator and macOS Swift/Rust FFI slices with `PRUNE_CARGO_TARGETS=1 SKIP_EXAMPLE_APP_BUILD=1 ./packages/swift-sdk/build_ios.sh --target tests --profile dev`.
- Ran `swift test --package-path packages/swift-sdk`: 409 tests executed, 13 skipped integration tests, 0 failures.
- Ran `LogExporterSelectionTests` on a clean temporary iPhone 17 simulator with iOS 26.5: 8 tests, 0 failures, including staging both `swift/run.log` and the Rust log from one session.
- Performed an end-to-end simulator smoke test: launch, lifecycle/persistence/shielded diagnostics, Export Logs, and verified the ZIP contains both Swift and Rust log trees.
- Verified the SwiftExampleApp simulator build succeeds as part of the Xcode test run.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured SDK logging with severity levels, categories, timestamps, error details, and sensitive-value redaction.
  * Logs are now written to Swift and Rust session files and can be flushed before export.
  * Added detailed lifecycle, wallet, persistence, synchronization, and initialization events.
  * Log exports now include Swift and Rust logs from each session.

* **Bug Fixes**
  * Improved visibility into persistence-save failures and native teardown errors.
  * Ensured logging sinks operate independently when one fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->