### PR TITLE
perf(drive-abci): don't create GroveDB checkpoints while replaying history

### DIFF
--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/should_checkpoint/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/should_checkpoint/v0/mod.rs
@@ -53,6 +53,16 @@ where
         let block_time = block_info.block_time_ms();
         let block_height = block_info.height();
 
+        // Checkpoints are restore points for a running node. Replaying history,
+        // ten minutes of chain time is a handful of blocks, so this fires dozens
+        // of times a second and all but the last `keep_n` are deleted again
+        // immediately — each one a RocksDB checkpoint over the whole database
+        // plus a copy of the platform state. The node writes its first real
+        // checkpoint once it reaches the tip.
+        if crate::utils::is_historical_block(block_time) {
+            return Ok(None);
+        }
+
         let most_recent_checkpoint_interval_time =
             block_time - block_time % checkpoint_interval_milliseconds;
 
@@ -94,6 +104,13 @@ mod tests {
     use crate::test::helpers::setup::TestPlatformBuilder;
     use dpp::version::PlatformVersion;
     use std::collections::BTreeMap;
+
+    fn now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock is before the unix epoch")
+            .as_millis() as u64
+    }
 
     fn make_block_execution_context(height: u64, block_time_ms: u64) -> BlockExecutionContext {
         let platform_version = PlatformVersion::latest();
@@ -158,13 +175,48 @@ mod tests {
             return;
         }
 
-        let block_execution_context = make_block_execution_context(1, 1_000_000);
+        // A block the network has just produced: checkpoints are restore points
+        // for a running node, so the age of the block decides whether one is worth
+        // taking, and a fixed fixture timestamp would read as ancient history.
+        let block_execution_context = make_block_execution_context(1, now_ms());
         let result = platform
             .should_checkpoint_v0(&block_execution_context, platform_version)
             .expect("expected Ok");
 
         // When there are no checkpoints, it should return Some (checkpoint needed)
         assert!(result.is_some(), "first block should trigger checkpoint");
+    }
+
+    /// Replaying history, ten minutes of chain time is a handful of blocks, so a
+    /// checkpoint would be taken dozens of times a second and all but the last
+    /// few deleted again immediately. A node catching up takes none.
+    #[test]
+    fn test_historical_block_does_not_checkpoint() {
+        let platform_version = PlatformVersion::latest();
+        if platform_version
+            .drive_abci
+            .methods
+            .block_end
+            .should_checkpoint
+            .is_none()
+        {
+            return;
+        }
+
+        let platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let block_execution_context =
+            make_block_execution_context(1, now_ms() - 24 * 60 * 60 * 1000);
+        let result = platform
+            .should_checkpoint_v0(&block_execution_context, platform_version)
+            .expect("expected Ok");
+
+        assert!(
+            result.is_none(),
+            "a day-old block is being replayed, not followed"
+        );
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/utils/mod.rs
+++ b/packages/rs-drive-abci/src/utils/mod.rs
@@ -1,6 +1,8 @@
+mod replay;
 mod serialization;
 mod spawn;
 
+pub use replay::is_historical_block;
 pub use serialization::from_opt_str_or_number;
 pub use serialization::from_str_or_number;
 pub use spawn::spawn_blocking_task_with_name_if_supported;

--- a/packages/rs-drive-abci/src/utils/replay.rs
+++ b/packages/rs-drive-abci/src/utils/replay.rs
@@ -1,0 +1,55 @@
+//! Telling a node that is replaying history from one that is following the tip.
+//!
+//! Some per-block work only earns its cost at the tip. Creating a GroveDB
+//! checkpoint every ten minutes of chain time is useful on a running node and
+//! pure waste while catching up, where ten minutes of chain time is a handful of
+//! blocks and every checkpoint but the last few is deleted within the second.
+
+/// A block older than this is not one the network just produced. Mainnet aims at
+/// about 2.5 minutes a block, so this leaves several blocks of slack for a node
+/// that is merely a little behind.
+const HISTORICAL_BLOCK_AGE_MS: u64 = 10 * 60 * 1000;
+
+/// True when a block with this timestamp is old enough that the node producing
+/// it is clearly replaying history rather than following the tip.
+pub fn is_historical_block(block_time_ms: u64) -> bool {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|since_epoch| since_epoch.as_millis() as u64)
+        .unwrap_or(0);
+    now_ms.saturating_sub(block_time_ms) > HISTORICAL_BLOCK_AGE_MS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock is before the unix epoch")
+            .as_millis() as u64
+    }
+
+    #[test]
+    fn a_block_from_a_year_ago_is_historical() {
+        assert!(is_historical_block(
+            now_ms() - 365 * 24 * 60 * 60 * 1000
+        ));
+    }
+
+    #[test]
+    fn a_block_from_a_minute_ago_is_not_historical() {
+        assert!(!is_historical_block(now_ms() - 60 * 1000));
+    }
+
+    #[test]
+    fn a_block_at_the_threshold_is_not_yet_historical() {
+        assert!(!is_historical_block(now_ms() - HISTORICAL_BLOCK_AGE_MS));
+    }
+
+    #[test]
+    fn a_block_timestamped_in_the_future_is_not_historical() {
+        assert!(!is_historical_block(now_ms() + 60 * 1000));
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

A node replaying mainnet history creates and destroys tens of thousands of GroveDB checkpoints.

Protocol version 11 (mainnet height 318,704) turns checkpoints on:

```rust
should_checkpoint: Some(0),
update_checkpoints: Some(0),
```

with `frequency_seconds: 600, num_checkpoints: 3`. The interval is in **chain time**, and mainnet blocks are ~2.5 minutes apart, so that is a checkpoint every four blocks. At replay speed that is roughly 37 a second, each one a RocksDB checkpoint over the whole database — hard-linking every SST, flushing and copying the WAL — plus a copy of the platform state, and all but the last three deleted again immediately.

Measured with per-block phase timing, replaying mainnet:

```
fb_checkpoint = 15,122 µs/block
```

against roughly 7,000 µs for everything else in a block put together. A finished mainnet sync left four checkpoint directories on disk out of some 26,000 created:

```
drive-db/checkpoints:  369259  424972  424976  424979   (100M)
```

The last three are four blocks apart, which is the cadence.

It shows up as an I/O stall rather than CPU: during the affected range drive-abci sat at 0.38 of one core with the system 47–73% idle and the disk at 2,000–4,000 tps.

## What was done?

Skip checkpoint creation for blocks more than ten minutes old. Checkpoints are restore points for a *running* node; a node catching up has no use for restore points into blocks it is about to replace, and it writes its first real checkpoint on reaching the tip.

The age test is a new `utils::is_historical_block`, with unit tests — the predicate is the testable part, since a historical replay makes every block historical by construction.

Checkpoints live outside the tree, so no app hash changes.

## How Has This Been Tested?

Same 3,000-block window from mainnet height 331,648, two local peers, back to back:

| | blocks/s | ms/block | `fb_checkpoint` |
|---|---|---|---|
| before | 47.6 | 21.01 | 12,136 µs |
| after | 121.6 | **8.23** | 0 |

−60.8% per block. The 47.6 blocks/s reproduces what a full sync does over that range.

Full mainnet replay, genesis to 424,981, with this change on top of an otherwise identical build: **4,684.9 s → 3,032.9 s**, 35% of the whole sync. Every committed app hash matched a reference sync across all 424,971 heights.

`cargo test -p drive-abci --lib should_checkpoint utils::replay` — 11 passed.

One existing test needed updating: `test_first_block_should_always_checkpoint` built its context with `block_time_ms = 1_000_000`, which is 1970 and now reads as history. It uses a current timestamp, and a companion test covers the new behaviour for an old block.

## Breaking Changes

A node interrupted mid-initial-sync will have no recent checkpoint. That is the case where a checkpoint is least useful — the remedy for trouble there is the resync it was already doing.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**

- [x] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
