### PR TITLE
ci: restore Rust dependency security auditing

### DIFF
--- a/.github/workflows/security-audit-rust.yml
+++ b/.github/workflows/security-audit-rust.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "30 23 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   rs-crates-security:
     name: Rust crates security audit
@@ -13,7 +16,13 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
-      - name: Audit crates
-        uses: rustsec/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up audit toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        # Use the tool's lockfile and a separate compiler from rust-toolchain.toml.
+        run: cargo +stable install cargo-audit --version 0.22.2 --locked
+
+      - name: Audit committed dependencies
+        # Preserve Cargo.lock so findings reflect the dependencies used by locked builds.
+        run: cargo +stable audit


### PR DESCRIPTION
## Issue being fixed or feature implemented

The nightly Rust security audit fails before scanning dependencies: `rustsec/audit-check@v1` installs cargo-audit with unlocked dependencies under the repository's Rust 1.92 toolchain, selecting a kstring release requiring Rust 1.96. [Example failed run](https://github.com/dashpay/platform/actions/runs/34067110350).

The old action also regenerates Cargo.lock before auditing, so it checks a different dependency graph from committed, locked builds. Its scheduled reporting path creates issues rather than reliably propagating audit failures to the workflow status.

## What was done?

- Install cargo-audit 0.22.2 with `--locked` under an explicit stable toolchain, independently of the repository compiler pin.
- Run `cargo +stable audit` directly against the committed Cargo.lock, preserving `.cargo/audit.toml` and its existing exception.
- Propagate the audit exit status to CI and restrict the workflow token to read-only repository access. Findings are printed in the job log; the workflow no longer creates issues or separate check reports.

Dependency upgrades are outside this PR. The current committed graph reports four vulnerabilities, so a completed audit is expected to fail for actionable findings. Maintenance/unsoundness warnings retain cargo-audit's default non-blocking behavior.

## How Has This Been Tested?

- `actionlint .github/workflows/security-audit-rust.yml` and `git diff --check` passed.
- Clean local installation of `cargo +stable install cargo-audit --version 0.22.2 --locked` into an empty temporary installation root passed on macOS arm64 with Rust 1.97.1. It selected the tool lockfile's kstring 2.0.2.
- Ran the freshly built binary with `cargo +stable audit` against this branch: completed normally and returned exit 1 for the four known advisories (crossbeam-epoch, h2, quinn-proto, rkyv), with 12 allowed warnings.
- Compared SHA-256 hashes before/after the audit: Cargo.lock was unchanged. The existing advisory exception was retained.

The GitHub-hosted Ubuntu execution has not yet been run; the audit workflow remains scheduled/manually dispatched.

## Breaking Changes

No product API changes. The nightly status now reflects the committed dependency graph and cargo-audit's exit status.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
