### PR TITLE
chore: bump grovedb to 2d95c567 (#850 merged: limited branches graft below a shared key)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "grovedb"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "axum 0.8.9",
  "bincode",
@@ -3014,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "grovedb-bulk-append-tree"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "bincode",
  "blake3",
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "grovedb-commitment-tree"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "blake3",
  "grovedb-bulk-append-tree",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "grovedb-dense-fixed-sized-merkle-tree"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "bincode",
  "blake3",
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "grovedb-element"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "grovedb-costs",
  "hex",
@@ -3101,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -3127,7 +3127,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merkle-mountain-range"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "bincode",
  "blake3",
@@ -3140,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "hex",
 ]
@@ -3148,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "grovedb-private-document-store"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "blake3",
  "grovedb-bulk-append-tree",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "grovedb-query"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3177,7 +3177,7 @@ dependencies = [
 [[package]]
 name = "grovedb-storage"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -3196,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "grovedbg-types"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?rev=97250247423ddc7fcc2865ea0025fc5bd41d0883#97250247423ddc7fcc2865ea0025fc5bd41d0883"
+source = "git+https://github.com/dashpay/grovedb?rev=2d95c56790fc9bcf3178711fdce0297734b51601#2d95c56790fc9bcf3178711fdce0297734b51601"
 dependencies = [
  "serde",
  "serde_with 3.21.0",

--- a/packages/rs-dpp/Cargo.toml
+++ b/packages/rs-dpp/Cargo.toml
@@ -71,7 +71,7 @@ strum = { version = "0.26", features = ["derive"] }
 json-schema-compatibility-validator = { path = '../rs-json-schema-compatibility-validator', optional = true }
 once_cell = "1.19.0"
 tracing = { version = "0.1.41" }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883", optional = true }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.40", features = ["full"] }

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -82,7 +82,7 @@ derive_more = { version = "1.0", features = ["from", "deref", "deref_mut"] }
 async-trait = "0.1.77"
 console-subscriber = { version = "0.4", optional = true }
 bls-signatures = { git = "https://github.com/dashpay/bls-signatures", rev = "0842b17583888e8f46c252a4ee84cdfd58e0546f", optional = true }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883" }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601" }
 nonempty = "0.11"
 # Shielded-pool snapshot needs raw RocksDB SstFileWriter + ingest_external_file_cf
 # bindings, and blake3 for the snapshot-file checksum.
@@ -108,7 +108,7 @@ dpp = { path = "../rs-dpp", default-features = false, features = [
 drive = { path = "../rs-drive", features = ["fixtures-and-mocks"] }
 drive-proof-verifier = { path = "../rs-drive-proof-verifier" }
 strategy-tests = { path = "../strategy-tests" }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883", features = ["client"] }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601", features = ["client"] }
 assert_matches = "1.5.0"
 drive-abci = { path = ".", features = ["testing-config", "mocks", "shielded_test_data"] }
 bls-signatures = { git = "https://github.com/dashpay/bls-signatures", rev = "0842b17583888e8f46c252a4ee84cdfd58e0546f" }
@@ -122,8 +122,8 @@ integer-encoding = { version = "4.0.0" }
 
 # For dump_only_default_and_aux_cfs_under_shielded_subtree_prefix — same
 # subtree-prefix algorithm grovedb uses internally.
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883" }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601" }
 
 [features]
 default = ["bls-signatures"]

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -52,13 +52,13 @@ enum-map = { version = "2.0.3", optional = true }
 intmap = { version = "3.0.1", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.13", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883", optional = true, default-features = false }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883" }
-grovedb-query = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883", optional = true }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883" }
-grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883" }
+grovedb = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601", optional = true, default-features = false }
+grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601", optional = true }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601" }
+grovedb-query = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601", optional = true }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601" }
+grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 thiserror = { version = "2.0.12" }
 bincode = { version = "=2.0.1" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883" }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601" }
 
 [features]
 mock-versions = []

--- a/packages/rs-platform-wallet/Cargo.toml
+++ b/packages/rs-platform-wallet/Cargo.toml
@@ -61,7 +61,7 @@ zeroize = "1"
 log = "0.4"
 
 # Shielded pool (optional, behind `shielded` feature)
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883", optional = true }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601", optional = true }
 # Direct `rusqlite` access so `FileBackedShieldedStore::open_path` can set
 # WAL + synchronous=NORMAL pragmas before handing the connection to
 # `ClientPersistentCommitmentTree`. Version locked to match the rev grovedb

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -18,7 +18,7 @@ drive = { path = "../rs-drive", default-features = false, features = [
 ] }
 
 drive-proof-verifier = { path = "../rs-drive-proof-verifier", default-features = false }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "97250247423ddc7fcc2865ea0025fc5bd41d0883", features = [
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "2d95c56790fc9bcf3178711fdce0297734b51601", features = [
   "client",
   "sqlite",
 ], optional = true }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Composite document queries (next PR in this stack: a page plus sub-queries derived from its results, joins / lookups / counts, proven as ONE merged grovedb proof) need `PathQuery::merge` to accept limited branches that share a key with another branch and diverge right below it. Today's merge (v1) grafts a limited input exclusively at the first key past the common path and refuses any collision there, so a limited page on `post` cannot merge with a by-id fetch on `post`, and a limited page cannot merge with a limited lookup under the same contract once a cross-contract sub-query lifts the common path to the root.

## What was done?

Pins grovedb at `2d95c567`, the develop merge commit of [dashpay/grovedb#850](https://github.com/dashpay/grovedb/pull/850), which makes the merge descend into an owned key and graft where the branches actually diverge, refusing only when the bodies would meet (ownership follows execution order: the root must select the key exactly and the first conditional matching it must be that exact key). The pin also carries #849 (flat-subtree drop) from grovedb develop. All six `Cargo.toml` pins move together; no platform code change.

## How Has This Been Tested?

`cargo check -p drive --features server` against the merge commit; the composite-query PRs stacked on this one run their end-to-end merge/prove/verify suites (rs-drive and drive-abci) against it.

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

