### PR TITLE
feat(dapi): composite document queries on the getDocuments V1 wire

### DIFF
--- a/packages/dapi-grpc/build.rs
+++ b/packages/dapi-grpc/build.rs
@@ -341,6 +341,7 @@ fn configure_platform(mut platform: MappingConfig) -> MappingConfig {
         // absent (same pattern DocumentQuery's own serde defaults follow
         // for pre-SQL-surface fixtures).
         .field_attribute("GetDocumentsRequestV1.chained", SERDE_DEFAULT)
+        .field_attribute("GetDocumentsRequestV1.sub_queries", SERDE_DEFAULT)
         // Same compat rule for the typed IN_TIME_RANGE operand: mock
         // vectors captured while the operand still rode `value` carry no
         // `time_range` key.

--- a/packages/dapi-grpc/protos/platform/v0/platform.proto
+++ b/packages/dapi-grpc/protos/platform/v0/platform.proto
@@ -1253,6 +1253,86 @@ message GetDocumentsRequest {
       string outer_document_type = 2;
     }
     ChainedJoin chained = 13;
+
+    // Composite mode — a page plus sub-queries DERIVED from its
+    // results, answered as ONE merged proof over one state root.
+    //
+    // Presence of any `sub_queries` selects composite mode: this
+    // request's own `data_contract_id` / `document_type` /
+    // `where_clauses` / `order_by` / `limit` describe the PAGE, and
+    // every sub-query's `IN` clause is derived by the node from the
+    // page's (or an earlier sub-query's) proven documents. The
+    // verifier re-derives every sub-query from the proven page with
+    // the same builders, re-merges, and verifies the whole
+    // composition — so the composition cannot be steered by the
+    // responding node, and a node that predates this field (proto3
+    // unknown field) serves a page-only proof that FAILS CLOSED
+    // client-side.
+    //
+    // Mode gates (rejected otherwise): `limit` is REQUIRED on the
+    // page (at most 100 — it bounds every derived clause); `selects`
+    // must be empty or a single DOCUMENTS projection; `group_by`,
+    // `having`, time-range clauses, cursors and `offset` are
+    // rejected (paginate with a range clause on the page's ordering
+    // property); `chained` and `sub_queries` are mutually exclusive.
+    // See `SubQuery` for the per-sub-query rules.
+    message SubQuery {
+      // The contract this sub-query targets. Empty = the page's own
+      // contract; otherwise any contract (profiles keyed by owner,
+      // names keyed by identity).
+      bytes data_contract_id = 1;
+      string document_type = 2;
+      // The FIXED clauses — everything but the derived `IN`, which
+      // must not be named here.
+      repeated WhereClause where_clauses = 3;
+      // Ordering (documents only). Every component of the merged proof
+      // walks in the page's direction: a bound field missing from here
+      // is appended in that direction by the node and the verifier
+      // alike, and an ordering that disagrees with the page's direction
+      // is refused (turning a limited lookup around would change the
+      // rows it returns).
+      repeated OrderClause order_by = 4;
+      // Documents lookups on a non-unique index REQUIRE a limit: it
+      // caps the rows the lookup returns in total, in walk order, like
+      // an ordinary IN query's limit (at most 100). Lookups already
+      // bounded by their values (a unique index, or an indexOnly
+      // terminal with every prefix fixed), by-id joins (completeness is
+      // set equality) and counts take none.
+      optional uint32 limit = 5;
+      enum Kind {
+        // The matching documents.
+        DOCUMENTS = 0;
+        // One count per derived value from the `countable` index
+        // covering the fixed clauses plus the bound field. Must be
+        // bound, and must not share its index path with a documents
+        // component (the count reads the value trees the documents
+        // query descends past).
+        COUNT = 1;
+      }
+      Kind kind = 6;
+      // The derived clause `<field> IN <values>`. Absent = a SIBLING:
+      // an independent documents query proven under the same root.
+      message Binding {
+        // Whose proven documents supply the values: `0` = the page,
+        // `n` = `sub_queries[n - 1]` (which must precede this one and
+        // be a DOCUMENTS sub-query).
+        uint32 source = 1;
+        // The source property read off each document: `$id`,
+        // `$ownerId`, or an identifier-typed property (dotted paths
+        // reach nested properties). Documents without it contribute
+        // nothing.
+        string source_property = 2;
+        // The sub-query field receiving the `IN` clause. `$id` makes
+        // this a by-id JOIN: the source property must then declare
+        // `refersTo: permanentDocument` targeting this document type,
+        // so every derived id resolves and a missing document is an
+        // invalid proof. Otherwise `$ownerId` or an indexed property
+        // (a LOOKUP, where absence is a proven fact).
+        string field = 3;
+      }
+      Binding bind = 7;
+    }
+    repeated SubQuery sub_queries = 14;
   }
 
   oneof version {
@@ -1605,6 +1685,10 @@ message GetDocumentsResponse {
         // among the inner projections, deduplicated). Routed when
         // the request's `chained` message is present.
         ChainedDocuments chained = 6;
+        // Composite-mode result: the page plus one result per
+        // sub-query, in request order. Routed when the request
+        // carries `sub_queries`.
+        CompositeDocuments composite = 7;
       }
     }
 
@@ -1613,6 +1697,25 @@ message GetDocumentsResponse {
     message ChainedDocuments {
       repeated bytes inner_documents = 1;
       repeated bytes outer_documents = 2;
+    }
+
+    // A composite query's page and per-sub-query results, documents
+    // serialized with their own document type.
+    message CompositeDocuments {
+      // The page, exactly as the page query alone would return it.
+      repeated bytes page_documents = 1;
+      message SubQueryResult {
+        oneof result {
+          // DOCUMENTS: a by-id join in first-appearance order of the
+          // derived ids; a lookup or sibling in query order.
+          Documents documents = 1;
+          // COUNT: one entry per derived value that has a count tree
+          // (a value with no entry counts zero), keyed by the
+          // value's index-key bytes.
+          CountEntries counts = 2;
+        }
+      }
+      repeated SubQueryResult sub_results = 2;
     }
 
     oneof result {

--- a/packages/dash-platform-queries/src/documents/document_query.rs
+++ b/packages/dash-platform-queries/src/documents/document_query.rs
@@ -875,6 +875,7 @@ fn encode_v1(
             // a second copy of that rule in the SDK.
             offset,
             chained: None,
+            sub_queries: Vec::new(),
         })),
     })
 }

--- a/packages/rs-drive-abci/src/query/document_query/v1/dispatch/chained.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/dispatch/chained.rs
@@ -338,6 +338,7 @@ mod tests {
             group_by: Vec::new(),
             having: Vec::new(),
             offset: None,
+            sub_queries: Vec::new(),
             chained: Some(ChainedJoin {
                 join_property: "postId".to_string(),
                 outer_document_type: "post".to_string(),

--- a/packages/rs-drive-abci/src/query/document_query/v1/dispatch/composite.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/dispatch/composite.rs
@@ -1,0 +1,810 @@
+//! Composite-mode dispatch: a page plus sub-queries derived from its
+//! results, answered as ONE merged proof. The request's own type,
+//! clauses and limit describe the PAGE; each `sub_queries` entry is a
+//! join, a lookup, a count, or a sibling (see the proto), whose `IN`
+//! clause the node derives from the proven page (or an earlier
+//! sub-query). On the proof path everything rides one merged grovedb
+//! proof (drive brackets its materialize/prove sequence with root-hash
+//! reads, since grovedb proves committed state only), and the verifier
+//! re-derives the whole composition from the proven page.
+
+use super::count::into_v1_entry;
+use crate::error::query::QueryError;
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::platform_types::platform_state::PlatformState;
+use crate::query::document_query::v1::conversions;
+use crate::query::response_metadata::CheckpointUsed;
+use crate::query::QueryValidationResult;
+use dapi_grpc::platform::v0::get_documents_request::get_documents_request_v1::{
+    select, sub_query, Select as ProtoSelect, Start as RequestV1Start, SubQuery as ProtoSubQuery,
+};
+use dapi_grpc::platform::v0::get_documents_request::{
+    HavingClause as ProtoHavingClause, OrderClause as ProtoOrderClause,
+    WhereClause as ProtoWhereClause,
+};
+use dapi_grpc::platform::v0::get_documents_response::get_documents_response_v1::{
+    composite_documents, result_data, CompositeDocuments, CountEntries, Documents, ResultData,
+};
+use dapi_grpc::platform::v0::get_documents_response::{
+    get_documents_response_v1, GetDocumentsResponseV1,
+};
+use dpp::check_validation_result_with_data;
+use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::document::serialization_traits::DocumentPlatformConversionMethodsV0;
+use dpp::validation::ValidationResult;
+use dpp::version::PlatformVersion;
+use drive::drive::contract::DataContractFetchInfo;
+use drive::error::query::QuerySyntaxError;
+use drive::query::{
+    BindingSource, DriveDocumentQuery, DriveSubQuery, SubQueryBinding, SubQueryKind, SubQueryResult,
+};
+use drive::util::grove_operations::GroveDBToUse;
+use std::sync::Arc;
+
+/// A sub-query's wire fields decoded into drive's typed forms, before
+/// the contract it targets is bound.
+struct DecodedSubQuery {
+    contract_index: usize,
+    document_type: String,
+    kind: SubQueryKind,
+    where_clauses: Vec<drive::query::WhereClause>,
+    order_by: Vec<drive::query::OrderClause>,
+    limit: Option<u16>,
+    binding: Option<SubQueryBinding>,
+}
+
+impl<C> Platform<C> {
+    /// Serve a composite-mode v1 request. Runs before select routing:
+    /// the composite surface owns its own (deliberately narrow) shape.
+    #[allow(clippy::too_many_arguments)]
+    pub(in crate::query::document_query::v1) fn dispatch_composite_v1(
+        &self,
+        data_contract_id: Vec<u8>,
+        document_type: String,
+        proto_sub_queries: Vec<ProtoSubQuery>,
+        proto_where_clauses: Vec<ProtoWhereClause>,
+        proto_order_by: Vec<ProtoOrderClause>,
+        limit: Option<u32>,
+        start: Option<RequestV1Start>,
+        prove: bool,
+        proto_selects: Vec<ProtoSelect>,
+        group_by: Vec<String>,
+        having: Vec<ProtoHavingClause>,
+        offset: Option<u32>,
+        platform_state: &PlatformState,
+        platform_version: &PlatformVersion,
+    ) -> Result<QueryValidationResult<GetDocumentsResponseV1>, Error> {
+        let unsupported = |message: &str| {
+            QueryValidationResult::new_with_error(QueryError::Query(QuerySyntaxError::Unsupported(
+                message.to_string(),
+            )))
+        };
+
+        // The composite surface is documents-shaped by construction:
+        // an empty `selects` or a single DOCUMENTS projection; every
+        // SQL-shaped knob and every cursor is rejected — pagination
+        // is a range clause on the page's ordering property.
+        let selects_are_documents = match proto_selects.as_slice() {
+            [] => true,
+            [single] => {
+                single.function == select::Function::Documents as i32 && single.field.is_empty()
+            }
+            _ => false,
+        };
+        if !selects_are_documents {
+            return Ok(unsupported(
+                "a composite request supports the DOCUMENTS projection only",
+            ));
+        }
+        if !group_by.is_empty() || !having.is_empty() {
+            return Ok(unsupported(
+                "a composite request supports no group_by or having clauses",
+            ));
+        }
+        if start.is_some() {
+            return Ok(unsupported(
+                "a composite request supports no cursor; paginate with a range clause on \
+                 the page's ordering property",
+            ));
+        }
+        if offset.is_some() {
+            return Ok(unsupported("a composite request supports no offset"));
+        }
+        if proto_where_clauses
+            .iter()
+            .chain(
+                proto_sub_queries
+                    .iter()
+                    .flat_map(|sub| sub.where_clauses.iter()),
+            )
+            .any(conversions::is_time_range_clause)
+        {
+            return Ok(unsupported(
+                "a composite request supports no time-range (IN_TIME_RANGE) clauses",
+            ));
+        }
+
+        // The page limit is REQUIRED — it bounds every derived clause.
+        let max_query_limit = self.config.drive.max_query_limit as u32;
+        let page_limit = match limit {
+            Some(n) if n >= 1 && n <= max_query_limit => n as u16,
+            other => {
+                return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                    QuerySyntaxError::InvalidLimit(format!(
+                        "composite requests require an explicit page limit in [1, {}], got {:?}",
+                        max_query_limit, other
+                    )),
+                )));
+            }
+        };
+
+        let where_clauses = match conversions::where_clauses_from_proto(proto_where_clauses) {
+            Ok(c) => c,
+            Err(e) => return Ok(QueryValidationResult::new_with_error(e)),
+        };
+        let order_by_clauses = match conversions::order_clauses_from_proto(proto_order_by) {
+            Ok(c) => c,
+            Err(e) => return Ok(QueryValidationResult::new_with_error(e)),
+        };
+
+        // Every contract the composition touches, fetched once: the
+        // page's first, then each distinct sub-query contract.
+        let (page_contract_id, page_contract) = check_validation_result_with_data!(
+            self.fetch_contract_for_document_query_v1(data_contract_id, platform_version)?
+        );
+        let mut contracts: Vec<Arc<DataContractFetchInfo>> = vec![page_contract];
+        let mut contract_ids: Vec<Vec<u8>> = vec![page_contract_id.to_vec()];
+
+        let mut decoded: Vec<DecodedSubQuery> = Vec::with_capacity(proto_sub_queries.len());
+        for (index, proto) in proto_sub_queries.into_iter().enumerate() {
+            let label = |message: String| {
+                QueryValidationResult::new_with_error(QueryError::InvalidArgument(format!(
+                    "sub-query {}: {}",
+                    index, message
+                )))
+            };
+            let contract_index = if proto.data_contract_id.is_empty() {
+                0
+            } else if let Some(position) = contract_ids
+                .iter()
+                .position(|id| *id == proto.data_contract_id)
+            {
+                position
+            } else {
+                let (id, fetched) = check_validation_result_with_data!(self
+                    .fetch_contract_for_document_query_v1(
+                        proto.data_contract_id.clone(),
+                        platform_version
+                    )?);
+                contracts.push(fetched);
+                contract_ids.push(id.to_vec());
+                contracts.len() - 1
+            };
+            let kind = match sub_query::Kind::try_from(proto.kind) {
+                Ok(sub_query::Kind::Documents) => SubQueryKind::Documents,
+                Ok(sub_query::Kind::Count) => SubQueryKind::Count,
+                Err(_) => return Ok(label(format!("unknown kind {}", proto.kind))),
+            };
+            let limit = match proto.limit {
+                None => None,
+                Some(n) if n >= 1 && n <= max_query_limit => Some(n as u16),
+                Some(n) => {
+                    return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                        QuerySyntaxError::InvalidLimit(format!(
+                            "sub-query {}: limit must be in [1, {}], got {}",
+                            index, max_query_limit, n
+                        )),
+                    )));
+                }
+            };
+            let where_clauses = match conversions::where_clauses_from_proto(proto.where_clauses) {
+                Ok(c) => c,
+                Err(e) => return Ok(QueryValidationResult::new_with_error(e)),
+            };
+            let order_by = match conversions::order_clauses_from_proto(proto.order_by) {
+                Ok(c) => c,
+                Err(e) => return Ok(QueryValidationResult::new_with_error(e)),
+            };
+            let binding = proto.bind.map(|bind| SubQueryBinding {
+                source: match bind.source {
+                    0 => BindingSource::Page,
+                    n => BindingSource::SubQuery(n as usize - 1),
+                },
+                source_property: bind.source_property,
+                field: bind.field,
+            });
+            decoded.push(DecodedSubQuery {
+                contract_index,
+                document_type: proto.document_type,
+                kind,
+                where_clauses,
+                order_by,
+                limit,
+                binding,
+            });
+        }
+
+        // Bind the typed shapes to the fetched contracts.
+        let page_contract_ref = &contracts[0].contract;
+        let page_type = check_validation_result_with_data!(page_contract_ref
+            .document_type_for_name(document_type.as_str())
+            .map_err(|_| QueryError::InvalidArgument(format!(
+                "document type {} not found for the queried contract",
+                document_type
+            ))));
+        let page = check_validation_result_with_data!(DriveDocumentQuery::from_typed_clauses(
+            where_clauses,
+            order_by_clauses,
+            Some(page_limit),
+            None,
+            true,
+            None,
+            page_contract_ref,
+            page_type,
+            &self.config.drive,
+            platform_version,
+        ));
+        let mut sub_queries: Vec<DriveSubQuery> = Vec::with_capacity(decoded.len());
+        for (index, sub) in decoded.into_iter().enumerate() {
+            let contract_ref = &contracts[sub.contract_index].contract;
+            let document_type = check_validation_result_with_data!(contract_ref
+                .document_type_for_name(sub.document_type.as_str())
+                .map_err(|_| QueryError::InvalidArgument(format!(
+                    "sub-query {}: document type {} not found for its contract",
+                    index, sub.document_type
+                ))));
+            sub_queries.push(DriveSubQuery {
+                contract: contract_ref,
+                document_type,
+                kind: sub.kind,
+                where_clauses: sub.where_clauses,
+                order_by: sub.order_by,
+                limit: sub.limit,
+                binding: sub.binding,
+            });
+        }
+        let composite = page.with_sub_queries(sub_queries);
+        // Fail the shape checks as query errors (client-attributable),
+        // before any execution.
+        match composite.validate_composite(platform_version) {
+            Ok(()) => {}
+            Err(drive::error::Error::Query(query_error)) => {
+                return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                    query_error,
+                )));
+            }
+            Err(e) => return Err(e.into()),
+        }
+
+        let response = if prove {
+            let (merged_proof, _page_documents) = match self
+                .drive
+                .query_composite_documents_with_proof(&composite, platform_version)
+            {
+                Ok(result) => result,
+                Err(drive::error::Error::Query(query_error)) => {
+                    return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                        query_error,
+                    )));
+                }
+                Err(e) => return Err(e.into()),
+            };
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, merged_proof, GroveDBToUse::Current)?;
+            GetDocumentsResponseV1 {
+                result: Some(get_documents_response_v1::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
+            }
+        } else {
+            let outcome =
+                match self
+                    .drive
+                    .query_composite_documents(&composite, None, None, platform_version)
+                {
+                    Ok(outcome) => outcome,
+                    Err(drive::error::Error::Query(query_error)) => {
+                        return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                            query_error,
+                        )));
+                    }
+                    Err(e) => return Err(e.into()),
+                };
+            let serialize_all = |documents: &[dpp::document::Document],
+                                 sub: Option<&DriveSubQuery>|
+             -> Result<Vec<Vec<u8>>, Error> {
+                let (document_type, contract) = match sub {
+                    None => (composite.document_type, composite.contract),
+                    Some(sub) => (sub.document_type, sub.contract),
+                };
+                documents
+                    .iter()
+                    .map(|document| {
+                        document
+                            .serialize(document_type, contract, platform_version)
+                            .map_err(Error::Protocol)
+                    })
+                    .collect()
+            };
+            let page_documents = serialize_all(&outcome.result.page_documents, None)?;
+            let mut sub_results = Vec::with_capacity(composite.sub_queries.len());
+            for (sub, result) in composite.sub_queries.iter().zip(outcome.result.sub_results) {
+                let result = match result {
+                    SubQueryResult::Documents(documents) => {
+                        composite_documents::sub_query_result::Result::Documents(Documents {
+                            documents: serialize_all(&documents, Some(sub))?,
+                        })
+                    }
+                    SubQueryResult::Counts(entries) => {
+                        composite_documents::sub_query_result::Result::Counts(CountEntries {
+                            entries: entries.into_iter().map(into_v1_entry).collect(),
+                        })
+                    }
+                };
+                sub_results.push(composite_documents::SubQueryResult {
+                    result: Some(result),
+                });
+            }
+            GetDocumentsResponseV1 {
+                result: Some(get_documents_response_v1::Result::Data(ResultData {
+                    variant: Some(result_data::Variant::Composite(CompositeDocuments {
+                        page_documents,
+                        sub_results,
+                    })),
+                })),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
+            }
+        };
+
+        Ok(QueryValidationResult::new_with_data(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::{setup_platform, store_data_contract, store_document};
+    use dapi_grpc::platform::v0::get_documents_request::document_field_value;
+    use dapi_grpc::platform::v0::get_documents_request::get_documents_request_v1::{
+        sub_query::Binding as ProtoBinding, ChainedJoin,
+    };
+    use dapi_grpc::platform::v0::get_documents_request::DocumentFieldValue as ProtoDocumentFieldValue;
+    use dapi_grpc::platform::v0::get_documents_request::GetDocumentsRequestV1;
+    use dapi_grpc::platform::v0::get_documents_request::WhereOperator as ProtoWhereOperator;
+    use dapi_grpc::platform::v0::get_documents_response::get_documents_response_v1::Result as ResponseResult;
+    use dpp::dashcore::Network;
+    use dpp::data_contract::document_type::random_document::CreateRandomDocument;
+    use dpp::document::{Document, DocumentV0Getters, DocumentV0Setters};
+    use dpp::identifier::Identifier;
+    use dpp::platform_value::Value;
+    use dpp::prelude::DataContract;
+    use dpp::tests::json_document::json_document_to_contract;
+    use drive::query::{InternalClauses, WhereClause, WhereOperator};
+
+    const FEED_CONTRACT_PATH: &str =
+        "../rs-drive/tests/supporting_files/contract/yappr-feed/yappr-feed-contract.json";
+    const DASHPAY_CONTRACT_PATH: &str =
+        "../rs-drive/tests/supporting_files/contract/dashpay/dashpay-contract.json";
+    const POST_A: [u8; 32] = [0xA1; 32];
+    const POST_B: [u8; 32] = [0xB2; 32];
+    const POST_D: [u8; 32] = [0xD4; 32];
+    const OWNER_1: [u8; 32] = [0x11; 32];
+    const OWNER_2: [u8; 32] = [0x22; 32];
+
+    /// Two `dash` posts (A by owner 1 quoting D, B by owner 2), the
+    /// quoted `btc` post D, two likes on A and one on B, and a profile
+    /// for owner 1 only.
+    fn setup_feed_state() -> (
+        crate::test::helpers::setup::TempPlatform<crate::rpc::core::MockCoreRPCLike>,
+        std::sync::Arc<PlatformState>,
+        &'static PlatformVersion,
+        DataContract,
+        DataContract,
+    ) {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let feed = json_document_to_contract(FEED_CONTRACT_PATH, false, version)
+            .expect("expected to parse the feed contract");
+        let dashpay = json_document_to_contract(DASHPAY_CONTRACT_PATH, false, version)
+            .expect("expected to parse the dashpay contract");
+        store_data_contract(&platform.platform, &feed, version);
+        store_data_contract(&platform.platform, &dashpay, version);
+
+        let post_type = feed.document_type_for_name("post").expect("post doctype");
+        let like_type = feed.document_type_for_name("like").expect("like doctype");
+        let profile_type = dashpay
+            .document_type_for_name("profile")
+            .expect("profile doctype");
+
+        for (id, owner, hashtag, quoted, seed) in [
+            (POST_D, OWNER_2, "btc", None, 4u64),
+            (POST_A, OWNER_1, "dash", Some(POST_D), 1),
+            (POST_B, OWNER_2, "dash", None, 2),
+        ] {
+            let mut post = post_type
+                .random_document(Some(seed), version)
+                .expect("post");
+            let mut props = std::collections::BTreeMap::new();
+            props.insert("hashtag".to_string(), Value::Text(hashtag.to_string()));
+            props.insert("message".to_string(), Value::Text(format!("post {seed}")));
+            if let Some(quoted) = quoted {
+                props.insert("quotedPostId".to_string(), Value::Identifier(quoted));
+            }
+            post.set_properties(props);
+            post.set_id(Identifier::from(id));
+            post.set_owner_id(Identifier::from(owner));
+            store_document(&platform.platform, &feed, post_type, &post, version);
+        }
+        for (owner, post, seed) in [
+            (OWNER_1, POST_A, 10u64),
+            (OWNER_2, POST_A, 11),
+            (OWNER_1, POST_B, 12),
+        ] {
+            let mut like = like_type
+                .random_document(Some(seed), version)
+                .expect("like");
+            let mut props = std::collections::BTreeMap::new();
+            props.insert("hashtag".to_string(), Value::Text("dash".to_string()));
+            props.insert("postId".to_string(), Value::Identifier(post));
+            like.set_properties(props);
+            like.set_owner_id(Identifier::from(owner));
+            store_document(&platform.platform, &feed, like_type, &like, version);
+        }
+        let mut profile = profile_type
+            .random_document(Some(30), version)
+            .expect("profile");
+        let mut props = std::collections::BTreeMap::new();
+        props.insert("displayName".to_string(), Value::Text("one".to_string()));
+        profile.set_properties(props);
+        profile.set_owner_id(Identifier::from(OWNER_1));
+        store_document(
+            &platform.platform,
+            &dashpay,
+            profile_type,
+            &profile,
+            version,
+        );
+
+        (platform, state, version, feed, dashpay)
+    }
+
+    fn sub(
+        contract_id: Vec<u8>,
+        document_type: &str,
+        kind: sub_query::Kind,
+        limit: Option<u32>,
+        bind: Option<(u32, &str, &str)>,
+    ) -> ProtoSubQuery {
+        ProtoSubQuery {
+            data_contract_id: contract_id,
+            document_type: document_type.to_string(),
+            where_clauses: Vec::new(),
+            order_by: Vec::new(),
+            limit,
+            kind: kind as i32,
+            bind: bind.map(|(source, source_property, field)| ProtoBinding {
+                source,
+                source_property: source_property.to_string(),
+                field: field.to_string(),
+            }),
+        }
+    }
+
+    /// Page: `dash` posts; sub-queries: like counts, the quoted posts
+    /// (by-id join), the authors' profiles (cross-contract lookup).
+    fn composite_request(
+        prove: bool,
+        feed_id: Vec<u8>,
+        dashpay_id: Vec<u8>,
+    ) -> GetDocumentsRequestV1 {
+        GetDocumentsRequestV1 {
+            data_contract_id: feed_id,
+            document_type: "post".to_string(),
+            where_clauses: vec![
+                dapi_grpc::platform::v0::get_documents_request::WhereClause {
+                    field: "hashtag".to_string(),
+                    operator: ProtoWhereOperator::Equal as i32,
+                    value: Some(ProtoDocumentFieldValue {
+                        variant: Some(document_field_value::Variant::Text("dash".to_string())),
+                    }),
+                    time_range: None,
+                },
+            ],
+            order_by: Vec::new(),
+            limit: Some(10),
+            start: None,
+            prove,
+            selects: Vec::new(),
+            group_by: Vec::new(),
+            having: Vec::new(),
+            offset: None,
+            chained: None,
+            sub_queries: vec![
+                sub(
+                    Vec::new(),
+                    "like",
+                    sub_query::Kind::Count,
+                    None,
+                    Some((0, "$id", "postId")),
+                ),
+                sub(
+                    Vec::new(),
+                    "post",
+                    sub_query::Kind::Documents,
+                    None,
+                    Some((0, "quotedPostId", "$id")),
+                ),
+                sub(
+                    dashpay_id,
+                    "profile",
+                    sub_query::Kind::Documents,
+                    None,
+                    Some((0, "$ownerId", "$ownerId")),
+                ),
+            ],
+        }
+    }
+
+    /// The same composition built directly against drive, as the SDK
+    /// builds it to verify a proof.
+    fn client_query<'a>(
+        feed: &'a DataContract,
+        dashpay: &'a DataContract,
+    ) -> DriveDocumentQuery<'a> {
+        let page = DriveDocumentQuery {
+            contract: feed,
+            document_type: feed.document_type_for_name("post").expect("post"),
+            internal_clauses: InternalClauses::extract_from_clauses(
+                vec![WhereClause {
+                    field: "hashtag".to_string(),
+                    operator: WhereOperator::Equal,
+                    value: Value::Text("dash".to_string()),
+                }],
+                PlatformVersion::latest(),
+            )
+            .expect("clauses extract"),
+            offset: None,
+            limit: Some(10),
+            order_by: Default::default(),
+            start_at: None,
+            start_at_included: false,
+            block_time_ms: None,
+            resolved_time_ranges: vec![],
+            sub_queries: vec![],
+        };
+        let bound = |contract: &'a DataContract,
+                     type_name: &str,
+                     kind,
+                     source_property: &str,
+                     field: &str| {
+            DriveSubQuery {
+                contract,
+                document_type: contract.document_type_for_name(type_name).expect("doctype"),
+                kind,
+                where_clauses: vec![],
+                order_by: vec![],
+                limit: None,
+                binding: Some(SubQueryBinding {
+                    source: BindingSource::Page,
+                    source_property: source_property.to_string(),
+                    field: field.to_string(),
+                }),
+            }
+        };
+        page.with_sub_queries(vec![
+            bound(feed, "like", SubQueryKind::Count, "$id", "postId"),
+            bound(feed, "post", SubQueryKind::Documents, "quotedPostId", "$id"),
+            bound(
+                dashpay,
+                "profile",
+                SubQueryKind::Documents,
+                "$ownerId",
+                "$ownerId",
+            ),
+        ])
+    }
+
+    #[test]
+    fn should_return_the_page_and_every_sub_result_without_proof() {
+        let (platform, state, version, feed, dashpay) = setup_feed_state();
+
+        let result = platform
+            .platform
+            .query_documents_v1(
+                composite_request(false, feed.id().to_vec(), dashpay.id().to_vec()),
+                &state,
+                version,
+            )
+            .expect("query executes");
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let response = result.data.expect("response data");
+        let Some(ResponseResult::Data(data)) = response.result else {
+            panic!("expected a data result");
+        };
+        let Some(result_data::Variant::Composite(composite)) = data.variant else {
+            panic!("expected the composite variant");
+        };
+
+        let post_type = feed.document_type_for_name("post").expect("post");
+        let page: Vec<[u8; 32]> = composite
+            .page_documents
+            .iter()
+            .map(|bytes| {
+                Document::from_bytes(bytes, post_type, version)
+                    .expect("post deserializes")
+                    .id()
+                    .to_buffer()
+            })
+            .collect();
+        assert_eq!(page, vec![POST_A, POST_B]);
+        assert_eq!(composite.sub_results.len(), 3);
+
+        let Some(composite_documents::sub_query_result::Result::Counts(counts)) =
+            &composite.sub_results[0].result
+        else {
+            panic!("expected count entries");
+        };
+        let like_counts: std::collections::BTreeMap<Vec<u8>, u64> = counts
+            .entries
+            .iter()
+            .map(|entry| (entry.key.clone(), entry.count))
+            .collect();
+        assert_eq!(
+            like_counts,
+            std::collections::BTreeMap::from([(POST_A.to_vec(), 2), (POST_B.to_vec(), 1)])
+        );
+
+        let Some(composite_documents::sub_query_result::Result::Documents(quoted)) =
+            &composite.sub_results[1].result
+        else {
+            panic!("expected quoted documents");
+        };
+        assert_eq!(quoted.documents.len(), 1, "A quotes D");
+        assert_eq!(
+            Document::from_bytes(&quoted.documents[0], post_type, version)
+                .expect("post deserializes")
+                .id()
+                .to_buffer(),
+            POST_D
+        );
+
+        let Some(composite_documents::sub_query_result::Result::Documents(profiles)) =
+            &composite.sub_results[2].result
+        else {
+            panic!("expected profile documents");
+        };
+        let profile_type = dashpay.document_type_for_name("profile").expect("profile");
+        assert_eq!(
+            profiles.documents.len(),
+            1,
+            "owner 2 has no profile: a proven absence"
+        );
+        assert_eq!(
+            Document::from_bytes(&profiles.documents[0], profile_type, version)
+                .expect("profile deserializes")
+                .owner_id()
+                .to_buffer(),
+            OWNER_1
+        );
+    }
+
+    #[test]
+    fn should_prove_end_to_end_through_the_v1_wire() {
+        let (platform, state, version, feed, dashpay) = setup_feed_state();
+
+        let result = platform
+            .platform
+            .query_documents_v1(
+                composite_request(true, feed.id().to_vec(), dashpay.id().to_vec()),
+                &state,
+                version,
+            )
+            .expect("query executes");
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let response = result.data.expect("response data");
+        let Some(ResponseResult::Proof(proof)) = response.result else {
+            panic!("expected a proof result");
+        };
+
+        let query = client_query(&feed, &dashpay);
+        let (_root_hash, verified) = query
+            .verify_composite_documents_proof(proof.grovedb_proof.as_slice(), version)
+            .expect("the composite proof verifies from the proof alone");
+        assert_eq!(
+            verified
+                .page_documents
+                .iter()
+                .map(|post| post.id().to_buffer())
+                .collect::<Vec<_>>(),
+            vec![POST_A, POST_B]
+        );
+        assert_eq!(verified.sub_results[0].counts().len(), 2);
+        assert_eq!(verified.sub_results[1].documents().len(), 1);
+        assert_eq!(verified.sub_results[2].documents().len(), 1);
+    }
+
+    #[test]
+    fn should_require_an_explicit_page_limit() {
+        let (platform, state, version, feed, dashpay) = setup_feed_state();
+
+        let mut no_limit = composite_request(false, feed.id().to_vec(), dashpay.id().to_vec());
+        no_limit.limit = None;
+        let result = platform
+            .platform
+            .query_documents_v1(no_limit, &state, version)
+            .expect("query executes");
+        assert!(
+            matches!(
+                result.errors.as_slice(),
+                [QueryError::Query(QuerySyntaxError::InvalidLimit(_))]
+            ),
+            "expected InvalidLimit, got {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn should_reject_chained_and_composite_together() {
+        let (platform, state, version, feed, dashpay) = setup_feed_state();
+
+        let mut both = composite_request(false, feed.id().to_vec(), dashpay.id().to_vec());
+        both.chained = Some(ChainedJoin {
+            join_property: "quotedPostId".to_string(),
+            outer_document_type: "post".to_string(),
+        });
+        let result = platform
+            .platform
+            .query_documents_v1(both, &state, version)
+            .expect("query executes");
+        assert!(
+            matches!(
+                result.errors.as_slice(),
+                [QueryError::Query(QuerySyntaxError::Unsupported(_))]
+            ),
+            "expected Unsupported, got {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn should_reject_an_unknown_sub_query_contract() {
+        let (platform, state, version, feed, dashpay) = setup_feed_state();
+
+        let mut unknown = composite_request(false, feed.id().to_vec(), dashpay.id().to_vec());
+        unknown.sub_queries[2].data_contract_id = vec![0x99; 32];
+        let result = platform
+            .platform
+            .query_documents_v1(unknown, &state, version)
+            .expect("query executes");
+        assert!(
+            matches!(
+                result.errors.as_slice(),
+                [QueryError::Query(QuerySyntaxError::DataContractNotFound(_))]
+            ),
+            "expected DataContractNotFound, got {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn should_surface_shape_rejections_as_query_errors() {
+        let (platform, state, version, feed, dashpay) = setup_feed_state();
+
+        // A count with a limit is a shape the drive validator refuses;
+        // it must come back as a client-attributable query error.
+        let mut counted_with_limit =
+            composite_request(false, feed.id().to_vec(), dashpay.id().to_vec());
+        counted_with_limit.sub_queries[0].limit = Some(5);
+        let result = platform
+            .platform
+            .query_documents_v1(counted_with_limit, &state, version)
+            .expect("query executes");
+        assert!(
+            matches!(
+                result.errors.as_slice(),
+                [QueryError::Query(QuerySyntaxError::Unsupported(_))]
+            ),
+            "expected Unsupported, got {:?}",
+            result.errors
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/query/document_query/v1/dispatch/composite.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/dispatch/composite.rs
@@ -37,7 +37,8 @@ use dpp::version::PlatformVersion;
 use drive::drive::contract::DataContractFetchInfo;
 use drive::error::query::QuerySyntaxError;
 use drive::query::{
-    BindingSource, DriveDocumentQuery, DriveSubQuery, SubQueryBinding, SubQueryKind, SubQueryResult,
+    BindingSource, DriveDocumentQuery, DriveSubQuery, SubQueryBinding, SubQueryKind,
+    SubQueryResult, MAX_SUB_QUERIES,
 };
 use drive::util::grove_operations::GroveDBToUse;
 use std::sync::Arc;
@@ -80,6 +81,16 @@ impl<C> Platform<C> {
                 message.to_string(),
             )))
         };
+
+        // Bound dispatch work before scanning clauses, allocating decoded
+        // sub-queries, or fetching any of the request's contracts.
+        if proto_sub_queries.len() > MAX_SUB_QUERIES {
+            return Ok(unsupported(&format!(
+                "a composite query carries at most {} sub-queries, got {}",
+                MAX_SUB_QUERIES,
+                proto_sub_queries.len(),
+            )));
+        }
 
         // The composite surface is documents-shaped by construction:
         // an empty `selects` or a single DOCUMENTS projection; every
@@ -720,6 +731,107 @@ mod tests {
         assert_eq!(verified.sub_results[0].counts().len(), 2);
         assert_eq!(verified.sub_results[1].documents().len(), 1);
         assert_eq!(verified.sub_results[2].documents().len(), 1);
+    }
+
+    #[test]
+    fn should_reject_oversized_sub_queries_before_decoding_or_contract_fetch() {
+        let (platform, state, version, feed, dashpay) = setup_feed_state();
+        let mut query = client_query(&feed, &dashpay);
+        query
+            .sub_queries
+            .resize(MAX_SUB_QUERIES + 1, query.sub_queries[0].clone());
+        let drive::error::Error::Query(QuerySyntaxError::Unsupported(expected_message)) = query
+            .validate_composite(version)
+            .expect_err("too many sub-queries")
+        else {
+            panic!("expected Drive's sub-query count rejection");
+        };
+
+        for prove in [false, true] {
+            let mut oversized = composite_request(prove, feed.id().to_vec(), dashpay.id().to_vec());
+            oversized
+                .sub_queries
+                .resize(MAX_SUB_QUERIES + 1, oversized.sub_queries[0].clone());
+            let mut missing_page_contract = oversized.clone();
+            missing_page_contract.data_contract_id = vec![0x99; 32];
+            let mut malformed_page_clause = oversized.clone();
+            malformed_page_clause.where_clauses[0].operator = i32::MAX;
+            let mut missing_sub_query_contract = oversized.clone();
+            missing_sub_query_contract.sub_queries[0].data_contract_id = vec![0x99; 32];
+            let mut malformed_sub_query = oversized.clone();
+            malformed_sub_query.sub_queries[0].kind = i32::MAX;
+
+            // The count rejection must precede both decoding errors and
+            // contract lookup errors, in either response mode.
+            for request in [
+                oversized,
+                missing_page_contract,
+                malformed_page_clause,
+                missing_sub_query_contract,
+                malformed_sub_query,
+            ] {
+                let result = platform
+                    .platform
+                    .query_documents_v1(request, &state, version)
+                    .expect("query returns a validation error");
+                assert!(result.data.is_none());
+                assert!(
+                    matches!(
+                        result.errors.as_slice(),
+                        [QueryError::Query(QuerySyntaxError::Unsupported(message))]
+                            if message == &expected_message
+                    ),
+                    "expected the sub-query count rejection, prove={prove}, got {:?}",
+                    result.errors
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn should_accept_sub_query_counts_through_the_maximum() {
+        let (platform, state, version, feed, dashpay) = setup_feed_state();
+        for count in [1, MAX_SUB_QUERIES] {
+            for prove in [false, true] {
+                let mut request =
+                    composite_request(prove, feed.id().to_vec(), dashpay.id().to_vec());
+                request.sub_queries = vec![request.sub_queries[0].clone(); count];
+                let result = platform
+                    .platform
+                    .query_documents_v1(request, &state, version)
+                    .expect("query executes");
+                assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+                match result.data.expect("response data").result.expect("result") {
+                    ResponseResult::Proof(proof) => {
+                        assert!(prove);
+                        let mut query = client_query(&feed, &dashpay);
+                        query.sub_queries = vec![query.sub_queries[0].clone(); count];
+                        let (_, verified) = query
+                            .verify_composite_documents_proof(&proof.grovedb_proof, version)
+                            .expect("composite proof verifies");
+                        assert_eq!(verified.page_documents.len(), 2);
+                        assert_eq!(verified.sub_results.len(), count);
+                        assert!(verified
+                            .sub_results
+                            .iter()
+                            .all(|sub| sub.counts().len() == 2));
+                    }
+                    ResponseResult::Data(data) => {
+                        assert!(!prove);
+                        let Some(result_data::Variant::Composite(composite)) = data.variant else {
+                            panic!("expected composite data");
+                        };
+                        assert_eq!(composite.page_documents.len(), 2);
+                        assert_eq!(composite.sub_results.len(), count);
+                        assert!(composite.sub_results.iter().all(|sub| matches!(
+                            &sub.result,
+                            Some(composite_documents::sub_query_result::Result::Counts(entries))
+                                if entries.entries.len() == 2
+                        )));
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/query/document_query/v1/dispatch/count.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/dispatch/count.rs
@@ -188,7 +188,7 @@ impl<C> Platform<C> {
     }
 }
 
-fn into_v1_entry(e: SplitCountEntry) -> CountEntry {
+pub(super) fn into_v1_entry(e: SplitCountEntry) -> CountEntry {
     CountEntry {
         in_key: e.in_key,
         key: e.key,

--- a/packages/rs-drive-abci/src/query/document_query/v1/dispatch/mod.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/dispatch/mod.rs
@@ -7,6 +7,7 @@
 
 mod average;
 mod chained;
+mod composite;
 mod count;
 mod documents;
 mod having;

--- a/packages/rs-drive-abci/src/query/document_query/v1/mod.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/mod.rs
@@ -230,7 +230,39 @@ impl<C> Platform<C> {
             having,
             offset,
             chained,
+            sub_queries,
         } = request_v1;
+
+        // Composite mode owns its own shape and routes before the
+        // SELECT machinery: the request's clauses describe the PAGE,
+        // and the sub-queries are derived from it.
+        if !sub_queries.is_empty() {
+            if chained.is_some() {
+                return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                    QuerySyntaxError::Unsupported(
+                        "a request carries either `chained` or `sub_queries`, not both: a \
+                         chained join is one sub-query shape"
+                            .to_string(),
+                    ),
+                )));
+            }
+            return self.dispatch_composite_v1(
+                data_contract_id,
+                document_type,
+                sub_queries,
+                proto_where_clauses,
+                proto_order_by,
+                limit,
+                start,
+                prove,
+                proto_selects,
+                group_by,
+                having,
+                offset,
+                platform_state,
+                platform_version,
+            );
+        }
 
         // Chained mode owns its own (deliberately narrow) shape and
         // routes before the SELECT machinery: the request's clauses

--- a/packages/rs-drive-abci/src/query/document_query/v1/tests.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v1/tests.rs
@@ -147,6 +147,7 @@ fn empty_v1_request() -> GetDocumentsRequestV1 {
         having: Vec::new(),
         offset: None,
         chained: None,
+        sub_queries: Vec::new(),
     }
 }
 
@@ -957,6 +958,7 @@ fn e2e_documents_select_matches_v0() {
         having: Vec::new(),
         offset: None,
         chained: None,
+        sub_queries: Vec::new(),
     };
     let v1_result = platform
         .query_documents_v1(request_v1, &state, version)
@@ -994,6 +996,7 @@ fn e2e_having_rejection_surfaces_in_response() {
         )],
         offset: None,
         chained: None,
+        sub_queries: Vec::new(),
     };
     let result = platform
         .query_documents_v1(request, &state, version)
@@ -1030,6 +1033,7 @@ fn reject_start_with_select_count() {
         having: Vec::new(),
         offset: None,
         chained: None,
+        sub_queries: Vec::new(),
     };
     let result = platform
         .query_documents_v1(request, &state, version)
@@ -1190,6 +1194,7 @@ mod ported_v0_count_tests {
             having: Vec::new(),
             offset: None,
             chained: None,
+            sub_queries: Vec::new(),
         }
     }
 
@@ -2079,6 +2084,7 @@ mod ranked_tests {
             having: Vec::new(),
             offset,
             chained: None,
+            sub_queries: Vec::new(),
         }
     }
 
@@ -2975,6 +2981,7 @@ mod ranked_tests {
             having: Vec::new(),
             offset: None,
             chained: None,
+            sub_queries: Vec::new(),
         };
 
         match ranked_error(&platform, &state, request.clone(), version) {
@@ -3110,6 +3117,7 @@ mod multi_in_wire_tests {
             having: Vec::new(),
             offset: None,
             chained: None,
+            sub_queries: Vec::new(),
         }
     }
 
@@ -3266,6 +3274,7 @@ mod having_range_tests {
             having: vec![clause],
             offset: None,
             chained: None,
+            sub_queries: Vec::new(),
         }
     }
 
@@ -3696,6 +3705,7 @@ mod having_range_tests {
             )],
             offset: None,
             chained: None,
+            sub_queries: Vec::new(),
         };
 
         match ranked_error(&platform, &state, request, version) {
@@ -3850,6 +3860,7 @@ mod having_range_tests {
             )],
             offset: None,
             chained: None,
+            sub_queries: Vec::new(),
         };
 
         match ranked_error(&platform, &state, request, version) {
@@ -4607,6 +4618,7 @@ mod time_range_proof_verification {
             having: Vec::new(),
             offset: None,
             chained: None,
+            sub_queries: Vec::new(),
         }
     }
 
@@ -5790,6 +5802,7 @@ mod time_range_proof_verification {
             having: Vec::new(),
             offset: None,
             chained: None,
+            sub_queries: Vec::new(),
         }
     }
 

--- a/packages/rs-drive-proof-verifier/src/proof/document_ranked.rs
+++ b/packages/rs-drive-proof-verifier/src/proof/document_ranked.rs
@@ -227,6 +227,7 @@ pub(crate) fn result_variant_name(
             Some(result_data::Variant::Averages(_)) => "a ResultData.averages payload",
             Some(result_data::Variant::Ranked(_)) => "a ResultData.ranked payload",
             Some(result_data::Variant::Chained(_)) => "a ResultData.chained payload",
+            Some(result_data::Variant::Composite(_)) => "a ResultData.composite payload",
         },
     }
 }


### PR DESCRIPTION
Replaces #4599, which GitHub closed as merged when a mistaken force-push briefly collapsed the stack's branches onto one commit. The branch is now rebased onto `v4.2-dev`, including the merged #4598.

## Issue being fixed or feature implemented

Second PR of the composite-query stack (core in #4598): puts composite document queries on the typed `getDocuments` V1 wire and serves them from drive-abci. A composite query is a page plus sub-queries derived from its proven results (joins, lookups, counts, siblings), answered as one merged proof; the motivating case is a social feed whose per-page enrichment is today a burst of dependent DAPI calls.

## What was done?

**Wire (`platform.proto`)**

- `GetDocumentsRequestV1.sub_queries` (field 14, `repeated SubQuery`): each sub-query carries its own contract (empty = the page's), document type, fixed `where_clauses` / `order_by`, optional `limit`, a `Kind` (`DOCUMENTS` | `COUNT`) and an optional `Binding { source, source_property, field }` whose `source` is `0` for the page or `n` for `sub_queries[n-1]`. Presence selects composite mode; the request's own clauses describe the page. `chained` and `sub_queries` are mutually exclusive. No CBOR anywhere: typed clauses only, like the rest of V1.
- `ResultData.composite` (variant 7, `CompositeDocuments`): the page documents plus one `SubQueryResult` per sub-query (`Documents` or `CountEntries`) on the no-proof path. The proof path is the single merged proof in the standard envelope.
- `build.rs`: serde default on `sub_queries` so mock vectors captured before the field stay wire-compatible (same rule as `chained`).

**drive-abci (`dispatch/composite.rs`)**

The decoded page is a `DriveDocumentQuery`; `with_sub_queries` attaches the decoded sub-queries, and `validate_composite` checks their shape. Both dispatch and the client-side proof tests use the unified query API introduced in #4598. The dispatcher also enforces Drive's shared `MAX_SUB_QUERIES` limit before scanning clauses, decoding typed query fields, allocating sub-query vectors, or fetching contracts, with the same validation error as Drive.

Routes before the SELECT machinery. Gates: page `limit` required in `[1, max_query_limit]`; `selects` empty or a single DOCUMENTS projection; `group_by`, `having`, cursors, `offset` and time-range clauses (page or sub-query) refused; each distinct sub-query contract fetched once; kinds, limits and bindings decoded into drive's typed shapes; drive's `validate_composite` failures surface as query errors. Proof path: `query_composite_documents_with_proof` under the standard proof envelope. No-proof path: documents serialized with their own type and contract, counts as `CountEntry` rows.

An old node ignores field 14 (proto3 unknown field) and serves the plain page; the verifier in #4598 refuses that page-only proof whenever a sub-query derived anything.

Mechanical: every existing `GetDocumentsRequestV1` literal gains `sub_queries: Vec::new()`; the proof verifier's result-variant name table gains the `composite` arm.

## How Has This Been Tested?

`dispatch/composite.rs` tests against the `yappr-feed` fixture plus the dashpay contract:

- `should_return_the_page_and_every_sub_result_without_proof`: like counts, quoted-post join, cross-contract profile lookup (a missing profile is a proven absence)
- `should_prove_end_to_end_through_the_v1_wire`: the wire proof verifies through `DriveDocumentQuery::verify_composite_documents_proof` rebuilt client-side
- `should_require_an_explicit_page_limit`, `should_reject_chained_and_composite_together`, `should_reject_an_unknown_sub_query_contract`, `should_surface_shape_rejections_as_query_errors`
- `should_reject_oversized_sub_queries_before_decoding_or_contract_fetch`: the count error takes precedence over malformed page/sub-query fields and missing contracts in both response modes.
- `should_accept_sub_query_counts_through_the_maximum`: 1 and 10 sub-queries succeed in both response modes, including proof verification.

Validation on the rebased branch against `v4.2-dev` containing #4598:

- `cargo test -p drive-abci --lib -- query::document_query::v1`: all 105 tests passed, including composite and chained queries.
- Strict Clippy on `drive-abci`, `dapi-grpc`, `drive-proof-verifier`, and `dash-platform-queries`, all targets, with `--no-deps -- -D warnings`: passed.
- `cargo check -p dash-sdk -p wasm-sdk --lib`: passed on the native host. Drive still emits its pre-existing `DocumentPropertyType` unused-import warning under verify-only features.
- Formatting and `git diff --check`: passed.

Cargo checks used the locked dependencies in offline mode. A browser/WASM-target build and a live-network test were not run for this rebase.

Regenerated JS gRPC clients follow in a separate commit on this branch (Docker regen).

## Breaking Changes

None. Additive wire fields; old clients and old nodes are unaffected (an old node answering a composite request fails closed on the client).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added composite document queries that combine a page query with related sub-queries, lookups, joins, and counts.
  * Composite results can return page documents alongside sub-query documents or count results.
  * Composite queries support both regular data responses and merged, verifiable proof responses.

* **Validation**
  * Added validation for unsupported combinations and incomplete composite requests, including missing limits and incompatible query options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
