### PR TITLE
fix(dpp): surface identifier-typed document properties as base58 in JS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,8 @@ jobs:
               - packages/js-dash-sdk/**
               - packages/wallet-lib/**
               - packages/wasm-sdk/**
+              - packages/wasm-dpp2/**
+              - packages/js-evo-sdk/**
               - packages/dapi/.env.example
               - packages/rs-drive-abci/.env.local
               - .github/actions/aws_ecr_login/**

--- a/packages/wasm-dpp2/src/data_contract/document/model.rs
+++ b/packages/wasm-dpp2/src/data_contract/document/model.rs
@@ -289,7 +289,12 @@ impl DocumentWasm {
                 .map(|(k, v)| (Value::Text(k.clone()), v.clone()))
                 .collect(),
         );
-        let js_value = serialization::platform_value_to_object(&properties_value)?;
+        // Identifier-typed properties surface as base58 strings — the
+        // form where-clauses accept back, so a proven join value can be
+        // used as a pagination cursor directly. Other binary properties
+        // stay Uint8Array.
+        let js_value =
+            serialization::platform_value_to_object_with_base58_identifiers(&properties_value)?;
         Ok(js_value.into())
     }
 

--- a/packages/wasm-dpp2/src/serialization/conversions.rs
+++ b/packages/wasm-dpp2/src/serialization/conversions.rs
@@ -374,6 +374,41 @@ fn stringify_key(key: &platform_value::Value) -> platform_value::Value {
     }
 }
 
+/// Serialize platform_value::Value to JsValue as a JS object like
+/// [`platform_value_to_object`], but with `Value::Identifier` VALUES as
+/// base58 strings (matching the `Identifier` JSON convention and the
+/// base58 form query where-clauses accept). `Value::Bytes*` still become
+/// Uint8Array. This is the document `properties` surface: every typed
+/// decode path (binary document deserialization, index-key synthesis)
+/// produces `Value::Identifier` for identifier-typed properties, so the
+/// variant alone marks them — no document-type schema is needed here.
+pub fn platform_value_to_object_with_base58_identifiers(
+    value: &platform_value::Value,
+) -> WasmDppResult<JsValue> {
+    platform_value_to_object(&identifier_values_to_base58(value))
+}
+
+/// Recursively convert `Value::Identifier` values to base58 `Value::Text`.
+/// Map keys are left alone — [`stringify_map_keys_for_object`] already
+/// renders identifier keys as base58.
+fn identifier_values_to_base58(value: &platform_value::Value) -> platform_value::Value {
+    use dpp::platform_value::Value;
+    use dpp::platform_value::string_encoding::{Encoding, encode};
+    match value {
+        Value::Identifier(bytes) => Value::Text(encode(bytes, Encoding::Base58)),
+        Value::Map(entries) => Value::Map(
+            entries
+                .iter()
+                .map(|(k, v)| (k.clone(), identifier_values_to_base58(v)))
+                .collect(),
+        ),
+        Value::Array(items) => {
+            Value::Array(items.iter().map(identifier_values_to_base58).collect())
+        }
+        other => other.clone(),
+    }
+}
+
 /// Serialize platform_value::Value to JsValue as JSON-compatible (human-readable).
 ///
 /// Converts Value::Identifier and Value::Bytes to base58/base64 strings for JSON compatibility.

--- a/packages/wasm-dpp2/tests/unit/Document.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/Document.spec.ts
@@ -256,6 +256,44 @@ describe('Document', () => {
 
       expect(documentInstance.properties).to.deep.equal(document2);
     });
+
+    it('should surface identifier-typed properties as base58 strings', () => {
+      const contractWithIdentifier = {
+        ...dataContractValue,
+        documentSchemas: {
+          note: {
+            type: 'object',
+            properties: {
+              message: { type: 'string', position: 0 },
+              authorId: {
+                type: 'array',
+                byteArray: true,
+                contentMediaType: 'application/x.dash.dpp.identifier',
+                minItems: 32,
+                maxItems: 32,
+                position: 1,
+              },
+            },
+            additionalProperties: false,
+          },
+        },
+      };
+      const dataContract = wasm.DataContract.fromJSON(contractWithIdentifier, false);
+      const documentInstance = createDocument({
+        id,
+        properties: { message: 'hi', authorId: id },
+        dataContractId: dataContract.id.toBase58(),
+      });
+
+      const bytes = documentInstance.toBytes(dataContract, new PlatformVersion(1));
+      const restored = wasm.Document.fromBytes(bytes, dataContract, 'note', new PlatformVersion(1));
+
+      // The schema-typed decode yields Value::Identifier for authorId,
+      // and the properties getter surfaces it as base58 — the form
+      // where-clauses accept back as a cursor.
+      expect(restored.properties.authorId).to.equal(id);
+      expect(restored.properties.message).to.equal('hi');
+    });
   });
 
   describe('revision', () => {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Since #4567/#4568 merged, the platform-test-suite "Test Suite" and "Test Suite in browser (1)" CI jobs fail on **every PR** against v4.2-dev:

```
IndexOnlyDocument.spec.js:331 — should fetch liked posts through a chained query with verified proofs
AssertionError: expected Uint8Array[...] to equal '<base58>'
```

The `Document` `properties` getter in wasm-dpp2 serialized property values through the non-human-readable serde path, so identifier-typed properties reached JS as `Uint8Array`. The chained-query surface documents them as base58 strings — that's the form inner where-clauses accept back, so a proven join value works as a pagination cursor directly (the README's documented pattern; a `Uint8Array` wouldn't even deserialize into the query's JSON where-clauses) — and the functional spec asserts it.

No schema threading is needed for the fix: every typed decode path already marks these values as `Value::Identifier` — binary document deserialization (`DocumentPropertyType` read) for full documents and `decode_value_for_tree_keys` for indexOnly index-key synthesis — so the variant alone identifies them at the JS boundary.

## What was done?

- Added `platform_value_to_object_with_base58_identifiers` to wasm-dpp2's serialization conversions: recursively converts `Value::Identifier` **values** to base58 `Value::Text` before the usual object serialization. Map keys already surfaced identifier keys as base58 via `stringify_map_keys_for_object`; now values match.
- The `Document` `properties` getter uses it. Other binary properties (`Value::Bytes*`) still surface as `Uint8Array`, and `toObject()` / `toJSON()` are unchanged.

This fixes the surface uniformly for every read path that returns `Document` wrappers (`getDocuments`, `getChainedDocuments` inner and outer halves, DPNS, document history), in both Node and browser bundles — the failure was never browser-specific; the Node "Test Suite" job fails on the same assertion (e.g. run 33496971715).

## How Has This Been Tested?

- New wasm-dpp2 unit test: a document round-tripped through `toBytes`/`fromBytes` with a contract carrying an identifier-typed property (`contentMediaType: application/x.dash.dpp.identifier`) surfaces that property as the base58 string, while other properties keep their shapes. This exercises the same `Value::Identifier`-producing decode path the chained query verifier uses.
- Full wasm-dpp2 unit suite: 1158 passing.
- `cargo check`/`clippy` for wasm-dpp2 on wasm32 clean.
- The failing functional spec `IndexOnlyDocument.spec.js` asserts this exact surface against a local network in the Test Suite CI jobs on this PR.

Also added `packages/wasm-dpp2/**` and `packages/js-evo-sdk/**` to the `e2e-tests-changed` CI filter: the suite drives the network through `@dashevo/evo-sdk` (wasm-dpp2 under it) since #4567, but changes to those packages didn't trigger the Test Suite jobs — including this PR's fix, which would otherwise merge unproven.

## Breaking Changes

None (no consensus impact). The JS `Document.properties` getter now returns base58 strings instead of `Uint8Array` for identifier-typed properties; the only in-repo consumer asserting on this surface is the chained-query functional spec, which expects base58.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Document identifier properties are now consistently represented as Base58 strings when serialized and deserialized.
  * Other binary properties continue to be handled as binary data.

* **Tests**
  * Added coverage to verify identifier and regular string property handling.
  * Expanded end-to-end test detection for relevant package changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->