### PR TITLE
feat(platform-wallet): expose address funding fee estimate

### DIFF
--- a/packages/dashmate/test/unit/doctor/analyse/analyseGatewayCertificateFactory.spec.js
+++ b/packages/dashmate/test/unit/doctor/analyse/analyseGatewayCertificateFactory.spec.js
@@ -14,6 +14,16 @@ function validTo(days) {
   return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toUTCString();
 }
 
+/**
+ * @param {string} value
+ * @return {string}
+ */
+function stripAnsi(value) {
+  const escape = String.fromCharCode(27);
+
+  return value.replace(new RegExp(`${escape}\\[[0-9;]*m`, 'g'), '');
+}
+
 describe('analyseGatewayCertificateFactory', () => {
   let analyseGatewayCertificate;
   let config;
@@ -907,13 +917,16 @@ describe('analyseGatewayCertificateFactory', () => {
       renewalFailed();
 
       const [renewal] = analyse(served()).filter((p) => p.getDescription().includes('not being renewed'));
+      const description = stripAnsi(renewal.getDescription());
+      const solution = stripAnsi(renewal.getSolution());
+      const misleadingCounter = /\b37\b[^\n.]*\b(?:attempts?|failures?|failed|wake-ups?)\b/i;
 
-      expect(renewal.getSolution()).to.contain('Last renewed');
-      expect(renewal.getDescription()).to.not.contain('failing since');
-      expect(renewal.getSolution()).to.not.contain('failing since');
+      expect(solution).to.contain('Last renewed');
+      expect(description).to.not.contain('failing since');
+      expect(solution).to.not.contain('failing since');
       // The counter counts scheduler wake-ups, not attempts.
-      expect(renewal.getDescription()).to.not.contain('37');
-      expect(renewal.getSolution()).to.not.contain('37');
+      expect(description).to.not.match(misleadingCounter);
+      expect(solution).to.not.match(misleadingCounter);
     });
 
     it('should name the cause instead of sending an operator to the logs', () => {

--- a/packages/platform-test-suite/test/functional/platform/IndexOnlyDocument.spec.js
+++ b/packages/platform-test-suite/test/functional/platform/IndexOnlyDocument.spec.js
@@ -6,6 +6,18 @@ const generateRandomIdentifier = require('../../../lib/test/utils/generateRandom
 const waitForSTPropagated = require('../../../lib/waitForSTPropagated');
 const createPlatformProofVerifier = require('../../../lib/test/createPlatformProofVerifier');
 
+function identifierLikeToBase58(evo, value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value && typeof value.toBase58 === 'function') {
+    return value.toBase58();
+  }
+
+  return evo.Identifier.fromBytes(Array.from(value)).toBase58();
+}
+
 const {
   Errors: {
     StateTransitionBroadcastError,
@@ -306,7 +318,7 @@ describe('Platform', () => {
       // quorum-signed root, re-deriving the outer query and checking
       // it against the proven inner values — the node cannot steer
       // the join.
-      const { sdk: evoSdk } = await createPlatformProofVerifier
+      const { evo, sdk: evoSdk } = await createPlatformProofVerifier
         .getEvoSdkForNetwork(process.env.NETWORK);
 
       const page = await evoSdk.documents.chained({
@@ -327,8 +339,8 @@ describe('Platform', () => {
 
       // The inner projection carries the pagination cursor.
       const [innerLike] = page.innerDocuments;
-      // Identifier-typed properties surface as base58 strings in JS.
-      expect(innerLike.properties.postId).to.equal(post.getId().toString());
+      expect(identifierLikeToBase58(evo, innerLike.properties.postId))
+        .to.equal(post.getId().toString());
     });
 
     it('should fail to query a subset-index projection without proofs', async () => {

--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/mod.rs
@@ -11,6 +11,8 @@ mod state_transition_validation;
 pub mod v0;
 mod version;
 
+pub use state_transition_estimated_fee_validation::calculate_address_funding_from_asset_lock_min_required_fee;
+
 #[cfg(feature = "json-conversion")]
 use crate::serialization::JsonConvertible;
 #[cfg(feature = "value-conversion")]

--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/state_transition_estimated_fee_validation.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/state_transition_estimated_fee_validation.rs
@@ -8,30 +8,130 @@ use crate::state_transition::{
 use crate::ProtocolError;
 use platform_version::version::PlatformVersion;
 
+/// Calculate the static minimum required fee for address funding from an asset lock.
+///
+/// This is the count-based DPP admission-floor formula used by
+/// `AddressFundingFromAssetLockTransition::calculate_min_required_fee`, exposed for
+/// callers that need to reserve funds before constructing the transition.
+pub fn calculate_address_funding_from_asset_lock_min_required_fee(
+    input_count: usize,
+    output_count: usize,
+    platform_version: &PlatformVersion,
+) -> Credits {
+    let min_fees = &platform_version.fee_version.state_transition_min_fees;
+    let asset_lock_base_cost = platform_version
+        .dpp
+        .state_transitions
+        .identities
+        .asset_locks
+        .required_asset_lock_duff_balance_for_processing_start_for_address_funding
+        * CREDITS_PER_DUFF;
+    let output_count = output_count.max(1);
+
+    asset_lock_base_cost.saturating_add(
+        min_fees
+            .address_funds_transfer_input_cost
+            .saturating_mul(input_count as u64)
+            .saturating_add(
+                min_fees
+                    .address_funds_transfer_output_cost
+                    .saturating_mul(output_count as u64),
+            ),
+    )
+}
+
 impl StateTransitionEstimatedFeeValidation for AddressFundingFromAssetLockTransition {
     fn calculate_min_required_fee(
         &self,
         platform_version: &PlatformVersion,
     ) -> Result<Credits, ProtocolError> {
-        let min_fees = &platform_version.fee_version.state_transition_min_fees;
-        let asset_lock_base_cost = platform_version
-            .dpp
-            .state_transitions
-            .identities
-            .asset_locks
-            .required_asset_lock_duff_balance_for_processing_start_for_address_funding
-            * CREDITS_PER_DUFF;
-        let input_count = self.inputs().len();
-        let output_count = self.outputs().len().max(1);
-        Ok(asset_lock_base_cost.saturating_add(
-            min_fees
-                .address_funds_transfer_input_cost
-                .saturating_mul(input_count as u64)
-                .saturating_add(
-                    min_fees
-                        .address_funds_transfer_output_cost
-                        .saturating_mul(output_count as u64),
-                ),
+        Ok(calculate_address_funding_from_asset_lock_min_required_fee(
+            self.inputs().len(),
+            self.outputs().len(),
+            platform_version,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::address_funds::PlatformAddress;
+    use crate::version::LATEST_PLATFORM_VERSION;
+    use std::collections::BTreeMap;
+
+    fn platform_address(seed: usize) -> PlatformAddress {
+        let mut hash = [0u8; 20];
+        hash[12..20].copy_from_slice(&(seed as u64).to_be_bytes());
+        PlatformAddress::P2pkh(hash)
+    }
+
+    fn transition_with_counts(
+        input_count: usize,
+        output_count: usize,
+    ) -> AddressFundingFromAssetLockTransition {
+        let mut transition =
+            AddressFundingFromAssetLockTransition::default_versioned(LATEST_PLATFORM_VERSION)
+                .expect("latest address funding transition");
+
+        let inputs = (0..input_count)
+            .map(|index| (platform_address(index), (index as u32, 1_000_000)))
+            .collect::<BTreeMap<_, _>>();
+        let outputs = (0..output_count)
+            .map(|index| {
+                let amount = if index + 1 == output_count {
+                    None
+                } else {
+                    Some(1_000_000)
+                };
+                (platform_address(1_000 + index), amount)
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        transition.set_inputs(inputs);
+        transition.set_outputs(outputs);
+        transition
+    }
+
+    #[test]
+    fn count_based_helper_matches_current_static_address_funding_fee() {
+        let cases = [
+            (0, 0, 56_000_000),
+            (0, 1, 56_000_000),
+            (0, 2, 62_000_000),
+            (1, 1, 56_500_000),
+            (1, 2, 62_500_000),
+            (3, 5, 81_500_000),
+            (10, 100, 655_000_000),
+        ];
+
+        for (input_count, output_count, expected_fee) in cases {
+            let fee = calculate_address_funding_from_asset_lock_min_required_fee(
+                input_count,
+                output_count,
+                LATEST_PLATFORM_VERSION,
+            );
+
+            assert_eq!(fee, expected_fee);
+        }
+    }
+
+    #[test]
+    fn count_based_helper_matches_transition_min_required_fee() {
+        let cases = [(0, 0), (0, 1), (0, 2), (1, 2), (3, 5), (10, 100)];
+
+        for (input_count, output_count) in cases {
+            let transition = transition_with_counts(input_count, output_count);
+            let helper_fee = calculate_address_funding_from_asset_lock_min_required_fee(
+                input_count,
+                output_count,
+                LATEST_PLATFORM_VERSION,
+            );
+            let transition_fee = transition
+                .calculate_min_required_fee(LATEST_PLATFORM_VERSION)
+                .expect("transition fee");
+
+            assert_eq!(helper_fee, transition_fee);
+        }
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/funding_fee.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/funding_fee.rs
@@ -1,0 +1,154 @@
+//! FFI helpers for address-funding fee estimates.
+
+use dpp::state_transition::address_funding_from_asset_lock_transition::calculate_address_funding_from_asset_lock_min_required_fee;
+
+use crate::check_ptr;
+use crate::error::*;
+use crate::handle::{Handle, PLATFORM_WALLET_MANAGER_STORAGE};
+
+/// Estimate the static minimum fee reserve (in credits) for an
+/// `AddressFundingFromAssetLockTransition`.
+///
+/// This is the same consensus admission-floor formula used by
+/// `AddressFundingFromAssetLockTransition::calculate_min_required_fee`, but
+/// parameterized by counts so hosts can reserve Core lock value before the
+/// transition exists. It is intentionally not a state-aware real-fee quote and
+/// performs no network request.
+///
+/// # Safety
+/// `out_fee` must point to 8 writable bytes (a `u64`).
+#[no_mangle]
+pub unsafe extern "C" fn platform_wallet_address_funding_estimate_fee(
+    handle: Handle,
+    input_count: usize,
+    output_count: usize,
+    out_fee: *mut u64,
+) -> PlatformWalletFFIResult {
+    check_ptr!(out_fee);
+
+    let Some(platform_version) =
+        PLATFORM_WALLET_MANAGER_STORAGE.with_item(handle, |manager| manager.sdk().version())
+    else {
+        return PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorInvalidHandle,
+            format!("invalid manager handle: {handle}"),
+        );
+    };
+
+    *out_fee = calculate_address_funding_from_asset_lock_min_required_fee(
+        input_count,
+        output_count,
+        platform_version,
+    );
+    PlatformWalletFFIResult::ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    unsafe extern "C" fn begin_changeset(
+        _context: *mut std::os::raw::c_void,
+        _wallet_id: *const u8,
+    ) -> i32 {
+        0
+    }
+
+    unsafe extern "C" fn end_changeset(
+        _context: *mut std::os::raw::c_void,
+        _wallet_id: *const u8,
+        _success: bool,
+    ) -> i32 {
+        0
+    }
+
+    fn create_mock_manager(protocol_version: u32) -> Handle {
+        let version =
+            dpp::version::PlatformVersion::get(protocol_version).expect("protocol version");
+        let sdk = dash_sdk::SdkBuilder::new_mock()
+            .with_version(version)
+            .build()
+            .expect("mock sdk");
+        let persistence = crate::persistence::PersistenceCallbacks {
+            on_changeset_begin_fn: Some(begin_changeset),
+            on_changeset_end_fn: Some(end_changeset),
+            ..Default::default()
+        };
+        let events = crate::event_handler::EventHandlerCallbacks {
+            context: std::ptr::null_mut(),
+            on_wallet_event_fn: None,
+            on_error_fn: None,
+            on_platform_address_sync_completed_fn: None,
+            on_shielded_sync_completed_fn: None,
+            on_shielded_sync_progress_fn: None,
+            on_shielded_tree_progress_fn: None,
+            release_fn: None,
+        };
+        let mut handle: Handle = 0;
+        let result = unsafe {
+            crate::manager::platform_wallet_manager_create(
+                &sdk as *const dash_sdk::Sdk as *const std::os::raw::c_void,
+                &persistence,
+                &events,
+                &mut handle,
+            )
+        };
+
+        assert_eq!(result.code, PlatformWalletFFIResultCode::Success);
+        handle
+    }
+
+    #[test]
+    fn estimate_fee_uses_address_funding_min_required_fee() {
+        unsafe {
+            let handle =
+                create_mock_manager(dpp::version::LATEST_PLATFORM_VERSION.protocol_version);
+            let mut fee: u64 = 0;
+
+            let result = platform_wallet_address_funding_estimate_fee(handle, 0, 2, &mut fee);
+
+            assert_eq!(result.code, PlatformWalletFFIResultCode::Success);
+            assert_eq!(fee, 62_000_000);
+
+            let destroy = crate::manager::platform_wallet_manager_destroy(handle);
+            assert_eq!(destroy.code, PlatformWalletFFIResultCode::Success);
+        }
+    }
+
+    #[test]
+    fn estimate_fee_preserves_one_output_minimum_for_zero_outputs() {
+        unsafe {
+            let handle =
+                create_mock_manager(dpp::version::LATEST_PLATFORM_VERSION.protocol_version);
+            let mut fee: u64 = 0;
+
+            let result = platform_wallet_address_funding_estimate_fee(handle, 0, 0, &mut fee);
+
+            assert_eq!(result.code, PlatformWalletFFIResultCode::Success);
+            assert_eq!(fee, 56_000_000);
+
+            let destroy = crate::manager::platform_wallet_manager_destroy(handle);
+            assert_eq!(destroy.code, PlatformWalletFFIResultCode::Success);
+        }
+    }
+
+    #[test]
+    fn estimate_fee_rejects_unknown_manager_handle() {
+        unsafe {
+            let mut fee: u64 = 0;
+            let result = platform_wallet_address_funding_estimate_fee(0, 0, 2, &mut fee);
+
+            assert_eq!(result.code, PlatformWalletFFIResultCode::ErrorInvalidHandle);
+        }
+    }
+
+    #[test]
+    fn estimate_fee_rejects_null_out_pointer() {
+        unsafe {
+            let result =
+                platform_wallet_address_funding_estimate_fee(0, 0, 2, std::ptr::null_mut());
+
+            assert_eq!(result.code, PlatformWalletFFIResultCode::ErrorNullPointer);
+        }
+    }
+}

--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/mod.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/mod.rs
@@ -3,6 +3,7 @@
 //! Mirrors the structure of `platform_wallet::wallet::platform_addresses`.
 
 mod fund_from_asset_lock;
+mod funding_fee;
 mod sync;
 mod transfer;
 mod wallet;
@@ -10,6 +11,7 @@ mod withdrawal;
 
 // Re-export all FFI types and functions.
 pub use fund_from_asset_lock::*;
+pub use funding_fee::*;
 pub use sync::*;
 pub use transfer::*;
 pub use wallet::*;

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
@@ -36,11 +36,16 @@ use dash_sdk::platform::transition::top_up_address::TopUpAddress;
 use dash_sdk::query_types::AddressInfos;
 use dpp::address_funds::fee_strategy::AddressFundsFeeStrategyStep;
 use dpp::address_funds::{AddressFundsFeeStrategy, PlatformAddress};
+use dpp::balances::credits::CREDITS_PER_DUFF;
 use dpp::fee::Credits;
 use dpp::identity::signer::Signer;
+use dpp::state_transition::address_funding_from_asset_lock_transition::calculate_address_funding_from_asset_lock_min_required_fee;
+use dpp::version::PlatformVersion;
 use key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockFundingType;
 use key_wallet::PlatformP2PKHAddress;
 use std::collections::BTreeMap;
+
+const ADDRESS_FUNDING_FROM_ASSET_LOCK_INPUT_COUNT: usize = 0;
 
 impl PlatformAddressWallet {
     /// Fund platform addresses from a Core L1 asset lock, with the
@@ -290,6 +295,16 @@ impl PlatformAddressWallet {
         // `remainder_fee_strategy` for why a positional index cannot be
         // computed correctly outside this layer.
         let fee_strategy = remainder_fee_strategy(&addresses)?;
+
+        // Step 1c: a fresh L1 asset lock is single-use and
+        // non-refundable. Reject or floor it before build/broadcast if
+        // it cannot satisfy DPP's static admission fee for this
+        // address-funding transition shape.
+        let funding = enforce_asset_lock_amount_covers_address_funding_floor(
+            funding,
+            addresses.len(),
+            self.sdk.version(),
+        )?;
 
         // Step 2: resolve funding. `AssetLockAddressTopUp` selects the
         // BIP44 funding family for the Core asset-lock tx. The
@@ -620,6 +635,59 @@ fn remainder_fee_strategy(
     Ok(vec![AddressFundsFeeStrategyStep::ReduceOutput(index)])
 }
 
+fn enforce_asset_lock_amount_covers_address_funding_floor(
+    funding: AssetLockFunding,
+    output_count: usize,
+    platform_version: &PlatformVersion,
+) -> Result<AssetLockFunding, PlatformWalletError> {
+    let required = minimum_address_funding_asset_lock_duffs(output_count, platform_version);
+
+    match funding {
+        AssetLockFunding::FromWalletBalance {
+            amount_duffs,
+            account_index,
+        } => {
+            if amount_duffs < required {
+                return Err(PlatformWalletError::AssetLockInsufficientFunds {
+                    available: amount_duffs,
+                    required,
+                });
+            }
+            Ok(AssetLockFunding::FromWalletBalance {
+                amount_duffs,
+                account_index,
+            })
+        }
+        AssetLockFunding::DrainAccountBalance {
+            account,
+            minimum_lock_duffs,
+        } => Ok(AssetLockFunding::DrainAccountBalance {
+            account,
+            minimum_lock_duffs: Some(
+                minimum_lock_duffs.map_or(required, |floor| floor.max(required)),
+            ),
+        }),
+        funding @ AssetLockFunding::FromExistingAssetLock { .. } => Ok(funding),
+    }
+}
+
+/// Minimum L1 asset-lock value that can pass DPP's count-based
+/// `AddressFundingFromAssetLock` admission-floor fee check.
+fn minimum_address_funding_asset_lock_duffs(
+    output_count: usize,
+    platform_version: &PlatformVersion,
+) -> u64 {
+    ceil_credits_to_duffs(calculate_address_funding_from_asset_lock_min_required_fee(
+        ADDRESS_FUNDING_FROM_ASSET_LOCK_INPUT_COUNT,
+        output_count,
+        platform_version,
+    ))
+}
+
+fn ceil_credits_to_duffs(credits: Credits) -> u64 {
+    credits / CREDITS_PER_DUFF + u64::from(credits % CREDITS_PER_DUFF != 0)
+}
+
 /// Pre-flight check for the recipient address map:
 /// - Non-empty
 /// - Exactly one `None`-amount entry (the remainder recipient)
@@ -804,6 +872,75 @@ fn validate_address_infos_complete(
 mod tests {
     use super::*;
     use dash_sdk::query_types::AddressInfo;
+    use dpp::version::LATEST_PLATFORM_VERSION;
+
+    #[derive(Debug)]
+    struct NullAddressSigner;
+
+    #[async_trait::async_trait]
+    impl Signer<PlatformAddress> for NullAddressSigner {
+        async fn sign(
+            &self,
+            _key: &PlatformAddress,
+            _data: &[u8],
+        ) -> Result<dpp::platform_value::BinaryData, dpp::ProtocolError> {
+            unreachable!("underfunded fresh asset lock must fail before address signing")
+        }
+
+        async fn sign_create_witness(
+            &self,
+            _key: &PlatformAddress,
+            _data: &[u8],
+        ) -> Result<dpp::address_funds::AddressWitness, dpp::ProtocolError> {
+            unreachable!("underfunded fresh asset lock must fail before address signing")
+        }
+
+        fn can_sign_with(&self, _key: &PlatformAddress) -> bool {
+            false
+        }
+    }
+
+    struct NullAssetLockSigner;
+
+    #[async_trait::async_trait]
+    impl key_wallet::signer::Signer for NullAssetLockSigner {
+        type Error = String;
+
+        fn supported_methods(&self) -> &[key_wallet::signer::SignerMethod] {
+            &[]
+        }
+
+        async fn sign_ecdsa(
+            &self,
+            _path: &key_wallet::DerivationPath,
+            _sighash: [u8; 32],
+        ) -> Result<
+            (
+                dashcore::secp256k1::ecdsa::Signature,
+                dashcore::secp256k1::PublicKey,
+            ),
+            Self::Error,
+        > {
+            unreachable!("underfunded fresh asset lock must fail before asset-lock signing")
+        }
+
+        async fn public_key(
+            &self,
+            _path: &key_wallet::DerivationPath,
+        ) -> Result<dashcore::secp256k1::PublicKey, Self::Error> {
+            unreachable!("underfunded fresh asset lock must fail before asset-lock signing")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl key_wallet::signer::ExtendedPubKeySigner for NullAssetLockSigner {
+        async fn extended_public_key(
+            &self,
+            _path: &key_wallet::DerivationPath,
+        ) -> Result<key_wallet::bip32::ExtendedPubKey, Self::Error> {
+            unreachable!("underfunded fresh asset lock must fail before xpub export")
+        }
+    }
 
     fn p2pkh(b: u8) -> PlatformAddress {
         PlatformAddress::P2pkh([b; 20])
@@ -1112,6 +1249,197 @@ mod tests {
             format!("{err}").contains("exactly one remainder"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn address_funding_floor_rounds_credits_up_to_duffs() {
+        assert_eq!(ceil_credits_to_duffs(0), 0);
+        assert_eq!(ceil_credits_to_duffs(CREDITS_PER_DUFF), 1);
+        assert_eq!(ceil_credits_to_duffs(CREDITS_PER_DUFF + 1), 2);
+    }
+
+    #[test]
+    fn address_funding_floor_uses_current_dpp_min_fee_for_output_count() {
+        assert_eq!(
+            minimum_address_funding_asset_lock_duffs(1, LATEST_PLATFORM_VERSION),
+            56_000
+        );
+        assert_eq!(
+            minimum_address_funding_asset_lock_duffs(2, LATEST_PLATFORM_VERSION),
+            62_000
+        );
+    }
+
+    #[test]
+    fn fresh_asset_lock_floor_rejects_undersized_exact_amount() {
+        let required = minimum_address_funding_asset_lock_duffs(2, LATEST_PLATFORM_VERSION);
+        let funding = AssetLockFunding::FromWalletBalance {
+            amount_duffs: required - 1,
+            account_index: 0,
+        };
+
+        let err = enforce_asset_lock_amount_covers_address_funding_floor(
+            funding,
+            2,
+            LATEST_PLATFORM_VERSION,
+        )
+        .expect_err("fresh asset lock below the admission floor must be rejected");
+
+        match err {
+            PlatformWalletError::AssetLockInsufficientFunds {
+                available,
+                required: actual_required,
+            } => {
+                assert_eq!(available, required - 1);
+                assert_eq!(actual_required, required);
+            }
+            other => panic!("expected AssetLockInsufficientFunds, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fresh_asset_lock_floor_accepts_exact_minimum() {
+        let required = minimum_address_funding_asset_lock_duffs(2, LATEST_PLATFORM_VERSION);
+        let funding = AssetLockFunding::FromWalletBalance {
+            amount_duffs: required,
+            account_index: 0,
+        };
+
+        let funding = enforce_asset_lock_amount_covers_address_funding_floor(
+            funding,
+            2,
+            LATEST_PLATFORM_VERSION,
+        )
+        .expect("DPP rejects only amounts below the admission floor");
+
+        assert!(matches!(
+            funding,
+            AssetLockFunding::FromWalletBalance {
+                amount_duffs,
+                account_index: 0
+            } if amount_duffs == required
+        ));
+    }
+
+    #[test]
+    fn address_funding_floor_is_installed_for_fresh_drain_builds() {
+        use key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockFundingAccount;
+
+        let required = minimum_address_funding_asset_lock_duffs(2, LATEST_PLATFORM_VERSION);
+        let funding = AssetLockFunding::DrainAccountBalance {
+            account: AssetLockFundingAccount::Bip44 { account_index: 0 },
+            minimum_lock_duffs: None,
+        };
+
+        let funding = enforce_asset_lock_amount_covers_address_funding_floor(
+            funding,
+            2,
+            LATEST_PLATFORM_VERSION,
+        )
+        .expect("drain builds should be floored before broadcast");
+
+        match funding {
+            AssetLockFunding::DrainAccountBalance {
+                minimum_lock_duffs, ..
+            } => assert_eq!(minimum_lock_duffs, Some(required)),
+            other => panic!("expected DrainAccountBalance, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn address_funding_floor_preserves_higher_fresh_drain_floor() {
+        use key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockFundingAccount;
+
+        let required = minimum_address_funding_asset_lock_duffs(2, LATEST_PLATFORM_VERSION);
+        let higher_floor = required + 1;
+        let funding = AssetLockFunding::DrainAccountBalance {
+            account: AssetLockFundingAccount::Bip44 { account_index: 0 },
+            minimum_lock_duffs: Some(higher_floor),
+        };
+
+        let funding = enforce_asset_lock_amount_covers_address_funding_floor(
+            funding,
+            2,
+            LATEST_PLATFORM_VERSION,
+        )
+        .expect("caller-supplied drain floors should survive when stricter");
+
+        match funding {
+            AssetLockFunding::DrainAccountBalance {
+                minimum_lock_duffs, ..
+            } => assert_eq!(minimum_lock_duffs, Some(higher_floor)),
+            other => panic!("expected DrainAccountBalance, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn address_funding_floor_does_not_block_existing_asset_lock_resume() {
+        let funding = AssetLockFunding::FromExistingAssetLock {
+            out_point: dashcore::OutPoint::null(),
+            consume_invitation_voucher: false,
+        };
+
+        let funding = enforce_asset_lock_amount_covers_address_funding_floor(
+            funding,
+            2,
+            LATEST_PLATFORM_VERSION,
+        )
+        .expect("existing locks are resumed rather than pre-sized");
+
+        assert!(matches!(
+            funding,
+            AssetLockFunding::FromExistingAssetLock {
+                out_point,
+                consume_invitation_voucher: false
+            } if out_point == dashcore::OutPoint::null()
+        ));
+    }
+
+    #[tokio::test]
+    async fn fund_from_asset_lock_rejects_underfloor_fresh_lock_before_broadcast() {
+        let (manager, wallet_id) = crate::test_support::test_platform_wallet_manager().await;
+        let wallet = manager.get_wallet(&wallet_id).await.expect("wallet handle");
+        let address = wallet
+            .platform()
+            .next_unused_receive_address(
+                key_wallet::account::account_collection::PlatformPaymentAccountKey {
+                    account: 0,
+                    key_class: 0,
+                },
+            )
+            .await
+            .expect("owned platform payment address");
+        let required = minimum_address_funding_asset_lock_duffs(1, LATEST_PLATFORM_VERSION);
+        let mut addresses = BTreeMap::new();
+        addresses.insert(address, None);
+
+        let err = wallet
+            .platform()
+            .fund_from_asset_lock(
+                AssetLockFunding::FromWalletBalance {
+                    amount_duffs: required - 1,
+                    account_index: 0,
+                },
+                0,
+                addresses,
+                vec![],
+                &NullAddressSigner,
+                &NullAssetLockSigner,
+                None,
+            )
+            .await
+            .expect_err("underfloor fresh asset lock must fail before broadcast");
+
+        match err {
+            PlatformWalletError::AssetLockInsufficientFunds {
+                available,
+                required: actual_required,
+            } => {
+                assert_eq!(available, required - 1);
+                assert_eq!(actual_required, required);
+            }
+            other => panic!("expected AssetLockInsufficientFunds, got {other:?}"),
+        }
     }
 
     #[test]

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
@@ -685,7 +685,7 @@ fn minimum_address_funding_asset_lock_duffs(
 }
 
 fn ceil_credits_to_duffs(credits: Credits) -> u64 {
-    credits / CREDITS_PER_DUFF + u64::from(credits % CREDITS_PER_DUFF != 0)
+    credits / CREDITS_PER_DUFF + u64::from(!credits.is_multiple_of(CREDITS_PER_DUFF))
 }
 
 /// Pre-flight check for the recipient address map:

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerAddressFunding.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerAddressFunding.swift
@@ -1,0 +1,39 @@
+import Foundation
+import DashSDKFFI
+
+extension PlatformWalletManager {
+    /// Static minimum fee reserve (in credits) for an
+    /// `AddressFundingFromAssetLockTransition`, computed at this manager's
+    /// network-tracked platform version. This is the consensus admission-floor
+    /// estimate, not a state-aware real-fee quote, and performs no network
+    /// request.
+    public func estimateAddressFundingFee(
+        inputCount: Int,
+        outputCount: Int
+    ) throws -> UInt64 {
+        guard isConfigured, handle != NULL_HANDLE else {
+            throw PlatformWalletError.invalidHandle(
+                "PlatformWalletManager not configured"
+            )
+        }
+        guard inputCount >= 0 else {
+            throw PlatformWalletError.invalidParameter(
+                "inputCount must be non-negative, got \(inputCount)"
+            )
+        }
+        guard outputCount >= 0 else {
+            throw PlatformWalletError.invalidParameter(
+                "outputCount must be non-negative, got \(outputCount)"
+            )
+        }
+
+        var fee: UInt64 = 0
+        try platform_wallet_address_funding_estimate_fee(
+            handle,
+            UInt(inputCount),
+            UInt(outputCount),
+            &fee
+        ).check()
+        return fee
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Adds a small static address-funding fee estimate surface so clients can reserve the DPP minimum-required fee without using the abandoned DAPI quote engine.

This targets `v4.2-dev` directly because #4501 has been merged. It intentionally does not estimate state-aware metered GroveDB cost or query live network state. It mirrors `AddressFundingFromAssetLockTransition::calculate_min_required_fee` from DPP and exposes that count-based formula through FFI and Swift.

## What was done?

- Added `calculate_address_funding_from_asset_lock_min_required_fee(input_count, output_count, platform_version)` in DPP and kept the existing transition trait implementation delegated to it.
- Added rustdoc on the public DPP helper.
- Added table-driven DPP test vectors for 0/1/2 outputs, mixed input/output counts, and a larger 10-input/100-output case.
- Added a DPP test proving the count-based helper matches `AddressFundingFromAssetLockTransition::calculate_min_required_fee` for real transition values.
- Added `platform_wallet_address_funding_estimate_fee` in `rs-platform-wallet-ffi`.
- Added Swift SDK wrapper `PlatformWalletManager.estimateAddressFundingFee(inputCount:outputCount:)`.
- Pinned the current 0-input / 2-output reserve used by Core -> Platform topups at `62_000_000` credits.

## How has this been tested?

- `cargo test -p dpp count_based_helper_matches`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p platform-wallet-ffi platform_addresses::funding_fee`
- `./build_ios.sh --target sim`
- `git diff --check`

## Notes

This replaces the closed fee-quote PR stack (#4444, #4445, #4446, #4447). The iOS app can use this static reserve together with the sender-owned remainder semantics merged in #4501: explicit recipient amount stays exact, the real Platform fee is deducted from the sender remainder output, and any unused reserve remains in the sender Platform balance.

Live-network testing belongs to the app/topup flow, not this DPP helper: this helper is deliberately a protocol-versioned minimum reserve formula, not an assertion that live GroveDB metered cost equals this value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local address-funding fee estimation to the platform wallet.
  * Swift SDK users can estimate required fees using input and output counts without a network request.
  * Exposed fee estimation through platform wallet bindings.

* **Bug Fixes**
  * Enforced minimum funding fees before asset-lock funding is signed or broadcast.
  * Improved handling of insufficient balances and drain transactions.

* **Tests**
  * Added coverage for fee calculations, validation, and funding thresholds.
  * Improved certificate renewal diagnostics and document identifier comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->