### PR TITLE
feat(drive): ranked windowed top-K — ranked indexes below timeRange buckets

### DIFF
--- a/packages/dash-platform-queries/src/documents/having_proof_helpers.rs
+++ b/packages/dash-platform-queries/src/documents/having_proof_helpers.rs
@@ -104,27 +104,16 @@ pub(super) fn verify_having_query(
         .or(Err(drive_proof_verifier::Error::EmptyResponseMetadata))?;
 
     // Resolve any pending time-range selection through the shared
-    // normalization helper, then reject the request outright if anything
-    // resolved — mirroring the server-side rejection in drive's
-    // `execute_document_having_request`. HAVING accepts equality prefixes
-    // on compound ranked indexes (which exclude transformed indexes), so a
-    // resolved bucket-start equality would pin a *plain* ranked index on
-    // the same timestamp field, and a malicious node could return a valid
-    // proof over raw-timestamp matches at the bucket boundary instead of
-    // the requested window. Without this guard the verifier would
-    // authenticate a request shape honest servers refuse.
+    // normalization helper — the resolved bucket-start equality joins the
+    // where set as the pin on the bucketed first level, and the
+    // provenance is threaded into index resolution below. The picker's
+    // admissibility rule is the load-bearing half: the resolved pin is
+    // only ever matched against the index bucketing that field with
+    // exactly the resolved grid — never a plain index over raw
+    // timestamps, where a malicious node could authenticate
+    // boundary-timestamp matches as window membership.
     let resolved_time_ranges =
         normalize_time_range_clauses_with_metadata_time(&mut request, mtd.time_ms)?;
-    if !resolved_time_ranges.is_empty() {
-        return Err(drive_proof_verifier::Error::RequestError {
-            error: "a HAVING query cannot carry a time-range (IN_TIME_RANGE) selection: its \
-                    equality prefixes pin plain ranked indexes, so a resolved bucket-start \
-                    equality would authenticate raw-timestamp matches at the bucket boundary \
-                    instead of window membership — the server rejects this request and the \
-                    verifier must not authenticate a proof for it"
-                .to_string(),
-        });
-    }
 
     let document_type = request
         .data_contract
@@ -148,6 +137,7 @@ pub(super) fn verify_having_query(
         request.document_type_name.clone(),
         document_type.indexes(),
         &mode,
+        &resolved_time_ranges,
         platform_version,
     )
     .map_err(|e| drive_proof_verifier::Error::RequestError {

--- a/packages/dash-platform-queries/src/documents/ranked_proof_helpers.rs
+++ b/packages/dash-platform-queries/src/documents/ranked_proof_helpers.rs
@@ -132,29 +132,17 @@ pub(super) fn verify_ranked_query(
         .or(Err(drive_proof_verifier::Error::EmptyResponseMetadata))?;
 
     // Resolve any pending time-range (`IN_TIME_RANGE`) selections through
-    // the shared normalization helper, then reject the request outright if
-    // anything resolved — mirroring the server, whose
-    // `execute_document_ranked_request` refuses non-empty provenance. The
-    // rejection is load-bearing, not a shape formality: ranked mode accepts
-    // equality pins on compound ranked indexes, and the ranked picker
-    // excludes transformed indexes, so a resolved bucket-start equality
-    // would pin a *plain* ranked index on the same timestamp field. A
-    // malicious node could then return a valid proof over that subtree —
-    // documents whose raw timestamp equals the bucket boundary, not the
-    // requested window — and without this guard the verifier would
-    // authenticate it even though an honest server rejects the request.
+    // the shared normalization helper — a `newest`/`oldest` selector
+    // re-derives its window from the quorum-signed metadata time, a
+    // `byStart` from the query itself, so client and prover land on the
+    // identical bucket-start pin. The provenance is threaded into index
+    // resolution below, whose admissibility rule is the load-bearing
+    // half: a resolved bucket-start equality is only ever matched against
+    // the index bucketing that field with exactly the resolved grid —
+    // never a plain index over raw timestamps, where a malicious node
+    // could authenticate boundary-timestamp matches as window membership.
     let resolved_time_ranges =
         normalize_time_range_clauses_with_metadata_time(&mut request, mtd.time_ms)?;
-    if !resolved_time_ranges.is_empty() {
-        return Err(drive_proof_verifier::Error::RequestError {
-            error: "a ranked query cannot carry a time-range (IN_TIME_RANGE) selection: \
-                    ranking groups by an index's own property, a document belongs to every \
-                    bucket containing its timestamp, and the resolved bucket-start equality \
-                    could only pin a plain index over raw timestamps — the server rejects \
-                    this request and the verifier must not authenticate a proof for it"
-                .to_string(),
-        });
-    }
 
     let document_type = request
         .data_contract
@@ -181,6 +169,7 @@ pub(super) fn verify_ranked_query(
         request.document_type_name.clone(),
         document_type.indexes(),
         &mode,
+        &resolved_time_ranges,
         platform_version,
     )
     .map_err(|e| drive_proof_verifier::Error::RequestError {

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v3/index_only_tests.rs
@@ -518,12 +518,11 @@ fn trending_posts_contract_with_windowed_like_counts_validates() {
 }
 
 #[test]
-fn trending_posts_ranked_windowed_index_is_still_rejected() {
-    // The deliberate tripwire for the ranked-x-timeRange gap: server-ordered
-    // "top posts this window" needs `rankedCountable` on the bucketed
-    // index, and contract validation still rejects that combination until
-    // bucket-aware ranked semantics land. When that feature ships, this
-    // test should flip into an acceptance test rather than be deleted.
+fn trending_posts_ranked_windowed_index_validates() {
+    // The former tripwire for the ranked-x-timeRange gap, flipped into the
+    // acceptance test it was written to become: server-ordered "top posts
+    // this window" declares `rankedCountable` on the bucketed index, and
+    // validation now admits ranked levels below the bucketed one.
     let mut schema = trending_posts_likes_schema();
     schema
         .get_mut("indices")
@@ -535,16 +534,43 @@ fn trending_posts_ranked_windowed_index_is_still_rejected() {
         .expect("byWindowPost exists")
         .set_value("rankedCountable", platform_value!(true))
         .expect("index key applies");
-    // Raised by the index parser rather than the doc-type-level checks, so
-    // it reaches here in a different `ProtocolError` wrapping than the
-    // errors `expect_structure_error` matches — assert on the message.
-    let error = parse_with(schema, PlatformVersion::latest(), false)
-        .expect_err("ranked flags on a bucketed index must be refused");
+    let document_type = parse_with(schema, PlatformVersion::latest(), false)
+        .expect("ranked below the bucketed level must validate");
+    let bucketed = document_type
+        .indices
+        .values()
+        .find(|index| index.time_range.is_some())
+        .expect("the windowed index parsed");
     assert!(
-        error
-            .to_string()
-            .contains("a timeRange index cannot be ranked"),
-        "expected the ranked-x-timeRange rejection, got: {error}"
+        bucketed.ranked_countable,
+        "the windowed index carries the per-window ranking"
+    );
+}
+
+#[test]
+fn trending_posts_ranked_at_bucketed_source_still_rejected() {
+    // The one spelling that stays deferred: ranking the bucketed level
+    // itself (ordering the windows by their aggregates). `at` naming the
+    // transform source is that spelling.
+    let mut schema = trending_posts_likes_schema();
+    schema
+        .get_mut("indices")
+        .expect("indices accessible")
+        .expect("indices present")
+        .as_array_mut()
+        .expect("indices is an array")
+        .get_mut(0)
+        .expect("byWindowPost exists")
+        .set_value(
+            "rankedCountable",
+            platform_value!({ "at": ["$createdAt", "postId"] }),
+        )
+        .expect("index key applies");
+    let error = parse_with(schema, PlatformVersion::latest(), false)
+        .expect_err("ranking the bucketed level itself must stay refused");
+    assert!(
+        error.to_string().contains("bucketed source"),
+        "expected the bucketed-source rejection, got: {error}"
     );
 }
 

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -2127,24 +2127,48 @@ impl Index {
                     "a timeRange index cannot be a contested resource".to_string(),
                 ));
             }
-            // The ranked query surface excludes bucketed indexes — a document
-            // is stored once per containing bucket, so ranking groups keyed by
-            // bucket starts would score each document `overlap_factor` times.
-            // Since no ranked query can ever select such an index, allowing
-            // the flags would only make the contract pay for ranked
-            // secondaries that are unreachable; reject the combination until
-            // bucket-aware ranked semantics are deliberately designed.
-            if ranked_countable
+            // Ranked axes compose with bucketing BELOW the bucketed level:
+            // a ranked level's per-prefix secondaries live inside their
+            // prefix's subtree, and a bucket start is just another prefix
+            // value — within any single bucket's subtree a document appears
+            // exactly once, so per-window rankings are exact regardless of
+            // window overlap (a document in several windows raises each
+            // window's own honest aggregate; that is the meaning of
+            // overlapping windows, not double counting). Ranked queries pin
+            // the bucket the same way they pin every other leading property
+            // — through a resolved time-range selection.
+            //
+            // What has no designed semantics yet is ranking the bucketed
+            // level ITSELF — ordering the windows by their aggregates. That
+            // needs its own routing shape (no prefix pin above the first
+            // level, a grid named by the query), so exactly that is still
+            // rejected, in its two spellings:
+            // - every ranked flag ranks the terminal level, so on a
+            //   single-property bucketed index the only rankable level IS
+            //   the bucketed one;
+            // - an `at` chain naming the transform's source ranks the
+            //   bucketed level explicitly.
+            let any_ranked_axis = ranked_countable
                 || !ranked_countable_at.is_empty()
                 || ranked_summable
-                || ranked_averageable
-            {
+                || ranked_averageable;
+            if any_ranked_axis && index_properties.len() == 1 {
                 return Err(DataContractError::InvalidContractStructure(
-                    "a timeRange index cannot be ranked (rankedCountable / rankedSummable / \
-                     rankedAverageable): ranked queries have no time-bucket semantics, so the \
-                     ranked secondaries would be maintained but never servable"
+                    "a single-property timeRange index cannot be ranked: its only level is \
+                     the bucketed one, and ranking the windows themselves (ordering bucket \
+                     starts by their aggregates) is not supported yet — add the property to \
+                     rank below the bucketed timestamp, e.g. [timestamp, hashtag]"
                         .to_string(),
                 ));
+            }
+            if ranked_countable_at.iter().any(|at| at == &transform.source) {
+                return Err(DataContractError::InvalidContractStructure(format!(
+                    "rankedCountable.at cannot name \"{}\", a timeRange index's bucketed \
+                     source: ranking the windows themselves (ordering bucket starts by \
+                     their aggregates) is not supported yet — rank the levels below the \
+                     bucketed timestamp instead",
+                    transform.source
+                )));
             }
             // Same reasoning as the ranked `nullSearchable` rejection above,
             // plus a write-path invariant: the insert, delete and update
@@ -4976,7 +5000,8 @@ mod tests {
     fn test_index_try_from_ranked_countable_at_on_time_range_index_rejected() {
         let mut index_map = prefix_ranked_index_map(ranked_at("$createdAt"));
         // Make the fixture a [$createdAt, postId] compound so `at` names the
-        // bucketed leading property.
+        // bucketed leading property — ranking the windows themselves, the one
+        // spelling still deferred.
         index_map[0].1 = Value::Array(vec![
             Value::Map(vec![(
                 Value::Text("$createdAt".to_string()),
@@ -4987,25 +5012,97 @@ mod tests {
                 Value::Text("asc".to_string()),
             )]),
         ]);
-        index_map.push((
-            Value::Text("timeRange".to_string()),
-            Value::Map(vec![
-                (
-                    Value::Text("on".to_string()),
-                    Value::Text("$createdAt".to_string()),
-                ),
-                (Value::Text("range".to_string()), Value::U64(21_600)),
-                (Value::Text("step".to_string()), Value::U64(7_200)),
-            ]),
-        ));
+        index_map.push((Value::Text("timeRange".to_string()), time_range_entry()));
         let result = Index::try_from_value_map(index_map.as_slice(), v3_admissions());
         let msg = format!(
             "{:?}",
-            result.expect_err("prefix form on a timeRange index must be rejected")
+            result.expect_err("at naming the bucketed source must be rejected")
         );
         assert!(
-            msg.contains("timeRange") && msg.contains("ranked"),
-            "error must state the timeRange/ranked conflict; got {msg}"
+            msg.contains("bucketed source"),
+            "error must state that the bucketed level itself cannot rank; got {msg}"
+        );
+    }
+
+    fn time_range_entry() -> Value {
+        Value::Map(vec![
+            (
+                Value::Text("on".to_string()),
+                Value::Text("$createdAt".to_string()),
+            ),
+            (Value::Text("range".to_string()), Value::U64(21_600)),
+            (Value::Text("step".to_string()), Value::U64(7_200)),
+        ])
+    }
+
+    /// Ranked levels BELOW the bucketed one are legal (any grid — overlap
+    /// included): within one bucket's subtree a document appears once, so
+    /// per-window rankings are exact. Both the at-form on a middle level
+    /// and the canonicalized terminal form must parse.
+    #[test]
+    fn test_index_try_from_ranked_below_bucketed_level_parses() {
+        // [$createdAt, hashtag, postId] with at: "hashtag" — per-window top
+        // hashtags.
+        let mut index_map = prefix_ranked_index_map(ranked_at("hashtag"));
+        index_map[0].1 = Value::Array(vec![
+            Value::Map(vec![(
+                Value::Text("$createdAt".to_string()),
+                Value::Text("asc".to_string()),
+            )]),
+            Value::Map(vec![(
+                Value::Text("hashtag".to_string()),
+                Value::Text("asc".to_string()),
+            )]),
+            Value::Map(vec![(
+                Value::Text("postId".to_string()),
+                Value::Text("asc".to_string()),
+            )]),
+        ]);
+        index_map.push((Value::Text("timeRange".to_string()), time_range_entry()));
+        let index = Index::try_from_value_map(index_map.as_slice(), v3_admissions())
+            .expect("ranked below the bucketed level must parse");
+        assert_eq!(index.ranked_countable_at, vec!["hashtag".to_string()]);
+        assert!(index.time_range.is_some());
+
+        // [$createdAt, postId] with the terminal boolean — per-window top
+        // posts.
+        let mut index_map = prefix_ranked_index_map(Value::Bool(true));
+        index_map[0].1 = Value::Array(vec![
+            Value::Map(vec![(
+                Value::Text("$createdAt".to_string()),
+                Value::Text("asc".to_string()),
+            )]),
+            Value::Map(vec![(
+                Value::Text("postId".to_string()),
+                Value::Text("asc".to_string()),
+            )]),
+        ]);
+        index_map.push((Value::Text("timeRange".to_string()), time_range_entry()));
+        let index = Index::try_from_value_map(index_map.as_slice(), v3_admissions())
+            .expect("the terminal ranked form below a bucketed level must parse");
+        assert!(index.ranked_countable);
+        assert!(index.time_range.is_some());
+    }
+
+    /// On a single-property bucketed index the only level IS the bucketed
+    /// one, so every ranked flag would rank the windows themselves — still
+    /// deferred, rejected with its own message.
+    #[test]
+    fn test_index_try_from_single_property_time_range_ranked_rejected() {
+        let mut index_map = prefix_ranked_index_map(Value::Bool(true));
+        index_map[0].1 = Value::Array(vec![Value::Map(vec![(
+            Value::Text("$createdAt".to_string()),
+            Value::Text("asc".to_string()),
+        )])]);
+        index_map.push((Value::Text("timeRange".to_string()), time_range_entry()));
+        let result = Index::try_from_value_map(index_map.as_slice(), v3_admissions());
+        let msg = format!(
+            "{:?}",
+            result.expect_err("a single-property bucketed ranked index must be rejected")
+        );
+        assert!(
+            msg.contains("single-property timeRange"),
+            "error must name the single-property case; got {msg}"
         );
     }
 

--- a/packages/rs-drive-abci/src/query/document_query/v1/tests.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/tests.rs
@@ -4114,6 +4114,7 @@ mod having_trust_boundary {
                 .expect("grade doctype exists")
                 .indexes(),
             &mode,
+            &[],
             PlatformVersion::latest(),
         )
         .expect("the fixture declares the avg axis")
@@ -5696,95 +5697,289 @@ mod time_range_proof_verification {
             );
         }
     }
-    // ----- routes that must refuse time-range selections ------------------
+    // ----- ranked windowed top-K (ranked × timeRange) ----------------------
 
+    use dash_platform_queries::documents::document_query::RankingDirection;
+    use drive::query::RankedEntryValue;
     use drive_proof_verifier::{DocumentHavingEntries, DocumentRankedEntries};
 
-    /// The HAVING route accepts equality prefixes that pin plain ranked
-    /// indexes, and its picker excludes transformed ones — so a resolved
-    /// bucket-start equality reaching it would be served from raw
-    /// timestamps at the bucket boundary instead of the selected window.
-    /// The server must refuse the combination outright (drive owns the
-    /// rejection, through `DocumentHavingRequest::resolved_time_ranges`).
-    #[test]
-    fn the_having_route_refuses_a_time_range_selection() {
-        let (platform, base_state, version) = setup_platform(None, Network::Testnet, None);
-        let (contract, _documents, state) = setup_trending(&platform, &base_state, version);
-
-        let request = GetDocumentsRequestV1 {
-            group_by: vec!["hashtag".to_string()],
-            having: vec![hc(
-                having_aggregate::Function::Count,
-                "",
-                having_clause::Operator::GreaterThan,
-                Value::U64(0),
-            )],
-            ..trending_request(contract.id().to_vec(), "ibiza", select_count_star())
-        };
-        let result = platform
-            .query_documents_v1(request, &state, version)
-            .expect("transport-level success");
-        assert!(
-            format!("{:?}", result.errors).contains("time-range"),
-            "the HAVING route must refuse a time-range selection, got {:?}",
-            result.errors
-        );
+    /// The trending contract with the per-window ranking: the bucketed
+    /// index also declares the ranked keywords, so each window's hashtag
+    /// leaderboard is a per-prefix secondary under that window's bucket
+    /// value tree. The raw `byCreatedHashtag` sibling covers the identical
+    /// property set WITHOUT the transform — the admissibility trap: a
+    /// picker matching by property names alone would route the resolved
+    /// bucket pin onto raw timestamps, and the window counts asserted
+    /// below (2 and 3) could never come back from it, since an
+    /// exact-timestamp prefix holds at most one post's hashtag.
+    fn register_ranked_trending_contract(
+        platform: &Platform<MockCoreRPCLike>,
+        platform_version: &PlatformVersion,
+    ) -> DataContract {
+        let factory = DataContractFactory::new(platform_version.protocol_version)
+            .expect("expected a factory");
+        let schemas = platform_value!({
+            DOCUMENT_TYPE: {
+                "type": "object",
+                "properties": {
+                    // 61, not 63: a ranked group key caps at 61 UTF-8-max
+                    // characters (grovedb's 247-byte secondary key bound)
+                    "hashtag": { "type": "string", "maxLength": 61, "position": 0 },
+                },
+                "indices": [
+                    {
+                        "name": BUCKETED_INDEX,
+                        "properties": [{ "$createdAt": "asc" }, { "hashtag": "asc" }],
+                        "countable": true,
+                        "rangeCountable": true,
+                        "rankedCountable": true,
+                        "timeRange": { "on": "$createdAt", "range": 21_600u64, "step": 7_200u64 },
+                    },
+                    {
+                        "name": "byCreatedHashtag",
+                        "properties": [{ "$createdAt": "asc" }, { "hashtag": "asc" }],
+                        "countable": true,
+                        "rangeCountable": true,
+                        "rankedCountable": true,
+                    },
+                ],
+                "required": ["$createdAt", "hashtag"],
+                "additionalProperties": false,
+            }
+        });
+        let contract = factory
+            .create_with_value_config(Identifier::new([11u8; 32]), 0, schemas, None, None)
+            .expect("a bucketed index may rank levels below the bucket")
+            .data_contract_owned();
+        store_data_contract(platform, &contract, platform_version);
+        contract
     }
 
-    /// The ranked and HAVING *verifiers* must refuse a time-range request
-    /// before authenticating anything: both surfaces pin plain ranked
-    /// indexes with equality prefixes, so a malicious node could otherwise
-    /// prove raw-timestamp matches at the bucket boundary against a request
-    /// shape every honest server rejects. The rejection fires ahead of
-    /// proof verification, so any signed response works as the fixture.
+    fn setup_ranked_trending(
+        platform: &TempPlatform<MockCoreRPCLike>,
+        base_state: &PlatformState,
+        platform_version: &PlatformVersion,
+    ) -> (DataContract, PlatformState) {
+        let contract = register_ranked_trending_contract(platform, platform_version);
+        insert_posts(platform, &contract, platform_version);
+        let state = state_with_committed_block_time(base_state, &platform.drive, platform_version);
+        (contract, state)
+    }
+
+    /// `SELECT COUNT(*) WHERE IN_TIME_RANGE($createdAt, <selection>)
+    /// GROUP BY hashtag ORDER BY $count DESC LIMIT 10` on the wire.
+    fn windowed_top_k_request(
+        contract_id: Vec<u8>,
+        selection: ProtoTimeRangeSelection,
+    ) -> GetDocumentsRequestV1 {
+        GetDocumentsRequestV1 {
+            data_contract_id: contract_id,
+            document_type: DOCUMENT_TYPE.to_string(),
+            where_clauses: vec![ProtoWhereClause {
+                field: CREATED_AT.to_string(),
+                operator: ProtoWhereOperator::InTimeRange as i32,
+                value: None,
+                time_range: Some(selection),
+            }],
+            order_by: vec![oc("$count", false)],
+            limit: Some(10),
+            start: None,
+            prove: true,
+            selects: select_count_star(),
+            group_by: vec!["hashtag".to_string()],
+            having: Vec::new(),
+            offset: None,
+            chained: None,
+        }
+    }
+
+    fn newest_selection() -> ProtoTimeRangeSelection {
+        ProtoTimeRangeSelection {
+            selector: ProtoTimeRangeSelector::Newest as i32,
+            start_ms: None,
+            grid: None,
+        }
+    }
+
+    fn by_start_selection(start_ms: u64) -> ProtoTimeRangeSelection {
+        ProtoTimeRangeSelection {
+            selector: ProtoTimeRangeSelector::ByStart as i32,
+            start_ms: Some(start_ms),
+            grid: None,
+        }
+    }
+
+    /// The ranked client query mirroring [`windowed_top_k_request`], with
+    /// the selection still pending for the entry point to resolve from the
+    /// signed metadata time (or, for `ByStart`, from the query itself).
+    fn windowed_top_k_query(
+        contract: &DataContract,
+        selector: TimeRangeSelector,
+    ) -> SdkDocumentQuery {
+        SdkDocumentQuery::new(Arc::new(contract.clone()), DOCUMENT_TYPE)
+            .expect("the fixture has this document type")
+            .with_select(SelectProjection::count_star())
+            .with_group_by("hashtag")
+            .order_by_selected_aggregate(RankingDirection::Descending)
+            .with_limit(10)
+            .with_time_range(CREATED_AT, selector)
+    }
+
+    fn assert_hashtag_counts(entries: &[drive::query::RankedEntry], expected: &[(&str, u64)]) {
+        assert_eq!(
+            entries.len(),
+            expected.len(),
+            "the page must hold exactly the window's groups"
+        );
+        for (entry, (hashtag, count)) in entries.iter().zip(expected) {
+            assert_eq!(
+                entry.key,
+                hashtag.as_bytes().to_vec(),
+                "group keys come back as raw index-key bytes in ranking order"
+            );
+            assert_eq!(entry.value, RankedEntryValue::Count(*count));
+        }
+    }
+
+    /// The headline capability: server-ordered top hashtags of the current
+    /// window, one query, one proof, verified through the SDK entry point.
+    /// The newest window holds two `#ibiza` posts and one `#berlin`, while
+    /// `#ibiza`'s third post sits only in older windows — so the counts
+    /// (2, 1) pin that the secondary served the pinned window's own
+    /// leaderboard: the raw sibling index could produce at most 1 per
+    /// group, and an all-time ranking would score ibiza 3.
     #[test]
-    fn ranked_and_having_verifiers_refuse_time_range_requests() {
+    fn windowed_top_k_serves_and_verifies_through_the_entry_point() {
         let (platform, base_state, version) = setup_platform(None, Network::Testnet, None);
-        let (contract, _documents, state) = setup_trending(&platform, &base_state, version);
-        let request = trending_request(contract.id().to_vec(), "ibiza", select_count_star());
+        let (contract, state) = setup_ranked_trending(&platform, &base_state, version);
+
+        let request = windowed_top_k_request(contract.id().to_vec(), newest_selection());
         let (proof, mtd, provider) = prove_and_sign(&platform, &state, request, version);
 
-        let time_range_query = || {
-            SdkDocumentQuery::new(Arc::new(contract.clone()), DOCUMENT_TYPE)
-                .expect("the fixture has this document type")
-                .with_select(SelectProjection::count_star())
-                .with_time_range(CREATED_AT, TimeRangeSelector::Newest)
-        };
-
-        let error =
+        let (page, _mtd, _proof) =
             <DocumentRankedEntries as FromProof<SdkDocumentQuery>>::maybe_from_proof_with_metadata(
-                time_range_query(),
-                signed_response(proof.clone(), &mtd),
-                Network::Testnet,
-                version,
-                &provider,
-            )
-            .expect_err("the ranked verifier must refuse a time-range request");
-        assert!(
-            error.to_string().contains("time-range"),
-            "expected the ranked time-range refusal, got {error}"
-        );
-
-        let error =
-            <DocumentHavingEntries as FromProof<SdkDocumentQuery>>::maybe_from_proof_with_metadata(
-                time_range_query().with_having(vec![drive::query::HavingClause {
-                    aggregate: drive::query::HavingAggregate {
-                        function: drive::query::HavingAggregateFunction::Count,
-                        field: String::new(),
-                    },
-                    operator: drive::query::HavingOperator::GreaterThan,
-                    right: drive::query::HavingRightOperand::Value(Value::U64(0)),
-                }]),
+                windowed_top_k_query(&contract, TimeRangeSelector::Newest),
                 signed_response(proof, &mtd),
                 Network::Testnet,
                 version,
                 &provider,
             )
-            .expect_err("the HAVING verifier must refuse a time-range request");
-        assert!(
-            error.to_string().contains("time-range"),
-            "expected the HAVING time-range refusal, got {error}"
+            .expect("a correctly signed windowed ranking must verify");
+        let page = page.expect("the newest window is not empty");
+        assert_eq!(page.starting_rank, 0);
+        assert_hashtag_counts(&page.entries, &[("ibiza", 2), ("berlin", 1)]);
+    }
+
+    /// A historic window's leaderboard, addressed absolutely with
+    /// `BY_START` — unreachable through the relative selectors. The window
+    /// starting one step back covers `[start − 2h, start + 4h)`, so it
+    /// holds all three `#ibiza` posts: a different ordering input than the
+    /// newest window's, provably from a window no "current" resolution
+    /// could produce.
+    #[test]
+    fn a_historic_windows_ranking_verifies_by_start() {
+        let (platform, base_state, version) = setup_platform(None, Network::Testnet, None);
+        let (contract, state) = setup_ranked_trending(&platform, &base_state, version);
+        let historic_start_ms = NEWEST_BUCKET_START_MS - 2 * HOUR_MS;
+
+        let request = windowed_top_k_request(
+            contract.id().to_vec(),
+            by_start_selection(historic_start_ms),
         );
+        let (proof, mtd, provider) = prove_and_sign(&platform, &state, request, version);
+
+        let (page, _mtd, _proof) =
+            <DocumentRankedEntries as FromProof<SdkDocumentQuery>>::maybe_from_proof_with_metadata(
+                windowed_top_k_query(
+                    &contract,
+                    TimeRangeSelector::ByStart {
+                        start_ms: historic_start_ms,
+                    },
+                ),
+                signed_response(proof, &mtd),
+                Network::Testnet,
+                version,
+                &provider,
+            )
+            .expect("a correctly signed historic ranking must verify");
+        let page = page.expect("the historic window is not empty");
+        assert_hashtag_counts(&page.entries, &[("ibiza", 3), ("berlin", 1)]);
+    }
+
+    /// The window-binding property of the relative selectors, on the
+    /// ranked surface: re-signing the response over a one-step-later
+    /// metadata time makes the verifier re-derive a *different* bucket
+    /// start, so the proof — built over the original window's secondary —
+    /// must fail path reconstruction rather than authenticate the stale
+    /// window as the new one.
+    #[test]
+    fn a_tampered_time_cannot_verify_another_windows_ranking() {
+        let (platform, base_state, version) = setup_platform(None, Network::Testnet, None);
+        let (contract, state) = setup_ranked_trending(&platform, &base_state, version);
+
+        let request = windowed_top_k_request(contract.id().to_vec(), newest_selection());
+        let (proof, mtd, provider) = prove_and_sign(&platform, &state, request, version);
+        let tampered = one_step_later(&contract, BUCKETED_INDEX, &mtd);
+        let resigned = resign_over(&platform, &proof, &tampered, version);
+
+        let error =
+            <DocumentRankedEntries as FromProof<SdkDocumentQuery>>::maybe_from_proof_with_metadata(
+                windowed_top_k_query(&contract, TimeRangeSelector::Newest),
+                signed_response(resigned, &tampered),
+                Network::Testnet,
+                version,
+                &provider,
+            )
+            .expect_err("a validly re-signed later time must not verify the stale window");
+        assert_proof_path_rejection(error);
+    }
+
+    /// The having-range face of the same secondary: "hashtags with at
+    /// least 2 posts in the current window", proved and verified. Only
+    /// `#ibiza` qualifies in the newest window — `#berlin` has 1, and
+    /// ibiza's third post lives outside the window.
+    #[test]
+    fn the_having_route_serves_a_windowed_bound() {
+        let (platform, base_state, version) = setup_platform(None, Network::Testnet, None);
+        let (contract, state) = setup_ranked_trending(&platform, &base_state, version);
+
+        let request = GetDocumentsRequestV1 {
+            order_by: Vec::new(),
+            having: vec![hc(
+                having_aggregate::Function::Count,
+                "",
+                having_clause::Operator::GreaterThanOrEquals,
+                Value::U64(2),
+            )],
+            ..windowed_top_k_request(contract.id().to_vec(), newest_selection())
+        };
+        let (proof, mtd, provider) = prove_and_sign(&platform, &state, request, version);
+
+        let query = SdkDocumentQuery::new(Arc::new(contract.clone()), DOCUMENT_TYPE)
+            .expect("the fixture has this document type")
+            .with_select(SelectProjection::count_star())
+            .with_group_by("hashtag")
+            .with_having(vec![drive::query::HavingClause {
+                aggregate: drive::query::HavingAggregate {
+                    function: drive::query::HavingAggregateFunction::Count,
+                    field: String::new(),
+                },
+                operator: drive::query::HavingOperator::GreaterThanOrEquals,
+                right: drive::query::HavingRightOperand::Value(Value::U64(2)),
+            }])
+            .with_limit(10)
+            .with_time_range(CREATED_AT, TimeRangeSelector::Newest);
+        let (entries, _mtd, _proof) =
+            <DocumentHavingEntries as FromProof<SdkDocumentQuery>>::maybe_from_proof_with_metadata(
+                query,
+                signed_response(proof, &mtd),
+                Network::Testnet,
+                version,
+                &provider,
+            )
+            .expect("a correctly signed windowed bound must verify");
+        let entries = entries.expect("one group meets the bound");
+        assert_hashtag_counts(&entries.entries, &[("ibiza", 2)]);
     }
 
     /// A drive query carrying resolution provenance has no faithful

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/batched_group_drain.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/batched_group_drain.rs
@@ -373,6 +373,7 @@ fn verified_page(
             &[],
             axis.ranked,
             axis.aggregate_field(),
+            &[],
         )
         .expect("the fixture declares this axis"),
         axis: axis.ranked,

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/ranked_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/ranked_index_e2e_tests.rs
@@ -1589,8 +1589,15 @@ fn verified_ranked_avg_page(
         document_type,
         contract_id: contract.id().to_buffer(),
         document_type_name: "review".to_string(),
-        index: find_ranked_index_for_axis(indexes, GROUP_PROPERTY, &[], RankedAxis::Avg, "grade")
-            .expect("the fixture declares rankedAverageable on grade"),
+        index: find_ranked_index_for_axis(
+            indexes,
+            GROUP_PROPERTY,
+            &[],
+            RankedAxis::Avg,
+            "grade",
+            &[],
+        )
+        .expect("the fixture declares rankedAverageable on grade"),
         prefix_branches: vec![vec![]],
         axis: RankedAxis::Avg,
         descending: true,

--- a/packages/rs-drive/src/drive/document/insert/add_document_for_contract/time_range_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_document_for_contract/time_range_index_e2e_tests.rs
@@ -1633,3 +1633,209 @@ fn multiple_in_route_refuses_an_in_clause_on_the_bucketed_source() {
         "expected the source-shape rejection, got {error:?}"
     );
 }
+
+/// The update walker's bucketed branch materializes ranking-chain
+/// continuations exactly as the insert walker does — the consensus
+/// property behind the chain-inversion dispatch it shares with the
+/// non-bucketed branch. An update that moves a document to a NEW group
+/// value inside its (unchanged) buckets materializes that group's value
+/// tree and its chain continuation through the update path alone; a
+/// wrapped (zero-contributing) continuation there would pin the new
+/// group's whole-subtree count at zero, and the per-window ranking would
+/// then disagree between a document that arrived by insert and one that
+/// arrived by update — a layout divergence, not just a wrong answer.
+#[test]
+fn ranked_chain_below_bucket_update_materializes_like_insert() {
+    use crate::query::drive_document_ranked_query::index_picker::resolve_ranked_query_for_mode;
+    use crate::query::drive_document_ranked_query::PrefixPin;
+    use crate::query::{DocumentRankedMode, RankedAxis, RankedEntryValue};
+
+    let platform_version = PlatformVersion::latest();
+    let drive = setup_drive_with_initial_state_structure(Some(platform_version));
+
+    let factory =
+        DataContractFactory::new(PlatformVersion::latest().protocol_version).expect("factory");
+    let index_map = vec![
+        (
+            Value::Text("name".to_string()),
+            Value::Text("trendingChain".to_string()),
+        ),
+        (
+            Value::Text("properties".to_string()),
+            Value::Array(vec![
+                platform_value!({"$createdAt": "asc"}),
+                platform_value!({"category": "asc"}),
+                platform_value!({"name": "asc"}),
+            ]),
+        ),
+        (
+            Value::Text("timeRange".to_string()),
+            Value::Map(vec![
+                (
+                    Value::Text("on".to_string()),
+                    Value::Text("$createdAt".to_string()),
+                ),
+                (
+                    Value::Text("range".to_string()),
+                    Value::U64(6 * HOUR_SECONDS),
+                ),
+                (
+                    Value::Text("step".to_string()),
+                    Value::U64(2 * HOUR_SECONDS),
+                ),
+            ]),
+        ),
+        (
+            Value::Text("countable".to_string()),
+            Value::Text("countable".to_string()),
+        ),
+        (Value::Text("rangeCountable".to_string()), Value::Bool(true)),
+        (
+            Value::Text("rankedCountable".to_string()),
+            Value::Map(vec![(
+                Value::Text("at".to_string()),
+                Value::Array(vec![Value::Text("category".to_string())]),
+            )]),
+        ),
+    ];
+    let document_schema = platform_value!({
+        "type": "object",
+        "properties": {
+            "category": {"type": "string", "maxLength": 61, "position": 0},
+            "name": {"type": "string", "maxLength": 61, "position": 1},
+        },
+        "required": ["category", "name", "$createdAt"],
+        "indices": Value::Array(vec![Value::Map(index_map)]),
+        "additionalProperties": false,
+    });
+    let schemas = platform_value!({ "post": document_schema });
+    let contract = factory
+        .create_with_value_config(Identifier::from([202u8; 32]), 0, schemas, None, None)
+        .expect("a ranked at-chain below a bucketed level registers")
+        .data_contract_owned();
+
+    drive
+        .apply_contract(
+            &contract,
+            BlockInfo::default(),
+            true,
+            StorageFlags::optional_default_as_cow(),
+            None,
+            platform_version,
+        )
+        .expect("apply contract");
+
+    let document_type = contract.document_type_for_name("post").expect("post");
+    let transform = document_type
+        .indexes()
+        .get("trendingChain")
+        .expect("trendingChain index")
+        .time_range
+        .clone()
+        .expect("time range transform");
+
+    let created_at = 7 * HOUR_MS + 123_456;
+    let buckets = transform.containing_buckets(created_at);
+    assert_eq!(buckets, vec![6 * HOUR_MS, 4 * HOUR_MS, 2 * HOUR_MS]);
+
+    let owner_bytes = fixture_bytes(3, created_at, "chain");
+    let mut document = Document::V0(DocumentV0 {
+        id: Identifier::from(fixture_bytes(4, created_at, "chain")),
+        owner_id: Identifier::from(owner_bytes),
+        properties: BTreeMap::from([
+            ("category".to_string(), Value::Text("a".to_string())),
+            ("name".to_string(), Value::Text("x".to_string())),
+        ]),
+        created_at: Some(created_at),
+        revision: Some(1),
+        ..Default::default()
+    });
+
+    drive
+        .add_document_for_contract(
+            DocumentAndContractInfo {
+                owned_document_info: OwnedDocumentInfo {
+                    document_info: DocumentRefInfo((
+                        &document,
+                        StorageFlags::optional_default_as_cow(),
+                    )),
+                    owner_id: Some(owner_bytes),
+                },
+                contract: &contract,
+                document_type,
+            },
+            false,
+            BlockInfo::default(),
+            true,
+            None,
+            platform_version,
+            None,
+        )
+        .expect("add document");
+
+    // The update materializes category "b" — a value tree that does not
+    // exist yet — inside every containing bucket, together with the
+    // "name" chain continuation below it. This is the exact tree set the
+    // buggy dispatch would have zero-wrapped.
+    document.set("category", Value::Text("b".to_string()));
+    document.set_revision(Some(2));
+    drive
+        .update_document_for_contract(
+            &document,
+            &contract,
+            document_type,
+            Some(owner_bytes),
+            BlockInfo::default(),
+            true,
+            None,
+            None,
+            platform_version,
+            None,
+        )
+        .expect("update document to a new group value");
+
+    for bucket in &buckets {
+        let mode = DocumentRankedMode {
+            axis: RankedAxis::Count,
+            descending: true,
+            k: 10,
+            offset: 0,
+            group_by_property: "category".to_string(),
+            aggregate_field: String::new(),
+            prefix_pins: vec![PrefixPin {
+                field: "$createdAt".to_string(),
+                values: vec![Value::U64(*bucket)],
+            }],
+        };
+        let ranked_query = resolve_ranked_query_for_mode(
+            contract.id().to_buffer(),
+            document_type,
+            "post".to_string(),
+            document_type.indexes(),
+            &mode,
+            &created_at_resolution(document_type),
+            platform_version,
+        )
+        .expect("the bucketed at-chain index covers the pinned request");
+        let page = ranked_query
+            .execute_top_k_no_proof(&drive, None, platform_version)
+            .expect("the per-window group ranking reads");
+        assert_eq!(
+            page.entries.len(),
+            1,
+            "bucket {bucket}: the stale group must be pruned and the new one present"
+        );
+        assert_eq!(
+            page.entries[0].key,
+            b"b".to_vec(),
+            "bucket {bucket}: the group key is the update's new category"
+        );
+        assert_eq!(
+            page.entries[0].value,
+            RankedEntryValue::Count(1),
+            "bucket {bucket}: an update-materialized chain continuation must count \
+             exactly like an insert-created one — zero here means the continuation \
+             was zero-wrapped on the update path"
+        );
+    }
+}

--- a/packages/rs-drive/src/drive/document/update/internal/update_document_for_contract_operations/v1/mod.rs
+++ b/packages/rs-drive/src/drive/document/update/internal/update_document_for_contract_operations/v1/mod.rs
@@ -1110,7 +1110,18 @@ impl Drive {
             path.push(entry_key.clone());
 
             let mut parent_value_tree_type = top_value_tree_type;
-            for (i, (_level, sub_level_tree_types)) in levels.iter().enumerate() {
+            // A prefix-ranking chain level (`rankedCountable: { at }`)
+            // inverts the zero-contribution choice below, exactly as in the
+            // non-bucketed branch above and the v2 insert walker: a chain
+            // level's value trees count their single continuation, so the
+            // continuation is inserted unwrapped and contributes its
+            // subtree count. The bucketed level itself can never be a
+            // grouping level (validation rejects `at` naming the transform
+            // source), but the stamps are read rather than assumed so the
+            // three walkers share one rule.
+            let mut parent_counts_continuations =
+                top_index_level.ranked_count_grouping() || top_index_level.count_propagating();
+            for (i, (level, sub_level_tree_types)) in levels.iter().enumerate() {
                 let property_name = &new_suffix[i * 2];
                 let value = &new_suffix[i * 2 + 1];
 
@@ -1119,10 +1130,16 @@ impl Drive {
                 if !batch_insertion_cache.contains(&qualified_path) {
                     // Continuation property-name tree: contributes zero on
                     // every axis its aggregating parent maintains, exactly
-                    // as on the insert path.
+                    // as on the insert path — except inside a ranking
+                    // chain, whose continuation stays unwrapped, unless
+                    // this child is a count-exempt sibling branch
+                    // (re-inversion per child; see the non-bucketed
+                    // dispatch above).
                     let property_name_tree_type = sub_level_tree_types.property_name_tree_type;
                     let ranked_axes = sub_level_tree_types.ranked_axes.as_slice();
-                    let inserted = if matches!(parent_value_tree_type, TreeType::NormalTree) {
+                    let inserted = if matches!(parent_value_tree_type, TreeType::NormalTree)
+                        || (parent_counts_continuations && !level.count_exempt_branch())
+                    {
                         self.batch_insert_empty_index_tree_if_not_exists(
                             PathKeyInfo::PathKeyRef::<0>((path.clone(), property_name.as_slice())),
                             property_name_tree_type,
@@ -1174,6 +1191,8 @@ impl Drive {
                 path.push(value.clone());
 
                 parent_value_tree_type = sub_level_tree_types.value_tree_type;
+                parent_counts_continuations =
+                    level.ranked_count_grouping() || level.count_propagating();
             }
 
             if new_terminator_is_unique {

--- a/packages/rs-drive/src/query/drive_document_having_query/drive_dispatcher.rs
+++ b/packages/rs-drive/src/query/drive_document_having_query/drive_dispatcher.rs
@@ -50,15 +50,15 @@ pub struct DocumentHavingRequest<'a> {
     /// at most one may instead be a bounded `IN` (one branch per
     /// element, merged; entries then carry `in_key`).
     pub where_clauses: &'a [WhereClause],
-    /// The fields among `where_clauses` whose equality clause was produced by
+    /// The provenance of any `where_clauses` equality produced by
     /// `IN_TIME_RANGE` resolution (see
-    /// [`crate::query::DriveDocumentQuery::resolved_time_ranges`]).
-    /// Must be empty: HAVING's equality prefixes pin plain ranked indexes
-    /// (its picker excludes transformed ones), so a resolved bucket-start
-    /// equality would authenticate raw-timestamp matches at the bucket
-    /// boundary instead of window membership. Carried (and rejected) here
-    /// for the same reason the ranked request carries it: drive owns the
-    /// rejection regardless of which upstream path built the request.
+    /// [`crate::query::DriveDocumentQuery::resolved_time_ranges`]). At most
+    /// one; index selection consumes it through
+    /// [`crate::query::index_admissible_for_resolved_time_range`], which
+    /// routes the resolved bucket-start pin to exactly the grid it was
+    /// resolved against — and keeps raw requests off bucketed indexes,
+    /// where a hand-written equality would authenticate raw-timestamp
+    /// matches at the bucket boundary instead of window membership.
     pub resolved_time_ranges: &'a [ResolvedTimeRange],
     /// Request `limit`. **Required**; `1 ..= MAX_HAVING_LIMIT`.
     pub limit: Option<u32>,
@@ -117,19 +117,21 @@ impl Drive {
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<DocumentHavingResponse, Error> {
-        // Before mode detection reads `where_clauses`: a resolved bucket
-        // equality is indistinguishable from a hand-written equality pin, and
-        // the pinned-prefix form would accept it against a plain ranked index
-        // over raw timestamps — a validly-proven answer to a different
-        // question. See `DocumentHavingRequest::resolved_time_ranges`.
-        if !request.resolved_time_ranges.is_empty() {
-            return Err(Error::Query(QuerySyntaxError::Unsupported(
-                "a HAVING query cannot carry a time-range (IN_TIME_RANGE) selection: its \
-                 equality prefixes pin plain ranked indexes, so a resolved bucket-start \
-                 equality would match raw timestamps at the bucket boundary instead of the \
-                 selected window"
-                    .to_string(),
-            )));
+        // A transform's source must be its index's first property, so no
+        // single index can serve two resolved buckets; rejected before
+        // routing, mirroring the ranked dispatcher. A single resolution is
+        // consumed by index selection (the picker's admissibility rule
+        // routes it to exactly the grid it was resolved against, and keeps
+        // raw requests off bucketed indexes) — the resolved bucket-start
+        // equality pins the bucketed first level like any other leading
+        // property.
+        if request.resolved_time_ranges.len() > 1 {
+            return Err(Error::Query(QuerySyntaxError::Unsupported(format!(
+                "at most one time-range selection (IN_TIME_RANGE) is supported per \
+                 having-range query; this one resolves {:?}, and no single index can \
+                 bucket more than one field",
+                request.resolved_time_ranges
+            ))));
         }
         let mode = detect_having_mode(
             &request.select,
@@ -155,6 +157,7 @@ impl Drive {
                     request.document_type,
                     document_type_name,
                     &mode,
+                    request.resolved_time_ranges,
                     transaction,
                     platform_version,
                 )?,
@@ -166,6 +169,7 @@ impl Drive {
                     request.document_type,
                     document_type_name,
                     &mode,
+                    request.resolved_time_ranges,
                     transaction,
                     platform_version,
                 )?,

--- a/packages/rs-drive/src/query/drive_document_having_query/executors.rs
+++ b/packages/rs-drive/src/query/drive_document_having_query/executors.rs
@@ -12,6 +12,7 @@ use super::super::drive_document_ranked_query::RankedEntry;
 use super::{resolve_having_query_for_mode, DocumentHavingMode};
 use crate::drive::Drive;
 use crate::error::Error;
+use crate::query::ResolvedTimeRange;
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dpp::data_contract::document_type::DocumentTypeRef;
 use dpp::version::PlatformVersion;
@@ -19,12 +20,14 @@ use grovedb::TransactionArg;
 
 impl Drive {
     /// One page of groups matching a having bound, read without a proof.
+    #[allow(clippy::too_many_arguments)]
     pub fn execute_document_having_range_no_proof(
         &self,
         contract_id: [u8; 32],
         document_type: DocumentTypeRef,
         document_type_name: String,
         mode: &DocumentHavingMode,
+        resolved_time_ranges: &[ResolvedTimeRange],
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<Vec<RankedEntry>, Error> {
@@ -35,6 +38,7 @@ impl Drive {
             document_type_name,
             indexes,
             mode,
+            resolved_time_ranges,
             platform_version,
         )?;
         having_query.execute_range_no_proof(self, transaction, platform_version)
@@ -46,12 +50,14 @@ impl Drive {
     /// [`DriveDocumentHavingQuery::verify_having_range_proof`](crate::query::DriveDocumentHavingQuery::verify_having_range_proof),
     /// reconstructing the same query from the same contract — which is
     /// why index resolution is shared with the no-proof executor.
+    #[allow(clippy::too_many_arguments)]
     pub fn execute_document_having_range_proof(
         &self,
         contract_id: [u8; 32],
         document_type: DocumentTypeRef,
         document_type_name: String,
         mode: &DocumentHavingMode,
+        resolved_time_ranges: &[ResolvedTimeRange],
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<Vec<u8>, Error> {
@@ -62,6 +68,7 @@ impl Drive {
             document_type_name,
             indexes,
             mode,
+            resolved_time_ranges,
             platform_version,
         )?;
         having_query.execute_range_with_proof(self, transaction, platform_version)

--- a/packages/rs-drive/src/query/drive_document_having_query/mod.rs
+++ b/packages/rs-drive/src/query/drive_document_having_query/mod.rs
@@ -85,6 +85,8 @@ use crate::error::query::QuerySyntaxError;
 #[cfg(any(feature = "server", feature = "verify"))]
 use crate::error::Error;
 #[cfg(any(feature = "server", feature = "verify"))]
+use crate::query::ResolvedTimeRange;
+#[cfg(any(feature = "server", feature = "verify"))]
 use grovedb::element::indexed::{encode_avg_sort_key, encode_count_sort_key, encode_sum_sort_key};
 #[cfg(any(feature = "server", feature = "verify"))]
 use grovedb::Query;
@@ -373,6 +375,7 @@ pub fn resolve_having_query_for_mode<'a>(
     document_type_name: String,
     indexes: &'a BTreeMap<String, Index>,
     mode: &DocumentHavingMode,
+    resolved_time_ranges: &[ResolvedTimeRange],
     platform_version: &PlatformVersion,
 ) -> Result<DriveDocumentHavingQuery<'a>, Error> {
     let axis = mode.bounds.axis();
@@ -387,6 +390,7 @@ pub fn resolve_having_query_for_mode<'a>(
         &pin_fields,
         axis,
         &mode.aggregate_field,
+        resolved_time_ranges,
     )
     .ok_or_else(|| {
         Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(

--- a/packages/rs-drive/src/query/drive_document_having_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_having_query/tests.rs
@@ -831,6 +831,7 @@ mod execution {
             case.document_type_name.to_string(),
             indexes,
             &mode,
+            &[],
             platform_version(),
         )
         .expect("the fixture declares the axis")
@@ -1449,6 +1450,7 @@ mod identifier_group_keys {
             DOCUMENT_TYPE.to_string(),
             indexes,
             &mode,
+            &[],
             platform_version(),
         )
         .expect("the fixture declares the avg axis")
@@ -1752,6 +1754,7 @@ mod pinned_prefix {
             DOCUMENT_TYPE.to_string(),
             indexes,
             &mode,
+            &[],
             platform_version(),
         )
         .expect("the fixture's compound index covers the pinned request")
@@ -2142,6 +2145,7 @@ mod pinned_prefix {
                 .expect("taggedGrade doctype exists")
                 .indexes(),
             &mode,
+            &[],
             pv,
         )
         .expect("the compound index covers the null-pinned request");
@@ -2299,6 +2303,7 @@ mod pinned_prefix {
                 .expect("taggedGrade doctype exists")
                 .indexes(),
             &mode,
+            &[],
             pv,
         )
         .expect("the compound index covers the mixed-null request");

--- a/packages/rs-drive/src/query/drive_document_ranked_query/drive_dispatcher.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/drive_dispatcher.rs
@@ -68,15 +68,19 @@ pub struct DocumentRankedRequest<'a> {
     /// at most one may instead be a bounded `IN` (one branch per
     /// element, merged; entries then carry `in_key`).
     pub where_clauses: &'a [WhereClause],
-    /// The fields among `where_clauses` whose equality clause was produced by
+    /// The provenance of any `where_clauses` equality produced by
     /// `IN_TIME_RANGE` resolution (see
-    /// [`crate::query::DriveDocumentQuery::resolved_time_ranges`]).
-    /// Must be empty: `where_clauses` must be empty, so there is nothing to
-    /// have resolved, and ranking over bucket keys is undesigned — a document
-    /// belongs to `overlap_factor` buckets at once, so it would contribute to
-    /// that many groups. Carried (and rejected) here for the same reason
-    /// `where_clauses` is: drive owns the rejection regardless of which
-    /// upstream path built the request.
+    /// [`crate::query::DriveDocumentQuery::resolved_time_ranges`]). At most
+    /// one, and its resolved bucket-start equality must appear among
+    /// `where_clauses` as the pin on the covering index's bucketed first
+    /// property. Index selection consumes it through
+    /// [`crate::query::index_admissible_for_resolved_time_range`]: a
+    /// resolved request is served only by the index bucketing that field
+    /// with exactly that grid, and a raw request never by a bucketed
+    /// index. Ranked levels sit strictly BELOW the bucketed one (contract
+    /// validation guarantees it), so the walk reads the pinned window's
+    /// own per-prefix secondary — one window, each document once,
+    /// regardless of grid overlap.
     pub resolved_time_ranges: &'a [ResolvedTimeRange],
     /// Request `limit` — the ranking's `k`. **Required**; there is no
     /// server default a verifying client could reproduce.
@@ -142,17 +146,16 @@ impl Drive {
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<DocumentRankedResponse, Error> {
-        // Unreachable behind the empty-`where_clauses` rule `detect_ranked_mode`
-        // enforces below — a resolved equality is a where clause — but stated
-        // here so the ranked surface's exclusion of bucketed indexes is a
-        // rejection rather than a silent fallback to another index.
-        if !request.resolved_time_ranges.is_empty() {
-            return Err(Error::Query(QuerySyntaxError::Unsupported(
-                "a ranked query cannot carry a time-range (IN_TIME_RANGE) selection: ranking \
-                 groups by an index's only property, and a document belongs to every bucket \
-                 that contains its timestamp, so it would be ranked into several groups at once"
-                    .to_string(),
-            )));
+        // A transform's source must be its index's first property, so no
+        // single index can serve two resolved buckets; rejected before
+        // routing, mirroring `DriveDocumentQuery::select_best_index`.
+        if request.resolved_time_ranges.len() > 1 {
+            return Err(Error::Query(QuerySyntaxError::Unsupported(format!(
+                "at most one time-range selection (IN_TIME_RANGE) is supported per ranked \
+                 query; this one resolves {:?}, and no single index can bucket more than \
+                 one field",
+                request.resolved_time_ranges
+            ))));
         }
 
         let mode = detect_ranked_mode(
@@ -179,6 +182,7 @@ impl Drive {
                     request.document_type,
                     document_type_name,
                     &mode,
+                    request.resolved_time_ranges,
                     transaction,
                     platform_version,
                 )?,
@@ -190,6 +194,7 @@ impl Drive {
                     request.document_type,
                     document_type_name,
                     &mode,
+                    request.resolved_time_ranges,
                     transaction,
                     platform_version,
                 )?,

--- a/packages/rs-drive/src/query/drive_document_ranked_query/executors/top_k_no_proof.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/executors/top_k_no_proof.rs
@@ -11,6 +11,7 @@ use super::super::{DocumentRankedMode, RankedPage};
 use super::ranked_query_for_mode;
 use crate::drive::Drive;
 use crate::error::Error;
+use crate::query::ResolvedTimeRange;
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dpp::data_contract::document_type::DocumentTypeRef;
 use dpp::version::PlatformVersion;
@@ -20,12 +21,14 @@ impl Drive {
     /// One page of `k` groups on a ranked index, unproven.
     ///
     /// Entry order is the ranking order; callers must not re-sort.
+    #[allow(clippy::too_many_arguments)]
     pub fn execute_document_ranked_top_k_no_proof(
         &self,
         contract_id: [u8; 32],
         document_type: DocumentTypeRef,
         document_type_name: String,
         mode: &DocumentRankedMode,
+        resolved_time_ranges: &[ResolvedTimeRange],
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<RankedPage, Error> {
@@ -36,6 +39,7 @@ impl Drive {
             document_type_name,
             indexes,
             mode,
+            resolved_time_ranges,
             platform_version,
         )?;
         ranked_query.execute_top_k_no_proof(self, transaction, platform_version)

--- a/packages/rs-drive/src/query/drive_document_ranked_query/executors/top_k_proof.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/executors/top_k_proof.rs
@@ -7,6 +7,7 @@ use super::super::DocumentRankedMode;
 use super::ranked_query_for_mode;
 use crate::drive::Drive;
 use crate::error::Error;
+use crate::query::ResolvedTimeRange;
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dpp::data_contract::document_type::DocumentTypeRef;
 use dpp::version::PlatformVersion;
@@ -19,12 +20,14 @@ impl Drive {
     /// [`DriveDocumentRankedQuery::verify_ranked_top_k_proof`](crate::query::DriveDocumentRankedQuery::verify_ranked_top_k_proof),
     /// reconstructing the same query from the same contract — which is
     /// why index resolution is shared with the no-proof executor.
+    #[allow(clippy::too_many_arguments)]
     pub fn execute_document_ranked_top_k_proof(
         &self,
         contract_id: [u8; 32],
         document_type: DocumentTypeRef,
         document_type_name: String,
         mode: &DocumentRankedMode,
+        resolved_time_ranges: &[ResolvedTimeRange],
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<Vec<u8>, Error> {
@@ -35,6 +38,7 @@ impl Drive {
             document_type_name,
             indexes,
             mode,
+            resolved_time_ranges,
             platform_version,
         )?;
         ranked_query.execute_top_k_with_proof(self, transaction, platform_version)

--- a/packages/rs-drive/src/query/drive_document_ranked_query/index_picker.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/index_picker.rs
@@ -10,6 +10,7 @@
 use super::{DocumentRankedMode, DriveDocumentRankedQuery, PrefixPin, RankedAxis};
 use crate::error::query::QuerySyntaxError;
 use crate::error::Error;
+use crate::query::{index_admissible_for_resolved_time_range, ResolvedTimeRange};
 use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
 use dpp::data_contract::document_type::{DocumentTypeRef, Index};
 use dpp::version::PlatformVersion;
@@ -44,7 +45,14 @@ use std::collections::BTreeMap;
 ///   index accumulates would silently answer about the wrong property.
 ///   A prefix-level Count ranking excludes both (the grammar rejects the
 ///   combination), so those arms never see an `at` index;
-/// - it carries no time-range transform.
+/// - it is admissible for the request's resolved time-range selections
+///   ([`index_admissible_for_resolved_time_range`]): a request whose
+///   leading pin was produced by `IN_TIME_RANGE` resolution may only be
+///   served by the index bucketing that field with exactly that grid,
+///   and a raw request never by a bucketed index — either mismatch
+///   would be a validly-proven wrong answer. The resolved bucket-start
+///   pin then descends the grid-qualified first level like any other
+///   leading-property pin, into that window's own per-prefix secondary.
 ///
 /// With no pins this degenerates to the original single-property rule —
 /// or, for an index ranked at its FIRST property, to the global group
@@ -79,14 +87,15 @@ pub fn find_ranked_index_for_axis<'b>(
     equality_pin_fields: &[String],
     axis: RankedAxis,
     aggregate_field: &str,
+    resolved_time_ranges: &[ResolvedTimeRange],
 ) -> Option<&'b Index> {
     indexes.values().find(|index| {
-        // Ranking over bucket keys is an undesigned surface: a document is
-        // stored once per bucket that contains it, so it would contribute to
-        // `overlap_factor` groups at once, and a ranked query carries no
-        // where clauses that could pin a single bucket. Exclude bucketed
-        // indexes until the semantics are deliberately designed.
-        if index.time_range.is_some() {
+        // Bucketed and raw indexes are never interchangeable, and one
+        // grid's index never serves another grid's resolution — the same
+        // provenance rule every other aggregate picker applies. This is
+        // what keeps a raw request off bucketed indexes AND routes a
+        // resolved request to exactly the grid it was resolved against.
+        if !index_admissible_for_resolved_time_range(index, resolved_time_ranges) {
             return false;
         }
         // The positions whose levels host this axis's secondaries — for
@@ -143,6 +152,7 @@ pub fn find_ranked_index_for_axis<'b>(
 pub fn find_ranked_index_for_mode<'b>(
     indexes: &'b BTreeMap<String, Index>,
     mode: &DocumentRankedMode,
+    resolved_time_ranges: &[ResolvedTimeRange],
 ) -> Option<&'b Index> {
     let pin_fields: Vec<String> = mode
         .prefix_pins
@@ -155,6 +165,7 @@ pub fn find_ranked_index_for_mode<'b>(
         &pin_fields,
         mode.axis,
         &mode.aggregate_field,
+        resolved_time_ranges,
     )
 }
 
@@ -186,19 +197,21 @@ pub fn resolve_ranked_query_for_mode<'a>(
     document_type_name: String,
     indexes: &'a BTreeMap<String, Index>,
     mode: &DocumentRankedMode,
+    resolved_time_ranges: &[ResolvedTimeRange],
     platform_version: &PlatformVersion,
 ) -> Result<DriveDocumentRankedQuery<'a>, Error> {
-    let index = find_ranked_index_for_mode(indexes, mode).ok_or_else(|| {
-        Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(
-            no_covering_index_message(
-                "ranked",
-                mode.axis,
-                &mode.group_by_property,
-                &mode.prefix_pins,
-                &mode.aggregate_field,
-            ),
-        ))
-    })?;
+    let index =
+        find_ranked_index_for_mode(indexes, mode, resolved_time_ranges).ok_or_else(|| {
+            Error::Query(QuerySyntaxError::WhereClauseOnNonIndexedProperty(
+                no_covering_index_message(
+                    "ranked",
+                    mode.axis,
+                    &mode.group_by_property,
+                    &mode.prefix_pins,
+                    &mode.aggregate_field,
+                ),
+            ))
+        })?;
     let prefix_branches =
         encode_prefix_branches(document_type, index, &mode.prefix_pins, platform_version)?;
     Ok(DriveDocumentRankedQuery {

--- a/packages/rs-drive/src/query/drive_document_ranked_query/path.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/path.rs
@@ -88,11 +88,24 @@ pub(crate) fn indexed_property_name_tree_path_for_index(
     path.push(contract_id.to_vec());
     path.push(vec![1u8]);
     path.push(document_type_name.as_bytes().to_vec());
-    for (property, value) in leading_properties.iter().zip(equality_prefix_values) {
-        path.push(property.name.as_bytes().to_vec());
+    // Level segments go through `Index::level_key`, the single source of
+    // the level-key rule: a bucketed (timeRange) first level is keyed by
+    // the grid-qualified `storage_key`, every other level by its bare
+    // property name. The pinned value under a bucketed level is the
+    // resolved bucket start, encoded exactly like the timestamp itself.
+    for (position, (property, value)) in leading_properties
+        .iter()
+        .zip(equality_prefix_values)
+        .enumerate()
+    {
+        path.push(index.level_key(position, &property.name).into_bytes());
         path.push(value.clone());
     }
-    path.push(terminal_property.name.as_bytes().to_vec());
+    path.push(
+        index
+            .level_key(leading_properties.len(), &terminal_property.name)
+            .into_bytes(),
+    );
     Ok(path)
 }
 

--- a/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/tests.rs
@@ -727,12 +727,13 @@ fn picker_requires_the_index_to_declare_the_requested_axis() {
     let indexes = index_map(vec![index]);
 
     assert!(
-        find_ranked_index_for_axis(&indexes, GROUP_PROPERTY, &[], RankedAxis::Count, "").is_some(),
+        find_ranked_index_for_axis(&indexes, GROUP_PROPERTY, &[], RankedAxis::Count, "", &[])
+            .is_some(),
         "the declared axis resolves"
     );
     for (axis, field) in [(RankedAxis::Sum, "grade"), (RankedAxis::Avg, "grade")] {
         assert!(
-            find_ranked_index_for_axis(&indexes, GROUP_PROPERTY, &[], axis, field).is_none(),
+            find_ranked_index_for_axis(&indexes, GROUP_PROPERTY, &[], axis, field, &[]).is_none(),
             "{axis:?} is not declared even though the index is summable and the stored \
              element could host that secondary"
         );
@@ -751,11 +752,12 @@ fn picker_requires_the_select_field_to_be_the_indexed_summable() {
 
     for axis in [RankedAxis::Sum, RankedAxis::Avg] {
         assert!(
-            find_ranked_index_for_axis(&indexes, GROUP_PROPERTY, &[], axis, "grade").is_some(),
+            find_ranked_index_for_axis(&indexes, GROUP_PROPERTY, &[], axis, "grade", &[]).is_some(),
             "{axis:?} on the indexed summable resolves"
         );
         assert!(
-            find_ranked_index_for_axis(&indexes, GROUP_PROPERTY, &[], axis, "tipAmount").is_none(),
+            find_ranked_index_for_axis(&indexes, GROUP_PROPERTY, &[], axis, "tipAmount", &[])
+                .is_none(),
             "{axis:?} on a different field must not resolve"
         );
     }
@@ -770,7 +772,8 @@ fn picker_rejects_an_unknown_group_property() {
     let indexes = index_map(vec![index]);
 
     assert!(
-        find_ranked_index_for_axis(&indexes, "chefId", &[], RankedAxis::Avg, "grade").is_none(),
+        find_ranked_index_for_axis(&indexes, "chefId", &[], RankedAxis::Avg, "grade", &[])
+            .is_none(),
         "no index groups by `chefId`"
     );
 }
@@ -790,10 +793,15 @@ fn picker_rejects_compound_indexes() {
     index.ranked_averageable = true;
     let indexes = index_map(vec![index]);
 
-    assert!(
-        find_ranked_index_for_axis(&indexes, GROUP_PROPERTY, &[], RankedAxis::Avg, "price")
-            .is_none()
-    );
+    assert!(find_ranked_index_for_axis(
+        &indexes,
+        GROUP_PROPERTY,
+        &[],
+        RankedAxis::Avg,
+        "price",
+        &[]
+    )
+    .is_none());
 }
 
 // ===================================================================
@@ -1047,6 +1055,7 @@ fn client_side_query<'a>(
         case.document_type_name.to_string(),
         indexes,
         &mode,
+        &[],
         platform_version(),
     )
     .expect("the fixture declares the axis")
@@ -2050,13 +2059,13 @@ fn a_doctype_with_several_indexes_ranks_each_group_property_on_its_own_index() {
     );
     assert_eq!(client_side_query(&contract, &by_chef).index.name, "byChef");
     assert_eq!(
-        find_ranked_index_for_axis(indexes, GROUP_PROPERTY, &[], RankedAxis::Avg, "grade")
+        find_ranked_index_for_axis(indexes, GROUP_PROPERTY, &[], RankedAxis::Avg, "grade", &[])
             .expect("the Avg ranking resolves")
             .name,
         "byRestaurant",
     );
     assert_eq!(
-        find_ranked_index_for_axis(indexes, CHEF_PROPERTY, &[], RankedAxis::Count, "")
+        find_ranked_index_for_axis(indexes, CHEF_PROPERTY, &[], RankedAxis::Count, "", &[])
             .expect("the Count ranking resolves")
             .name,
         "byChef",
@@ -2107,7 +2116,8 @@ fn a_doctype_with_several_indexes_ranks_each_group_property_on_its_own_index() {
     // ranking over chefs has no index — and `byChefRestaurant` must not
     // be press-ganged into serving it.
     assert!(
-        find_ranked_index_for_axis(indexes, CHEF_PROPERTY, &[], RankedAxis::Avg, "grade").is_none(),
+        find_ranked_index_for_axis(indexes, CHEF_PROPERTY, &[], RankedAxis::Avg, "grade", &[])
+            .is_none(),
         "`byChefRestaurant` leads with chefId but is compound and unranked"
     );
     let avg_by_chef = RankedCase {
@@ -2311,6 +2321,7 @@ mod pinned_prefix {
             DOCUMENT_TYPE.to_string(),
             indexes,
             &mode,
+            &[],
             platform_version(),
         )
         .expect("the fixture's compound index covers the pinned request")
@@ -2548,6 +2559,7 @@ mod pinned_prefix {
                 .expect("taggedGrade doctype exists")
                 .indexes(),
             &mode,
+            &[],
             pv,
         )
         .expect("the compound index covers the null-pinned request");
@@ -2919,6 +2931,7 @@ mod pinned_prefix {
                 .expect("grade doctype exists")
                 .indexes(),
             &mode,
+            &[],
             platform_version(),
         )
         .expect_err("duplicate encoded elements must be rejected");
@@ -3153,6 +3166,7 @@ mod pinned_prefix {
                 .expect("dualGrade doctype exists")
                 .indexes(),
             &mode,
+            &[],
             pv,
         )
         .expect("covered");
@@ -3805,6 +3819,7 @@ mod prefix_level {
             document_type_name.to_string(),
             indexes,
             &mode,
+            &[],
             platform_version(),
         )
         .expect("the fixture declares the prefix-level ranking")

--- a/packages/wasm-sdk/src/queries/document.rs
+++ b/packages/wasm-sdk/src/queries/document.rs
@@ -523,7 +523,7 @@ pub(super) fn parse_where_clause(json_clause: &JsonValue) -> Result<WhereClause,
 /// buckets the field with more than one `timeRange` grid (the bare selector
 /// is ambiguous there and the server rejects it). Like the contract grammar
 /// and the wire, a zero phase is spelled by omission.
-fn parse_time_range_clause(
+pub(super) fn parse_time_range_clause(
     json_clause: &JsonValue,
 ) -> Result<(String, TimeRangeSelector, Option<TimeRangeGridSpec>), WasmSdkError> {
     let object = json_clause.as_object().ok_or_else(|| {

--- a/packages/wasm-sdk/src/queries/document_ranked.rs
+++ b/packages/wasm-sdk/src/queries/document_ranked.rs
@@ -21,7 +21,9 @@
 //! network enforces.
 
 use crate::error::WasmSdkError;
-use crate::queries::document::{json_to_platform_value, parse_where_clause};
+use crate::queries::document::{
+    json_to_platform_value, parse_time_range_clause, parse_where_clause,
+};
 use crate::queries::utils::deserialize_required_query;
 use crate::queries::ProofMetadataResponseWasm;
 use crate::sdk::WasmSdk;
@@ -201,6 +203,21 @@ export interface DocumentsRankedQuery {
    * @default []
    */
   where?: DocumentsIndexPin[];
+
+  /**
+   * Optional time-range bucket selection — at most one entry, pinning the
+   * covering bucketed index's window (same shape and semantics as
+   * `DocumentsQuery.timeRange`). `"newest"`/`"oldest"` rank the current
+   * window; `"byStart"` ranks any window, current or historic, named by
+   * its grid-aligned start in milliseconds.
+   * @default []
+   */
+  timeRange?: {
+    field: string;
+    selector: "newest" | "oldest" | "byStart";
+    startMs?: number;
+    grid?: { range: number; step: number; phase?: number };
+  }[];
 }
 
 /**
@@ -294,6 +311,21 @@ export interface DocumentsHavingQuery {
    * @default []
    */
   where?: DocumentsIndexPin[];
+
+  /**
+   * Optional time-range bucket selection — at most one entry, pinning the
+   * covering bucketed index's window (same shape and semantics as
+   * `DocumentsQuery.timeRange`). `"newest"`/`"oldest"` rank the current
+   * window; `"byStart"` ranks any window, current or historic, named by
+   * its grid-aligned start in milliseconds.
+   * @default []
+   */
+  timeRange?: {
+    field: string;
+    selector: "newest" | "oldest" | "byStart";
+    startMs?: number;
+    grid?: { range: number; step: number; phase?: number };
+  }[];
 }
 
 /** Which axis a returned aggregate value came from. */
@@ -499,6 +531,10 @@ struct DocumentsRankedQueryInput {
     /// `deny_unknown_fields` still holds).
     #[serde(rename = "where", default)]
     where_clauses: Option<Vec<JsonValue>>,
+    /// Time-range bucket selections — same shape as `DocumentsQuery`'s
+    /// `timeRange` member (`{ field, selector, startMs?, grid? }`).
+    #[serde(rename = "timeRange", default)]
+    time_range: Option<Vec<JsonValue>>,
 }
 
 #[derive(Deserialize)]
@@ -514,6 +550,10 @@ struct DocumentsHavingQueryInput {
     direction: Option<String>,
     #[serde(rename = "where", default)]
     where_clauses: Option<Vec<JsonValue>>,
+    /// Time-range bucket selections — same shape as `DocumentsQuery`'s
+    /// `timeRange` member (`{ field, selector, startMs?, grid? }`).
+    #[serde(rename = "timeRange", default)]
+    time_range: Option<Vec<JsonValue>>,
 }
 
 /// Translate the JS aggregate union into rs-drive's `SELECT` projection.
@@ -737,6 +777,26 @@ fn assert_having_shape(
     })
 }
 
+/// Attach the (at most one) time-range selection to an already-built
+/// query. The selection stays pending — the server resolves it from
+/// committed block time, the proof verifier from the signed metadata
+/// time (or, for `byStart`, from the query itself) — and its resolved
+/// bucket-start equality becomes the pin on the covering bucketed
+/// index's first level.
+fn apply_time_range_selections(
+    mut query: DocumentQuery,
+    entries: Option<&[JsonValue]>,
+) -> Result<DocumentQuery, WasmSdkError> {
+    for entry in entries.unwrap_or(&[]) {
+        let (field, selector, grid) = parse_time_range_clause(entry)?;
+        query = match grid {
+            None => query.with_time_range(field, selector),
+            Some(grid) => query.with_time_range_grid(field, selector, grid),
+        };
+    }
+    Ok(query)
+}
+
 /// Turn a `where` list into pins on an already-built query.
 fn apply_index_pins(
     mut query: DocumentQuery,
@@ -786,6 +846,7 @@ fn apply_ranked_shape(
     }
 
     let query = apply_index_pins(query, input.where_clauses.as_deref())?;
+    let query = apply_time_range_selections(query, input.time_range.as_deref())?;
 
     assert_ranked_shape(&query, platform_version)?;
     Ok(query)
@@ -824,6 +885,7 @@ fn apply_having_shape(
     }
 
     let query = apply_index_pins(query, input.where_clauses.as_deref())?;
+    let query = apply_time_range_selections(query, input.time_range.as_deref())?;
 
     assert_having_shape(&query, platform_version)?;
     Ok(query)
@@ -1498,6 +1560,7 @@ mod tests {
         where_clauses: Option<Vec<JsonValue>>,
     ) -> DocumentsRankedQueryInput {
         DocumentsRankedQueryInput {
+            time_range: None,
             data_contract_id: any_contract_id(),
             document_type_name: DOC_TYPE.to_string(),
             group_by: group_by.to_string(),
@@ -1516,6 +1579,7 @@ mod tests {
         direction: Option<&str>,
     ) -> DocumentsHavingQueryInput {
         DocumentsHavingQueryInput {
+            time_range: None,
             data_contract_id: any_contract_id(),
             document_type_name: DOC_TYPE.to_string(),
             group_by: GROUP_BY.to_string(),


### PR DESCRIPTION
## Issue being fixed or feature implemented

Server-ordered windowed top-K — "top hashtags this window", ordered, proved, one query — did not exist on PV14. Contract validation rejected every ranked keyword on a `timeRange` index, and the ranked/having query surfaces rejected time-range selections, so the two features could not be combined. Both rejections predate per-prefix ranked secondaries (#4529) and the typed `TimeRangeSelection` operand (#4574); with those in place the combination is sound: a bucket start is just another prefix value, a document appears exactly once inside any single bucket's subtree, so **per-window rankings are exact regardless of grid overlap** — a document in several overlapping windows raises each window's own honest aggregate, which is the meaning of overlapping windows, not double counting.

This closes the gap for real trending contracts: `[timeRange($createdAt), hashtag]` + `rankedCountable` now registers and serves proved top-K for the current window (`newest`/`oldest`) or **any historic window** (`byStart`).

## What was done?

**Validation (rs-dpp).** The blanket ban is replaced by the one real rule: ranked levels sit strictly *below* the bucketed level. Still rejected, each with its own message: a single-property bucketed ranked index, and an `at` chain naming the transform source — both spell "rank the windows themselves", which needs its own routing shape (no pin above level 0, a grid named by the query) and stays deferred. The former tripwire test (`trending_posts_ranked_windowed_index_is_still_rejected`) flips into the acceptance test it was written to become.

**Write path (rs-drive).** Insert and delete already compose: the bucket fan-out loop recurses through the shared level-descent walkers, so per-prefix ranked secondaries below a bucket are created, populated and pruned by existing generic code (grovedb's indexed trees are position-independent — secondary prefixes derive from the subtree path, and nested indexed shapes are covered by its own suite). The one real gap was the **update walker's bucketed reimplementation**, which lacked the ranking-chain inversion its non-bucketed branch and the v2 insert walker share: a `rankedCountable: { at }` continuation materialized by update inside a bucket was zero-wrapped where insert writes it unwrapped — a consensus-divergent layout. This PR ports the `parent_counts_continuations` / `count_exempt_branch` dispatch into the bucketed branch.

**Routing (rs-drive).** The ranked and having-range dispatchers accept one resolved time-range selection (rejecting only two-plus, mirroring the generic route); the index picker replaces its blanket bucketed-index exclusion with the same grid-provenance admissibility rule every other aggregate picker applies (`index_admissible_for_resolved_time_range`): a resolved bucket-start pin is served only by the index bucketing that field with exactly that grid, and a raw request never by a bucketed index. The shared prover/verifier path builder now derives level segments through `Index::level_key`, addressing the grid-qualified first level.

**Verification (dash-platform-queries).** The ranked and having proof helpers resolve pending selections from the quorum-signed metadata time (or the query itself, for `byStart`) and thread the provenance into the shared index resolution, replacing their outright guards. The admissibility rule is the load-bearing half: it is what keeps a malicious node from proving raw-timestamp boundary matches as window membership.

**Surface (wasm-sdk).** `DocumentsRankedQuery` and `DocumentsHavingQuery` gain the `timeRange` member, same `{ field, selector, startMs?, grid? }` shape as `DocumentsQuery`.

## How Has This Been Tested?

- **Windowed top-K e2e** (drive-abci): top hashtags of the current window (counts 2/1) and of a `BY_START`-addressed historic window (counts 3/1 — a different ordering input no "current" resolution could produce), proved by the real v1 handler and verified through the SDK `FromProof` entry points. The fixture contract also declares a **raw ranked index over the identical property set** — the admissibility trap: a picker matching by property names alone would land on raw timestamps, whose per-group counts could never exceed 1, so the asserted counts pin the grid-matched selection.
- **Tamper**: re-signing over a one-step-later metadata time makes the verifier re-derive a different window and fails proof reconstruction.
- **Having-range face**: "hashtags with ≥ 2 posts in the current window", proved and verified.
- **Update-walker consensus test** (rs-drive): an update that moves a document to a new group value materializes the ranking-chain continuation inside all three overlapping buckets through the update path alone; the test asserts update-materialized chains count identically to insert-created ones — and **fails against the unfixed dispatch** (verified by temporarily reverting it).
- **Validation matrix** (rs-dpp): ranked-below-bucket parses (at-form on a middle level, terminal boolean, any grid); single-property bucketed ranked and `at`-naming-the-source stay rejected with their own messages.
- Full batteries green: dpp index (327), drive ranked (111) / having (41) / time_range (26), drive-abci time-range proof suite (20), dash-platform-queries (42), wasm-sdk (103); `cargo check --all-targets` and clippy clean across all touched crates.

## Breaking Changes

None for consensus on any released network: everything sits inside PV14's still-unreleased meta-schema v3 grammar and the dev-train query wire. Previously-rejected contract shapes now register; previously-rejected query shapes now serve.

Not included (deliberately): ranking the bucketed level itself ("busiest windows") — coherent but needs its own routing shape, kept deferred with targeted rejections; estimation-accuracy notes from the write-path survey (the indexed-element byte underestimate now multiplies by overlap factor — a pre-existing gap ranked-under-plain-prefix shares).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)