### PR TITLE
perf(sdk): reuse connections via sticky address rotation

### DIFF
--- a/packages/rs-dapi-client/Cargo.toml
+++ b/packages/rs-dapi-client/Cargo.toml
@@ -55,6 +55,7 @@ http-serde = { version = "2.1", optional = true }
 rand = { version = "0.8.5", features = [
   "small_rng",
   "getrandom",
+  "alloc",
 ], default-features = false }
 thiserror = "2.0.17"
 tracing = "0.1.41"

--- a/packages/rs-dapi-client/src/address_list.rs
+++ b/packages/rs-dapi-client/src/address_list.rs
@@ -14,6 +14,13 @@ use std::time::Duration;
 
 const DEFAULT_BASE_BAN_PERIOD: Duration = Duration::from_secs(60);
 
+/// Default number of addresses that receive traffic at a time.
+///
+/// Kept small so requests reuse warm connections instead of sampling the whole
+/// list (hundreds of nodes on mainnet), where nearly every request would land
+/// on a cold host and pay a fresh TCP + TLS handshake.
+const DEFAULT_ACTIVE_SET_SIZE: usize = 5;
+
 /// DAPI address.
 #[derive(Debug, Clone, Eq)]
 #[cfg_attr(feature = "mocks", derive(serde::Serialize, serde::Deserialize))]
@@ -148,6 +155,14 @@ impl AddressStatus {
         self.ban_count > 0
     }
 
+    /// Check if [Address] is live at `now`: never banned, or its ban period has
+    /// already expired.
+    fn is_live(&self, now: chrono::DateTime<Utc>) -> bool {
+        self.banned_until
+            .map(|banned_until| banned_until < now)
+            .unwrap_or(true)
+    }
+
     /// Clears ban record.
     pub fn unban(&mut self) {
         self.ban_count = 0;
@@ -166,12 +181,26 @@ pub enum AddressListError {
     InvalidAddressUri(String),
 }
 
+/// Sticky rotation state: the addresses currently receiving traffic, and the
+/// most recently served one that round-robin selection advances from.
+#[derive(Debug, Default)]
+struct Rotation {
+    active: Vec<Address>,
+    last_served: Option<Address>,
+}
+
 /// A structure to manage DAPI addresses to select from
 /// for [DapiRequest](crate::DapiRequest) execution.
+///
+/// Address selection is sticky: requests rotate over a small active set of
+/// addresses and the rest of the list serves as failover standby (see
+/// [AddressList::get_live_address]).
 #[derive(Debug, Clone)]
 pub struct AddressList {
     addresses: Arc<RwLock<HashMap<Address, AddressStatus>>>,
+    rotation: Arc<RwLock<Rotation>>,
     base_ban_period: Duration,
+    active_set_size: usize,
 }
 
 impl Default for AddressList {
@@ -196,8 +225,19 @@ impl AddressList {
     pub fn with_settings(base_ban_period: Duration) -> Self {
         AddressList {
             addresses: Arc::new(RwLock::new(HashMap::new())),
+            rotation: Arc::new(RwLock::new(Rotation::default())),
             base_ban_period,
+            active_set_size: DEFAULT_ACTIVE_SET_SIZE,
         }
+    }
+
+    /// Set how many addresses receive traffic at a time (minimum 1).
+    ///
+    /// Smaller values maximize connection reuse, larger values spread load over
+    /// more nodes.
+    pub fn with_active_set_size(mut self, size: usize) -> Self {
+        self.active_set_size = size.max(1);
+        self
     }
 
     /// Bans address
@@ -294,7 +334,14 @@ impl AddressList {
         self.add(Address::try_from(uri).expect("valid uri"))
     }
 
-    /// Randomly select a not-banned address.
+    /// Select a not-banned address to send the next request to.
+    ///
+    /// Selection is sticky: requests rotate round-robin over a small active
+    /// set of addresses (see [AddressList::with_active_set_size]) instead of
+    /// sampling the whole list, so connections to those hosts stay warm. An
+    /// active address that got banned or removed is dropped from the set here
+    /// and a random live standby address is promoted in its place, so the ban
+    /// ladder remains the only health signal.
     ///
     /// An address is considered live when it has never been banned or when its
     /// ban period has already expired.
@@ -303,19 +350,52 @@ impl AddressList {
         // poisoned lock; adopt poison-tolerant locking consistently (SEC-003).
         let guard = self.addresses.read().unwrap();
 
-        let mut rng = SmallRng::from_entropy();
         let now = chrono::Utc::now();
 
-        guard
-            .iter()
-            .filter(|(_, status)| {
-                status
-                    .banned_until
-                    .map(|banned_until| banned_until < now)
-                    .unwrap_or(true)
-            })
-            .choose(&mut rng)
-            .map(|(addr, _)| addr.clone())
+        // Lock ordering: `addresses` before `rotation`; this is the only place
+        // both locks are held at once.
+        let mut rotation = self.rotation.write().unwrap();
+
+        // Drop active addresses that are banned or no longer in the list.
+        rotation.active.retain(|address| {
+            guard
+                .get(address)
+                .map(|status| status.is_live(now))
+                .unwrap_or(false)
+        });
+
+        // Refill vacancies with random live standby addresses.
+        let vacancies = self.active_set_size.saturating_sub(rotation.active.len());
+        if vacancies > 0 {
+            let promoted = guard
+                .iter()
+                .filter(|&(address, status)| {
+                    status.is_live(now) && !rotation.active.contains(address)
+                })
+                .choose_multiple(&mut SmallRng::from_entropy(), vacancies);
+
+            rotation
+                .active
+                .extend(promoted.into_iter().map(|(address, _)| address.clone()));
+        }
+
+        if rotation.active.is_empty() {
+            return None;
+        }
+
+        // Advance relative to the last-served address rather than a bare index:
+        // eviction shifts indices, and an index-based cursor could serve the
+        // same address twice in a row after churn. Start from the head when the
+        // last-served address is gone (or nothing has been served yet).
+        let last_position = rotation
+            .last_served
+            .as_ref()
+            .and_then(|last| rotation.active.iter().position(|address| address == last));
+
+        let index = last_position.map_or(0, |position| (position + 1) % rotation.active.len());
+        let address = rotation.active[index].clone();
+        rotation.last_served = Some(address.clone());
+        Some(address)
     }
 
     /// Get all not banned addresses.
@@ -344,12 +424,7 @@ impl AddressList {
 
         guard
             .iter()
-            .filter(|(_, status)| {
-                status
-                    .banned_until
-                    .map(|banned_until| banned_until < now)
-                    .unwrap_or(true)
-            })
+            .filter(|(_, status)| status.is_live(now))
             .map(|(addr, _)| addr.clone())
             .collect()
     }
@@ -370,11 +445,7 @@ impl AddressList {
         guard
             .iter()
             .map(|(addr, status)| {
-                let banned = status.ban_count > 0
-                    && status
-                        .banned_until
-                        .map(|banned_until| banned_until >= now)
-                        .unwrap_or(false);
+                let banned = status.ban_count > 0 && !status.is_live(now);
                 AddressBanInfo {
                     uri: addr.to_string(),
                     banned,
@@ -681,6 +752,134 @@ mod tests {
     #[test]
     fn test_address_list_get_live_address_returns_none_when_empty() {
         let list = AddressList::new();
+        assert!(list.get_live_address().is_none());
+    }
+
+    #[test]
+    fn test_get_live_address_sticks_to_small_active_set() {
+        let mut list = AddressList::new();
+        for i in 0..50 {
+            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
+        }
+
+        let distinct: std::collections::HashSet<String> = (0..200)
+            .map(|_| list.get_live_address().unwrap().to_string())
+            .collect();
+
+        assert_eq!(
+            distinct.len(),
+            DEFAULT_ACTIVE_SET_SIZE,
+            "all traffic must rotate over exactly the active set"
+        );
+    }
+
+    #[test]
+    fn test_get_live_address_round_robins_over_active_set() {
+        let mut list = AddressList::new().with_active_set_size(2);
+        for i in 0..5 {
+            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
+        }
+
+        let picks: Vec<String> = (0..6)
+            .map(|_| list.get_live_address().unwrap().to_string())
+            .collect();
+
+        // Strict alternation between the two active members.
+        assert_ne!(picks[0], picks[1]);
+        assert_eq!(picks[0], picks[2]);
+        assert_eq!(picks[1], picks[3]);
+        assert_eq!(picks[0], picks[4]);
+        assert_eq!(picks[1], picks[5]);
+    }
+
+    #[test]
+    fn test_get_live_address_ban_evicts_active_and_promotes_standby() {
+        let mut list = AddressList::new().with_active_set_size(1);
+        for i in 0..3 {
+            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
+        }
+
+        let first = list.get_live_address().unwrap();
+        for _ in 0..5 {
+            assert_eq!(
+                list.get_live_address().unwrap(),
+                first,
+                "selection must be sticky until the active address fails"
+            );
+        }
+
+        list.ban(&first);
+
+        let second = list.get_live_address().unwrap();
+        assert_ne!(second, first, "banned address must leave the active set");
+        for _ in 0..5 {
+            assert_eq!(
+                list.get_live_address().unwrap(),
+                second,
+                "selection must stick to the promoted standby"
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_live_address_no_immediate_repeat_after_other_member_evicted() {
+        // Regression: with an index-based cursor, evicting an active member
+        // other than the one just served shifted indices and could serve the
+        // same address twice in a row.
+        let mut list = AddressList::new().with_active_set_size(2);
+        for i in 0..3 {
+            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
+        }
+
+        let first = list.get_live_address().unwrap();
+        let second = list.get_live_address().unwrap();
+        let third = list.get_live_address().unwrap();
+        assert_eq!(first, third, "two-member set alternates");
+
+        // Ban the member that was NOT just served; a standby gets promoted.
+        list.ban(&second);
+
+        let next = list.get_live_address().unwrap();
+        assert_ne!(
+            next, third,
+            "must not serve the same address twice in a row after eviction"
+        );
+        assert_ne!(next, second, "banned address must not be served");
+    }
+
+    #[test]
+    fn test_get_live_address_removed_address_pruned_from_active_set() {
+        let mut list = AddressList::new().with_active_set_size(1);
+        list.add("http://127.0.0.1:3000".parse().unwrap());
+        list.add("http://127.0.0.1:3001".parse().unwrap());
+
+        let first = list.get_live_address().unwrap();
+        list.remove(&first);
+
+        let second = list.get_live_address().unwrap();
+        assert_ne!(second, first);
+    }
+
+    #[test]
+    fn test_get_live_address_with_fewer_live_addresses_than_active_set() {
+        let mut list = AddressList::new(); // default active set size 5
+        list.add("http://127.0.0.1:3000".parse().unwrap());
+        list.add("http://127.0.0.1:3001".parse().unwrap());
+
+        let distinct: std::collections::HashSet<String> = (0..10)
+            .map(|_| list.get_live_address().unwrap().to_string())
+            .collect();
+        assert_eq!(distinct.len(), 2, "both live addresses rotate");
+    }
+
+    #[test]
+    fn test_get_live_address_all_banned_returns_none() {
+        let mut list = AddressList::new().with_active_set_size(1);
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        list.add(addr.clone());
+
+        assert!(list.get_live_address().is_some());
+        list.ban(&addr);
         assert!(list.get_live_address().is_none());
     }
 

--- a/packages/rs-dapi-client/src/address_list.rs
+++ b/packages/rs-dapi-client/src/address_list.rs
@@ -3,7 +3,7 @@
 use crate::address_ban_info::AddressBanInfo;
 use crate::Uri;
 use chrono::Utc;
-use rand::{rngs::SmallRng, seq::IteratorRandom, SeedableRng};
+use rand::{rngs::SmallRng, seq::IteratorRandom, Rng, SeedableRng};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -14,12 +14,24 @@ use std::time::Duration;
 
 const DEFAULT_BASE_BAN_PERIOD: Duration = Duration::from_secs(60);
 
+/// Longest ban window either ban path can produce. Bounds `e^ban_count`,
+/// which otherwise overflows `DateTime + Duration` arithmetic (a panic that
+/// poisons the shared lock) once `ban_count` reaches the mid-20s.
+const MAX_BAN_PERIOD: Duration = Duration::from_secs(24 * 60 * 60);
+
 /// Default number of addresses that receive traffic at a time.
 ///
 /// Kept small so requests reuse warm connections instead of sampling the whole
 /// list (hundreds of nodes on mainnet), where nearly every request would land
 /// on a cold host and pay a fresh TCP + TLS handshake.
 const DEFAULT_ACTIVE_SET_SIZE: usize = 5;
+
+/// How long an address may hold an active-set slot before it is retired and a
+/// random live standby is promoted in its place. Bounding slot tenure keeps
+/// connections warm for minutes at a time while preventing any small set of
+/// nodes from observing the client's entire query stream for the whole
+/// process lifetime.
+const SLOT_LIFETIME: Duration = Duration::from_secs(5 * 60);
 
 /// DAPI address.
 #[derive(Debug, Clone, Eq)]
@@ -98,7 +110,8 @@ impl AddressStatus {
     /// Ban the [Address] and record the `reason` for the ban.
     ///
     /// Applies exponential backoff: the ban window is `base × e^ban_count`
-    /// (where `ban_count` is the value *before* this call), and `banned_until`
+    /// (where `ban_count` is the value *before* this call), capped at 24 hours
+    /// (or `base` itself if larger), and `banned_until`
     /// is always re-based to `now + window` unconditionally, regardless of any
     /// existing active ban.  Concretely, a health failure on a node that already
     /// holds a longer rate-limit window (set via [`AddressStatus::ban_for`]) will
@@ -111,7 +124,14 @@ impl AddressStatus {
     /// The counter resets to 0 on [`AddressStatus::unban`].
     pub fn ban_with_reason(&mut self, base_ban_period: &Duration, reason: Option<String>) {
         let coefficient = (self.ban_count as f64).exp();
-        let ban_period = Duration::from_secs_f64(base_ban_period.as_secs_f64() * coefficient);
+        let max_ban_period = MAX_BAN_PERIOD.max(*base_ban_period);
+        let ban_secs = base_ban_period.as_secs_f64() * coefficient;
+        // NaN/inf compare false, so any overflowing window falls to the cap.
+        let ban_period = if ban_secs < max_ban_period.as_secs_f64() {
+            Duration::from_secs_f64(ban_secs)
+        } else {
+            max_ban_period
+        };
 
         self.banned_until = Some(chrono::Utc::now() + ban_period);
         self.ban_count += 1;
@@ -121,7 +141,8 @@ impl AddressStatus {
     /// Ban the address for an exact `period` (server-advertised), bypassing the
     /// exponential ladder used by [`AddressStatus::ban_with_reason`].
     ///
-    /// The ban window is flat (not exponential).  `banned_until` is advanced to
+    /// The ban window is flat (not exponential) and capped at 24 hours.
+    /// `banned_until` is advanced to
     /// `now + period` only when that timestamp is **later** than the current
     /// `banned_until`, so a short-reset call never shortens a longer active ban
     /// (health ban or a prior longer rate-limit ban).  `ban_reason` is updated
@@ -138,6 +159,9 @@ impl AddressStatus {
     /// sequences.  [`AddressStatus::ban_with_reason`] re-bases `banned_until`
     /// unconditionally — see its docs for the intentional cross-method semantics.
     pub fn ban_for(&mut self, period: Duration, reason: Option<String>) {
+        // A server-advertised window is clamped like the ladder: a hostile or
+        // buggy period must not overflow `DateTime + Duration`.
+        let period = period.min(MAX_BAN_PERIOD);
         let advertised_until = chrono::Utc::now() + period;
         if self
             .banned_until
@@ -181,26 +205,47 @@ pub enum AddressListError {
     InvalidAddressUri(String),
 }
 
-/// Sticky rotation state: the addresses currently receiving traffic, and the
-/// most recently served one that round-robin selection advances from.
-#[derive(Debug, Default)]
+/// One member of the sticky active set: the address plus the moment its slot
+/// expires and a random standby replaces it.
+#[derive(Debug)]
+struct ActiveMember {
+    address: Address,
+    slot_expires_at: chrono::DateTime<Utc>,
+}
+
+/// Sticky rotation state: the addresses currently receiving traffic, the most
+/// recently served one that round-robin selection advances from, and the
+/// configured active-set size. Shared (behind one lock) by every clone of an
+/// [AddressList] so all clones drive the same rotation.
+#[derive(Debug)]
 struct Rotation {
-    active: Vec<Address>,
+    active: Vec<ActiveMember>,
     last_served: Option<Address>,
+    active_set_size: usize,
+}
+
+impl Default for Rotation {
+    fn default() -> Self {
+        Rotation {
+            active: Vec::new(),
+            last_served: None,
+            active_set_size: DEFAULT_ACTIVE_SET_SIZE,
+        }
+    }
 }
 
 /// A structure to manage DAPI addresses to select from
 /// for [DapiRequest](crate::DapiRequest) execution.
 ///
 /// Address selection is sticky: requests rotate over a small active set of
-/// addresses and the rest of the list serves as failover standby (see
+/// addresses (5 by default, see [AddressList::with_active_set_size]) and the
+/// rest of the list serves as failover standby (see
 /// [AddressList::get_live_address]).
 #[derive(Debug, Clone)]
 pub struct AddressList {
     addresses: Arc<RwLock<HashMap<Address, AddressStatus>>>,
     rotation: Arc<RwLock<Rotation>>,
     base_ban_period: Duration,
-    active_set_size: usize,
 }
 
 impl Default for AddressList {
@@ -227,16 +272,22 @@ impl AddressList {
             addresses: Arc::new(RwLock::new(HashMap::new())),
             rotation: Arc::new(RwLock::new(Rotation::default())),
             base_ban_period,
-            active_set_size: DEFAULT_ACTIVE_SET_SIZE,
         }
     }
 
-    /// Set how many addresses receive traffic at a time (minimum 1).
+    /// Set how many addresses receive traffic at a time.
     ///
-    /// Smaller values maximize connection reuse, larger values spread load over
-    /// more nodes.
-    pub fn with_active_set_size(mut self, size: usize) -> Self {
-        self.active_set_size = size.max(1);
+    /// Defaults to 5. `0` is clamped to 1. Smaller values maximize connection
+    /// reuse, larger values spread load over more nodes. The effective size is
+    /// additionally capped by the number of live addresses, so a very large
+    /// value (e.g. `usize::MAX`) disables stickiness and round-robins over the
+    /// whole list.
+    ///
+    /// The size lives in the rotation state shared by every clone of this
+    /// list, so it applies to all clones and takes effect on the next
+    /// selection (shrinking drops the excess members).
+    pub fn with_active_set_size(self, size: usize) -> Self {
+        self.rotation.write().unwrap().active_set_size = size.max(1);
         self
     }
 
@@ -336,66 +387,110 @@ impl AddressList {
 
     /// Select a not-banned address to send the next request to.
     ///
+    /// Not a pure getter: every call advances the shared rotation cursor and
+    /// may promote or retire active-set members, steering traffic for all
+    /// clones of this list.
+    ///
     /// Selection is sticky: requests rotate round-robin over a small active
     /// set of addresses (see [AddressList::with_active_set_size]) instead of
     /// sampling the whole list, so connections to those hosts stay warm. An
-    /// active address that got banned or removed is dropped from the set here
-    /// and a random live standby address is promoted in its place, so the ban
-    /// ladder remains the only health signal.
+    /// active address that got banned, removed or evicted on failover (see
+    /// [AddressList::evict_from_rotation]) is dropped from the set here and a
+    /// random live standby address is promoted in its place. Each slot also
+    /// expires after a jittered lifetime (5–7.5 minutes), so no node holds a
+    /// slot — and a view of this client's query stream — indefinitely.
     ///
     /// An address is considered live when it has never been banned or when its
     /// ban period has already expired.
     pub fn get_live_address(&self) -> Option<Address> {
         // TODO(low): module-wide `.read()/.write().unwrap()` panics on a
-        // poisoned lock; adopt poison-tolerant locking consistently (SEC-003).
+        // poisoned lock; adopt poison-tolerant locking consistently.
         let guard = self.addresses.read().unwrap();
 
         let now = chrono::Utc::now();
+
+        // Seeded outside the critical section: `from_entropy` panics if the OS
+        // entropy source fails, and a panic while holding the write lock would
+        // poison it and permanently disable address selection.
+        let mut rng = SmallRng::from_entropy();
 
         // Lock ordering: `addresses` before `rotation`; this is the only place
         // both locks are held at once.
         let mut rotation = self.rotation.write().unwrap();
 
-        // Drop active addresses that are banned or no longer in the list.
-        rotation.active.retain(|address| {
-            guard
-                .get(address)
-                .map(|status| status.is_live(now))
-                .unwrap_or(false)
+        // Drop active addresses that are banned, no longer in the list, or
+        // whose slot lifetime expired.
+        rotation.active.retain(|member| {
+            now < member.slot_expires_at
+                && guard
+                    .get(&member.address)
+                    .map(|status| status.is_live(now))
+                    .unwrap_or(false)
         });
 
-        // Refill vacancies with random live standby addresses.
-        let vacancies = self.active_set_size.saturating_sub(rotation.active.len());
+        // Honor a shrunken size (the rotation state is shared, so it may have
+        // been reconfigured through any clone).
+        let size = rotation.active_set_size;
+        rotation.active.truncate(size);
+
+        // Refill vacancies with random live standby addresses. Bounded by the
+        // list length so an oversized configured value cannot over-allocate in
+        // `choose_multiple`.
+        let vacancies = size.saturating_sub(rotation.active.len()).min(guard.len());
         if vacancies > 0 {
             let promoted = guard
                 .iter()
                 .filter(|&(address, status)| {
-                    status.is_live(now) && !rotation.active.contains(address)
+                    status.is_live(now)
+                        && !rotation
+                            .active
+                            .iter()
+                            .any(|member| member.address == *address)
                 })
-                .choose_multiple(&mut SmallRng::from_entropy(), vacancies);
+                .choose_multiple(&mut rng, vacancies);
 
             rotation
                 .active
-                .extend(promoted.into_iter().map(|(address, _)| address.clone()));
+                .extend(promoted.into_iter().map(|(address, _)| ActiveMember {
+                    address: address.clone(),
+                    // Jitter staggers expiries so slots retire one at a time
+                    // instead of the whole set at once.
+                    slot_expires_at: now + SLOT_LIFETIME.mul_f64(rng.gen_range(1.0..1.5)),
+                }));
         }
 
         if rotation.active.is_empty() {
             return None;
         }
 
-        // Advance relative to the last-served address rather than a bare index:
-        // eviction shifts indices, and an index-based cursor could serve the
-        // same address twice in a row after churn. Start from the head when the
-        // last-served address is gone (or nothing has been served yet).
-        let last_position = rotation
-            .last_served
-            .as_ref()
-            .and_then(|last| rotation.active.iter().position(|address| address == last));
+        // Advance from the last-served address: eviction re-orders the active
+        // set, so a positional cursor would not survive churn. Start from the
+        // head when the last-served address is gone (or nothing has been
+        // served yet).
+        let last_position = rotation.last_served.as_ref().and_then(|last| {
+            rotation
+                .active
+                .iter()
+                .position(|member| member.address == *last)
+        });
 
         let index = last_position.map_or(0, |position| (position + 1) % rotation.active.len());
-        let address = rotation.active[index].clone();
+        let address = rotation.active[index].address.clone();
         rotation.last_served = Some(address.clone());
         Some(address)
+    }
+
+    /// Drop `address` from the sticky active set, leaving its ban state
+    /// untouched; the next selection promotes a random live standby in its
+    /// place.
+    ///
+    /// This is the failover path for callers that disable banning
+    /// ([RequestSettings::ban_failed_address](crate::RequestSettings)): a
+    /// failing node must stop receiving its slot's traffic even when it is
+    /// never banned.
+    pub fn evict_from_rotation(&self, address: &Address) {
+        let mut rotation = self.rotation.write().unwrap();
+        rotation.active.retain(|member| member.address != *address);
     }
 
     /// Get all not banned addresses.
@@ -823,9 +918,6 @@ mod tests {
 
     #[test]
     fn test_get_live_address_no_immediate_repeat_after_other_member_evicted() {
-        // Regression: with an index-based cursor, evicting an active member
-        // other than the one just served shifted indices and could serve the
-        // same address twice in a row.
         let mut list = AddressList::new().with_active_set_size(2);
         for i in 0..3 {
             list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
@@ -881,6 +973,210 @@ mod tests {
         assert!(list.get_live_address().is_some());
         list.ban(&addr);
         assert!(list.get_live_address().is_none());
+    }
+
+    #[test]
+    fn test_get_live_address_expired_slot_is_recycled() {
+        let mut list = AddressList::new();
+        for i in 0..10 {
+            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
+        }
+
+        // Populate the active set, then back-date every slot's expiry.
+        list.get_live_address().unwrap();
+        {
+            let mut rotation = list.rotation.write().unwrap();
+            assert_eq!(rotation.active.len(), DEFAULT_ACTIVE_SET_SIZE);
+            for member in rotation.active.iter_mut() {
+                member.slot_expires_at = chrono::Utc::now() - Duration::from_secs(1);
+            }
+        }
+
+        let before = chrono::Utc::now();
+        assert!(
+            list.get_live_address().is_some(),
+            "selection must survive whole-set expiry"
+        );
+
+        let rotation = list.rotation.read().unwrap();
+        assert_eq!(rotation.active.len(), DEFAULT_ACTIVE_SET_SIZE);
+        assert!(
+            rotation
+                .active
+                .iter()
+                .all(|member| member.slot_expires_at > before),
+            "expired slots must be retired and re-issued with fresh expiries"
+        );
+    }
+
+    #[test]
+    fn test_get_live_address_sole_address_survives_slot_expiry() {
+        let mut list = AddressList::new().with_active_set_size(1);
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        list.add(addr.clone());
+
+        assert_eq!(list.get_live_address().unwrap(), addr);
+        list.rotation.write().unwrap().active[0].slot_expires_at =
+            chrono::Utc::now() - Duration::from_secs(1);
+
+        assert_eq!(
+            list.get_live_address().unwrap(),
+            addr,
+            "the only live address must be re-promoted after its slot expires"
+        );
+    }
+
+    #[test]
+    fn test_evict_from_rotation_removes_member_without_ban() {
+        let mut list = AddressList::new().with_active_set_size(2);
+        for i in 0..3 {
+            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
+        }
+
+        let served = list.get_live_address().unwrap();
+        list.evict_from_rotation(&served);
+
+        assert!(
+            !list
+                .rotation
+                .read()
+                .unwrap()
+                .active
+                .iter()
+                .any(|member| member.address == served),
+            "evicted address must leave the active set"
+        );
+        assert!(
+            !list.is_banned(&served),
+            "eviction must not touch ban state"
+        );
+        assert!(list.get_live_address().is_some());
+    }
+
+    #[test]
+    fn test_update_address_ban_status_evicts_when_banning_disabled() {
+        use crate::{transport::AppliedRequestSettings, CanRetry, ExecutionError, ExecutionResult};
+
+        #[derive(Debug)]
+        struct RetryableError;
+        impl std::fmt::Display for RetryableError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "retryable")
+            }
+        }
+        impl CanRetry for RetryableError {
+            fn can_retry(&self) -> bool {
+                true
+            }
+        }
+
+        let mut list = AddressList::new().with_active_set_size(2);
+        for i in 0..3 {
+            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
+        }
+        let failed = list.get_live_address().unwrap();
+
+        let result: ExecutionResult<i32, RetryableError> = Err(ExecutionError {
+            inner: RetryableError,
+            retries: 0,
+            address: Some(failed.clone()),
+        });
+        let settings = AppliedRequestSettings {
+            connect_timeout: None,
+            timeout: Duration::from_secs(10),
+            retries: 5,
+            ban_failed_address: false,
+            max_decoding_message_size: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            ca_certificate: None,
+        };
+        crate::update_address_ban_status(&list, &result, &settings);
+
+        assert!(
+            !list
+                .rotation
+                .read()
+                .unwrap()
+                .active
+                .iter()
+                .any(|member| member.address == failed),
+            "failed address must leave the rotation even when banning is disabled"
+        );
+        assert!(!list.is_banned(&failed), "banning stays disabled");
+    }
+
+    #[test]
+    fn test_with_active_set_size_is_shared_across_clones_and_shrinks() {
+        let mut list = AddressList::new();
+        for i in 0..10 {
+            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
+        }
+
+        // Fill the default-sized active set through the original handle.
+        list.get_live_address().unwrap();
+        assert_eq!(
+            list.rotation.read().unwrap().active.len(),
+            DEFAULT_ACTIVE_SET_SIZE
+        );
+
+        // Reconfiguring through a clone applies to the shared rotation.
+        let _clone = list.clone().with_active_set_size(2);
+
+        let distinct: std::collections::HashSet<String> = (0..20)
+            .map(|_| list.get_live_address().unwrap().to_string())
+            .collect();
+        assert_eq!(
+            distinct.len(),
+            2,
+            "shrunken size set through a clone must constrain every handle"
+        );
+    }
+
+    #[test]
+    fn test_with_active_set_size_max_uses_whole_list() {
+        let mut list = AddressList::new().with_active_set_size(usize::MAX);
+        for i in 0..3 {
+            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
+        }
+
+        // Must not over-allocate or panic; effectively disables stickiness.
+        let distinct: std::collections::HashSet<String> = (0..9)
+            .map(|_| list.get_live_address().unwrap().to_string())
+            .collect();
+        assert_eq!(distinct.len(), 3, "all live addresses rotate");
+    }
+
+    #[test]
+    fn test_ban_ladder_window_is_capped() {
+        let mut status = AddressStatus::default();
+        let base = Duration::from_secs(60);
+
+        // Pre-cap, ban #27 overflowed `DateTime + Duration` and panicked.
+        for _ in 0..40 {
+            status.ban(&base);
+        }
+
+        let until = status.banned_until.expect("banned_until set");
+        let window = until - chrono::Utc::now();
+        assert!(
+            window <= chrono::TimeDelta::from_std(MAX_BAN_PERIOD).unwrap(),
+            "ban window must be capped at MAX_BAN_PERIOD"
+        );
+    }
+
+    #[test]
+    fn test_ban_for_huge_period_is_clamped() {
+        let mut status = AddressStatus::default();
+
+        // Pre-clamp this overflowed `DateTime + Duration` and panicked.
+        status.ban_for(Duration::from_secs(u64::MAX), None);
+
+        let until = status.banned_until.expect("banned_until set");
+        let window = until - chrono::Utc::now();
+        assert!(
+            window <= chrono::TimeDelta::from_std(MAX_BAN_PERIOD).unwrap(),
+            "advertised ban window must be clamped to MAX_BAN_PERIOD"
+        );
     }
 
     #[test]

--- a/packages/rs-dapi-client/src/address_list.rs
+++ b/packages/rs-dapi-client/src/address_list.rs
@@ -5,7 +5,7 @@ use crate::Uri;
 use chrono::Utc;
 use rand::{rngs::SmallRng, seq::IteratorRandom, Rng, SeedableRng};
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::str::FromStr;
@@ -28,9 +28,8 @@ const DEFAULT_ACTIVE_SET_SIZE: usize = 5;
 
 /// How long an address may hold an active-set slot before it is retired and a
 /// random live standby is promoted in its place. Bounding slot tenure keeps
-/// connections warm for minutes at a time while preventing any small set of
-/// nodes from observing the client's entire query stream for the whole
-/// process lifetime.
+/// connections warm for minutes at a time while spreading traffic to standby
+/// nodes over the process lifetime, when alternatives are available.
 const SLOT_LIFETIME: Duration = Duration::from_secs(5 * 60);
 
 /// DAPI address.
@@ -111,7 +110,7 @@ impl AddressStatus {
     ///
     /// Applies exponential backoff: the ban window is `base × e^ban_count`
     /// (where `ban_count` is the value *before* this call), capped at 24 hours
-    /// (or `base` itself if larger), and `banned_until`
+    /// even when `base` is larger, and `banned_until`
     /// is always re-based to `now + window` unconditionally, regardless of any
     /// existing active ban.  Concretely, a health failure on a node that already
     /// holds a longer rate-limit window (set via [`AddressStatus::ban_for`]) will
@@ -124,13 +123,12 @@ impl AddressStatus {
     /// The counter resets to 0 on [`AddressStatus::unban`].
     pub fn ban_with_reason(&mut self, base_ban_period: &Duration, reason: Option<String>) {
         let coefficient = (self.ban_count as f64).exp();
-        let max_ban_period = MAX_BAN_PERIOD.max(*base_ban_period);
         let ban_secs = base_ban_period.as_secs_f64() * coefficient;
         // NaN/inf compare false, so any overflowing window falls to the cap.
-        let ban_period = if ban_secs < max_ban_period.as_secs_f64() {
+        let ban_period = if ban_secs < MAX_BAN_PERIOD.as_secs_f64() {
             Duration::from_secs_f64(ban_secs)
         } else {
-            max_ban_period
+            MAX_BAN_PERIOD
         };
 
         self.banned_until = Some(chrono::Utc::now() + ban_period);
@@ -220,6 +218,9 @@ struct ActiveMember {
 #[derive(Debug)]
 struct Rotation {
     active: Vec<ActiveMember>,
+    /// Evicted members to deprioritize during the next refill. Only active
+    /// members are recorded, bounding this set even after repeated errors.
+    evicted: HashSet<Address>,
     last_served: Option<Address>,
     active_set_size: usize,
 }
@@ -228,6 +229,7 @@ impl Default for Rotation {
     fn default() -> Self {
         Rotation {
             active: Vec::new(),
+            evicted: HashSet::new(),
             last_served: None,
             active_set_size: DEFAULT_ACTIVE_SET_SIZE,
         }
@@ -397,8 +399,9 @@ impl AddressList {
     /// active address that got banned, removed or evicted on failover (see
     /// [AddressList::evict_from_rotation]) is dropped from the set here and a
     /// random live standby address is promoted in its place. Each slot also
-    /// expires after a jittered lifetime (5–7.5 minutes), so no node holds a
-    /// slot — and a view of this client's query stream — indefinitely.
+    /// expires after a jittered lifetime (5–7.5 minutes). Evicted and expired
+    /// members are used to refill slots only after all live standbys have
+    /// been selected, preserving availability when alternatives are scarce.
     ///
     /// An address is considered live when it has never been banned or when its
     /// ban period has already expired.
@@ -417,15 +420,20 @@ impl AddressList {
         // Lock ordering: `addresses` before `rotation`; this is the only place
         // both locks are held at once.
         let mut rotation = self.rotation.write().unwrap();
+        let mut retired = mem::take(&mut rotation.evicted);
 
         // Drop active addresses that are banned, no longer in the list, or
         // whose slot lifetime expired.
         rotation.active.retain(|member| {
-            now < member.slot_expires_at
-                && guard
+            if now >= member.slot_expires_at {
+                retired.insert(member.address.clone());
+                false
+            } else {
+                guard
                     .get(&member.address)
                     .map(|status| status.is_live(now))
                     .unwrap_or(false)
+            }
         });
 
         // Honor a shrunken size (the rotation state is shared, so it may have
@@ -434,20 +442,31 @@ impl AddressList {
         rotation.active.truncate(size);
 
         // Refill vacancies with random live standby addresses. Bounded by the
-        // list length so an oversized configured value cannot over-allocate in
-        // `choose_multiple`.
-        let vacancies = size.saturating_sub(rotation.active.len()).min(guard.len());
+        // remaining list length so whole-list mode skips refilling once full
+        // and an oversized configured value cannot over-allocate.
+        let vacancies = size.min(guard.len()).saturating_sub(rotation.active.len());
         if vacancies > 0 {
-            let promoted = guard
-                .iter()
-                .filter(|&(address, status)| {
-                    status.is_live(now)
-                        && !rotation
-                            .active
-                            .iter()
-                            .any(|member| member.address == *address)
-                })
+            let candidates = guard.iter().filter(|&(address, status)| {
+                status.is_live(now)
+                    && !rotation
+                        .active
+                        .iter()
+                        .any(|member| member.address == *address)
+            });
+            let mut promoted = candidates
+                .clone()
+                .filter(|(address, _)| !retired.contains(*address))
                 .choose_multiple(&mut rng, vacancies);
+            // Prefer genuine standbys, but do not lose usable capacity when
+            // fewer standbys are live than there are vacancies.
+            let remaining = vacancies - promoted.len();
+            if remaining > 0 && !retired.is_empty() {
+                promoted.extend(
+                    candidates
+                        .filter(|(address, _)| retired.contains(*address))
+                        .choose_multiple(&mut rng, remaining),
+                );
+            }
 
             rotation
                 .active
@@ -481,16 +500,23 @@ impl AddressList {
     }
 
     /// Drop `address` from the sticky active set, leaving its ban state
-    /// untouched; the next selection promotes a random live standby in its
-    /// place.
+    /// untouched; the next selection prefers a random live standby in its
+    /// place, falling back to evicted members if there are too few standbys.
     ///
     /// This is the failover path for callers that disable banning
     /// ([RequestSettings::ban_failed_address](crate::RequestSettings)): a
-    /// failing node must stop receiving its slot's traffic even when it is
-    /// never banned.
+    /// failing node yields its slot's traffic to an available standby even
+    /// when it is never banned.
     pub fn evict_from_rotation(&self, address: &Address) {
         let mut rotation = self.rotation.write().unwrap();
-        rotation.active.retain(|member| member.address != *address);
+        if let Some(index) = rotation
+            .active
+            .iter()
+            .position(|member| member.address == *address)
+        {
+            let member = rotation.active.remove(index);
+            rotation.evicted.insert(member.address);
+        }
     }
 
     /// Get all not banned addresses.
@@ -984,13 +1010,18 @@ mod tests {
 
         // Populate the active set, then back-date every slot's expiry.
         list.get_live_address().unwrap();
-        {
+        let retired = {
             let mut rotation = list.rotation.write().unwrap();
             assert_eq!(rotation.active.len(), DEFAULT_ACTIVE_SET_SIZE);
             for member in rotation.active.iter_mut() {
                 member.slot_expires_at = chrono::Utc::now() - Duration::from_secs(1);
             }
-        }
+            rotation
+                .active
+                .iter()
+                .map(|member| member.address.clone())
+                .collect::<Vec<_>>()
+        };
 
         let before = chrono::Utc::now();
         assert!(
@@ -1000,6 +1031,13 @@ mod tests {
 
         let rotation = list.rotation.read().unwrap();
         assert_eq!(rotation.active.len(), DEFAULT_ACTIVE_SET_SIZE);
+        assert!(
+            rotation
+                .active
+                .iter()
+                .all(|member| !retired.contains(&member.address)),
+            "live standbys must replace expired members when enough are available"
+        );
         assert!(
             rotation
                 .active
@@ -1051,6 +1089,68 @@ mod tests {
             "eviction must not touch ban state"
         );
         assert!(list.get_live_address().is_some());
+        assert!(
+            list.rotation
+                .read()
+                .unwrap()
+                .active
+                .iter()
+                .all(|member| member.address != served),
+            "the available standby must replace the evicted address"
+        );
+    }
+
+    #[test]
+    fn should_keep_sole_live_address_available_after_eviction() {
+        let mut list = AddressList::new().with_active_set_size(1);
+        let address: Address = "http://127.0.0.1:3000".parse().unwrap();
+        let banned: Address = "http://127.0.0.1:3001".parse().unwrap();
+        list.add(address.clone());
+        list.add(banned.clone());
+        list.ban(&banned);
+        assert_eq!(list.get_live_address(), Some(address.clone()));
+        list.evict_from_rotation(&address);
+        assert_eq!(list.get_live_address(), Some(address.clone()));
+        assert!(!list.is_banned(&address));
+    }
+
+    #[test]
+    fn should_use_all_live_standbys_before_recycling_expired_members() {
+        let mut list = AddressList::new().with_active_set_size(3);
+        for i in 0..4 {
+            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
+        }
+        list.get_live_address().unwrap();
+        let standby = list
+            .get_live_addresses()
+            .into_iter()
+            .find(|address| {
+                !list
+                    .rotation
+                    .read()
+                    .unwrap()
+                    .active
+                    .iter()
+                    .any(|member| member.address == *address)
+            })
+            .unwrap();
+        for member in &mut list.rotation.write().unwrap().active {
+            member.slot_expires_at = chrono::Utc::now() - Duration::from_secs(1);
+        }
+        list.get_live_address().unwrap();
+        let rotation = list.rotation.read().unwrap();
+        assert_eq!(
+            rotation.active.len(),
+            3,
+            "fallback must preserve the effective active-set size"
+        );
+        assert!(
+            rotation
+                .active
+                .iter()
+                .any(|member| member.address == standby),
+            "the one available standby must be promoted before recycling expired members"
+        );
     }
 
     #[test]
@@ -1070,8 +1170,8 @@ mod tests {
             }
         }
 
-        let mut list = AddressList::new().with_active_set_size(2);
-        for i in 0..3 {
+        let mut list = AddressList::new().with_active_set_size(1);
+        for i in 0..2 {
             list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
         }
         let failed = list.get_live_address().unwrap();
@@ -1103,6 +1203,18 @@ mod tests {
             "failed address must leave the rotation even when banning is disabled"
         );
         assert!(!list.is_banned(&failed), "banning stays disabled");
+        let next = list.get_live_address().unwrap();
+        assert_ne!(
+            next, failed,
+            "the next retry must select the available standby"
+        );
+        for _ in 0..5 {
+            assert_eq!(
+                list.get_live_address().unwrap(),
+                next,
+                "the replacement must remain sticky"
+            );
+        }
     }
 
     #[test]
@@ -1177,6 +1289,25 @@ mod tests {
             window <= chrono::TimeDelta::from_std(MAX_BAN_PERIOD).unwrap(),
             "advertised ban window must be clamped to MAX_BAN_PERIOD"
         );
+    }
+
+    #[test]
+    fn should_cap_oversized_base_bans_without_poisoning_the_list() {
+        for base in [Duration::from_secs(48 * 60 * 60), Duration::MAX] {
+            let mut list = AddressList::with_settings(base);
+            let address: Address = "http://127.0.0.1:3000".parse().unwrap();
+            list.add(address.clone());
+            list.ban(&address);
+            let until = list.addresses.read().unwrap()[&address]
+                .banned_until
+                .unwrap();
+            assert!(
+                until - chrono::Utc::now() <= chrono::TimeDelta::from_std(MAX_BAN_PERIOD).unwrap()
+            );
+            assert!(list.get_live_address().is_none());
+            list.unban(&address);
+            assert_eq!(list.get_live_address(), Some(address));
+        }
     }
 
     #[test]

--- a/packages/rs-dapi-client/src/address_list.rs
+++ b/packages/rs-dapi-client/src/address_list.rs
@@ -633,6 +633,12 @@ impl FromIterator<Address> for AddressList {
 mod tests {
     use super::*;
 
+    fn list_with_addresses(count: usize) -> AddressList {
+        (0..count)
+            .map(|i| format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap())
+            .collect()
+    }
+
     #[test]
     fn test_get_live_addresses_empty_list() {
         let list = AddressList::new();
@@ -878,10 +884,7 @@ mod tests {
 
     #[test]
     fn test_get_live_address_sticks_to_small_active_set() {
-        let mut list = AddressList::new();
-        for i in 0..50 {
-            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
-        }
+        let list = list_with_addresses(50);
 
         let distinct: std::collections::HashSet<String> = (0..200)
             .map(|_| list.get_live_address().unwrap().to_string())
@@ -896,10 +899,7 @@ mod tests {
 
     #[test]
     fn test_get_live_address_round_robins_over_active_set() {
-        let mut list = AddressList::new().with_active_set_size(2);
-        for i in 0..5 {
-            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
-        }
+        let list = list_with_addresses(5).with_active_set_size(2);
 
         let picks: Vec<String> = (0..6)
             .map(|_| list.get_live_address().unwrap().to_string())
@@ -915,10 +915,7 @@ mod tests {
 
     #[test]
     fn test_get_live_address_ban_evicts_active_and_promotes_standby() {
-        let mut list = AddressList::new().with_active_set_size(1);
-        for i in 0..3 {
-            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
-        }
+        let list = list_with_addresses(3).with_active_set_size(1);
 
         let first = list.get_live_address().unwrap();
         for _ in 0..5 {
@@ -944,10 +941,7 @@ mod tests {
 
     #[test]
     fn test_get_live_address_no_immediate_repeat_after_other_member_evicted() {
-        let mut list = AddressList::new().with_active_set_size(2);
-        for i in 0..3 {
-            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
-        }
+        let list = list_with_addresses(3).with_active_set_size(2);
 
         let first = list.get_live_address().unwrap();
         let second = list.get_live_address().unwrap();
@@ -1003,10 +997,7 @@ mod tests {
 
     #[test]
     fn test_get_live_address_expired_slot_is_recycled() {
-        let mut list = AddressList::new();
-        for i in 0..10 {
-            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
-        }
+        let list = list_with_addresses(10);
 
         // Populate the active set, then back-date every slot's expiry.
         list.get_live_address().unwrap();
@@ -1066,10 +1057,7 @@ mod tests {
 
     #[test]
     fn test_evict_from_rotation_removes_member_without_ban() {
-        let mut list = AddressList::new().with_active_set_size(2);
-        for i in 0..3 {
-            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
-        }
+        let list = list_with_addresses(3).with_active_set_size(2);
 
         let served = list.get_live_address().unwrap();
         list.evict_from_rotation(&served);
@@ -1116,10 +1104,7 @@ mod tests {
 
     #[test]
     fn should_use_all_live_standbys_before_recycling_expired_members() {
-        let mut list = AddressList::new().with_active_set_size(3);
-        for i in 0..4 {
-            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
-        }
+        let list = list_with_addresses(4).with_active_set_size(3);
         list.get_live_address().unwrap();
         let standby = list
             .get_live_addresses()
@@ -1155,41 +1140,22 @@ mod tests {
 
     #[test]
     fn test_update_address_ban_status_evicts_when_banning_disabled() {
-        use crate::{transport::AppliedRequestSettings, CanRetry, ExecutionError, ExecutionResult};
+        use crate::{transport::TransportError, ExecutionError, ExecutionResult, RequestSettings};
+        use dapi_grpc::tonic::Status;
 
-        #[derive(Debug)]
-        struct RetryableError;
-        impl std::fmt::Display for RetryableError {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, "retryable")
-            }
-        }
-        impl CanRetry for RetryableError {
-            fn can_retry(&self) -> bool {
-                true
-            }
-        }
-
-        let mut list = AddressList::new().with_active_set_size(1);
-        for i in 0..2 {
-            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
-        }
+        let list = list_with_addresses(2).with_active_set_size(1);
         let failed = list.get_live_address().unwrap();
 
-        let result: ExecutionResult<i32, RetryableError> = Err(ExecutionError {
-            inner: RetryableError,
+        let result: ExecutionResult<i32, TransportError> = Err(ExecutionError {
+            inner: TransportError::Grpc(Status::unavailable("node down")),
             retries: 0,
             address: Some(failed.clone()),
         });
-        let settings = AppliedRequestSettings {
-            connect_timeout: None,
-            timeout: Duration::from_secs(10),
-            retries: 5,
-            ban_failed_address: false,
-            max_decoding_message_size: None,
-            #[cfg(not(target_arch = "wasm32"))]
-            ca_certificate: None,
-        };
+        let settings = RequestSettings {
+            ban_failed_address: Some(false),
+            ..RequestSettings::default()
+        }
+        .finalize();
         crate::update_address_ban_status(&list, &result, &settings);
 
         assert!(
@@ -1219,10 +1185,7 @@ mod tests {
 
     #[test]
     fn test_with_active_set_size_is_shared_across_clones_and_shrinks() {
-        let mut list = AddressList::new();
-        for i in 0..10 {
-            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
-        }
+        let list = list_with_addresses(10);
 
         // Fill the default-sized active set through the original handle.
         list.get_live_address().unwrap();
@@ -1246,10 +1209,7 @@ mod tests {
 
     #[test]
     fn test_with_active_set_size_max_uses_whole_list() {
-        let mut list = AddressList::new().with_active_set_size(usize::MAX);
-        for i in 0..3 {
-            list.add(format!("http://127.0.0.1:{}", 3000 + i).parse().unwrap());
-        }
+        let list = list_with_addresses(3).with_active_set_size(usize::MAX);
 
         // Must not over-allocate or panic; effectively disables stickiness.
         let distinct: std::collections::HashSet<String> = (0..9)

--- a/packages/rs-dapi-client/src/connection_pool.rs
+++ b/packages/rs-dapi-client/src/connection_pool.rs
@@ -100,9 +100,12 @@ impl ConnectionPool {
         // Only connection-affecting settings participate in the key (see
         // `AppliedRequestSettings::connection_key`), so requests differing only
         // in per-request knobs (timeout, retries, banning) share a connection.
+        // The settings segment is always present (and contains no `:`), so the
+        // two branches cannot produce colliding shapes even for a URI whose
+        // path mimics a key fragment.
         match settings {
             Some(settings) => format!("{}:{}:{}", prefix, uri, settings.connection_key()),
-            None => format!("{}:{}", prefix, uri),
+            None => format!("{}:{}:none", prefix, uri),
         }
     }
 }

--- a/packages/rs-dapi-client/src/connection_pool.rs
+++ b/packages/rs-dapi-client/src/connection_pool.rs
@@ -97,7 +97,13 @@ impl ConnectionPool {
         settings: Option<&AppliedRequestSettings>,
     ) -> String {
         let prefix: PoolPrefix = class.into();
-        format!("{}:{}{:?}", prefix, uri, settings)
+        // Only connection-affecting settings participate in the key (see
+        // `AppliedRequestSettings::connection_key`), so requests differing only
+        // in per-request knobs (timeout, retries, banning) share a connection.
+        match settings {
+            Some(settings) => format!("{}:{}:{}", prefix, uri, settings.connection_key()),
+            None => format!("{}:{}", prefix, uri),
+        }
     }
 }
 
@@ -176,8 +182,10 @@ impl From<&PoolItem> for PoolPrefix {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::RequestSettings;
     use dapi_grpc::tonic::transport::Channel;
     use std::str::FromStr;
+    use std::time::Duration;
 
     fn test_uri() -> Uri {
         Uri::from_str("http://127.0.0.1:3000").unwrap()
@@ -334,6 +342,42 @@ mod tests {
     async fn test_pool_item_platform_into_core_panics() {
         let item = make_platform_pool_item();
         let _client: CoreGrpcClient = item.into();
+    }
+
+    #[tokio::test]
+    async fn test_connection_pool_shares_client_across_per_request_settings() {
+        let pool = ConnectionPool::new(10);
+        let uri = test_uri();
+
+        // Settings differing only in per-request knobs (timeout, retries,
+        // banning) must map to the same pooled connection...
+        let stored = RequestSettings {
+            timeout: Some(Duration::from_secs(30)),
+            retries: Some(3),
+            ban_failed_address: Some(false),
+            ..RequestSettings::default()
+        }
+        .finalize();
+        pool.put(&uri, Some(&stored), make_platform_pool_item());
+
+        let default = RequestSettings::default().finalize();
+        assert!(
+            pool.get(PoolPrefix::Platform, &uri, Some(&default))
+                .is_some(),
+            "per-request settings must not split pooled connections"
+        );
+
+        // ...while connection-affecting settings still get their own entry.
+        let connect = RequestSettings {
+            connect_timeout: Some(Duration::from_secs(3)),
+            ..RequestSettings::default()
+        }
+        .finalize();
+        assert!(
+            pool.get(PoolPrefix::Platform, &uri, Some(&connect))
+                .is_none(),
+            "connection-affecting settings must key separate connections"
+        );
     }
 
     #[tokio::test]

--- a/packages/rs-dapi-client/src/dapi_client.rs
+++ b/packages/rs-dapi-client/src/dapi_client.rs
@@ -239,10 +239,14 @@ pub fn update_address_ban_status<R, E>(
                             );
                         }
                     } else {
+                        // Banning is disabled for this request, but failover
+                        // must still move traffic away from the failing node:
+                        // drop it from the sticky rotation, ban state untouched.
+                        address_list.evict_from_rotation(address);
                         tracing::debug!(
                             ?error,
                             ?address,
-                            "we should ban the address {address} due to the error but banning is disabled"
+                            "banning is disabled; evicted address {address} from rotation due to the error"
                         );
                     }
                 } else {

--- a/packages/rs-dapi-client/src/request_settings.rs
+++ b/packages/rs-dapi-client/src/request_settings.rs
@@ -80,6 +80,10 @@ impl RequestSettings {
 }
 
 /// DAPI settings ready to use.
+///
+/// When adding a field, decide whether it affects the constructed transport
+/// client and update `connection_key` accordingly (its exhaustive
+/// destructuring will not compile until you do).
 #[derive(Debug, Clone)]
 pub struct AppliedRequestSettings {
     /// Timeout for establishing a connection.
@@ -112,20 +116,55 @@ impl AppliedRequestSettings {
     /// Per-request knobs (request timeout, retries, address banning) are
     /// deliberately excluded so requests that differ only in those reuse the
     /// same pooled connection.
-    pub fn connection_key(&self) -> String {
+    pub(crate) fn connection_key(&self) -> String {
+        // Exhaustive destructuring: adding a settings field breaks this
+        // binding, forcing an explicit connection-affecting-or-not decision.
         #[cfg(not(target_arch = "wasm32"))]
-        let ca_certificate = self.ca_certificate.as_ref().map(|cert| {
-            use std::hash::{DefaultHasher, Hash, Hasher};
-            let mut hasher = DefaultHasher::new();
-            cert.as_ref().hash(&mut hasher);
-            hasher.finish()
+        let Self {
+            connect_timeout,
+            timeout: _,
+            retries: _,
+            ban_failed_address: _,
+            max_decoding_message_size,
+            ca_certificate,
+        } = self;
+        #[cfg(target_arch = "wasm32")]
+        let Self {
+            connect_timeout,
+            timeout: _,
+            retries: _,
+            ban_failed_address: _,
+            max_decoding_message_size,
+        } = self;
+
+        // The wasm transport ignores all settings when building its client
+        // (see `wasm_channel::create_channel`), so nothing may split the key
+        // there.
+        #[cfg(target_arch = "wasm32")]
+        let connect_timeout = {
+            let _ = connect_timeout;
+            &None::<Duration>
+        };
+
+        // The full certificate bytes (hex), not a short hash: two trust
+        // anchors must never share a pool key, or a request pinned to one CA
+        // silently reuses a channel built against the other.
+        #[cfg(not(target_arch = "wasm32"))]
+        let ca_certificate = ca_certificate.as_ref().map(|cert| {
+            use std::fmt::Write;
+            let bytes = cert.as_ref();
+            let mut hex = String::with_capacity(bytes.len() * 2);
+            for byte in bytes {
+                write!(hex, "{byte:02x}").expect("writing to a String cannot fail");
+            }
+            hex
         });
         #[cfg(target_arch = "wasm32")]
-        let ca_certificate: Option<u64> = None;
+        let ca_certificate: Option<String> = None;
 
         format!(
             "connect_timeout={:?},max_decoding_message_size={:?},ca_certificate={:?}",
-            self.connect_timeout, self.max_decoding_message_size, ca_certificate
+            connect_timeout, max_decoding_message_size, ca_certificate
         )
     }
 }

--- a/packages/rs-dapi-client/src/request_settings.rs
+++ b/packages/rs-dapi-client/src/request_settings.rs
@@ -105,6 +105,29 @@ impl AppliedRequestSettings {
         self.ca_certificate = ca_cert;
         self
     }
+
+    /// Cache key fragment for the [ConnectionPool](crate::ConnectionPool),
+    /// covering only the fields that affect the constructed transport client:
+    /// connect timeout, response decoding limit and CA certificate.
+    /// Per-request knobs (request timeout, retries, address banning) are
+    /// deliberately excluded so requests that differ only in those reuse the
+    /// same pooled connection.
+    pub fn connection_key(&self) -> String {
+        #[cfg(not(target_arch = "wasm32"))]
+        let ca_certificate = self.ca_certificate.as_ref().map(|cert| {
+            use std::hash::{DefaultHasher, Hash, Hasher};
+            let mut hasher = DefaultHasher::new();
+            cert.as_ref().hash(&mut hasher);
+            hasher.finish()
+        });
+        #[cfg(target_arch = "wasm32")]
+        let ca_certificate: Option<u64> = None;
+
+        format!(
+            "connect_timeout={:?},max_decoding_message_size={:?},ca_certificate={:?}",
+            self.connect_timeout, self.max_decoding_message_size, ca_certificate
+        )
+    }
 }
 
 #[cfg(test)]
@@ -198,5 +221,58 @@ mod tests {
         let cert = Certificate::from_pem("fake-pem-data");
         let result = applied.with_ca_certificate(Some(cert));
         assert!(result.ca_certificate.is_some());
+    }
+
+    #[test]
+    fn test_connection_key_ignores_per_request_settings() {
+        let custom = RequestSettings {
+            timeout: Some(Duration::from_secs(30)),
+            retries: Some(1),
+            ban_failed_address: Some(false),
+            ..RequestSettings::default()
+        }
+        .finalize();
+        let default = RequestSettings::default().finalize();
+
+        assert_eq!(
+            custom.connection_key(),
+            default.connection_key(),
+            "timeout/retries/banning must not split pooled connections"
+        );
+    }
+
+    #[test]
+    fn test_connection_key_differs_on_connection_settings() {
+        let default = RequestSettings::default().finalize();
+
+        let connect_timeout = RequestSettings {
+            connect_timeout: Some(Duration::from_secs(3)),
+            ..RequestSettings::default()
+        }
+        .finalize();
+        assert_ne!(default.connection_key(), connect_timeout.connection_key());
+
+        let decode_limit = RequestSettings {
+            max_decoding_message_size: Some(16 * 1024 * 1024),
+            ..RequestSettings::default()
+        }
+        .finalize();
+        assert_ne!(default.connection_key(), decode_limit.connection_key());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_connection_key_differs_on_ca_certificate() {
+        let default = RequestSettings::default().finalize();
+        let with_ca = RequestSettings::default()
+            .finalize()
+            .with_ca_certificate(Some(Certificate::from_pem("fake-pem-data")));
+
+        assert_ne!(default.connection_key(), with_ca.connection_key());
+
+        let with_other_ca = RequestSettings::default()
+            .finalize()
+            .with_ca_certificate(Some(Certificate::from_pem("other-pem-data")));
+        assert_ne!(with_ca.connection_key(), with_other_ca.connection_key());
     }
 }

--- a/packages/rs-dapi-client/src/request_settings.rs
+++ b/packages/rs-dapi-client/src/request_settings.rs
@@ -119,32 +119,24 @@ impl AppliedRequestSettings {
     pub(crate) fn connection_key(&self) -> String {
         // Exhaustive destructuring: adding a settings field breaks this
         // binding, forcing an explicit connection-affecting-or-not decision.
-        #[cfg(not(target_arch = "wasm32"))]
         let Self {
+            #[cfg(not(target_arch = "wasm32"))]
             connect_timeout,
+            #[cfg(target_arch = "wasm32")]
+                connect_timeout: _,
             timeout: _,
             retries: _,
             ban_failed_address: _,
             max_decoding_message_size,
+            #[cfg(not(target_arch = "wasm32"))]
             ca_certificate,
-        } = self;
-        #[cfg(target_arch = "wasm32")]
-        let Self {
-            connect_timeout,
-            timeout: _,
-            retries: _,
-            ban_failed_address: _,
-            max_decoding_message_size,
         } = self;
 
         // The wasm channel builder ignores `connect_timeout`, so it does not
         // split the key there. The decoding limit still participates because
         // `grpc.rs` applies it to the client after channel construction.
         #[cfg(target_arch = "wasm32")]
-        let connect_timeout = {
-            let _ = connect_timeout;
-            &None::<Duration>
-        };
+        let connect_timeout = None::<Duration>;
 
         // The full certificate bytes (hex), not a short hash: two trust
         // anchors must never share a pool key, or a request pinned to one CA

--- a/packages/rs-dapi-client/src/request_settings.rs
+++ b/packages/rs-dapi-client/src/request_settings.rs
@@ -137,9 +137,9 @@ impl AppliedRequestSettings {
             max_decoding_message_size,
         } = self;
 
-        // The wasm transport ignores all settings when building its client
-        // (see `wasm_channel::create_channel`), so nothing may split the key
-        // there.
+        // The wasm channel builder ignores `connect_timeout`, so it does not
+        // split the key there. The decoding limit still participates because
+        // `grpc.rs` applies it to the client after channel construction.
         #[cfg(target_arch = "wasm32")]
         let connect_timeout = {
             let _ = connect_timeout;

--- a/packages/rs-dapi-client/tests/unimplemented_failover.rs
+++ b/packages/rs-dapi-client/tests/unimplemented_failover.rs
@@ -72,6 +72,38 @@ async fn unimplemented_node_is_banned_and_request_retried_on_another() {
 }
 
 #[tokio::test]
+async fn should_retry_on_standby_without_banning_the_failed_node() {
+    let addresses: AddressList = "http://127.0.0.1:10001,http://127.0.0.1:10002"
+        .parse()
+        .unwrap();
+    let addresses = addresses.with_active_set_size(1);
+    let failed = addresses.get_live_address().unwrap();
+    let failed_uri = failed.uri().clone();
+    let request = ScriptedRequest::new(move |uri| {
+        if uri == failed_uri {
+            Err(TransportError::Grpc(Status::unimplemented("old node")))
+        } else {
+            Ok(FakeResponse)
+        }
+    });
+    let client = DapiClient::new(addresses, RequestSettings::default());
+    let response = client
+        .execute(
+            request,
+            RequestSettings {
+                ban_failed_address: Some(false),
+                retries: Some(1),
+                ..RequestSettings::default()
+            },
+        )
+        .await
+        .expect("one retry must reach the available standby");
+    assert_eq!(response.retries, 1);
+    assert_ne!(response.address, failed);
+    assert!(!client.address_list().is_banned(&failed));
+}
+
+#[tokio::test]
 async fn unimplemented_on_all_nodes_still_surfaces_error() {
     // No node implements the method: every attempt answers UNIMPLEMENTED.
     // `hit_uris` counts total attempts (all of which are errors here).


### PR DESCRIPTION
## Issue being fixed or feature implemented

Randomly choosing a DAPI node for every attempt spreads requests across cold hosts and repeatedly pays TCP/TLS setup costs. Per-request settings also split the native connection pool even when the underlying transport settings are identical.

## What was done?

- Rotate requests over a shared sticky active set (default 5), with random standby promotion after banning, removal, or eviction. `AddressList::with_active_set_size` configures all clones; `usize::MAX` opts into whole-list round-robin selection without oversized allocations or redundant refill scans once full.
- Expire slots after a jittered 5–7.5 minutes. During refill, prefer live standbys over just-expired or evicted members; recycle those members only after available standbys are exhausted. This preserves capacity and sole-node availability without changing ban state when banning is disabled.
- Key pooled clients by connection timeout, decoding limit, and full CA certificate bytes. Request timeout, retries, and banning do not split the pool. WASM excludes connection timeout but retains the client decoding limit.
- Cap exponential and advertised ban windows at 24 hours, including oversized configured base periods, to prevent timestamp-overflow panics while holding the address-list lock.

The latest review fixes are in `4233c69f2a`: standby preference, unconditional ban cap, whole-list vacancy calculation, and the WASM comment. Tests now check selection after eviction, standby replacement after expiry, fallback with insufficient standbys, oversized base periods, and executor retry with banning disabled.

Connection settings use one exhaustive native/WASM destructure. Rotation tests share an address-list fixture and use an existing retryable transport error, reducing duplication without changing routing or pooling behavior.

Scope for final review: configuration remains client-level through `AddressList` (usable with `SdkBuilder::with_address_list`). A dedicated WASM/JS settings surface is deferred; per-request settings would conflict over shared rotation. The address-based cursor preserves ordering through eviction, and ban state remains centralized in the address map. No `Arc<Address>` API refactor is included.

## How Has This Been Tested?

Locally on macOS at `02cefdfeb3`:

- `cargo test -p rs-dapi-client --locked --offline`: **144 passed**.
- `cargo test -p rs-dapi-client --all-features --locked --offline`: **151 passed**.
- `cargo clippy -p rs-dapi-client --all-features --all-targets --locked --offline -- --no-deps -D warnings`: passed.
- `cargo check -p dash-sdk --locked --offline`: passed; reports an existing unused import in untouched Drive code.
- `cargo check -p rs-dapi-client --target wasm32-unknown-unknown --locked --offline`: passed.
- `cargo fmt --all --check` and `git diff --check`: passed.

The strengthened tests reproduced five failures before the fixes. The executor regression uses a scripted transport, without network access. Code-review-validator and code-simplifier passes found no remaining blocking issue in the focused changes.

The [earlier native testnet benchmark](https://github.com/dashpay/platform/pull/4545#issuecomment-5479919626) reported about 1.5× faster sequential queries. It predates these review fixes; no new browser or network benchmark is claimed.

[GitHub Actions run 34168862720](https://github.com/dashpay/platform/actions/runs/34168862720) passed at `4233c69f2a`, including the JS build and the evo-sdk and wasm-sdk test jobs. Title and dependency checks also passed. That run predates the simplification commit `02cefdfeb3`; CI for the new head is pending.

Rust workspace CI is skipped for this fork by repository policy. The local checks above are the Rust validation evidence; a full workspace CI pass is not claimed.

## Breaking Changes

No API signatures removed or changed. Address selection now uses sticky rotation, and ban windows are capped at 24 hours even for larger configured base periods.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Address selection now uses sticky round-robin rotation across a configurable active set.
  * Added an option to configure the active address set size.

* **Performance**
  * Connections are reused more efficiently when requests differ only in per-request settings.

* **Bug Fixes**
  * Address rotation now removes unavailable or banned addresses and replaces them with live alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
