### PR TITLE
feat(dapi): typed IN_TIME_RANGE operand with BY_START historic window selection

### DIFF
--- a/packages/dapi-grpc/build.rs
+++ b/packages/dapi-grpc/build.rs
@@ -341,6 +341,10 @@ fn configure_platform(mut platform: MappingConfig) -> MappingConfig {
         // absent (same pattern DocumentQuery's own serde defaults follow
         // for pre-SQL-surface fixtures).
         .field_attribute("GetDocumentsRequestV1.chained", SERDE_DEFAULT)
+        // Same compat rule for the typed IN_TIME_RANGE operand: mock
+        // vectors captured while the operand still rode `value` carry no
+        // `time_range` key.
+        .field_attribute("GetDocumentsRequest.WhereClause.time_range", SERDE_DEFAULT)
         .field_attribute("ResponseMetadata.height", SERDE_WITH_STRING)
         .field_attribute("ResponseMetadata.time_ms", SERDE_WITH_STRING)
         .field_attribute("start_at_ms", SERDE_WITH_STRING)

--- a/packages/dapi-grpc/protos/platform/v0/platform.proto
+++ b/packages/dapi-grpc/protos/platform/v0/platform.proto
@@ -596,15 +596,15 @@ message GetDocumentsRequest {
     STARTS_WITH = 10;
     // Time-range bucket selection (v1 only; the v0 CBOR surface is
     // unaffected). `field` names a timestamp covered by a `timeRange`
-    // index. Operand: `text` selector `"newest"`/`"oldest"` when one grid
-    // buckets the field, or `list` `[selector, range, step(, phase)]` in
-    // the contract's declared seconds to name one of several grids (zero
-    // phase is spelled by omission — one wire spelling per grid). The
-    // server resolves it to a bucket-start equality from current block
-    // time; the verifier re-derives the same bucket from the quorum-signed
-    // metadata time — an ordinary index/count proof. See `timeRange` in
-    // the document meta-schema and
-    // `drive::query::resolve_time_range_bucket_clause`.
+    // index. The operand is `WhereClause.time_range` (a
+    // `TimeRangeSelection`); `WhereClause.value` must be unset. For the
+    // relative selectors (`NEWEST` / `OLDEST`) the server resolves the
+    // selection to a bucket-start equality from current block time and
+    // the verifier re-derives the same bucket from the quorum-signed
+    // metadata time; `BY_START` names the window absolutely, so both
+    // sides read the start straight from the query — an ordinary
+    // index/count proof either way. See `timeRange` in the document
+    // meta-schema and `drive::query::resolve_time_range_bucket_clause`.
     IN_TIME_RANGE = 11;
   }
 
@@ -658,6 +658,54 @@ message GetDocumentsRequest {
     }
   }
 
+  // Operand of an `IN_TIME_RANGE` where clause: which window of a
+  // `timeRange` grid the query selects. Typed rather than riding
+  // `DocumentFieldValue` — the selection is not a field value, and a
+  // structured message keeps the selector an enum instead of a
+  // magic string.
+  //
+  // The relative selectors are resolved server-side: `NEWEST` is the
+  // freshest started window (largest grid start <= block time; the
+  // latest partial slice of history), `OLDEST` the oldest window still
+  // active at block time (a near-full trailing window of ~`range` —
+  // best for "trending over the last window"). The proof verifier
+  // re-derives the same window from the quorum-signed response
+  // metadata time, so neither side trusts the other's clock.
+  //
+  // `BY_START` names a window absolutely — any window, current or
+  // historic — by its start. `start_ms` is then required and must lie
+  // on the grid (`start_ms == phase + k * step`, in milliseconds);
+  // an unaligned start is rejected rather than snapped. A window with
+  // no documents (including one that has not started yet) is a
+  // provable empty answer, not an error. The relative selectors must
+  // NOT carry `start_ms` — one wire spelling per meaning.
+  message TimeRangeSelection {
+    enum Selector {
+      NEWEST = 0;
+      OLDEST = 1;
+      BY_START = 2;
+    }
+    // Names one of the field's declared grids, in the contract's own
+    // seconds — verbatim from the contract's `timeRange` declaration.
+    // Required when more than one `timeRange` grid buckets the field
+    // (the bare selector is ambiguous there and rejected); optional
+    // while exactly one grid does. A zero `phase` is the proto3
+    // default, matching the contract grammar where `phase` is an
+    // omittable key — every grid has exactly one wire spelling by
+    // construction.
+    message Grid {
+      uint64 range = 1 [jstype = JS_STRING];
+      uint64 step = 2 [jstype = JS_STRING];
+      uint64 phase = 3 [jstype = JS_STRING];
+    }
+    Selector selector = 1;
+    // `BY_START` only: the selected window's start, as a millisecond
+    // timestamp on the grid (see the message docstring). Rejected on
+    // the relative selectors.
+    optional uint64 start_ms = 2 [jstype = JS_STRING];
+    Grid grid = 3;
+  }
+
   // Single `field <op> value` clause. The server reassembles a
   // `Vec<WhereClause>` from the request's `where_clauses` field,
   // runs the same `WhereClause::group_clauses` validator (rejects
@@ -666,10 +714,16 @@ message GetDocumentsRequest {
   // then hands the structured clauses to the executor. Wire
   // semantics are identical to v0's CBOR `[field, op, value]`
   // triples — only the envelope differs.
+  //
+  // Exactly one operand field is set, keyed by the operator:
+  // `operator = IN_TIME_RANGE` carries its operand in `time_range`
+  // (`value` must be unset); every other operator carries `value`
+  // (`time_range` must be unset). Either mismatch is rejected.
   message WhereClause {
     string field = 1;
     WhereOperator operator = 2;
     DocumentFieldValue value = 3;
+    TimeRangeSelection time_range = 4;
   }
 
   // Per-group aggregate operand for the left side of a

--- a/packages/dash-platform-queries/src/documents/document_query.rs
+++ b/packages/dash-platform-queries/src/documents/document_query.rs
@@ -11,10 +11,12 @@ use dapi_grpc::platform::v0::{
         get_documents_request_v0::Start,
         get_documents_request_v1::{select, Select as ProtoSelect, Start as V1Start},
         having_aggregate, having_clause, order_clause,
+        time_range_selection::{Grid as ProtoTimeRangeGrid, Selector as ProtoTimeRangeSelector},
         DocumentFieldValue as ProtoDocumentFieldValue, GetDocumentsRequestV0,
         GetDocumentsRequestV1, HavingAggregate as ProtoHavingAggregate,
         HavingClause as ProtoHavingClause, OrderClause as ProtoOrderClause,
-        WhereClause as ProtoWhereClause, WhereOperator as ProtoWhereOperator,
+        TimeRangeSelection as ProtoTimeRangeSelection, WhereClause as ProtoWhereClause,
+        WhereOperator as ProtoWhereOperator,
     },
     GetDocumentsRequest, Proof, ResponseMetadata,
 };
@@ -245,12 +247,15 @@ impl DocumentQuery {
     }
 
     /// Restrict the query to a single time-range bucket of `field`
-    /// (a timestamp covered by a `timeRange` index), selecting either the
-    /// [`TimeRangeSelector::Newest`] or [`TimeRangeSelector::Oldest`] currently
-    /// active range. Emitted as an `IN_TIME_RANGE` clause on the v1 wire and
-    /// resolved server-side from the current block time; the proof verifier
-    /// re-derives the identical bucket from the quorum-signed response
-    /// metadata time. Requires protocol version 14+ — the first version
+    /// (a timestamp covered by a `timeRange` index). The relative selectors
+    /// ([`TimeRangeSelector::Newest`] / [`TimeRangeSelector::Oldest`]) pick a
+    /// currently active range, resolved server-side from the current block
+    /// time; the proof verifier re-derives the identical bucket from the
+    /// quorum-signed response metadata time. A
+    /// [`TimeRangeSelector::ByStart`] selection names a window absolutely —
+    /// current or historic — by its grid-aligned start, which both sides
+    /// read straight from the query. Emitted as an `IN_TIME_RANGE` clause
+    /// on the v1 wire. Requires protocol version 14+ — the first version
     /// whose contract grammar hosts `timeRange` indexes.
     ///
     /// The bare selector is unambiguous only while exactly one grid buckets
@@ -778,51 +783,41 @@ fn encode_v1(
         .into_iter()
         .map(where_clause_to_proto)
         .collect::<Result<Vec<_>, _>>()?;
-    // Append time-range selections as `IN_TIME_RANGE` clauses. A grid-less
-    // selection rides as the bare `"newest"`/`"oldest"` text operand; a
-    // grid-targeted one as the list operand `[selector, range, step]` /
-    // `[selector, range, step, phase]` in the contract's declared seconds
-    // (zero phase spelled by omission — one wire spelling per grid, the
-    // same rule the contract grammar and the storage key follow). The
-    // server resolves them to a concrete bucket from current block time;
-    // the verifier re-derives the same bucket from the signed response
-    // metadata time.
+    // Append time-range selections as `IN_TIME_RANGE` clauses carrying the
+    // typed `time_range` operand (`value` stays unset — the selection is
+    // not a field value). The grid, when named, repeats the contract's
+    // declared seconds verbatim; a zero phase is proto3's default, so a
+    // phaseless grid has exactly one wire spelling by construction. The
+    // server resolves the relative selectors to a concrete bucket from
+    // current block time and the verifier re-derives the same bucket from
+    // the signed response metadata time; a `ByStart` selection carries its
+    // window's start in the query itself, so both sides read it verbatim.
     for TimeRangeClause {
         field,
         selector,
         grid,
     } in time_range_clauses
     {
-        let selector_value = ProtoDocumentFieldValue {
-            variant: Some(document_field_value::Variant::Text(
-                selector.as_str().to_string(),
-            )),
-        };
-        let operand = match grid {
-            None => selector_value,
-            Some(spec) => {
-                let uint = |n: u64| ProtoDocumentFieldValue {
-                    variant: Some(document_field_value::Variant::Uint64Value(n)),
-                };
-                let mut values = vec![
-                    selector_value,
-                    uint(spec.range_seconds),
-                    uint(spec.step_seconds),
-                ];
-                if spec.phase_seconds != 0 {
-                    values.push(uint(spec.phase_seconds));
-                }
-                ProtoDocumentFieldValue {
-                    variant: Some(document_field_value::Variant::List(
-                        document_field_value::ValueList { values },
-                    )),
-                }
+        let (proto_selector, start_ms) = match selector {
+            TimeRangeSelector::Newest => (ProtoTimeRangeSelector::Newest, None),
+            TimeRangeSelector::Oldest => (ProtoTimeRangeSelector::Oldest, None),
+            TimeRangeSelector::ByStart { start_ms } => {
+                (ProtoTimeRangeSelector::ByStart, Some(start_ms))
             }
         };
         where_clauses.push(ProtoWhereClause {
             field,
             operator: ProtoWhereOperator::InTimeRange as i32,
-            value: Some(operand),
+            value: None,
+            time_range: Some(ProtoTimeRangeSelection {
+                selector: proto_selector as i32,
+                start_ms,
+                grid: grid.map(|spec| ProtoTimeRangeGrid {
+                    range: spec.range_seconds,
+                    step: spec.step_seconds,
+                    phase: spec.phase_seconds,
+                }),
+            }),
         });
     }
     let order_by = order_by_clauses
@@ -1182,6 +1177,10 @@ fn where_clause_to_proto(clause: WhereClause) -> Result<ProtoWhereClause, Error>
         field: clause.field,
         operator: where_operator_to_proto(clause.operator) as i32,
         value: Some(value_to_proto(clause.value)?),
+        // The typed IN_TIME_RANGE operand; never set on an ordinary value
+        // clause (time-range selections are encoded by `encode_v1` itself,
+        // from `time_range_clauses`).
+        time_range: None,
     })
 }
 
@@ -1449,7 +1448,7 @@ mod encode_version_gate_tests {
     }
 
     #[test]
-    fn a_time_range_query_encodes_the_operator_for_protocol_version_14() {
+    fn a_time_range_query_encodes_the_typed_operand_for_protocol_version_14() {
         let platform_version = PlatformVersion::get(14).expect("protocol version 14 exists");
         let request = GetDocumentsRequest::try_from_platform_versioned(
             newest_time_range_query(),
@@ -1459,15 +1458,65 @@ mod encode_version_gate_tests {
         let Some(V1(v1)) = request.version else {
             panic!("protocol version 14 encodes on the v1 wire");
         };
-        let operators: Vec<i32> = v1
-            .where_clauses
-            .iter()
-            .map(|clause| clause.operator)
-            .collect();
+        let [clause] = v1.where_clauses.as_slice() else {
+            panic!("the pending selector must ride as exactly one IN_TIME_RANGE clause");
+        };
+        assert_eq!(clause.operator, ProtoWhereOperator::InTimeRange as i32);
         assert_eq!(
-            operators,
-            vec![ProtoWhereOperator::InTimeRange as i32],
-            "the pending selector must ride as exactly one IN_TIME_RANGE clause"
+            clause.value, None,
+            "the selection is not a field value; the generic operand stays unset"
+        );
+        let selection = clause
+            .time_range
+            .as_ref()
+            .expect("the typed operand carries the selection");
+        assert_eq!(selection.selector, ProtoTimeRangeSelector::Newest as i32);
+        assert_eq!(selection.start_ms, None);
+        assert_eq!(selection.grid, None, "a grid-less selection names no grid");
+    }
+
+    #[test]
+    fn a_by_start_selection_encodes_its_window_start_and_grid() {
+        let platform_version = PlatformVersion::get(14).expect("protocol version 14 exists");
+        let query = DocumentQuery::new(post_contract(), "post")
+            .expect("the fixture has this document type")
+            .with_time_range_grid(
+                "$createdAt",
+                TimeRangeSelector::ByStart {
+                    start_ms: 1_756_684_800_000,
+                },
+                TimeRangeGridSpec {
+                    range_seconds: 86_400,
+                    step_seconds: 86_400,
+                    phase_seconds: 0,
+                },
+            );
+        let request = GetDocumentsRequest::try_from_platform_versioned(query, platform_version)
+            .expect("protocol version 14 hosts timeRange indexes");
+        let Some(V1(v1)) = request.version else {
+            panic!("protocol version 14 encodes on the v1 wire");
+        };
+        let [clause] = v1.where_clauses.as_slice() else {
+            panic!("the selection must ride as exactly one IN_TIME_RANGE clause");
+        };
+        let selection = clause
+            .time_range
+            .as_ref()
+            .expect("the typed operand carries the selection");
+        assert_eq!(selection.selector, ProtoTimeRangeSelector::ByStart as i32);
+        assert_eq!(
+            selection.start_ms,
+            Some(1_756_684_800_000),
+            "the absolute window start rides in the query itself"
+        );
+        assert_eq!(
+            selection.grid,
+            Some(ProtoTimeRangeGrid {
+                range: 86_400,
+                step: 86_400,
+                phase: 0,
+            }),
+            "the grid repeats the contract's declared seconds verbatim"
         );
     }
 

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
@@ -438,6 +438,116 @@ fn rejects_only_bucketed_indexes() {
     );
 }
 
+/// The "trending posts" contract shape: a like is an indexOnly entry, and
+/// trending means posts with many likes inside a time window — so the
+/// window timestamp is the LIKE's `$createdAt`, not the post's. Windowed
+/// like-counts per post come from a bucketed countable index over
+/// `(timeRange($createdAt), postId)` with daily tumbling windows; the
+/// ranked `byPost` provides all-time top posts and doubles as the
+/// required `$createdAt`-free proof index.
+fn trending_posts_likes_schema() -> Value {
+    platform_value!({
+        "type": "object",
+        "indexOnly": true,
+        "documentsMutable": false,
+        "properties": {
+            "postId": {
+                "type": "array",
+                "byteArray": true,
+                "minItems": 32,
+                "maxItems": 32,
+                "contentMediaType": "application/x.dash.dpp.identifier",
+                "refersTo": { "type": "identity" },
+                "position": 0
+            }
+        },
+        "required": ["postId", "$createdAt"],
+        "indices": [
+            {
+                "name": "byWindowPost",
+                "properties": [{ "$createdAt": "asc" }, { "postId": "asc" }],
+                "terminal": "$ownerId",
+                "timeRange": { "on": "$createdAt", "range": 86_400u64, "step": 86_400u64 },
+                "countable": true,
+                "rangeCountable": true
+            },
+            {
+                "name": "byPost",
+                "properties": [{ "postId": "asc" }],
+                "countable": true,
+                "rangeCountable": true,
+                "rankedCountable": true
+            }
+        ],
+        "additionalProperties": false
+    })
+}
+
+#[test]
+fn trending_posts_contract_with_windowed_like_counts_validates() {
+    // What the trending-posts shape can register today: provable per-post
+    // like counts in any daily window (current via NEWEST/OLDEST, historic
+    // via BY_START), plus all-time top posts from the ranked `byPost`.
+    // Server-ORDERED top posts within a window would need the ranked flags
+    // on the bucketed index, which is still rejected — see the companion
+    // test below.
+    let document_type = parse_with(
+        trending_posts_likes_schema(),
+        PlatformVersion::latest(),
+        false,
+    )
+    .expect("the trending-posts likes shape validates");
+    let bucketed = document_type
+        .indices
+        .values()
+        .find(|index| index.time_range.is_some())
+        .expect("the windowed index parsed");
+    assert!(
+        bucketed.countable.is_countable(),
+        "windowed counts need the count trees"
+    );
+    assert!(
+        !bucketed.ranked_countable,
+        "the bucketed index carries counts only — ranking it is not yet grammar"
+    );
+    assert_eq!(
+        bucketed.time_range.as_ref().unwrap().overlap_factor(),
+        1,
+        "daily tumbling windows: every like lands in exactly one bucket"
+    );
+}
+
+#[test]
+fn trending_posts_ranked_windowed_index_is_still_rejected() {
+    // The deliberate tripwire for the ranked-x-timeRange gap: server-ordered
+    // "top posts this window" needs `rankedCountable` on the bucketed
+    // index, and contract validation still rejects that combination until
+    // bucket-aware ranked semantics land. When that feature ships, this
+    // test should flip into an acceptance test rather than be deleted.
+    let mut schema = trending_posts_likes_schema();
+    schema
+        .get_mut("indices")
+        .expect("indices accessible")
+        .expect("indices present")
+        .as_array_mut()
+        .expect("indices is an array")
+        .get_mut(0)
+        .expect("byWindowPost exists")
+        .set_value("rankedCountable", platform_value!(true))
+        .expect("index key applies");
+    // Raised by the index parser rather than the doc-type-level checks, so
+    // it reaches here in a different `ProtocolError` wrapping than the
+    // errors `expect_structure_error` matches — assert on the message.
+    let error = parse_with(schema, PlatformVersion::latest(), false)
+        .expect_err("ranked flags on a bucketed index must be refused");
+    assert!(
+        error
+            .to_string()
+            .contains("a timeRange index cannot be ranked"),
+        "expected the ranked-x-timeRange rejection, got: {error}"
+    );
+}
+
 #[test]
 fn rejects_terminal_repeating_an_index_property() {
     // byLiker's prefix is [$ownerId]; making $ownerId its terminal too

--- a/packages/rs-dpp/src/data_contract/document_type/index/time_range.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/time_range.rs
@@ -244,7 +244,7 @@ impl TimeRangeTransform {
         if step_ms == 0 || start_ms < phase_ms {
             return false;
         }
-        (start_ms - phase_ms) % step_ms == 0
+        (start_ms - phase_ms).is_multiple_of(step_ms)
     }
 
     /// The start of the newest range that is active at the millisecond

--- a/packages/rs-dpp/src/data_contract/document_type/index/time_range.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/time_range.rs
@@ -38,11 +38,13 @@ use serde::{Deserialize, Serialize};
 /// window of history (see [`Self::oldest_active_start`]).
 ///
 /// Note that the *server-ordered* form (`ORDER BY COUNT(*)` — the ranked
-/// query surface) cannot yet be combined with a time-range selection: ranked
-/// queries accept no where clauses in this protocol version (their routing
-/// deliberately has no equality-prefix support yet), so "top K by count
-/// within the bucket" is served as the grouped count above with client-side
-/// ordering until ranked prefix routing lands at a future protocol version.
+/// query surface) cannot yet be combined with a time-range selection:
+/// contract validation rejects the ranked keywords on a `timeRange` index
+/// (with overlapping windows a document would be ranked into
+/// `overlap_factor` groups at once) and the ranked dispatcher rejects
+/// time-range selections, so "top K by count within the bucket" is served
+/// as the grouped count above with client-side ordering until bucket-aware
+/// ranked semantics are deliberately designed.
 ///
 /// At the GroveDB storage layer, a transformed first property gets its own
 /// index level keyed by [`Self::storage_key`] — the property name qualified
@@ -220,6 +222,29 @@ impl TimeRangeTransform {
             })
             .filter(|start| *start >= phase_ms)
             .collect()
+    }
+
+    /// Whether the millisecond timestamp `start_ms` is one of this grid's
+    /// range starts — i.e. `phase + k * step` for some `k = 0, 1, 2, …` on
+    /// the millisecond timeline.
+    ///
+    /// This is the validity check for an absolutely-named window (the
+    /// `BY_START` selector of an `IN_TIME_RANGE` query): a start off the
+    /// grid names no window, and the resolver rejects it rather than
+    /// snapping — a snapped start would silently answer a different window
+    /// than the one the caller spelled. Whether the window has begun, or
+    /// holds any documents, is deliberately NOT checked here: an empty
+    /// window is a provable empty answer, not an invalid question.
+    ///
+    /// Returns `false` for a malformed zero-step transform, which a
+    /// validated contract can never carry — same defensive posture as
+    /// [`Self::most_recent_start`].
+    pub fn is_bucket_start(&self, start_ms: u64) -> bool {
+        let (step_ms, phase_ms) = (self.step_ms(), self.phase_ms());
+        if step_ms == 0 || start_ms < phase_ms {
+            return false;
+        }
+        (start_ms - phase_ms) % step_ms == 0
     }
 
     /// The start of the newest range that is active at the millisecond
@@ -436,6 +461,41 @@ mod tests {
         };
         let raw = DocumentPropertyType::encode_date_timestamp(4_999);
         assert_eq!(t_phased.entry_keys_for_raw(&raw), Vec::<Vec<u8>>::new());
+    }
+
+    #[test]
+    fn bucket_starts_are_exactly_the_phased_step_multiples() {
+        let t = transform(); // range 6h, step 2h, phase 0
+        let h = HOUR_MS;
+        assert!(t.is_bucket_start(0));
+        assert!(t.is_bucket_start(2 * h));
+        assert!(t.is_bucket_start(6 * h));
+        // off-grid: not a step multiple, and a range end is not a start
+        assert!(!t.is_bucket_start(h));
+        assert!(!t.is_bucket_start(2 * h + 1));
+        // a phased grid shifts the valid starts and voids the epoch sliver
+        let phased = TimeRangeTransform {
+            source: "$createdAt".to_string(),
+            range_seconds: 60,
+            step_seconds: 20,
+            phase_seconds: 5,
+        };
+        assert!(phased.is_bucket_start(5_000));
+        assert!(phased.is_bucket_start(45_000));
+        assert!(!phased.is_bucket_start(0));
+        assert!(!phased.is_bucket_start(20_000));
+        // future starts are valid grid points — emptiness is the query's
+        // provable answer, not this predicate's concern
+        assert!(t.is_bucket_start(1_000_000 * h * 2));
+        // malformed zero-step transform answers false instead of dividing
+        // by zero
+        let malformed = TimeRangeTransform {
+            source: "$createdAt".to_string(),
+            range_seconds: 60,
+            step_seconds: 0,
+            phase_seconds: 0,
+        };
+        assert!(!malformed.is_bucket_start(0));
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/query/document_query/v1/conversions.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/conversions.rs
@@ -30,10 +30,11 @@ use crate::error::query::QueryError;
 use dapi_grpc::platform::v0::get_documents_request::{
     document_field_value,
     get_documents_request_v1::{select, Select as ProtoSelect},
-    having_aggregate, having_clause, order_clause, DocumentFieldValue as ProtoDocumentFieldValue,
-    HavingAggregate as ProtoHavingAggregate, HavingClause as ProtoHavingClause,
-    OrderClause as ProtoOrderClause, WhereClause as ProtoWhereClause,
-    WhereOperator as ProtoWhereOperator,
+    having_aggregate, having_clause, order_clause,
+    time_range_selection::Selector as ProtoTimeRangeSelector,
+    DocumentFieldValue as ProtoDocumentFieldValue, HavingAggregate as ProtoHavingAggregate,
+    HavingClause as ProtoHavingClause, OrderClause as ProtoOrderClause,
+    WhereClause as ProtoWhereClause, WhereOperator as ProtoWhereOperator,
 };
 use dpp::platform_value::Value;
 use drive::query::TimeRangeGridSpec;
@@ -90,102 +91,90 @@ pub(super) fn is_time_range_clause(clause: &ProtoWhereClause) -> bool {
 }
 
 /// Decode an `IN_TIME_RANGE` wire where clause into its
-/// `(field, selector, grid)`. Two operand shapes:
+/// `(field, selector, grid)`.
 ///
-/// - `DocumentFieldValue.text` — the bare selector (`"newest"` /
-///   `"oldest"`). Unambiguous only while exactly one grid buckets the
-///   field; the resolver rejects it otherwise.
-/// - `DocumentFieldValue.list` — `[text(selector), uint64(range),
-///   uint64(step)]` or `[…, uint64(phase)]`, naming one grid in the
-///   contract's own declared units (seconds). Required when several grids
-///   bucket the field. Like the contract grammar and the storage key, a
-///   zero phase is spelled by omission — the three-element form — so every
-///   grid has exactly one wire spelling.
+/// The operand is the typed `WhereClause.time_range` message
+/// (`TimeRangeSelection`); the generic `value` operand must be unset — the
+/// selection is not a field value, and a clause carrying both would be two
+/// spellings of one question. Shape rules, each rejected explicitly:
+///
+/// - `selector` must be a known discriminant (`NEWEST` / `OLDEST` /
+///   `BY_START`); unknown integers are wire-level garbage.
+/// - `BY_START` requires `start_ms` (the window's start, a millisecond
+///   timestamp on the grid — alignment itself is the resolver's check,
+///   since only it sees the contract); the relative selectors must NOT
+///   carry `start_ms` — one wire spelling per meaning.
+/// - `grid`, when present, names one of the field's grids in the
+///   contract's own declared seconds and must carry non-zero `range` and
+///   `step` (zero is proto3's absent-field default, so an all-default
+///   `Grid` is indistinguishable from a forgotten one — rejected here with
+///   a better message than the resolver's no-such-grid miss). A zero
+///   `phase` IS the canonical spelling of a phaseless grid, matching the
+///   contract grammar where `phase` is an omittable key.
 pub(super) fn time_range_clause_from_proto(
     clause: ProtoWhereClause,
 ) -> Result<(String, TimeRangeSelector, Option<TimeRangeGridSpec>), QueryError> {
     let field = clause.field;
-    let parse_selector = |text: &str| {
-        TimeRangeSelector::from_string(text).ok_or_else(|| {
-            QueryError::InvalidArgument(format!(
-                "IN_TIME_RANGE selector must be \"newest\" or \"oldest\", got \"{}\"",
-                text
-            ))
-        })
-    };
-    match clause.value.and_then(|v| v.variant) {
-        Some(document_field_value::Variant::Text(selector_text)) => {
-            Ok((field, parse_selector(&selector_text)?, None))
+    if clause.value.is_some() {
+        return Err(QueryError::InvalidArgument(format!(
+            "IN_TIME_RANGE clause on field '{}' must not set `value`: the operand is the \
+             typed `time_range` selection",
+            field
+        )));
+    }
+    let selection = clause.time_range.ok_or_else(|| {
+        QueryError::InvalidArgument(format!(
+            "IN_TIME_RANGE clause on field '{}' has no `time_range` selection set",
+            field
+        ))
+    })?;
+    let proto_selector = ProtoTimeRangeSelector::try_from(selection.selector).map_err(|_| {
+        QueryError::InvalidArgument(format!(
+            "unknown TimeRangeSelection.Selector discriminant on field '{}': {} (valid \
+             values: NEWEST = 0, OLDEST = 1, BY_START = 2)",
+            field, selection.selector
+        ))
+    })?;
+    let selector = match (proto_selector, selection.start_ms) {
+        (ProtoTimeRangeSelector::Newest, None) => TimeRangeSelector::Newest,
+        (ProtoTimeRangeSelector::Oldest, None) => TimeRangeSelector::Oldest,
+        (ProtoTimeRangeSelector::ByStart, Some(start_ms)) => {
+            TimeRangeSelector::ByStart { start_ms }
         }
-        Some(document_field_value::Variant::List(list)) => {
-            let mut values = list.values.into_iter();
-            let selector = match values.next().and_then(|v| v.variant) {
-                Some(document_field_value::Variant::Text(s)) => parse_selector(&s)?,
-                _ => {
-                    return Err(QueryError::InvalidArgument(format!(
-                        "IN_TIME_RANGE list operand on field '{}' must start with the \
-                         text selector \"newest\" or \"oldest\"",
-                        field
-                    )))
-                }
-            };
-            let mut grid_number = |name: &str| -> Result<u64, QueryError> {
-                match values.next().and_then(|v| v.variant) {
-                    Some(document_field_value::Variant::Uint64Value(n)) => Ok(n),
-                    _ => Err(QueryError::InvalidArgument(format!(
-                        "IN_TIME_RANGE list operand on field '{}' must carry the grid's \
-                         {} as a uint64 of seconds, exactly as the contract declares it",
-                        field, name
-                    ))),
-                }
-            };
-            let range_seconds = grid_number("range")?;
-            let step_seconds = grid_number("step")?;
-            let phase_seconds = match values.next() {
-                None => 0,
-                Some(v) => match v.variant {
-                    Some(document_field_value::Variant::Uint64Value(0)) => {
-                        return Err(QueryError::InvalidArgument(format!(
-                            "IN_TIME_RANGE list operand on field '{}': a zero phase is \
-                             spelled by omission (use the three-element form), so every \
-                             grid has exactly one wire spelling",
-                            field
-                        )))
-                    }
-                    Some(document_field_value::Variant::Uint64Value(n)) => n,
-                    _ => {
-                        return Err(QueryError::InvalidArgument(format!(
-                            "IN_TIME_RANGE list operand on field '{}' must carry the \
-                             grid's phase as a uint64 of seconds",
-                            field
-                        )))
-                    }
-                },
-            };
-            if values.next().is_some() {
+        (ProtoTimeRangeSelector::ByStart, None) => {
+            return Err(QueryError::InvalidArgument(format!(
+                "IN_TIME_RANGE BY_START on field '{}' requires `start_ms` naming the \
+                 window's start (a millisecond timestamp on the grid)",
+                field
+            )))
+        }
+        (ProtoTimeRangeSelector::Newest | ProtoTimeRangeSelector::Oldest, Some(_)) => {
+            return Err(QueryError::InvalidArgument(format!(
+                "IN_TIME_RANGE on field '{}': `start_ms` is only meaningful with \
+                 BY_START; the relative selectors resolve their window from block time",
+                field
+            )))
+        }
+    };
+    let grid = selection
+        .grid
+        .map(|grid| {
+            if grid.range == 0 || grid.step == 0 {
                 return Err(QueryError::InvalidArgument(format!(
-                    "IN_TIME_RANGE list operand on field '{}' takes at most \
-                     [selector, range, step, phase]",
+                    "IN_TIME_RANGE grid on field '{}' must carry the contract's declared \
+                     `range` and `step` (non-zero seconds); a zero phase is the canonical \
+                     spelling of a phaseless grid",
                     field
                 )));
             }
-            Ok((
-                field,
-                selector,
-                Some(TimeRangeGridSpec {
-                    range_seconds,
-                    step_seconds,
-                    phase_seconds,
-                }),
-            ))
-        }
-        _ => Err(QueryError::InvalidArgument(format!(
-            "IN_TIME_RANGE clause on field '{}' must carry either a text operand \
-             (\"newest\" / \"oldest\") or a list operand [selector, range, step] / \
-             [selector, range, step, phase] naming one of the field's grids",
-            field
-        ))),
-    }
+            Ok(TimeRangeGridSpec {
+                range_seconds: grid.range,
+                step_seconds: grid.step,
+                phase_seconds: grid.phase,
+            })
+        })
+        .transpose()?;
+    Ok((field, selector, grid))
 }
 
 /// Map a wire [`ProtoDocumentFieldValue`] onto a
@@ -257,6 +246,17 @@ fn value_from_proto_at_depth(
 /// and value-shape failures.
 pub(super) fn where_clause_from_proto(clause: ProtoWhereClause) -> Result<WhereClause, QueryError> {
     let operator = where_operator_from_proto(clause.operator)?;
+    // `time_range` is IN_TIME_RANGE's operand and those clauses are
+    // partitioned out before this conversion (see `is_time_range_clause`),
+    // so on any clause reaching here a set `time_range` is a malformed mix
+    // of the two operand kinds.
+    if clause.time_range.is_some() {
+        return Err(QueryError::InvalidArgument(format!(
+            "WhereClause on field '{}' sets `time_range`, which is only valid with the \
+             IN_TIME_RANGE operator",
+            clause.field
+        )));
+    }
     let value = clause.value.ok_or_else(|| {
         QueryError::InvalidArgument(format!(
             "WhereClause on field '{}' has no value set; every clause must carry a \

--- a/packages/rs-drive-abci/src/query/document_query/v1/dispatch/chained.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/dispatch/chained.rs
@@ -337,6 +337,7 @@ mod tests {
                         // fields.
                         variant: Some(document_field_value::Variant::BytesValue(OWNER_1.to_vec())),
                     }),
+                    time_range: None,
                 },
             ],
             order_by: Vec::new(),

--- a/packages/rs-drive-abci/src/query/document_query/v1/tests.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/tests.rs
@@ -16,10 +16,11 @@ use dapi_grpc::platform::v0::get_documents_request::get_documents_request_v1::{
 };
 use dapi_grpc::platform::v0::get_documents_request::{
     document_field_value, having_aggregate, having_clause, order_clause,
+    time_range_selection::{Grid as ProtoTimeRangeGrid, Selector as ProtoTimeRangeSelector},
     DocumentFieldValue as ProtoDocumentFieldValue, GetDocumentsRequestV0,
     HavingAggregate as ProtoHavingAggregate, HavingClause as ProtoHavingClause,
-    OrderClause as ProtoOrderClause, WhereClause as ProtoWhereClause,
-    WhereOperator as ProtoWhereOperator,
+    OrderClause as ProtoOrderClause, TimeRangeSelection as ProtoTimeRangeSelection,
+    WhereClause as ProtoWhereClause, WhereOperator as ProtoWhereOperator,
 };
 use dpp::dashcore::Network;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
@@ -74,6 +75,7 @@ fn wc(field: &str, operator: ProtoWhereOperator, value: Value) -> ProtoWhereClau
         field: field.to_string(),
         operator: operator as i32,
         value: Some(pv(value)),
+        time_range: None,
     }
 }
 
@@ -418,6 +420,7 @@ fn nested_list_rejected_at_depth_two() {
         field: "any".to_string(),
         operator: ProtoWhereOperator::In as i32,
         value: Some(nested_list_value),
+        time_range: None,
     };
     let request = GetDocumentsRequestV1 {
         where_clauses: vec![nested_clause],
@@ -4570,11 +4573,18 @@ mod time_range_proof_verification {
                 ProtoWhereOperator::Equal,
                 Value::Text(hashtag.to_string()),
             ),
-            wc(
-                CREATED_AT,
-                ProtoWhereOperator::InTimeRange,
-                Value::Text(TimeRangeSelector::Newest.as_str().to_string()),
-            ),
+            ProtoWhereClause {
+                field: CREATED_AT.to_string(),
+                operator: ProtoWhereOperator::InTimeRange as i32,
+                value: None,
+                // Grid-less: exactly one grid buckets the field here, so the
+                // bare relative selector is unambiguous.
+                time_range: Some(ProtoTimeRangeSelection {
+                    selector: ProtoTimeRangeSelector::Newest as i32,
+                    start_ms: None,
+                    grid: None,
+                }),
+            },
         ]
     }
 
@@ -5352,24 +5362,9 @@ mod time_range_proof_verification {
         (contract, state)
     }
 
-    /// The wire's structured `IN_TIME_RANGE` operand:
-    /// `[selector, range, step]` (seconds, as the contract declares them).
+    /// The wire's typed `IN_TIME_RANGE` operand: a `NEWEST` selection
+    /// naming `grid` in the contract's declared seconds.
     fn structured_where_clauses(hashtag: &str, grid: TimeRangeGridSpec) -> Vec<ProtoWhereClause> {
-        let uint = |n: u64| ProtoDocumentFieldValue {
-            variant: Some(document_field_value::Variant::Uint64Value(n)),
-        };
-        let mut values = vec![
-            ProtoDocumentFieldValue {
-                variant: Some(document_field_value::Variant::Text(
-                    TimeRangeSelector::Newest.as_str().to_string(),
-                )),
-            },
-            uint(grid.range_seconds),
-            uint(grid.step_seconds),
-        ];
-        if grid.phase_seconds != 0 {
-            values.push(uint(grid.phase_seconds));
-        }
         vec![
             wc(
                 "hashtag",
@@ -5379,10 +5374,15 @@ mod time_range_proof_verification {
             ProtoWhereClause {
                 field: CREATED_AT.to_string(),
                 operator: ProtoWhereOperator::InTimeRange as i32,
-                value: Some(ProtoDocumentFieldValue {
-                    variant: Some(document_field_value::Variant::List(
-                        document_field_value::ValueList { values },
-                    )),
+                value: None,
+                time_range: Some(ProtoTimeRangeSelection {
+                    selector: ProtoTimeRangeSelector::Newest as i32,
+                    start_ms: None,
+                    grid: Some(ProtoTimeRangeGrid {
+                        range: grid.range_seconds,
+                        step: grid.step_seconds,
+                        phase: grid.phase_seconds,
+                    }),
                 }),
             },
         ]
@@ -5423,37 +5423,223 @@ mod time_range_proof_verification {
         );
     }
 
-    /// A four-element operand spelling a zero phase is refused: like the
-    /// contract grammar and the storage key, zero is spelled by omission so
-    /// every grid has exactly one wire spelling.
+    /// The typed operand's shape rules, each refused explicitly at decode.
+    /// (The old list operand's zero-phase canonicalization has no analogue:
+    /// a zero phase in the `Grid` message IS proto3's default, so a
+    /// phaseless grid has exactly one wire spelling by construction.)
     #[test]
-    fn an_explicit_zero_phase_operand_is_refused_as_non_canonical() {
+    fn malformed_typed_operands_are_refused() {
         let (platform, base_state, version) = setup_platform(None, Network::Testnet, None);
-        let (contract, state) = setup_two_grids(&platform, &base_state, version);
+        let (contract, _documents, state) = setup_trending(&platform, &base_state, version);
 
-        let mut clauses = structured_where_clauses("ibiza", TRENDING_GRID);
-        // append an explicit zero phase to the list operand
-        if let Some(ProtoDocumentFieldValue {
-            variant: Some(document_field_value::Variant::List(list)),
-        }) = clauses[1].value.as_mut()
-        {
-            list.values.push(ProtoDocumentFieldValue {
-                variant: Some(document_field_value::Variant::Uint64Value(0)),
-            });
-        } else {
-            panic!("the helper builds a list operand");
+        let mutated = |f: &dyn Fn(&mut ProtoWhereClause)| {
+            let mut request = trending_request(contract.id().to_vec(), "ibiza", select_count_star());
+            f(&mut request.where_clauses[1]);
+            request
+        };
+        let cases: Vec<(&str, GetDocumentsRequestV1, &str)> = vec![
+            (
+                "a generic value next to the typed operand",
+                mutated(&|clause| {
+                    clause.value = Some(ProtoDocumentFieldValue {
+                        variant: Some(document_field_value::Variant::Text("newest".to_string())),
+                    });
+                }),
+                "must not set `value`",
+            ),
+            (
+                "an IN_TIME_RANGE operator with no selection at all",
+                mutated(&|clause| clause.time_range = None),
+                "no `time_range` selection",
+            ),
+            (
+                "an unknown selector discriminant",
+                mutated(&|clause| {
+                    clause.time_range.as_mut().expect("set by the helper").selector = 99;
+                }),
+                "discriminant",
+            ),
+            (
+                "BY_START without its window start",
+                mutated(&|clause| {
+                    let selection = clause.time_range.as_mut().expect("set by the helper");
+                    selection.selector = ProtoTimeRangeSelector::ByStart as i32;
+                    selection.start_ms = None;
+                }),
+                "requires `start_ms`",
+            ),
+            (
+                "a start on a relative selector",
+                mutated(&|clause| {
+                    clause.time_range.as_mut().expect("set by the helper").start_ms =
+                        Some(NEWEST_BUCKET_START_MS);
+                }),
+                "only meaningful with",
+            ),
+            (
+                "an all-default grid",
+                mutated(&|clause| {
+                    clause.time_range.as_mut().expect("set by the helper").grid =
+                        Some(ProtoTimeRangeGrid::default());
+                }),
+                "non-zero",
+            ),
+        ];
+        for (label, request, expected_fragment) in cases {
+            let result = platform
+                .query_documents_v1(request, &state, version)
+                .expect("transport-level success");
+            assert!(
+                format!("{:?}", result.errors).contains(expected_fragment),
+                "{} must be refused with a message containing {:?}, got {:?}",
+                label,
+                expected_fragment,
+                result.errors
+            );
         }
+    }
+
+    /// The wire's `BY_START` selection on `field`, grid-less (the trending
+    /// contract buckets `$createdAt` with a single grid).
+    fn by_start_where_clauses(hashtag: &str, start_ms: u64) -> Vec<ProtoWhereClause> {
+        vec![
+            wc(
+                "hashtag",
+                ProtoWhereOperator::Equal,
+                Value::Text(hashtag.to_string()),
+            ),
+            ProtoWhereClause {
+                field: CREATED_AT.to_string(),
+                operator: ProtoWhereOperator::InTimeRange as i32,
+                value: None,
+                time_range: Some(ProtoTimeRangeSelection {
+                    selector: ProtoTimeRangeSelector::ByStart as i32,
+                    start_ms: Some(start_ms),
+                    grid: None,
+                }),
+            },
+        ]
+    }
+
+    /// An off-grid start names no window: refused rather than snapped —
+    /// a snapped start would prove an answer to a question the client
+    /// didn't ask.
+    #[test]
+    fn an_off_grid_by_start_is_refused() {
+        let (platform, base_state, version) = setup_platform(None, Network::Testnet, None);
+        let (contract, _documents, state) = setup_trending(&platform, &base_state, version);
+
+        // one hour past a bucket start on a two-hour step: between grid points
         let request = GetDocumentsRequestV1 {
-            where_clauses: clauses,
+            where_clauses: by_start_where_clauses("ibiza", NEWEST_BUCKET_START_MS + HOUR_MS),
             ..trending_request(contract.id().to_vec(), "ibiza", select_count_star())
         };
         let result = platform
             .query_documents_v1(request, &state, version)
             .expect("transport-level success");
         assert!(
-            format!("{:?}", result.errors).contains("omission"),
-            "expected the one-spelling-per-grid refusal, got {:?}",
+            format!("{:?}", result.errors).contains("not a window start"),
+            "an off-grid start must be refused, got {:?}",
             result.errors
+        );
+    }
+
+    /// The capability the absolute selector adds: a *historic* window —
+    /// unreachable through `newest`/`oldest`, which only address windows
+    /// still touching block time — counted and verified end-to-end. The
+    /// window starting one step before the newest bucket covers
+    /// `[start − 2h, start + 4h)`, so it holds all three `#ibiza` posts,
+    /// while the newest window holds two: the differing counts pin that
+    /// the query addressed the named window and not "the current one".
+    #[test]
+    fn a_historic_window_counts_and_verifies_by_start() {
+        let (platform, base_state, version) = setup_platform(None, Network::Testnet, None);
+        let (contract, _documents, state) = setup_trending(&platform, &base_state, version);
+        let historic_start_ms = NEWEST_BUCKET_START_MS - 2 * HOUR_MS;
+
+        let request = GetDocumentsRequestV1 {
+            where_clauses: by_start_where_clauses("ibiza", historic_start_ms),
+            ..trending_request(contract.id().to_vec(), "ibiza", select_count_star())
+        };
+        let (proof, mtd, provider) = prove_and_sign(&platform, &state, request, version);
+
+        let query = SdkDocumentQuery::new(Arc::new(contract.clone()), DOCUMENT_TYPE)
+            .expect("the fixture has this document type")
+            .with_select(SelectProjection::count_star())
+            .with_where(WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("ibiza".to_string()),
+            })
+            .with_time_range(
+                CREATED_AT,
+                TimeRangeSelector::ByStart {
+                    start_ms: historic_start_ms,
+                },
+            );
+        let (count, _mtd, _proof) =
+            <DocumentCount as FromProof<SdkDocumentQuery>>::maybe_from_proof_with_metadata(
+                query,
+                signed_response(proof, &mtd),
+                Network::Testnet,
+                version,
+                &provider,
+            )
+            .expect("a correctly signed historic-window count must verify");
+        assert_eq!(
+            count.expect("the historic window is not empty"),
+            DocumentCount(3),
+            "the historic window holds all three #ibiza posts; the newest holds two"
+        );
+    }
+
+    /// The mirror image of the relative selectors' tamper tests: a
+    /// `BY_START` proof is clock-invariant. Re-signing the response over a
+    /// one-step-later metadata time still verifies, because the window is
+    /// named absolutely in the query and its resolution never consults the
+    /// signed time — the property that makes historic windows stable to
+    /// query. (The same nudge makes a `newest` proof fail; see
+    /// [`a_tampered_metadata_time_is_rejected_at_the_sum_entry_point`].)
+    #[test]
+    fn a_by_start_proof_is_indifferent_to_the_signed_time() {
+        let (platform, base_state, version) = setup_platform(None, Network::Testnet, None);
+        let (contract, _documents, state) = setup_trending(&platform, &base_state, version);
+        let historic_start_ms = NEWEST_BUCKET_START_MS - 2 * HOUR_MS;
+
+        let request = GetDocumentsRequestV1 {
+            where_clauses: by_start_where_clauses("ibiza", historic_start_ms),
+            ..trending_request(contract.id().to_vec(), "ibiza", select_count_star())
+        };
+        let (proof, mtd, provider) = prove_and_sign(&platform, &state, request, version);
+        let later = one_step_later(&contract, BUCKETED_INDEX, &mtd);
+        let resigned = resign_over(&platform, &proof, &later, version);
+
+        let query = SdkDocumentQuery::new(Arc::new(contract.clone()), DOCUMENT_TYPE)
+            .expect("the fixture has this document type")
+            .with_select(SelectProjection::count_star())
+            .with_where(WhereClause {
+                field: "hashtag".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("ibiza".to_string()),
+            })
+            .with_time_range(
+                CREATED_AT,
+                TimeRangeSelector::ByStart {
+                    start_ms: historic_start_ms,
+                },
+            );
+        let (count, _mtd, _proof) =
+            <DocumentCount as FromProof<SdkDocumentQuery>>::maybe_from_proof_with_metadata(
+                query,
+                signed_response(resigned, &later),
+                Network::Testnet,
+                version,
+                &provider,
+            )
+            .expect("an absolute window's proof does not depend on the signed time");
+        assert_eq!(
+            count.expect("the historic window is not empty"),
+            DocumentCount(3)
         );
     }
 

--- a/packages/rs-drive-abci/src/query/document_query/v1/tests.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/tests.rs
@@ -5433,7 +5433,8 @@ mod time_range_proof_verification {
         let (contract, _documents, state) = setup_trending(&platform, &base_state, version);
 
         let mutated = |f: &dyn Fn(&mut ProtoWhereClause)| {
-            let mut request = trending_request(contract.id().to_vec(), "ibiza", select_count_star());
+            let mut request =
+                trending_request(contract.id().to_vec(), "ibiza", select_count_star());
             f(&mut request.where_clauses[1]);
             request
         };
@@ -5455,7 +5456,11 @@ mod time_range_proof_verification {
             (
                 "an unknown selector discriminant",
                 mutated(&|clause| {
-                    clause.time_range.as_mut().expect("set by the helper").selector = 99;
+                    clause
+                        .time_range
+                        .as_mut()
+                        .expect("set by the helper")
+                        .selector = 99;
                 }),
                 "discriminant",
             ),
@@ -5471,8 +5476,11 @@ mod time_range_proof_verification {
             (
                 "a start on a relative selector",
                 mutated(&|clause| {
-                    clause.time_range.as_mut().expect("set by the helper").start_ms =
-                        Some(NEWEST_BUCKET_START_MS);
+                    clause
+                        .time_range
+                        .as_mut()
+                        .expect("set by the helper")
+                        .start_ms = Some(NEWEST_BUCKET_START_MS);
                 }),
                 "only meaningful with",
             ),

--- a/packages/rs-drive/src/query/mod.rs
+++ b/packages/rs-drive/src/query/mod.rs
@@ -692,9 +692,15 @@ impl From<InternalClauses> for Vec<WhereClause> {
     }
 }
 
-/// Which active time range a `TOP(timeRange(...))` selection resolves to,
-/// when the index's ranges overlap (`range > step`). Time-range queries are a
-/// v1-only feature; the v0 query surface is unaffected.
+/// Which window of a `timeRange` grid an `IN_TIME_RANGE` selection resolves
+/// to. Time-range queries are a v1-only feature; the v0 query surface is
+/// unaffected.
+///
+/// The two relative selectors are resolved against an authoritative "now"
+/// (block time on the server, the quorum-signed metadata time on the
+/// verifier); [`Self::ByStart`] names a window absolutely, so its resolution
+/// reads the query alone and needs no clock at all — which is what makes
+/// historic windows addressable.
 #[cfg(any(feature = "server", feature = "verify"))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -706,24 +712,41 @@ pub enum TimeRangeSelector {
     /// The oldest range still active at now. Covers a near-full trailing
     /// window of ~range of history. Best for "trending over the last window".
     Oldest,
+    /// The range starting exactly at `start_ms` (a millisecond timestamp).
+    /// Must lie on the grid — `phase + k * step`, the same values
+    /// [`TimeRangeTransform::containing_buckets`] produces and the storage
+    /// keys spell — or resolution rejects it (see
+    /// [`TimeRangeTransform::is_bucket_start`]). A window with no documents,
+    /// including one that has not started yet, is a provable empty answer
+    /// rather than an error.
+    ByStart {
+        /// The selected window's start on the millisecond timeline.
+        start_ms: u64,
+    },
 }
 
 #[cfg(any(feature = "server", feature = "verify"))]
 impl TimeRangeSelector {
-    /// The selector's wire spelling — the `IN_TIME_RANGE` clause's operand on
-    /// the v1 `getDocuments` wire. The single source of truth for the string
-    /// form: the SDK encoder, the drive-abci decoder and the wasm-sdk JSON
-    /// parser all go through these two functions (and the serde derive above
-    /// is renamed to match), so the spellings cannot drift apart.
+    /// The selector's JSON spelling — the `selector` string of the wasm-sdk
+    /// query surface. The single source of truth for the string form: the
+    /// wasm-sdk JSON parser and every error message quote these spellings.
+    /// (The gRPC wire does not use them: since the typed
+    /// `TimeRangeSelection` operand, the selector rides as a proto enum.)
+    ///
+    /// [`Self::ByStart`] names its *kind* only — the `start_ms` payload
+    /// rides in a separate JSON field, so [`Self::from_string`] cannot
+    /// construct it and parsers of the full shape handle it themselves.
     pub fn as_str(&self) -> &'static str {
         match self {
             TimeRangeSelector::Newest => "newest",
             TimeRangeSelector::Oldest => "oldest",
+            TimeRangeSelector::ByStart { .. } => "byStart",
         }
     }
 
-    /// Parses the wire spelling. Returns `None` for anything but the exact
-    /// strings [`Self::as_str`] produces.
+    /// Parses the spelling of the payload-free selectors. Returns `None`
+    /// for anything else — including `"byStart"`, whose `start_ms` payload
+    /// a bare string cannot carry (see [`Self::as_str`]).
     pub fn from_string(value: &str) -> Option<Self> {
         match value {
             "newest" => Some(TimeRangeSelector::Newest),
@@ -793,11 +816,14 @@ impl ResolvedTimeRange {
 /// [`WhereClause`] on the bucketed source field, using the named grid's
 /// `timeRange` transform and an authoritative `block_time_ms`.
 ///
-/// The server supplies `block_time_ms` from current block time and the
-/// verifier re-derives it from the quorum-signed response metadata `time_ms`,
-/// so both produce the identical concrete equality query — the existing
-/// index/count proofs apply unchanged and the engine never needs a dedicated
-/// time-range operator.
+/// For the relative selectors the server supplies `block_time_ms` from
+/// current block time and the verifier re-derives it from the quorum-signed
+/// response metadata `time_ms`, so both produce the identical concrete
+/// equality query — the existing index/count proofs apply unchanged and the
+/// engine never needs a dedicated time-range operator. A
+/// [`TimeRangeSelector::ByStart`] selection ignores `block_time_ms`
+/// entirely: the start is in the query itself (validated to lie on the
+/// grid), so both sides read the same window with no clock involved.
 ///
 /// `grid` selects among several time-range indexes on the same field: `None`
 /// is accepted only while exactly one grid buckets the field (the common
@@ -853,9 +879,9 @@ pub fn resolve_time_range_bucket_clause(
         None => {
             if grids.len() > 1 {
                 return Err(Error::Query(QuerySyntaxError::Unsupported(format!(
-                    "field \"{}\" is bucketed by {} different grids; the IN_TIME_RANGE operand \
-                     must name one as [selector, range, step] or [selector, range, step, phase] \
-                     (seconds, as the contract declares them)",
+                    "field \"{}\" is bucketed by {} different grids; the IN_TIME_RANGE \
+                     selection must name one in its `grid` (range/step/phase, in seconds, \
+                     as the contract declares them)",
                     field,
                     grids.len()
                 ))));
@@ -867,6 +893,25 @@ pub fn resolve_time_range_bucket_clause(
     let bucket_start = match selector {
         TimeRangeSelector::Newest => transform.newest_active_start(block_time_ms),
         TimeRangeSelector::Oldest => transform.oldest_active_start(block_time_ms),
+        // Absolute selection: the start comes from the query itself, so no
+        // clock is consulted — prover and verifier agree by construction.
+        // Only grid membership is checked; an empty (or not-yet-started)
+        // window is a provable empty answer, not an invalid question.
+        TimeRangeSelector::ByStart { start_ms } => {
+            if !transform.is_bucket_start(start_ms) {
+                return Err(Error::Query(QuerySyntaxError::Unsupported(format!(
+                    "byStart {} on \"{}\" is not a window start of the grid range={}s \
+                     step={}s phase={}s: starts are phase + k*step on the millisecond \
+                     timeline, and an off-grid start is rejected rather than snapped",
+                    start_ms,
+                    field,
+                    transform.range_seconds,
+                    transform.step_seconds,
+                    transform.phase_seconds
+                ))));
+            }
+            Some(start_ms)
+        }
     }
     .ok_or(Error::Query(QuerySyntaxError::Unsupported(format!(
         "no time range on \"{}\" is active yet: the block time predates the grid's phase \

--- a/packages/rs-platform-version/src/version/v14.rs
+++ b/packages/rs-platform-version/src/version/v14.rs
@@ -114,12 +114,14 @@ pub const PROTOCOL_VERSION_14: ProtocolVersion = 14;
 ///    per-document write amplification is capped per index by
 ///    `SystemLimits::max_time_range_overlap_factor`), and the v1
 ///    `getDocuments` handler resolves the new `IN_TIME_RANGE` operator —
-///    bare `"newest"`/`"oldest"` on a single-grid field, or a structured
-///    `[selector, range, step(, phase)]` operand naming one grid — into a
-///    bucket-start equality from committed block time, making "newest
-///    window" trending/leaderboard document and count/sum/avg queries
-///    provable. `unique: true` is admitted only for non-overlapping windows
-///    (`range == step`) sourced from the immutable `$createdAt`.
+///    a typed `TimeRangeSelection` operand: `NEWEST`/`OLDEST` (resolved to
+///    a bucket-start equality from committed block time) or `BY_START`
+///    (naming any window, current or historic, by its grid-aligned start),
+///    with a `grid` member naming one grid where several bucket the field
+///    — making trending/leaderboard document and count/sum/avg queries
+///    provable over the current or any named window. `unique: true` is
+///    admitted only for non-overlapping windows (`range == step`) sourced
+///    from the immutable `$createdAt`.
 ///
 /// The first two are orthogonal by construction: the ranked upgrade decides the
 /// *property-name* tree type, the demotion decides the *value* tree type

--- a/packages/wasm-sdk/src/queries/document.rs
+++ b/packages/wasm-sdk/src/queries/document.rs
@@ -123,14 +123,22 @@ export interface DocumentsQuery {
   /**
    * Time-range bucket selections for "trending"-style queries. Each entry
    * picks a single bucket of a timestamp field covered by a `timeRange`
-   * index. The server resolves the bucket from the current block time and
-   * the proof verifier re-derives it from the signed response metadata, so
-   * the result is provable. Requires protocol version 14+ (the first
-   * version whose contract grammar hosts `timeRange` indexes).
+   * index. For the relative selectors the server resolves the bucket from
+   * the current block time and the proof verifier re-derives it from the
+   * signed response metadata; `"byStart"` names the bucket absolutely, so
+   * both sides read it straight from the query. Provable either way.
+   * Requires protocol version 14+ (the first version whose contract
+   * grammar hosts `timeRange` indexes).
    *
    * - `selector: "oldest"` → the oldest still-active range (a near-full
    *   trailing window of ~`range`; best for "trending over the last window").
    * - `selector: "newest"` → the freshest started range (latest partial slice).
+   * - `selector: "byStart"` → the range starting exactly at `startMs` — any
+   *   window, current or historic. `startMs` is then required and must be a
+   *   window start on the grid (`phase + k * step`, in milliseconds); an
+   *   off-grid start is rejected rather than snapped, and an empty window
+   *   is a provable empty answer. The relative selectors must not carry
+   *   `startMs`.
    *
    * `grid` names one of the field's grids in the contract's own declared
    * seconds (`{ range, step, phase? }`) — required when the contract buckets
@@ -140,7 +148,8 @@ export interface DocumentsQuery {
    */
   timeRange?: {
     field: string;
-    selector: "newest" | "oldest";
+    selector: "newest" | "oldest" | "byStart";
+    startMs?: number;
     grid?: { range: number; step: number; phase?: number };
   }[];
 }
@@ -500,8 +509,14 @@ pub(super) fn parse_where_clause(json_clause: &JsonValue) -> Result<WhereClause,
     })
 }
 
-/// Parse a JSON time-range clause `{ field, selector, grid? }` for
-/// [`DocumentQuery::with_time_range`] / `with_time_range_grid`.
+/// Parse a JSON time-range clause `{ field, selector, startMs?, grid? }`
+/// for [`DocumentQuery::with_time_range`] / `with_time_range_grid`.
+///
+/// `selector` is `"newest"`, `"oldest"`, or `"byStart"`. The relative
+/// selectors resolve their window from block time and must not carry
+/// `startMs`; `"byStart"` names a window absolutely — `startMs` is then
+/// required and must be a window start on the grid (`phase + k * step`,
+/// milliseconds), which the server validates against the contract.
 ///
 /// `grid` is `{ range, step, phase? }` in the contract's own declared
 /// seconds, naming one of the field's grids — required when the contract
@@ -513,7 +528,7 @@ fn parse_time_range_clause(
 ) -> Result<(String, TimeRangeSelector, Option<TimeRangeGridSpec>), WasmSdkError> {
     let object = json_clause.as_object().ok_or_else(|| {
         WasmSdkError::invalid_argument(
-            "timeRange clause must be an object { field, selector, grid? }",
+            "timeRange clause must be an object { field, selector, startMs?, grid? }",
         )
     })?;
     let field = object
@@ -523,15 +538,46 @@ fn parse_time_range_clause(
             WasmSdkError::invalid_argument("timeRange clause requires a string `field`")
         })?
         .to_string();
-    let selector = object
+    let selector_text = object
         .get("selector")
         .and_then(JsonValue::as_str)
-        .and_then(TimeRangeSelector::from_string)
         .ok_or_else(|| {
             WasmSdkError::invalid_argument(
-                "timeRange clause `selector` must be \"newest\" or \"oldest\"",
+                "timeRange clause `selector` must be \"newest\", \"oldest\" or \"byStart\"",
             )
         })?;
+    let start_ms = match object.get("startMs") {
+        None | Some(JsonValue::Null) => None,
+        Some(value) => Some(value.as_u64().ok_or_else(|| {
+            WasmSdkError::invalid_argument(
+                "timeRange clause `startMs` must be an unsigned integer millisecond timestamp",
+            )
+        })?),
+    };
+    let selector = match (selector_text, start_ms) {
+        ("byStart", Some(start_ms)) => TimeRangeSelector::ByStart { start_ms },
+        ("byStart", None) => {
+            return Err(WasmSdkError::invalid_argument(
+                "timeRange clause `selector: \"byStart\"` requires `startMs` naming the \
+                 window's start (a millisecond timestamp on the grid)",
+            ));
+        }
+        (other, start_ms) => {
+            let selector = TimeRangeSelector::from_string(other).ok_or_else(|| {
+                WasmSdkError::invalid_argument(
+                    "timeRange clause `selector` must be \"newest\", \"oldest\" or \"byStart\"",
+                )
+            })?;
+            if start_ms.is_some() {
+                return Err(WasmSdkError::invalid_argument(
+                    "timeRange clause `startMs` is only meaningful with `selector: \
+                     \"byStart\"`; the relative selectors resolve their window from block \
+                     time",
+                ));
+            }
+            selector
+        }
+    };
     let grid = match object.get("grid") {
         None | Some(JsonValue::Null) => None,
         Some(grid_json) => {
@@ -1160,10 +1206,10 @@ mod tests {
     use serde_json::json;
 
     /// This parser is the only boundary turning the public JavaScript
-    /// `{ field, selector, grid? }` shape into a typed time-range clause —
-    /// native and protobuf tests construct their queries after it, so a
-    /// parser that dropped the grid or mis-typed a member would not fail
-    /// them. Pin every branch here.
+    /// `{ field, selector, startMs?, grid? }` shape into a typed time-range
+    /// clause — native and protobuf tests construct their queries after it,
+    /// so a parser that dropped the grid or mis-typed a member would not
+    /// fail them. Pin every branch here.
     #[test]
     fn parses_a_bare_selector_without_a_grid() {
         let (field, selector, grid) =
@@ -1215,7 +1261,44 @@ mod tests {
     #[test]
     fn rejects_an_invalid_selector() {
         parse_time_range_clause(&json!({ "field": "$createdAt", "selector": "latest" }))
-            .expect_err("only \"newest\" and \"oldest\" are selectors");
+            .expect_err("only \"newest\", \"oldest\" and \"byStart\" are selectors");
+    }
+
+    #[test]
+    fn parses_by_start_with_its_window_start() {
+        let (field, selector, grid) = parse_time_range_clause(&json!({
+            "field": "$createdAt",
+            "selector": "byStart",
+            "startMs": 1_756_684_800_000u64,
+        }))
+        .expect("the absolute shape parses");
+        assert_eq!(field, "$createdAt");
+        assert_eq!(
+            selector,
+            TimeRangeSelector::ByStart {
+                start_ms: 1_756_684_800_000
+            }
+        );
+        assert_eq!(grid, None);
+    }
+
+    #[test]
+    fn by_start_requires_a_start_and_relative_selectors_refuse_one() {
+        parse_time_range_clause(&json!({ "field": "$createdAt", "selector": "byStart" }))
+            .expect_err("byStart without startMs names no window");
+        parse_time_range_clause(&json!({
+            "field": "$createdAt",
+            "selector": "newest",
+            "startMs": 1_756_684_800_000u64,
+        }))
+        .expect_err("a relative selector resolves its window from block time, not startMs");
+        // and startMs must be an unsigned integer of milliseconds
+        parse_time_range_clause(&json!({
+            "field": "$createdAt",
+            "selector": "byStart",
+            "startMs": -5,
+        }))
+        .expect_err("a negative start is not a millisecond timestamp");
     }
 
     #[test]


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `IN_TIME_RANGE` operand rode the generic `DocumentFieldValue` slot as a magic string (`"newest"`/`"oldest"`) or a positional list naming a grid, and those two relative selectors were the platform's entire window-addressing vocabulary: only windows touching current block time were reachable, on every query surface. "Yesterday's window" was inexpressible.

This PR replaces the string operand with a properly typed selection and adds `BY_START`, which names **any window — current or historic — absolutely** by its grid-aligned start. It is the query-surface prerequisite for provable historic trending, and for the planned ranked×timeRange follow-up (windowed top-K), whose routing can now accept a typed window pin.

## What was done?

**Wire** (`platform.proto`): a new nested `TimeRangeSelection` message — `enum Selector { NEWEST, OLDEST, BY_START }`, an `optional uint64 start_ms`, and a structured `Grid { range, step, phase }` (contract-declared seconds) — carried in a new `WhereClause.time_range` field. For `operator = IN_TIME_RANGE` the generic `value` must be unset, and vice versa; either mismatch is rejected. The old text/list spelling is **removed outright rather than deprecated**: the PV14 wire has only ever shipped on the 4.2 dev prerelease train. The list operand's zero-phase canonicalization rule becomes structural (proto3's default IS the omission), so its rejection branch is deleted with it.

**`BY_START` semantics**: the start must lie on the grid (`phase + k * step`, milliseconds); an off-grid start is rejected rather than snapped — a snapped start would prove an answer to a question the client didn't ask. A window with no documents (including one that has not started yet) is a provable empty answer. Resolution reads the query alone and never consults a clock, so prover and verifier agree by construction.

**Per layer**:
- `rs-drive`: `TimeRangeSelector::ByStart { start_ms }` + the resolver arm in `resolve_time_range_bucket_clause` (validates grid alignment, ignores `block_time_ms`).
- `rs-dpp`: `TimeRangeTransform::is_bucket_start` — the single source of the alignment rule.
- `rs-drive-abci`: strict decoder rewrite for the typed operand — unknown discriminants, `BY_START` without `start_ms`, `start_ms` on a relative selector, an all-default `Grid`, and a `value`/`time_range` mix are each rejected explicitly.
- `dash-platform-queries`: typed encoder; the existing `with_time_range` / `with_time_range_grid` builders take the new variant with no API change.
- `wasm-sdk`: JSON surface gains `{ selector: "byStart", startMs }` with matching TS types and parser validation.

Also corrects the stale doc note in `time_range.rs` claiming ranked queries accept no where clauses (they take equality-prefix pins since the ranked prefix work); the accurate statement is that contract validation and the ranked dispatcher exclude bucketed indexes until bucket-aware ranked semantics are designed.

## How Has This Been Tested?

- **Historic-window e2e** (`a_historic_window_counts_and_verifies_by_start`): a `BY_START` count of the window one step behind "newest" returns 3 posts where the newest window holds 2 — proved by the real v1 handler and verified through the SDK `FromProof` entry point. The differing counts pin that the named window, not "the current one", was addressed.
- **Clock invariance** (`a_by_start_proof_is_indifferent_to_the_signed_time`): re-signing the response over a one-step-later metadata time still verifies a `BY_START` proof — the mirror image of the existing tamper tests, where the same nudge correctly fails a `NEWEST` proof.
- **Decode rejection matrix** (`malformed_typed_operands_are_refused`): six malformed-operand shapes, each asserted against its specific error.
- Off-grid start rejection, grid-alignment unit tests on the transform (including the phased-grid and zero-step edges), typed-operand encoder tests in `dash-platform-queries` (grid-less `NEWEST` and `BY_START` + grid), and wasm-sdk parser tests for every `byStart` branch.
- Existing time-range proof-verification suite (18 tests) green; `cargo check --tests` green across all touched crates.

## Breaking Changes

None for consensus or any released network. The v1 `getDocuments` `IN_TIME_RANGE` operand encoding changes incompatibly, but that wire exists only on the unreleased 4.2 dev train — a dev.7 client sending the old text/list operand to a node with this change gets an explicit `InvalidArgument` naming the typed operand, not a silent misread.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for absolute time-range queries using the `byStart` selector and a specified window start.
  * Added typed time-range selections with explicit grid settings.
  * Added validation for grid-aligned starts and malformed time-range parameters.

* **Bug Fixes**
  * Improved compatibility when reading older time-range query formats.
  * Clarified and strengthened handling of invalid or unsupported time-range clauses.

* **Documentation**
  * Updated time-range query documentation and examples for the new selectors and grid behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->