### PR TITLE
fix(wasm-sdk): seed the contract cache from contract fetches and share in-flight fetches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8856,6 +8856,7 @@ dependencies = [
  "dpp-json-convertible-derive",
  "drive",
  "drive-proof-verifier",
+ "futures",
  "getrandom 0.2.17",
  "hex",
  "hmac",

--- a/packages/wasm-sdk/Cargo.toml
+++ b/packages/wasm-sdk/Cargo.toml
@@ -66,6 +66,9 @@ console_error_panic_hook = { version = "0.1.6" }
 thiserror = { version = "2.0.17" }
 wasm-bindgen = { version = "=0.2.108" }
 wasm-bindgen-futures = { version = "0.4.58" }
+# `future::Shared` — one in-flight contract fetch per id, joined by every
+# concurrent cache miss (see `WasmSdk::get_or_fetch_contract`).
+futures = { version = "0.3.30" }
 drive-proof-verifier = { path = "../rs-drive-proof-verifier", default-features = false } # TODO: I think it's not needed (LKl)
 tracing = { version = "0.1.41" }
 tracing-subscriber = { version = "0.3.22", default-features = false, features = [

--- a/packages/wasm-sdk/src/queries/data_contract.rs
+++ b/packages/wasm-sdk/src/queries/data_contract.rs
@@ -91,6 +91,37 @@ fn build_limit_query(params: &DataContractHistoryQueryParsed) -> LimitQuery<(Ide
     }
 }
 
+impl WasmSdk {
+    /// Fetch one contract (proved) and seed the trusted-context cache
+    /// with it, so the document queries that follow find it there
+    /// instead of each fetching it again. Backs `getDataContract`.
+    pub(crate) async fn fetch_contract_seeding_cache(
+        &self,
+        id: Identifier,
+    ) -> Result<Option<DataContract>, WasmSdkError> {
+        let contract = DataContract::fetch_by_identifier(self.as_ref(), id).await?;
+        if let Some(contract) = &contract {
+            self.cache_contract(contract.clone());
+        }
+        Ok(contract)
+    }
+
+    /// Fetch several contracts in one round trip (proved) and seed the
+    /// trusted-context cache with every one that resolved. Backs
+    /// `getDataContracts` — the natural preload call, which until this
+    /// seeded nothing and left every first query to refetch.
+    pub(crate) async fn fetch_contracts_seeding_cache(
+        &self,
+        ids: Vec<Identifier>,
+    ) -> Result<DataContracts, WasmSdkError> {
+        let contracts: DataContracts = DataContract::fetch_many(self.as_ref(), ids).await?;
+        for contract in contracts.values().flatten() {
+            self.cache_contract(contract.clone());
+        }
+        Ok(contracts)
+    }
+}
+
 #[wasm_bindgen]
 impl WasmSdk {
     #[wasm_bindgen(js_name = "getDataContract")]
@@ -102,7 +133,8 @@ impl WasmSdk {
             WasmSdkError::invalid_argument(format!("Invalid data contract ID: {}", err))
         })?;
 
-        let data_contract = DataContract::fetch_by_identifier(self.as_ref(), id)
+        let data_contract = self
+            .fetch_contract_seeding_cache(id)
             .await?
             .map(DataContractWasm::from);
 
@@ -126,6 +158,7 @@ impl WasmSdk {
 
         contract
             .map(|contract| {
+                self.cache_contract(contract.clone());
                 ProofMetadataResponseWasm::from_sdk_parts(
                     DataContractWasm::from(contract),
                     metadata,
@@ -174,9 +207,8 @@ impl WasmSdk {
         let identifiers: Vec<Identifier> =
             try_to_vec::<IdentifierWasm, _, _>(ids, "ids", "identifier")?;
 
-        // Fetch all contracts
-        let contracts_result: DataContracts =
-            DataContract::fetch_many(self.as_ref(), identifiers).await?;
+        // Fetch all contracts, seeding the cache with each one found
+        let contracts_result = self.fetch_contracts_seeding_cache(identifiers).await?;
 
         let contracts_map = Map::new();
 
@@ -245,7 +277,10 @@ impl WasmSdk {
 
         for (id, contract_opt) in contracts_result {
             let key: JsValue = IdentifierWasm::from(id).to_base58().into();
-            let value = contract_opt.map(DataContractWasm::from);
+            let value = contract_opt.map(|contract| {
+                self.cache_contract(contract.clone());
+                DataContractWasm::from(contract)
+            });
 
             contracts_map.set(&key, &JsValue::from(value));
         }
@@ -255,5 +290,92 @@ impl WasmSdk {
             metadata,
             proof,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! The cache-seeding contract of the contract fetch entry points:
+    //! what `getDataContract` / `getDataContracts` fetch must land in
+    //! the trusted-context cache, because those calls are how an app
+    //! preloads its contracts — and a preload that seeds nothing leaves
+    //! every first document query per contract fetching it again.
+
+    use super::*;
+    use crate::context_provider::WasmTrustedContext;
+    use dash_sdk::dpp::data_contract::accessors::v0::{
+        DataContractV0Getters, DataContractV0Setters,
+    };
+    use dash_sdk::dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
+    use dash_sdk::dpp::version::PlatformVersion;
+    use dash_sdk::Sdk;
+
+    /// Built at the SDK's own platform version, the version the mock
+    /// deserializes at, so the round-tripped contract compares equal.
+    fn custom_contract(id_byte: u8, platform_version: &PlatformVersion) -> DataContract {
+        let mut contract = load_system_data_contract(SystemDataContract::DPNS, platform_version)
+            .expect("DPNS contract fixture should load");
+        contract.set_id(Identifier::new([id_byte; 32]));
+        contract
+    }
+
+    #[tokio::test]
+    async fn a_single_contract_fetch_seeds_the_cache() {
+        let mut inner_sdk = Sdk::new_mock();
+        let expected = custom_contract(0xA1, inner_sdk.version());
+        let id = expected.id();
+        inner_sdk
+            .mock()
+            .expect_fetch(id, Some(expected.clone()))
+            .await
+            .expect("mock contract response should be configured");
+        let sdk =
+            WasmSdk::new_for_testing(inner_sdk, Some(WasmTrustedContext::for_testing(vec![])));
+        assert!(sdk.get_cached_contract(&id).is_none());
+
+        let fetched = sdk
+            .fetch_contract_seeding_cache(id)
+            .await
+            .expect("proved contract fetch should succeed");
+
+        assert_eq!(fetched.as_ref(), Some(&expected));
+        assert_eq!(sdk.get_cached_contract(&id).as_deref(), Some(&expected));
+    }
+
+    #[tokio::test]
+    async fn a_batched_contract_fetch_seeds_the_cache_with_every_resolved_contract() {
+        let mut inner_sdk = Sdk::new_mock();
+        let found = custom_contract(0xA2, inner_sdk.version());
+        let missing_id = Identifier::new([0xB3; 32]);
+        let ids = vec![found.id(), missing_id];
+        let response: DataContracts = [(found.id(), Some(found.clone())), (missing_id, None)]
+            .into_iter()
+            .collect();
+        inner_sdk
+            .mock()
+            .expect_fetch_many::<Identifier, DataContract, Vec<Identifier>, DataContracts>(
+                ids.clone(),
+                Some(response),
+            )
+            .await
+            .expect("mock contracts response should be configured");
+        let sdk =
+            WasmSdk::new_for_testing(inner_sdk, Some(WasmTrustedContext::for_testing(vec![])));
+
+        let fetched = sdk
+            .fetch_contracts_seeding_cache(ids)
+            .await
+            .expect("proved batched contract fetch should succeed");
+
+        assert_eq!(fetched.get(&found.id()), Some(&Some(found.clone())));
+        assert_eq!(fetched.get(&missing_id), Some(&None));
+        assert_eq!(
+            sdk.get_cached_contract(&found.id()).as_deref(),
+            Some(&found)
+        );
+        assert!(
+            sdk.get_cached_contract(&missing_id).is_none(),
+            "a contract the network does not have seeds nothing"
+        );
     }
 }

--- a/packages/wasm-sdk/src/sdk.rs
+++ b/packages/wasm-sdk/src/sdk.rs
@@ -1,12 +1,24 @@
 use crate::context_provider::{WasmContext, WasmTrustedContext};
 use crate::error::WasmSdkError;
 use dash_sdk::dpp::version::PlatformVersion;
+use dash_sdk::platform::{DataContract, Identifier};
 use dash_sdk::sdk::Uri;
 use dash_sdk::{Sdk, SdkBuilder};
+use futures::future::{FutureExt, LocalBoxFuture, Shared};
 use rs_dapi_client::{Address, RequestSettings};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::future::Future;
 use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
 use std::time::Duration;
 use wasm_bindgen::prelude::wasm_bindgen;
+
+/// One contract fetch in flight, shareable by every concurrent cache miss
+/// for the same id. The output is cloned into each waiter, so it must be
+/// `Clone` — which is why the error side is the (cloneable)
+/// [`WasmSdkError`] rather than the SDK's own error.
+type SharedContractFetch = Shared<LocalBoxFuture<'static, Result<DataContract, WasmSdkError>>>;
 
 fn parse_addresses(addresses: &'static [&str]) -> Vec<Address> {
     addresses
@@ -27,6 +39,27 @@ fn default_local_addresses() -> Vec<Address> {
 pub struct WasmSdk {
     sdk: Sdk,
     trusted_context: Option<WasmTrustedContext>,
+    /// Contract fetches currently on the wire, keyed by contract id.
+    ///
+    /// A cold cache is hit by a BURST, not a single call: an app's first
+    /// paint fires several document queries against the same contract
+    /// before any of them has cached it, and without this map every one
+    /// of them would issue its own `getDataContract`. A miss either joins
+    /// the fetch already in flight for its id or starts (and registers)
+    /// one; the entry is removed by the fetch itself when it settles.
+    /// `Rc<RefCell>` because the wasm target is single-threaded and the
+    /// map is only ever touched between `.await`s.
+    inflight_contract_fetches: Rc<RefCell<HashMap<Identifier, SharedContractFetch>>>,
+}
+
+impl WasmSdk {
+    fn new(sdk: Sdk, trusted_context: Option<WasmTrustedContext>) -> Self {
+        Self {
+            sdk,
+            trusted_context,
+            inflight_contract_fetches: Rc::new(RefCell::new(HashMap::new())),
+        }
+    }
 }
 
 // Dereference WasmSdk to Sdk so that we can use &WasmSdk everywhere where &Sdk is needed
@@ -103,18 +136,15 @@ impl WasmSdk {
         &self,
         contract_id: dash_sdk::platform::Identifier,
     ) -> Result<dash_sdk::platform::DataContract, crate::error::WasmSdkError> {
-        use dash_sdk::platform::Fetch;
-
-        let contract = dash_sdk::platform::DataContract::fetch(self.as_ref(), contract_id)
-            .await?
-            .ok_or_else(|| crate::error::WasmSdkError::not_found("Data contract not found"))?;
-
-        self.cache_contract(contract.clone());
-
-        Ok(contract)
+        fetch_contract_into_cache(self.sdk.clone(), self.trusted_context.clone(), contract_id).await
     }
 
-    /// Fetch a contract, checking cache first
+    /// Fetch a contract, checking the cache first.
+    ///
+    /// A miss does not always fetch: when a fetch for the same id is
+    /// already in flight (another query missed the cold cache a moment
+    /// ago), this call joins it and every waiter receives that one
+    /// fetch's result — see [`Self::join_or_start_contract_fetch`].
     pub(crate) async fn get_or_fetch_contract(
         &self,
         contract_id: dash_sdk::platform::Identifier,
@@ -123,7 +153,50 @@ impl WasmSdk {
             return Ok((*cached).clone());
         }
 
-        self.refresh_contract(contract_id).await
+        let sdk = self.sdk.clone();
+        let trusted_context = self.trusted_context.clone();
+        self.join_or_start_contract_fetch(contract_id, move || {
+            fetch_contract_into_cache(sdk, trusted_context, contract_id)
+        })
+        .await
+    }
+
+    /// Single-flight over contract fetches: join the fetch already in
+    /// flight for `contract_id`, or start the one `make_fetch` builds and
+    /// register it for later arrivals. The registration is removed by the
+    /// fetch itself once it settles, AFTER the cache is seeded, so a call
+    /// arriving after removal finds the cache rather than fetching again.
+    ///
+    /// `make_fetch` is only invoked when no fetch is in flight — the whole
+    /// point — which is what the single-flight test pins.
+    pub(crate) async fn join_or_start_contract_fetch<F>(
+        &self,
+        contract_id: Identifier,
+        make_fetch: impl FnOnce() -> F,
+    ) -> Result<DataContract, WasmSdkError>
+    where
+        F: Future<Output = Result<DataContract, WasmSdkError>> + 'static,
+    {
+        let fetch = {
+            let mut inflight = self.inflight_contract_fetches.borrow_mut();
+            match inflight.get(&contract_id) {
+                Some(existing) => existing.clone(),
+                None => {
+                    let registry = Rc::clone(&self.inflight_contract_fetches);
+                    let fetch = make_fetch();
+                    let shared: SharedContractFetch = async move {
+                        let result = fetch.await;
+                        registry.borrow_mut().remove(&contract_id);
+                        result
+                    }
+                    .boxed_local()
+                    .shared();
+                    inflight.insert(contract_id, shared.clone());
+                    shared
+                }
+            }
+        };
+        fetch.await
     }
 
     /// Remove a contract from the cache
@@ -343,10 +416,7 @@ impl WasmSdkBuilder {
 
     pub fn build(self) -> Result<WasmSdk, WasmSdkError> {
         let sdk = self.inner.build().map_err(WasmSdkError::from)?;
-        Ok(WasmSdk {
-            sdk,
-            trusted_context: self.trusted_context,
-        })
+        Ok(WasmSdk::new(sdk, self.trusted_context))
     }
 
     #[wasm_bindgen(js_name = "withContextProvider")]
@@ -478,11 +548,35 @@ impl WasmSdk {
     /// Pair a mock `Sdk` with a trusted context so tests in sibling modules can
     /// drive the paths that read the contract and quorum caches.
     pub(crate) fn new_for_testing(sdk: Sdk, trusted_context: Option<WasmTrustedContext>) -> Self {
-        Self {
-            sdk,
-            trusted_context,
-        }
+        Self::new(sdk, trusted_context)
     }
+
+    /// How many contract fetches are registered as in flight right now.
+    pub(crate) fn inflight_contract_fetch_count(&self) -> usize {
+        self.inflight_contract_fetches.borrow().len()
+    }
+}
+
+/// The one real contract fetch: a proved `DataContract::fetch`, whose
+/// result seeds the trusted-context cache before it is handed back. Takes
+/// the SDK and context by value so the returned future is `'static` and
+/// can be registered as a shared in-flight fetch.
+async fn fetch_contract_into_cache(
+    sdk: Sdk,
+    trusted_context: Option<WasmTrustedContext>,
+    contract_id: Identifier,
+) -> Result<DataContract, WasmSdkError> {
+    use dash_sdk::platform::Fetch;
+
+    let contract = DataContract::fetch(&sdk, contract_id)
+        .await?
+        .ok_or_else(|| WasmSdkError::not_found("Data contract not found"))?;
+
+    if let Some(context) = trusted_context {
+        context.add_known_contract(contract.clone());
+    }
+
+    Ok(contract)
 }
 
 #[cfg(test)]
@@ -673,10 +767,8 @@ mod tests {
             .await
             .expect("mock contract response should be configured");
 
-        let sdk = WasmSdk {
-            sdk: inner_sdk,
-            trusted_context: Some(WasmTrustedContext::for_testing(vec![])),
-        };
+        let sdk =
+            WasmSdk::new_for_testing(inner_sdk, Some(WasmTrustedContext::for_testing(vec![])));
         assert!(sdk.get_cached_contract(&contract_id).is_none());
 
         let refreshed = sdk
@@ -708,10 +800,7 @@ mod tests {
             .await
             .expect("mock contract response should be configured");
 
-        let sdk = WasmSdk {
-            sdk: inner_sdk,
-            trusted_context: Some(context),
-        };
+        let sdk = WasmSdk::new_for_testing(inner_sdk, Some(context));
         let refreshed = sdk
             .refresh_contract(contract_id)
             .await
@@ -736,10 +825,8 @@ mod tests {
             .await
             .expect("mock absence response should be configured");
 
-        let sdk = WasmSdk {
-            sdk: inner_sdk,
-            trusted_context: Some(WasmTrustedContext::for_testing(vec![])),
-        };
+        let sdk =
+            WasmSdk::new_for_testing(inner_sdk, Some(WasmTrustedContext::for_testing(vec![])));
 
         assert!(sdk.refresh_contract(contract_id).await.is_err());
         assert!(sdk.get_cached_contract(&contract_id).is_none());
@@ -748,12 +835,101 @@ mod tests {
     #[tokio::test]
     async fn refresh_contract_propagates_fetch_errors() {
         let contract_id = dash_sdk::platform::Identifier::new([0x77; 32]);
-        let sdk = WasmSdk {
-            sdk: Sdk::new_mock(),
-            trusted_context: Some(WasmTrustedContext::for_testing(vec![])),
-        };
+        let sdk = WasmSdk::new_for_testing(
+            Sdk::new_mock(),
+            Some(WasmTrustedContext::for_testing(vec![])),
+        );
 
         assert!(sdk.refresh_contract(contract_id).await.is_err());
         assert!(sdk.get_cached_contract(&contract_id).is_none());
+    }
+
+    /// The single-flight contract: two misses for one id while nothing
+    /// is cached start ONE fetch, both receive its result, and the
+    /// registration is gone once it settles. The fetch is gated on a
+    /// channel the test holds, so both arrivals are observably in flight
+    /// together regardless of how fast a real fetch would resolve.
+    #[tokio::test]
+    async fn concurrent_cache_misses_share_one_in_flight_fetch() {
+        use std::cell::Cell;
+
+        let sdk = WasmSdk::new_for_testing(
+            Sdk::new_mock(),
+            Some(WasmTrustedContext::for_testing(vec![])),
+        );
+        let expected = custom_contract(0x88, 1, sdk.sdk.version());
+        let contract_id = expected.id();
+
+        let (release, gate) = futures::channel::oneshot::channel::<()>();
+        let gate = gate.shared();
+        let fetches_started = Rc::new(Cell::new(0usize));
+        let make_fetch = |contract: DataContract| {
+            let gate = gate.clone();
+            let fetches_started = Rc::clone(&fetches_started);
+            move || {
+                fetches_started.set(fetches_started.get() + 1);
+                async move {
+                    gate.await.expect("the test releases the gate");
+                    Ok(contract)
+                }
+            }
+        };
+
+        let mut first =
+            Box::pin(sdk.join_or_start_contract_fetch(contract_id, make_fetch(expected.clone())));
+        let mut second =
+            Box::pin(sdk.join_or_start_contract_fetch(contract_id, make_fetch(expected.clone())));
+
+        assert!(futures::poll!(first.as_mut()).is_pending());
+        assert!(futures::poll!(second.as_mut()).is_pending());
+        assert_eq!(
+            fetches_started.get(),
+            1,
+            "the second miss must join the in-flight fetch, not start its own"
+        );
+        assert_eq!(sdk.inflight_contract_fetch_count(), 1);
+
+        release.send(()).expect("both waiters are alive");
+        let (first, second) = futures::join!(first, second);
+        assert_eq!(first.expect("first waiter"), expected);
+        assert_eq!(second.expect("second waiter"), expected);
+        assert_eq!(
+            sdk.inflight_contract_fetch_count(),
+            0,
+            "a settled fetch deregisters itself"
+        );
+    }
+
+    /// A miss arriving AFTER the shared fetch settled must find the cache
+    /// the fetch seeded, not start a second fetch: `get_or_fetch_contract`
+    /// checks the cache before consulting the in-flight registry.
+    #[tokio::test]
+    async fn a_miss_after_the_shared_fetch_settles_is_served_from_the_cache() {
+        let mut inner_sdk = Sdk::new_mock();
+        let expected = custom_contract(0x99, 1, inner_sdk.version());
+        let contract_id = expected.id();
+        inner_sdk
+            .mock()
+            .expect_fetch(contract_id, Some(expected.clone()))
+            .await
+            .expect("mock contract response should be configured");
+        let sdk =
+            WasmSdk::new_for_testing(inner_sdk, Some(WasmTrustedContext::for_testing(vec![])));
+
+        let fetched = sdk
+            .get_or_fetch_contract(contract_id)
+            .await
+            .expect("the first miss fetches");
+        assert_eq!(fetched, expected);
+        assert_eq!(sdk.inflight_contract_fetch_count(), 0);
+
+        // Nothing is registered, so a fetch here could only come from a
+        // cache miss — and the cache was seeded by the fetch above.
+        assert!(sdk.get_cached_contract(&contract_id).is_some());
+        let again = sdk
+            .get_or_fetch_contract(contract_id)
+            .await
+            .expect("served from the cache");
+        assert_eq!(again, expected);
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

An app that preloads its data contracts through `contracts.fetch()` / `contracts.getMany()` warms nothing: the wasm-sdk entry points fetched the contract and discarded it, and the trusted-context contract cache was only ever seeded lazily by the first document query per contract. That first query per contract therefore issued its own `getDataContract`, and because `get_or_fetch_contract` had no single-flight, every CONCURRENT first query against the same contract fetched it again. On a social app's feed cold load this was 7 stray `getDataContract` calls on top of the batched preload, for 3 contracts.

## What was done?

- `getDataContract`, `getDataContracts`, and their `*WithProofInfo` twins seed the trusted-context known-contracts cache with every contract they resolve (new `fetch_contract_seeding_cache` / `fetch_contracts_seeding_cache` helpers back the JS entry points).
- `get_or_fetch_contract` is single-flight: a miss joins the fetch already in flight for that id (one `Shared` future per id, registered in an `Rc<RefCell<HashMap>>` and deregistered by the fetch itself once it settles, after the cache is seeded), so a burst of cold misses costs one fetch.
- `futures` added as a direct dependency of wasm-sdk for `future::Shared`.

## How Has This Been Tested?

New host tests in `wasm-sdk` (`cargo test -p wasm-sdk`, 107 passing):

- `a_single_contract_fetch_seeds_the_cache` / `a_batched_contract_fetch_seeds_the_cache_with_every_resolved_contract` (absent contracts seed nothing)
- `concurrent_cache_misses_share_one_in_flight_fetch`: two misses for one id while nothing is cached start exactly one (gated) fetch, both receive its result, and the registration is gone once it settles
- `a_miss_after_the_shared_fetch_settles_is_served_from_the_cache`

Also `cargo check -p wasm-sdk --target wasm32-unknown-unknown` and clippy on the package (no findings in wasm-sdk sources).

## Breaking Changes

None. Callers that never touched the cache see fewer network calls and identical results.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved data contract retrieval by reusing concurrent requests for the same contract.
  - Resolved contracts are now cached consistently for faster subsequent access.
  - Added support for efficient caching during both single and batched contract fetches.

- **Bug Fixes**
  - Prevented redundant contract fetches when multiple requests occur at the same time.
  - Ensured cache behavior remains correct after an in-progress fetch completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->