### PR TITLE
perf(drive-abci): don't read every withdrawal document to build a debug log line

### DIFF
--- a/packages/rs-drive-abci/src/execution/platform_events/withdrawals/pool_withdrawals_into_transactions_queue/v1/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/withdrawals/pool_withdrawals_into_transactions_queue/v1/mod.rs
@@ -49,6 +49,16 @@ where
                     .withdrawal_transactions_per_block_limit,
                 "No queued withdrawal documents found to pool into transactions"
             );
+            // Reading every withdrawal document the chain ever produced, only to
+            // count them for a log line. Withdrawal documents are never removed,
+            // so this grows without bound with chain history — measured at 4.8 ms
+            // a block by height 200,000 on mainnet, and it ran on every block
+            // that had nothing queued, which is nearly all of them. Do it only
+            // when the line it feeds will actually be emitted.
+            if !tracing::enabled!(tracing::Level::DEBUG) {
+                return Ok(());
+            }
+
             let all_documents = self
                 .drive
                 .fetch_oldest_withdrawal_documents(transaction, platform_version)?;
@@ -57,7 +67,7 @@ where
                     height = block_info.height,
                     "No withdrawal documents found at all"
                 );
-            } else if tracing::enabled!(tracing::Level::DEBUG) {
+            } else {
                 // Count documents by status
                 let queued_count = all_documents
                     .get(&(withdrawals_contract::WithdrawalStatus::QUEUED as u8))


### PR DESCRIPTION
## Issue being fixed or feature implemented

`pool_withdrawals_into_transactions_queue_v1` reads every withdrawal document the chain has ever produced, on nearly every block, and throws the result away.

When nothing is queued — which is almost always — it calls `fetch_oldest_withdrawal_documents`, which passes `limit: None`. That deserializes every withdrawal document, groups them by status and sorts each group. The result feeds one `tracing::debug!` line and is otherwise discarded.

Withdrawal documents are never removed, so the cost grows with chain history. Replaying mainnet with per-block phase timing:

| height window | cost of this call |
|---|---|
| 0–25k | 0 µs |
| 50k | 43 µs |
| 100k | 375 µs |
| 150k | 3,741 µs |
| 175–200k | **4,791 µs** |

Against roughly 7,000 µs for everything else in a block put together, and still climbing at 200k. Every other per-block phase is flat with depth; this one is the entire slope.

## What was done?

Return before the diagnostic query when a `DEBUG` line would not be emitted. The counting block below it was already guarded by `tracing::enabled!`; the expensive fetch that feeds it was not.

## How Has This Been Tested?

Replaying mainnet history from a local peer, genesis to 424,981, comparing against `v4.2-dev`. Every committed app hash matched between the two runs across all 424,971 heights, and the final app hash matched an independent reference sync.

`cargo test -p drive-abci --lib withdrawal` — 176 passed.

## Breaking Changes

None. The skipped work only ever fed a log line that is off by default.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**

- [x] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved withdrawal queue processing when no pending withdrawals are available.
  * Avoided unnecessary processing in empty-queue scenarios, improving efficiency without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->