### PR TITLE
ci: run the shielded wallet suite and stop the shield filter sweeping up unrelated tests

### DIFF
--- a/.github/workflows/tests-rs-wallet.yml
+++ b/.github/workflows/tests-rs-wallet.yml
@@ -201,9 +201,16 @@ jobs:
             --locked \
             -- --no-deps -D warnings
 
-      # Mirrors the workspace job's non-shielded step for the wallet crates:
-      # same package subset, same `not test(~shield)` filter (shielded wallet
-      # tests are not run there either).
+      # The shielded-wallet suite (Orchard proving, viewing-key binds, note
+      # scans) is excluded by MODULE PATH, not by the word "shield". A
+      # `test(~shield)` substring match also swept up ~47 pure-logic tests
+      # across the three crates — input selection, FFI error codes, memo
+      # encoding, SQLite viewing-key rows — that cost a tenth of a second and
+      # have no compensating job anywhere.
+      #
+      # `--no-tests fail` is the zero-match guard: a filter that stops
+      # selecting anything must fail the step, not pass green. Pinned rather
+      # than left to nextest's default, which is a default and not a promise.
       - name: Run wallet tests (non-shielded)
         run: |
           cargo nextest run \
@@ -212,7 +219,8 @@ jobs:
             --package platform-wallet-ffi \
             --all-features \
             --locked \
-            -E 'not test(~shield)'
+            --no-tests fail \
+            -E 'not test(~wallet::shielded::)'
         env:
           RUST_MIN_STACK: 4194304
           CARGO_PROFILE_DEV_DEBUG: "0"

--- a/.github/workflows/tests-rs-wallet.yml
+++ b/.github/workflows/tests-rs-wallet.yml
@@ -201,17 +201,22 @@ jobs:
             --locked \
             -- --no-deps -D warnings
 
-      # The shielded-wallet suite (Orchard proving, viewing-key binds, note
-      # scans) is excluded by MODULE PATH, not by the word "shield". A
-      # `test(~shield)` substring match also swept up ~47 pure-logic tests
-      # across the three crates — input selection, FFI error codes, memo
-      # encoding, SQLite viewing-key rows — that cost a tenth of a second and
-      # have no compensating job anywhere.
+      # No test filter: this job runs everything in the three wallet packages,
+      # shielded suite included. There is nothing here worth excluding —
+      # `wallet::shielded::` is 145 tests in ~6 s wall (~97 s of CPU) under
+      # nextest, and `--all-features` compiles those binaries whether or not
+      # they are selected, so skipping them saved execution time on artifacts
+      # already paid for and thrown away.
       #
-      # `--no-tests fail` is the zero-match guard: a filter that stops
-      # selecting anything must fail the step, not pass green. Pinned rather
-      # than left to nextest's default, which is a default and not a promise.
-      - name: Run wallet tests (non-shielded)
+      # This job and tests-rs-workspace.yml are mutually exclusive paths for a
+      # given PR, so the shielded suite has to run in BOTH or a wallet-scoped
+      # PR silently loses it. The workspace job carves the wallet packages out
+      # of its own shield exclusion for the same reason.
+      #
+      # `--no-tests fail` is the zero-match guard: a selection that matches
+      # nothing must fail the step, not pass green. Pinned rather than left to
+      # nextest's default, which is a default and not a promise.
+      - name: Run wallet tests
         run: |
           cargo nextest run \
             --package platform-wallet \
@@ -219,8 +224,7 @@ jobs:
             --package platform-wallet-ffi \
             --all-features \
             --locked \
-            --no-tests fail \
-            -E 'not test(~wallet::shielded::)'
+            --no-tests fail
         env:
           RUST_MIN_STACK: 4194304
           CARGO_PROFILE_DEV_DEBUG: "0"

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -324,6 +324,20 @@ jobs:
       # caught minutes after merge — the same safety-net pattern as the
       # shielded phase. Keeping this phase's filter identical across events
       # keeps the `rust` codecov flag comparable between PR and push runs.
+      #
+      # `test(~shield)` is a substring match on the FULL test path, so it does
+      # not mean "the shielded suites" — it means "anything with the word in
+      # its name". The shielded phase below compensates for dpp / drive /
+      # drive-abci / dash-sdk, which genuinely need it: they are Orchard
+      # proving tests, and that phase runs them under `cargo test` in a shared
+      # process so one verifying key is built instead of one per test.
+      #
+      # The three wallet packages have no such compensator and no such need —
+      # their whole `wallet::shielded::` suite is 145 tests in ~6 s under
+      # nextest's process-per-test model — so excluding them dropped 145
+      # shielded tests plus ~47 more that merely contain the word (input
+      # selection, FFI error codes, memo encoding, SQLite viewing-key rows)
+      # into a gap no job covered. They are carved out of the exclusion here.
       - name: Run non-shielded tests with nextest (parallel, compiles all packages)
         if: steps.coverage-cache.outputs.reuse == 'false'
         run: |
@@ -352,7 +366,8 @@ jobs:
             --package keyword-search-contract \
             --all-features \
             --locked \
-            -E 'not test(~shield) and (not binary_id(=drive-abci::strategy_tests) or test(~comprehensive_mixed_operations))'
+            --no-tests fail \
+            -E '(not test(~shield) or package(platform-wallet) or package(platform-wallet-storage) or package(platform-wallet-ffi)) and (not binary_id(=drive-abci::strategy_tests) or test(~comprehensive_mixed_operations))'
         env:
           RUST_MIN_STACK: 4194304
           CARGO_PROFILE_DEV_DEBUG: "0"
@@ -370,6 +385,9 @@ jobs:
       # The chain simulations excluded from the phase above. PR runs skip
       # them (and upload no rust-strategy coverage — codecov carries the base
       # commit's forward); push, nightly, and dispatch runs execute them all.
+      # The `~shield` exclusion here IS compensated — drive-abci is in the
+      # shielded phase below — so it stays; `--no-tests fail` is the guard
+      # against the whole expression silently selecting nothing.
       - name: Run full chain-simulation suite (push and nightly only)
         id: strategy-tests
         if: >-
@@ -380,6 +398,7 @@ jobs:
             --package drive-abci \
             --all-features \
             --locked \
+            --no-tests fail \
             -E 'binary_id(=drive-abci::strategy_tests) and not test(~comprehensive_mixed_operations) and not test(~shield)'
         env:
           RUST_MIN_STACK: 4194304

--- a/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
@@ -2303,23 +2303,24 @@ mod shield_input_selection_tests {
 
     #[test]
     fn regression_reports_max_from_usable_suffix_not_total_account_balance() {
-        // Real account snapshot: the leading address is below the reserve, so
+        // Account snapshot whose leading address cannot pay the fee, so
         // capacity must come from the usable suffix, not the account total.
-        assert!(
-            297_264_780 <= reserve(),
-            "regression shape requires the leading address to stay below the reserve; \
-             re-seed the balances if the versioned reserve drops under 297_264_780"
-        );
+        // The leading balance is derived from the reserve — one credit below
+        // the strict `> reserve` viability threshold, the largest balance that
+        // must still be rejected as input 0 — so the shape holds whatever the
+        // versioned fee schedule does next.
+        let dust = reserve() - 1;
+        let usable = 3_623_849_220;
         let candidates = vec![
-            (addr(1), 297_264_780),
+            (addr(1), dust),
             (addr(2), 2_000_000_000),
             (addr(3), 1_623_849_220),
         ];
         let plan = plan(candidates).unwrap();
-        let expected_max = 3_623_849_220 - reserve();
+        let expected_max = usable - reserve();
 
-        assert_eq!(plan.preflight.account_balance_credits, 3_921_114_000);
-        assert_eq!(plan.preflight.usable_balance_credits, 3_623_849_220);
+        assert_eq!(plan.preflight.account_balance_credits, dust + usable);
+        assert_eq!(plan.preflight.usable_balance_credits, usable);
         assert_eq!(plan.preflight.fee_reserve_credits, reserve());
         assert_eq!(plan.preflight.max_shieldable_credits, expected_max);
         assert!(plan.preflight.can_shield);
@@ -2329,11 +2330,13 @@ mod shield_input_selection_tests {
         assert!(!chosen.contains_key(&addr(1)));
         assert_eq!(chosen.values().sum::<u64>(), expected_max);
 
+        // `available` reports the usable suffix, never the account total —
+        // the whole point of the regression.
         let err = plan.select_inputs(expected_max + 1).unwrap_err();
         assert!(matches!(
             err,
             PlatformWalletError::PlatformShieldCapacityExceeded { available, required }
-                if available == 3_623_849_220 && required == 3_623_849_221
+                if available == usable && required == usable + 1
         ));
     }
 


### PR DESCRIPTION
## TL;DR

Two bugs in our test workflows meant 185 wallet tests were being skipped on every CI run, and 145 of them were running in no job at all. One of the skipped tests had been failing for some time — a test that guards the maximum spendable balance reported to a user. Nothing surfaced it, because the filter meant to skip one suite was matching a word instead.

This turns those tests back on, fixes the one that was red, and adds a guard so a filter that stops matching anything fails the build instead of quietly reporting success.

## User story

As a **developer working on wallet code**, I want the tests I write to actually run in CI, so that a broken change is caught before it merges rather than months later by someone who did not write it.

As a **reviewer**, I want a green check to mean the suite ran, so that an empty test run cannot pass as success.

## Scenario

**Actual behavior**

A test filter intended to skip the shielded wallet suite instead skipped every test whose name contained the word "shield" anywhere. That swept in 40 unrelated tests — input-selection arithmetic, error-code mappings, memo encoding — one of which was failing and reported by nothing. Separately, the 145 tests it was actually aimed at were excluded by both workflows and covered by neither, so they ran nowhere.

**Expected behavior**

Each workflow skips only what it means to skip and what another job genuinely covers. The 145 shielded wallet tests run. The 40 unrelated tests run. A filter that matches nothing fails the step.

## Issue being fixed or feature implemented

Two independent CI defects, plus the one failing test they were hiding.

### Bug 1 — the filter matched a word, not a suite

Both Rust test workflows excluded shielded tests with `-E 'not test(~shield)'`. nextest's `test(~…)` is a substring match against the **full test path**, module segments included, so this does not select "the shielded suites" — it selects anything with the word `shield` anywhere in its name.

Across the three wallet packages it dropped **185 tests**. Only 145 were the shielded suite. The other 40 were ordinary logic tests that happen to contain the word:

- 12 in `wallet::platform_wallet::shield_input_selection_tests` — pure arithmetic over input selection and reported maximum spendable balance
- 4 in `changeset::shielded_changeset::activity_changeset_tests`
- 24 in `platform-wallet-ffi` — error-code mappings, memo encoding, preflight null-pointer checks

They cost about a tenth of a second and were being thrown away.

**One of them was failing.** `regression_reports_max_from_usable_suffix_not_total_account_balance` guards the maximum spendable balance a shield operation reports — funds-adjacent. It had been red for some time and nothing surfaced it, because the filter aimed at the shielded suite swept up the module by name.

The failure was a stale fixture, not a code bug. `reserve()` is `2 × compute_minimum_shielded_fee(2 actions)`; the v10 event constants (proof verification `100_000_000 → 40_000_000`, storage `344 → 550` bytes/action) moved it from `325_702_400` to `228_280_000`. The test's hardcoded leading balance of `297_264_780` sits between the two, so the "leading address is below the reserve" shape it asserts stopped existing. The planner is correct either way — with a lower reserve that address genuinely is a viable fee-paying input. The fixture now derives that balance as `reserve() - 1`, the largest value that must still be rejected by the strict `> reserve` test: a tighter boundary than the constant was, and one no future fee change can invalidate. The shape-precondition guard is deleted because it became true by construction.

### Bug 2 — 145 tests ran in no CI job at all

`tests-rs-workspace.yml` excluded shielded tests and compensated with a dedicated "Run shielded tests" phase. That phase runs `--package dpp --package drive --package drive-abci --package dash-sdk`. The three wallet packages are not in it.

So the entire `wallet::shielded::` suite — Orchard proving, viewing-key binds, note scans, sync — was excluded by both workflows and executed by neither. 145 tests, no coverage, no signal.

Measured on this branch: **145 run, 145 passed, 6.1 s wall clock** (roughly 40–100 s of CPU depending on cache warmth). Nothing was red; the suite had simply gone unobserved.

The cost argument for excluding them does not hold either. `--all-features` compiles those test binaries whether or not the filter selects them, so the exclusion saved only *execution* time on artifacts that were already built and then discarded. Six seconds.

Fixed in both workflows, because they are mutually exclusive paths — `tests-rs-wallet.yml` is a fast path that runs *instead of* the workspace job for wallet-scoped PRs, so fixing one alone leaves the suite unrun on the other. Dropping either commit leaves the suite unrun on that path.

## What was done?

Three files: the two workflows and one test fixture.

### Why the workspace fix scopes by package, not module path

The workspace job's `~shield` exclusion is legitimate for dpp / drive / drive-abci / dash-sdk: those are Orchard proving tests, and the compensating phase deliberately runs them under `cargo test` in one shared process so a single verifying key is built rather than one per test. Retargeting that filter by module path would pull them into the `nextest` phase, where process-per-test means each rebuilds its own VK — and they would run twice.

The wallet packages need none of that: 145 tests in 6 s under nextest. So the exclusion is scoped by package instead — keep a test if it is not shield-named **or** it belongs to a wallet package:

```
-E '(not test(~shield) or package(platform-wallet) or package(platform-wallet-storage) or package(platform-wallet-ffi))
    and (not binary_id(=drive-abci::strategy_tests) or test(~comprehensive_mixed_operations))'
```

The strategy-simulation step keeps its `~shield` exclusion unchanged, because drive-abci *is* in the compensating phase, so that exclusion is compensated and is not a hole.

### Zero-match guard

Every nextest invocation touched here pins `--no-tests fail`. A filter that stops selecting anything now fails the step instead of reporting green over an empty run — verified by pointing a deliberately non-matching expression at the suite and watching it exit 4. Pinned rather than left to nextest's default: a default that can change across a version bump is not a guarantee.

### Scope note

The fixture fix travels with the workflow change on purpose — narrowing the filter is precisely what makes that test start running, so shipping the workflow alone would land this PR red on its own change.

## How Has This Been Tested?

On this branch, through the repository's own commands:

- **New wallet job command, exactly as the workflow runs it: 1804 tests run, 1804 passed**, 25.6 s — including all 145 shielded tests and the previously-failing balance regression.
- **Shielded suite alone: 145 run, 145 passed**, 6.1 s wall clock.
- The workspace filterset selects all 1804 wallet tests, byte-identical to an unfiltered listing (empty `diff`).
- `package()` scoping confirmed to discriminate: excluding two wallet packages from a `test(~shield)` selection leaves exactly the 24 `platform-wallet-ffi` tests and nothing else.
- Zero-match guard: a deliberately non-matching expression exits 4 with "error: no tests to run".
- `cargo clippy -p platform-wallet --all-targets --all-features --locked -- -D warnings`: clean.
- Both workflow files parse under PyYAML and their changed steps round-trip to the intended commands.

**Not verified, stated deliberately.** The workspace job itself was not executed — proving the expression's effect on dpp/drive/drive-abci would mean building their test binaries. Its behaviour there rests on the `package()` discrimination proof plus boolean reasoning, not on execution.

**Flakiness caveat.** The 145-test result is one run on one machine with generous parallelism. It establishes that the suite passes and is not slow; it does not establish that it is non-flaky on a loaded CI runner, and Orchard proving tests are exactly the kind that can be. The honest expectation is "turn it on and watch the first few runs", not "turn it on and forget it". If it proves flaky, the right response is to fix or quarantine the specific tests, not to reinstate a filter that hides 40 unrelated ones with them.

## Breaking Changes

None. CI configuration and one test fixture; no library, API, or runtime behaviour changes.

## Note for reviewers also following #3968

That branch adds further `platform-wallet-storage` tests with `shielded` in their names, which the old filter would also have swept up. They do not exist on this base, so they are not counted in any figure above.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved wallet test coverage by ensuring shielded wallet tests run reliably.
  - Added safeguards so test jobs fail when no tests match the selected criteria.
  - Updated test validation to remain accurate across changing fee and reserve schedules.
  - Corrected wallet workspace test selection to prevent relevant shielded tests from being skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->