### PR TITLE
docs(drive): update ranked dispatcher docs stale since pinned-prefix form

### DIFF
--- a/packages/rs-drive/src/query/drive_document_ranked_query/drive_dispatcher.rs
+++ b/packages/rs-drive/src/query/drive_document_ranked_query/drive_dispatcher.rs
@@ -71,12 +71,14 @@ pub struct DocumentRankedRequest<'a> {
     /// The fields among `where_clauses` whose equality clause was produced by
     /// `IN_TIME_RANGE` resolution (see
     /// [`crate::query::DriveDocumentQuery::resolved_time_ranges`]).
-    /// Must be empty: `where_clauses` must be empty, so there is nothing to
-    /// have resolved, and ranking over bucket keys is undesigned — a document
-    /// belongs to `overlap_factor` buckets at once, so it would contribute to
-    /// that many groups. Carried (and rejected) here for the same reason
-    /// `where_clauses` is: drive owns the rejection regardless of which
-    /// upstream path built the request.
+    /// Must be empty: bucketed (timeRange) indexes are excluded from the
+    /// ranked surface (see the rejection in
+    /// [`Drive::execute_document_ranked_request`]), because ranking over
+    /// bucket keys is undesigned — a document belongs to `overlap_factor`
+    /// buckets at once, so it would contribute to that many groups. Carried
+    /// (and rejected) here for the same reason `having` and `start_at` are:
+    /// drive owns the rejection regardless of which upstream path built the
+    /// request.
     pub resolved_time_ranges: &'a [ResolvedTimeRange],
     /// Request `limit` — the ranking's `k`. **Required**; there is no
     /// server default a verifying client could reproduce.
@@ -127,7 +129,7 @@ impl Drive {
     /// Errors:
     /// - Request-shape failures (wrong `group_by` arity, an `order_by`
     ///   that does not name the `select`'s aggregate, a missing or
-    ///   out-of-range `limit`, a `where` clause, a `having`) come back
+    ///   out-of-range `limit`, a malformed `where` pin, a `having`) come back
     ///   as `Error::Query(QuerySyntaxError::*)` —
     ///   see [`super::mode_detection::detect_ranked_mode_v0`] for the
     ///   full grammar.
@@ -142,15 +144,24 @@ impl Drive {
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<DocumentRankedResponse, Error> {
-        // Unreachable behind the empty-`where_clauses` rule `detect_ranked_mode`
-        // enforces below — a resolved equality is a where clause — but stated
-        // here so the ranked surface's exclusion of bucketed indexes is a
-        // rejection rather than a silent fallback to another index.
+        // Load-bearing, not a shape formality: `detect_ranked_mode` accepts
+        // equality pins, and a resolved bucket-start equality is an ordinary
+        // `==` clause on the bucketed source field, so nothing in the grammar
+        // stops it. Without this guard the request would fall through to
+        // index selection, where the picker excludes bucketed indexes —
+        // surfacing as a misleading "no covering index" error, or, if a plain
+        // ranked index happens to cover the same properties, matching it and
+        // answering a raw-timestamp question the caller never asked.
+        // Rejecting the provenance up front keeps the ranked surface's
+        // exclusion of bucketed indexes a precise refusal rather than a
+        // silent fallback to another index.
         if !request.resolved_time_ranges.is_empty() {
             return Err(Error::Query(QuerySyntaxError::Unsupported(
                 "a ranked query cannot carry a time-range (IN_TIME_RANGE) selection: ranking \
-                 groups by an index's only property, and a document belongs to every bucket \
-                 that contains its timestamp, so it would be ranked into several groups at once"
+                 reads a pre-built secondary keyed by document properties, and a document \
+                 belongs to every bucket that contains its timestamp — it would be ranked \
+                 into several groups at once — so bucketed (timeRange) indexes are excluded \
+                 from the ranked surface"
                     .to_string(),
             )));
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Three pieces of documentation in `packages/rs-drive/src/query/drive_document_ranked_query/drive_dispatcher.rs` went stale when the pinned-prefix ranked form (#4529) landed and were never updated. All three rested on the pre-#4529 premise that a ranked request's `where_clauses` must be empty — which is no longer true, since the pinned-prefix form accepts one equality pin per leading property of a compound ranked index (and the `where_clauses` field doc immediately above already says so correctly).

Left as-is, the stale text actively misleads: the guard comment claimed the time-range rejection was *unreachable* behind a grammar rule that no longer exists, which would invite someone to delete a check that is in fact load-bearing.

## What was done?

Doc/comment-only change — no behavior change.

- **`DocumentRankedRequest::resolved_time_ranges` field doc** — dropped the false "`where_clauses` must be empty, so there is nothing to have resolved" premise. It now says resolved time ranges must be empty because bucketed (`timeRange`) indexes are excluded from the ranked surface, pointing at the rejection in `execute_document_ranked_request`. Also fixed the trailing "carried for the same reason `where_clauses` is" — `where_clauses` is no longer carried-and-rejected; `having` and `start_at` are, so it now references those.
- **Guard comment on the `resolved_time_ranges` rejection** — previously "Unreachable behind the empty-`where_clauses` rule `detect_ranked_mode` enforces below". Verified against `mode_detection` and the index picker: there is **no** empty-where rule anymore, and `prefix_pins_from_where_clauses` accepts any `==` clause as a pin. A resolved `IN_TIME_RANGE` is exactly that — the abci handler pushes an ordinary equality on the bucketed source field into `where_clauses` — so the grammar passes it straight through. Downstream, `find_ranked_index_for_axis` skips any index with `time_range.is_some()`, so without this guard the request would usually die with a misleading "no covering index" error; but if the contract happens to declare a *plain* ranked index over the same properties, the pin would match it and silently answer a raw-timestamp-equality question the caller never asked. The comment now says the guard is load-bearing and names both failure modes. (The SDK verifier's mirror of this guard in `dash-platform-queries/src/documents/ranked_proof_helpers.rs` already documents this exact scenario; the drive side was the one left behind.)
- **Rejection error string** — "ranking groups by an index's only property" was pre-compound-index phrasing. Now: "ranking reads a pre-built secondary keyed by document properties, and a document belongs to every bucket that contains its timestamp — it would be ranked into several groups at once — so bucketed (timeRange) indexes are excluded from the ranked surface".
- **Method error-list doc** — one adjacent stale phrase in the same doc block listed "a `where` clause" as a request-shape failure; now "a malformed `where` pin".

## How Has This Been Tested?

- `cargo fmt -p drive` and `cargo check -p drive --features server` (the module is gated behind `server`) — clean.
- Grepped for test assertions on the changed error string across `rs-drive`, `rs-drive-abci`, and `dash-platform-queries`; none pin the exact text, so no test updates were needed.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified error messages and technical documentation for ranked document queries.
  * Improved guidance for malformed filter pins and unsupported resolved time ranges.
  * Explained how equality pins are handled and why certain query configurations are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->