### PR TITLE
feat(dashmate): run a Tor sidecar so Core reaches onion peers and publishes an onion service

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -123,7 +123,9 @@ export default function getBaseConfigFactory() {
         tor: {
           enabled: true,
           docker: {
-            image: 'osminogin/tor-simple:0.4.9.11',
+            // Pinned to the multi-arch index digest: the tag is a third
+            // party's and can be re-pushed. Bumping Tor means updating both.
+            image: 'osminogin/tor-simple:0.4.9.11@sha256:7aef2e7d957e2236d5fac7fca8e67c15fe65e6349eb90099da1cdc26bc4caa69',
           },
           control: {
             password: 'torpassword',

--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -117,6 +117,18 @@ export default function getBaseConfigFactory() {
           host: '127.0.0.1',
           port: 29998,
         },
+        // Tor sidecar. Off by default: it adds an onion service and onion
+        // peers on top of the node's IPv4 identity, it does not replace it.
+        // The masternode ProTx address stays IPv4; see docs/config/core.md.
+        tor: {
+          enabled: false,
+          docker: {
+            image: 'osminogin/tor-simple:0.4.9.11',
+          },
+          control: {
+            password: 'torpassword',
+          },
+        },
         spork: {
           address: null,
           privateKey: null,

--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -117,11 +117,11 @@ export default function getBaseConfigFactory() {
           host: '127.0.0.1',
           port: 29998,
         },
-        // Tor sidecar. Off by default: it adds an onion service and onion
+        // Tor sidecar. On by default: it adds an onion service and onion
         // peers on top of the node's IPv4 identity, it does not replace it.
         // The masternode ProTx address stays IPv4; see docs/config/core.md.
         tor: {
-          enabled: false,
+          enabled: true,
           docker: {
             image: 'osminogin/tor-simple:0.4.9.11',
           },

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -10,6 +10,7 @@ import {
   SSL_PROVIDERS,
 } from '../src/constants.js';
 import { stockImagePattern, historicalStockImagePattern } from '../src/config/stockImages.js';
+import generateRandomString from '../src/util/generateRandomString.js';
 
 /**
  * @param {HomeDir} homeDir
@@ -1726,11 +1727,13 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
         // skip anything keyed there.
         Object.entries(configFile.configs)
           .forEach(([, options]) => {
-            // The Tor sidecar is new and off by default, so an existing node
-            // keeps behaving as before. The schema requires the section, so a
-            // config without it cannot be loaded.
+            // The Tor sidecar is new and on by default, and an existing node
+            // gets it too: the next start pulls the image and Core registers
+            // its onion service. Each node gets its own control password, as
+            // setup would have given it.
             if (options.core && options.core.tor === undefined) {
               options.core.tor = base.getStored('core.tor');
+              options.core.tor.control.password = generateRandomString(12);
             }
           });
 

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1717,16 +1717,7 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
                 'platform.gateway.ssl.providerConfigs.letsencrypt.acmeDirectoryUrl',
               );
             }
-          });
 
-        return configFile;
-      },
-      '4.2.1': (configFile) => {
-        // Keyed above 4.2.0 rather than added to it: a config written by a
-        // development build of this cycle is already stamped 4.2.0 and would
-        // skip anything keyed there.
-        Object.entries(configFile.configs)
-          .forEach(([, options]) => {
             // The Tor sidecar is new and on by default, and an existing node
             // gets it too: the next start pulls the image and Core registers
             // its onion service. Each node gets its own control password, as

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1720,6 +1720,22 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
 
         return configFile;
       },
+      '4.2.1': (configFile) => {
+        // Keyed above 4.2.0 rather than added to it: a config written by a
+        // development build of this cycle is already stamped 4.2.0 and would
+        // skip anything keyed there.
+        Object.entries(configFile.configs)
+          .forEach(([, options]) => {
+            // The Tor sidecar is new and off by default, so an existing node
+            // keeps behaving as before. The schema requires the section, so a
+            // config without it cannot be loaded.
+            if (options.core && options.core.tor === undefined) {
+              options.core.tor = base.getStored('core.tor');
+            }
+          });
+
+        return configFile;
+      },
       '4.1.1': (configFile) => {
         // The drive and rs-dapi tags are derived from the package version, and
         // the migration that re-pins them no longer fires for a config already

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1718,12 +1718,11 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
               );
             }
 
-            // The Tor sidecar is new and on by default, and an existing node
-            // gets it too: the next start pulls the image and Core registers
-            // its onion service. Each node gets its own control password, as
-            // setup would have given it.
+            // Backfill Tor without silently enabling it on existing nodes.
+            // Setup offers it separately; preserve any existing Tor settings.
             if (options.core && options.core.tor === undefined) {
               options.core.tor = base.getStored('core.tor');
+              options.core.tor.enabled = false;
               options.core.tor.control.password = generateRandomString(12);
             }
           });

--- a/packages/dashmate/docker-compose.tor.yml
+++ b/packages/dashmate/docker-compose.tor.yml
@@ -1,0 +1,31 @@
+---
+
+x-default-logging: &default-logging
+  driver: local
+  options:
+    max-size: "500m"
+    max-file: "5"
+    compress: "true"
+
+services:
+  # Shares Core's network namespace: Core reaches the SOCKS and control ports on
+  # loopback, and the onion service Core registers targets loopback too. Tor is
+  # therefore not exposed to the host or to other containers. Compose starts it
+  # after Core because of the shared namespace; Core keeps retrying the control
+  # port until Tor is up, so no depends_on is needed (and one would be a cycle).
+  core_tor:
+    image: ${CORE_TOR_DOCKER_IMAGE:?err}
+    labels:
+      org.dashmate.service.title: "Core Tor"
+    restart: unless-stopped
+    logging: *default-logging
+    network_mode: "service:core"
+    volumes:
+      - core_tor_data:/var/lib/tor
+      - ${DASHMATE_HOME_DIR:?err}/${CONFIG_NAME:?err}/core/tor/torrc:/etc/tor/torrc:ro
+    stop_grace_period: 30s
+    profiles:
+      - core
+
+volumes:
+  core_tor_data:

--- a/packages/dashmate/docs/config/core.md
+++ b/packages/dashmate/docs/config/core.md
@@ -108,7 +108,9 @@ What it does not do:
 - It does not route clearnet traffic through Tor. Masternode quorum traffic stays direct, so enabling Tor does not put the node at risk of PoSe penalties from Tor exit latency.
 - It does not change the address a masternode is registered with. Dash Core requires an IPv4 address in the masternode registration and checks it on startup, so `externalIp` still has to be a public IPv4 address. The onion service is an additional way to reach the node.
 
-Tor is on by default, for new nodes and for nodes upgraded from an earlier dashmate: the upgrade adds the section to every config, and the next `dashmate update` or `dashmate start` pulls the image and starts the sidecar. To run without it, `dashmate config set core.tor.enabled false` and then `dashmate restart`. On a node that was set up with `--no-enable-tor`, `dashmate config set core.tor.enabled true` followed by `dashmate restart` turns it on.
+New mainnet/testnet setups ask whether to enable Tor, with Yes selected by default. Use `dashmate setup --enable-tor` or `--no-enable-tor` to choose explicitly; local setups enable it unless `--no-enable-tor` is given.
+
+Upgrading an existing node adds the Tor section with `core.tor.enabled` set to `false`, so the upgrade does not join the Tor network. Existing Tor settings are preserved. To opt in after upgrading, run `dashmate config set core.tor.enabled true` followed by `dashmate restart`. To turn it off, set `core.tor.enabled` to `false` and restart.
 
 ## Sporks
 

--- a/packages/dashmate/docs/config/core.md
+++ b/packages/dashmate/docs/config/core.md
@@ -88,6 +88,27 @@ ZMQ settings control real-time blockchain event notifications:
 
 **Security Note**: Be cautious when setting `host` to `0.0.0.0` as it makes ZMQ publicly accessible.
 
+## Tor
+
+The `core.tor` section runs a Tor daemon next to Core. Core then reaches onion peers through it and publishes an onion service of its own, so peers on Tor can connect inbound.
+
+| Option | Description | Default | Example |
+|--------|-------------|---------|---------|
+| `core.tor.enabled` | Run the Tor sidecar | `false` | `true` |
+| `core.tor.docker.image` | Docker image for the Tor daemon | `osminogin/tor-simple:0.4.9.11` | `osminogin/tor-simple:latest` |
+| `core.tor.control.password` | Password Core uses on the Tor control port | random on setup | `"s3cret"` |
+
+What it does:
+- Core dials `.onion` peers through the sidecar's SOCKS proxy and accepts inbound onion connections. The onion address shows up as `Onion service` in `dashmate status core` once Tor has published it, which takes a minute or two after start.
+- Core creates the onion service itself over the Tor control port and stores its key in the Core data directory, so the address is stable across restarts.
+- The sidecar shares Core's network namespace and listens on loopback only. Nothing Tor-related is exposed to the host.
+
+What it does not do:
+- It does not route clearnet traffic through Tor. Masternode quorum traffic stays direct, so enabling Tor does not put the node at risk of PoSe penalties from Tor exit latency.
+- It does not change the address a masternode is registered with. Dash Core requires an IPv4 address in the masternode registration and checks it on startup, so `externalIp` still has to be a public IPv4 address. The onion service is an additional way to reach the node.
+
+Enable it on an existing node with `dashmate config set core.tor.enabled true` and then `dashmate restart`.
+
 ## Sporks
 
 The `core.spork` section configures spork functionality. Sporks are a governance mechanism in Dash that allow network parameters to be changed without requiring a node software update.

--- a/packages/dashmate/docs/config/core.md
+++ b/packages/dashmate/docs/config/core.md
@@ -95,13 +95,14 @@ The `core.tor` section runs a Tor daemon next to Core. Core then reaches onion p
 | Option | Description | Default | Example |
 |--------|-------------|---------|---------|
 | `core.tor.enabled` | Run the Tor sidecar | `true` | `false` |
-| `core.tor.docker.image` | Docker image for the Tor daemon | `osminogin/tor-simple:0.4.9.11` | `osminogin/tor-simple:latest` |
+| `core.tor.docker.image` | Docker image for the Tor daemon | `osminogin/tor-simple:0.4.9.11@sha256:7aef2e…` | `osminogin/tor-simple:latest` |
 | `core.tor.control.password` | Password Core uses on the Tor control port | random on setup | `"s3cret"` |
 
 What it does:
 - Core dials `.onion` peers through the sidecar's SOCKS proxy and accepts inbound onion connections. The onion address shows up as `Onion service` in `dashmate status core` once Tor has published it, which takes a minute or two after start.
 - Core creates the onion service itself over the Tor control port and stores its key in the Core data directory, so the address is stable across restarts.
 - The sidecar shares Core's network namespace and listens on loopback only. Nothing Tor-related is exposed to the host.
+- The default image is pinned by digest, so a re-pushed tag cannot change what runs. Tor updates arrive through dashmate releases; set `core.tor.docker.image` to follow a tag instead.
 
 What it does not do:
 - It does not route clearnet traffic through Tor. Masternode quorum traffic stays direct, so enabling Tor does not put the node at risk of PoSe penalties from Tor exit latency.

--- a/packages/dashmate/docs/config/core.md
+++ b/packages/dashmate/docs/config/core.md
@@ -94,7 +94,7 @@ The `core.tor` section runs a Tor daemon next to Core. Core then reaches onion p
 
 | Option | Description | Default | Example |
 |--------|-------------|---------|---------|
-| `core.tor.enabled` | Run the Tor sidecar | `false` | `true` |
+| `core.tor.enabled` | Run the Tor sidecar | `true` | `false` |
 | `core.tor.docker.image` | Docker image for the Tor daemon | `osminogin/tor-simple:0.4.9.11` | `osminogin/tor-simple:latest` |
 | `core.tor.control.password` | Password Core uses on the Tor control port | random on setup | `"s3cret"` |
 
@@ -107,7 +107,7 @@ What it does not do:
 - It does not route clearnet traffic through Tor. Masternode quorum traffic stays direct, so enabling Tor does not put the node at risk of PoSe penalties from Tor exit latency.
 - It does not change the address a masternode is registered with. Dash Core requires an IPv4 address in the masternode registration and checks it on startup, so `externalIp` still has to be a public IPv4 address. The onion service is an additional way to reach the node.
 
-Enable it on an existing node with `dashmate config set core.tor.enabled true` and then `dashmate restart`.
+Tor is on by default, for new nodes and for nodes upgraded from an earlier dashmate: the upgrade adds the section to every config, and the next `dashmate update` or `dashmate start` pulls the image and starts the sidecar. To run without it, `dashmate config set core.tor.enabled false` and then `dashmate restart`. On a node that was set up with `--no-enable-tor`, `dashmate config set core.tor.enabled true` followed by `dashmate restart` turns it on.
 
 ## Sporks
 

--- a/packages/dashmate/docs/services/core.md
+++ b/packages/dashmate/docs/services/core.md
@@ -40,6 +40,8 @@ To interact with Core RPC use `dashmate core cli` command.
 
 Optionally, you can enable the Insight API and UI to provide a web interface for exploring the blockchain. The `core.insight.enabled` configuration option enables Insight API and `core.insight.ui.enabled` enables block explorer.
 
+Optionally, `core.tor.enabled` runs a Tor daemon (`core_tor` service) in Core's network namespace. Core uses it to reach onion peers and to publish an onion service for inbound connections. It listens on loopback only and exposes no ports. See [Tor configuration](../config/core.md#tor).
+
 **Responsibilities**:
 - Process blockchain transactions
 - Handle masternode operations

--- a/packages/dashmate/docs/services/core.md
+++ b/packages/dashmate/docs/services/core.md
@@ -40,7 +40,7 @@ To interact with Core RPC use `dashmate core cli` command.
 
 Optionally, you can enable the Insight API and UI to provide a web interface for exploring the blockchain. The `core.insight.enabled` configuration option enables Insight API and `core.insight.ui.enabled` enables block explorer.
 
-By default (`core.tor.enabled`), dashmate runs a Tor daemon (`core_tor` service) in Core's network namespace. Core uses it to reach onion peers and to publish an onion service for inbound connections. It listens on loopback only and exposes no ports. See [Tor configuration](../config/core.md#tor).
+When `core.tor.enabled` is true, dashmate runs a Tor daemon (`core_tor` service) in Core's network namespace. Core uses it to reach onion peers and to publish an onion service for inbound connections. It listens on loopback only and exposes no ports. New setups offer Tor enabled by default; upgrades keep it disabled unless already configured. See [Tor configuration](../config/core.md#tor).
 
 **Responsibilities**:
 - Process blockchain transactions

--- a/packages/dashmate/docs/services/core.md
+++ b/packages/dashmate/docs/services/core.md
@@ -40,7 +40,7 @@ To interact with Core RPC use `dashmate core cli` command.
 
 Optionally, you can enable the Insight API and UI to provide a web interface for exploring the blockchain. The `core.insight.enabled` configuration option enables Insight API and `core.insight.ui.enabled` enables block explorer.
 
-Optionally, `core.tor.enabled` runs a Tor daemon (`core_tor` service) in Core's network namespace. Core uses it to reach onion peers and to publish an onion service for inbound connections. It listens on loopback only and exposes no ports. See [Tor configuration](../config/core.md#tor).
+By default (`core.tor.enabled`), dashmate runs a Tor daemon (`core_tor` service) in Core's network namespace. Core uses it to reach onion peers and to publish an onion service for inbound connections. It listens on loopback only and exposes no ports. See [Tor configuration](../config/core.md#tor).
 
 **Responsibilities**:
 - Process blockchain transactions

--- a/packages/dashmate/src/commands/setup.js
+++ b/packages/dashmate/src/commands/setup.js
@@ -34,6 +34,7 @@ export default class SetupCommand extends BaseCommand {
     'debug-logs': Flags.boolean({ char: 'd', description: 'enable debug logs', allowNo: true }),
     'node-count': Flags.integer({ char: 'c', description: 'number of nodes to setup' }),
     'miner-interval': Flags.string({ char: 'm', description: 'interval between blocks' }),
+    'enable-tor': Flags.boolean({ description: 'run a Tor sidecar so Core reaches onion peers and publishes an onion service', allowNo: true }),
 
     verbose: Flags.boolean({ char: 'v', description: 'use verbose mode for output', default: false }),
   };
@@ -56,6 +57,7 @@ export default class SetupCommand extends BaseCommand {
       'node-count': nodeCount,
       'debug-logs': debugLogs,
       'miner-interval': minerInterval,
+      'enable-tor': enableTor,
       verbose: isVerbose,
     },
     configFile,
@@ -165,6 +167,7 @@ I will assist you with setting up a Dash node on mainnet or testnet. I can also 
         nodeCount,
         debugLogs,
         minerInterval,
+        enableTor,
         isVerbose,
       });
     } catch (e) {

--- a/packages/dashmate/src/commands/setup.js
+++ b/packages/dashmate/src/commands/setup.js
@@ -34,7 +34,7 @@ export default class SetupCommand extends BaseCommand {
     'debug-logs': Flags.boolean({ char: 'd', description: 'enable debug logs', allowNo: true }),
     'node-count': Flags.integer({ char: 'c', description: 'number of nodes to setup' }),
     'miner-interval': Flags.string({ char: 'm', description: 'interval between blocks' }),
-    'enable-tor': Flags.boolean({ description: 'run a Tor sidecar so Core reaches onion peers and publishes an onion service', allowNo: true }),
+    'enable-tor': Flags.boolean({ description: 'run a Tor sidecar so Core reaches onion peers and publishes an onion service (default: enabled)', allowNo: true }),
 
     verbose: Flags.boolean({ char: 'v', description: 'use verbose mode for output', default: false }),
   };

--- a/packages/dashmate/src/commands/status/core.js
+++ b/packages/dashmate/src/commands/status/core.js
@@ -46,6 +46,7 @@ export default class CoreStatusCommand extends ConfigBaseCommand {
       'Peer count': 'n/a',
       'P2P service': 'n/a',
       'P2P port': 'n/a',
+      'Onion service': 'n/a',
       'RPC service': 'n/a',
       'Block height': 'n/a',
       'Header height': 'n/a',
@@ -67,6 +68,8 @@ export default class CoreStatusCommand extends ConfigBaseCommand {
         peersCount,
         p2pService,
         p2pPortState,
+        torEnabled,
+        onionService,
         rpcService,
         blockHeight,
         remoteBlockHeight,
@@ -88,6 +91,11 @@ export default class CoreStatusCommand extends ConfigBaseCommand {
       plain['Peer count'] = peersCount || 'n/a';
       plain['P2P service'] = p2pService || 'n/a';
       plain['P2P port'] = colors.portState(p2pPortState)(p2pPortState) || 'n/a';
+      if (torEnabled) {
+        plain['Onion service'] = onionService || 'not published yet';
+      } else {
+        plain['Onion service'] = 'disabled';
+      }
       plain['RPC service'] = rpcService || 'n/a';
       plain['Block height'] = colors.blockHeight(blockHeight, headerHeight, remoteBlockHeight)(blockHeight) || 'n/a';
       plain['Header height'] = headerHeight || 'n/a';

--- a/packages/dashmate/src/config/configFile/ConfigFile.js
+++ b/packages/dashmate/src/config/configFile/ConfigFile.js
@@ -2,6 +2,7 @@ import Config from '../Config.js';
 import ConfigIsNotPresentError from '../errors/ConfigIsNotPresentError.js';
 import GroupIsNotPresentError from '../errors/GroupIsNotPresentError.js';
 import ConfigAlreadyPresentError from '../errors/ConfigAlreadyPresentError.js';
+import generateRandomString from '../../util/generateRandomString.js';
 
 export default class ConfigFile {
   /**
@@ -187,6 +188,9 @@ export default class ConfigFile {
     const fromConfig = this.getConfig(fromConfigName);
 
     this.configsMap[name] = new Config(name, fromConfig.getStoredOptions());
+    // A new node must not share a control password with the config it was
+    // copied from, least of all the placeholder the base config carries.
+    this.configsMap[name].set('core.tor.control.password', generateRandomString(12));
     this.configsMap[name].markAsChanged();
 
     this.changed = true;

--- a/packages/dashmate/src/config/configJsonSchema.js
+++ b/packages/dashmate/src/config/configJsonSchema.js
@@ -343,7 +343,8 @@ export default {
             enabled: {
               type: 'boolean',
               description: 'Run a Tor sidecar so Core reaches onion peers and '
-                + 'publishes an onion service for inbound connections. The '
+                + 'publishes an onion service for inbound connections. On by '
+                + 'default. The '
                 + 'node keeps its IPv4 address: the onion service is an '
                 + 'additional address, not a replacement for the one in the '
                 + 'masternode registration.',

--- a/packages/dashmate/src/config/configJsonSchema.js
+++ b/packages/dashmate/src/config/configJsonSchema.js
@@ -337,6 +337,37 @@ export default {
           required: ['host', 'port'],
           additionalProperties: false,
         },
+        tor: {
+          type: 'object',
+          properties: {
+            enabled: {
+              type: 'boolean',
+              description: 'Run a Tor sidecar so Core reaches onion peers and '
+                + 'publishes an onion service for inbound connections. The '
+                + 'node keeps its IPv4 address: the onion service is an '
+                + 'additional address, not a replacement for the one in the '
+                + 'masternode registration.',
+            },
+            docker: {
+              $ref: '#/definitions/docker',
+            },
+            control: {
+              type: 'object',
+              properties: {
+                password: {
+                  type: 'string',
+                  minLength: 1,
+                  description: 'Tor control port password Core authenticates '
+                    + 'with to create its onion service',
+                },
+              },
+              required: ['password'],
+              additionalProperties: false,
+            },
+          },
+          required: ['enabled', 'docker', 'control'],
+          additionalProperties: false,
+        },
         spork: {
           type: 'object',
           properties: {
@@ -514,7 +545,7 @@ export default {
             + '(~10% chain-size disk overhead on mainnet).',
         },
       },
-      required: ['docker', 'p2p', 'rpc', 'zmq', 'spork', 'masternode', 'miner', 'devnet', 'log',
+      required: ['docker', 'p2p', 'rpc', 'zmq', 'tor', 'spork', 'masternode', 'miner', 'devnet', 'log',
         'indexes', 'insight'],
       additionalProperties: false,
     },

--- a/packages/dashmate/src/config/generateEnvsFactory.js
+++ b/packages/dashmate/src/config/generateEnvsFactory.js
@@ -58,6 +58,10 @@ export default function generateEnvsFactory(configFile, homeDir, getConfigProfil
       }
     }
 
+    if (config.get('core.tor.enabled')) {
+      dockerComposeFiles.push('docker-compose.tor.yml');
+    }
+
     if (config.get('core.insight.enabled')) {
       let insightComposeFile = 'docker-compose.insight_api.yml';
       if (config.get('core.insight.ui.enabled')) {

--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -173,6 +173,7 @@ export default class DockerCompose {
     await this.throwErrorIfNotInstalled();
 
     try {
+      await this.#removeDisabledTor(config, options);
       await dockerCompose.upAll({
         ...this.#createOptions(config, options),
         commandOptions: ['--no-build'],
@@ -246,9 +247,55 @@ export default class DockerCompose {
     await this.throwErrorIfNotInstalled();
 
     try {
+      await this.#removeDisabledTor(config, options);
       await dockerCompose.stop(this.#createOptions(config, options));
     } catch (e) {
       throw new DockerComposeError(e);
+    }
+  }
+
+  /**
+   * A disabled sidecar is absent from Compose's model, so stop/up cannot remove
+   * it. Use project and service labels to find it without touching other nodes
+   * or deleting its persistent Tor state. Platform-only operations leave it alone.
+   *
+   * @param {Config} config
+   * @param {Object} [options]
+   * @param {string[]} [options.profiles]
+   * @return {Promise<void>}
+   */
+  async #removeDisabledTor(config, { profiles = [] } = {}) {
+    if (config.get('core.tor.enabled') || (profiles.length > 0 && !profiles.includes('core'))) {
+      return;
+    }
+
+    const { COMPOSE_PROJECT_NAME: projectName } = this.#generateEnvs(config);
+    const containers = await this.#docker.listContainers({
+      all: true,
+      filters: {
+        label: [
+          `com.docker.compose.project=${projectName}`,
+          'com.docker.compose.service=core_tor',
+        ],
+      },
+    });
+
+    for (const { Id } of containers) {
+      const container = this.#docker.getContainer(Id);
+      try {
+        try {
+          await container.stop({ t: 30 });
+        } catch (e) {
+          if (e.statusCode !== 304) { // Already stopped containers still need removal.
+            throw e;
+          }
+        }
+        await container.remove();
+      } catch (e) {
+        if (e.statusCode !== 404) { // Another lifecycle operation may have removed it.
+          throw e;
+        }
+      }
     }
   }
 

--- a/packages/dashmate/src/listr/tasks/setup/regular/getConfigurationOutputFromContext.js
+++ b/packages/dashmate/src/listr/tasks/setup/regular/getConfigurationOutputFromContext.js
@@ -26,5 +26,7 @@ export default async function getConfigurationOutputFromContext(ctx) {
                    Platform HTTP port: ${ctx.config.get('platform.gateway.listeners.dapiAndDrive.port')}`;
   }
 
+  output += `\n\nTor: ${ctx.config.get('core.tor.enabled') ? 'enabled' : 'disabled'}`;
+
   return output;
 }

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -138,7 +138,7 @@ export default function setupLocalPresetTaskFactory(
                 });
                 config.set('core.rpc.users', rpcUsers);
 
-                config.set('core.tor.enabled', ctx.enableTor === true);
+                config.set('core.tor.enabled', ctx.enableTor !== false);
                 config.set('core.tor.control.password', generateRandomString(12));
 
                 config.set('externalIp', hostDockerInternalIp);

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -138,6 +138,9 @@ export default function setupLocalPresetTaskFactory(
                 });
                 config.set('core.rpc.users', rpcUsers);
 
+                config.set('core.tor.enabled', ctx.enableTor === true);
+                config.set('core.tor.control.password', generateRandomString(12));
+
                 config.set('externalIp', hostDockerInternalIp);
 
                 const subnet = config.get('docker.network.subnet')

--- a/packages/dashmate/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
@@ -158,7 +158,7 @@ export default function setupRegularPresetTaskFactory(
           if (ctx.enableTor === undefined) {
             ctx.enableTor = await task.prompt({
               type: 'toggle',
-              header: `  Dashmate can run a Tor sidecar next to Core. Core then reaches onion peers
+              header: `  Dashmate runs a Tor sidecar next to Core. Core then reaches onion peers
   through it and publishes its own onion service, so peers on Tor can reach
   this node too. Clearnet traffic, including masternode quorum traffic, stays
   direct, and the node keeps its public IPv4 address: masternodes must still be
@@ -166,7 +166,7 @@ export default function setupRegularPresetTaskFactory(
               message: 'Enable Tor?',
               enabled: 'Yes',
               disabled: 'No',
-              initial: false,
+              initial: true,
             });
           }
 

--- a/packages/dashmate/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupRegularPresetTaskFactory.js
@@ -153,6 +153,34 @@ export default function setupRegularPresetTaskFactory(
         task: () => configureNodeTask(),
       },
       {
+        title: 'Configure Tor',
+        task: async (ctx, task) => {
+          if (ctx.enableTor === undefined) {
+            ctx.enableTor = await task.prompt({
+              type: 'toggle',
+              header: `  Dashmate can run a Tor sidecar next to Core. Core then reaches onion peers
+  through it and publishes its own onion service, so peers on Tor can reach
+  this node too. Clearnet traffic, including masternode quorum traffic, stays
+  direct, and the node keeps its public IPv4 address: masternodes must still be
+  registered with that address, the onion service is an extra one.\n`,
+              message: 'Enable Tor?',
+              enabled: 'Yes',
+              disabled: 'No',
+              initial: false,
+            });
+          }
+
+          ctx.config.set('core.tor.enabled', ctx.enableTor === true);
+          ctx.config.set('core.tor.control.password', generateRandomString(12));
+
+          // eslint-disable-next-line no-param-reassign
+          task.output = ctx.enableTor ? 'enabled' : 'disabled';
+        },
+        options: {
+          persistentOutput: true,
+        },
+      },
+      {
         enabled: (ctx) => ctx.config && ctx.config.get('platform.enable'),
         task: () => configureSSLCertificateTask(),
       },

--- a/packages/dashmate/src/status/scopes/core.js
+++ b/packages/dashmate/src/status/scopes/core.js
@@ -33,6 +33,9 @@ export default function getCoreScopeFactory(
       network,
       rpcService,
       p2pService,
+      torEnabled: config.get('core.tor.enabled'),
+      // The onion service Core registered through the Tor sidecar, once it has.
+      onionService: null,
       version: null,
       chain: null,
       latestVersion: null,
@@ -103,10 +106,17 @@ export default function getCoreScopeFactory(
       core.verificationProgress = verificationprogress;
       core.sizeOnDisk = size_on_disk;
 
-      const { subversion, connections } = networkInfo.result;
+      const { subversion, connections, localaddresses } = networkInfo.result;
 
       core.peersCount = connections;
       core.version = extractCoreVersion(subversion);
+
+      const onionAddress = (localaddresses ?? [])
+        .find(({ address }) => address.endsWith('.onion'));
+
+      if (onionAddress) {
+        core.onionService = `${onionAddress.address}:${onionAddress.port}`;
+      }
     } catch (e) {
       if (process.env.DEBUG) {
         // eslint-disable-next-line no-console

--- a/packages/dashmate/src/status/scopes/core.js
+++ b/packages/dashmate/src/status/scopes/core.js
@@ -111,8 +111,7 @@ export default function getCoreScopeFactory(
       core.peersCount = connections;
       core.version = extractCoreVersion(subversion);
 
-      const onionAddress = (localaddresses ?? [])
-        .find(({ address }) => address.endsWith('.onion'));
+      const onionAddress = localaddresses?.find(({ address }) => address.endsWith('.onion'));
 
       if (onionAddress) {
         core.onionService = `${onionAddress.address}:${onionAddress.port}`;

--- a/packages/dashmate/src/templates/renderTemplateFactory.js
+++ b/packages/dashmate/src/templates/renderTemplateFactory.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import dots from 'dot';
 import crypto from 'crypto';
+import hashTorControlPassword from '../tor/hashTorControlPassword.js';
 
 /**
  * @return {renderTemplate}
@@ -23,7 +24,7 @@ export default function renderTemplateFactory() {
 
     const template = dots.template(templateString);
 
-    return template({ ...variables, crypto });
+    return template({ ...variables, crypto, hashTorControlPassword });
   }
 
   return renderTemplate;

--- a/packages/dashmate/src/tor/hashTorControlPassword.js
+++ b/packages/dashmate/src/tor/hashTorControlPassword.js
@@ -1,0 +1,33 @@
+import crypto from 'crypto';
+
+// Tor's HashedControlPassword format: "16:" + hex(salt) + "60" + hex(hash), where
+// the hash is the RFC 2440 iterated-and-salted S2K of salt||password with the
+// count indicator 0x60. Same output as `tor --hash-password`.
+const S2K_INDICATOR = 0x60;
+// RFC 2440 decodes the indicator as (16 + low nibble) * 2^(high nibble + 6);
+// for 0x60 that is 16 * 2^12 bytes hashed.
+const S2K_COUNT = (16 + (S2K_INDICATOR % 16)) * (2 ** (Math.floor(S2K_INDICATOR / 16) + 6));
+const SALT_LENGTH = 8;
+
+/**
+ * @param {string} password
+ * @param {Buffer} [salt] - for deterministic output in tests
+ * @return {string}
+ */
+export default function hashTorControlPassword(password, salt = crypto.randomBytes(SALT_LENGTH)) {
+  if (salt.length !== SALT_LENGTH) {
+    throw new Error(`Tor S2K salt must be ${SALT_LENGTH} bytes`);
+  }
+
+  const secret = Buffer.concat([salt, Buffer.from(password, 'utf8')]);
+
+  const hash = crypto.createHash('sha1');
+  let remaining = S2K_COUNT;
+  while (remaining > 0) {
+    const chunk = remaining >= secret.length ? secret : secret.subarray(0, remaining);
+    hash.update(chunk);
+    remaining -= chunk.length;
+  }
+
+  return `16:${salt.toString('hex')}${S2K_INDICATOR.toString(16)}${hash.digest('hex')}`.toUpperCase();
+}

--- a/packages/dashmate/src/util/generateRandomString.js
+++ b/packages/dashmate/src/util/generateRandomString.js
@@ -1,3 +1,5 @@
+import { randomInt } from 'node:crypto';
+
 /**
  *
  * @param {number} length
@@ -8,7 +10,7 @@ export default function generateRandomString(length) {
   const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
   const charactersLength = characters.length;
   for (let i = 0; i < length; i++) {
-    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    result += characters.charAt(randomInt(charactersLength));
   }
   return result;
 }

--- a/packages/dashmate/templates/core/dash.conf.dot
+++ b/packages/dashmate/templates/core/dash.conf.dot
@@ -54,6 +54,20 @@ allowprivatenet=0
 {{?it.externalIp }}
 externalip={{=it.externalIp}}
 {{?}}
+
+# Tor. The sidecar shares this container's network namespace, so its SOCKS and
+# control ports are on loopback. Only onion destinations use the proxy: clearnet
+# peers (including quorum traffic) stay direct, so `proxy=` is deliberately not
+# set. Core registers an onion service through the control port and binds the
+# default onion target (127.0.0.1:<network onion port>) for its inbound side.
+{{? it.core.tor.enabled }}
+onion=127.0.0.1:9050
+listenonion=1
+torcontrol=127.0.0.1:9051
+torpassword={{=it.core.tor.control.password}}
+{{??}}
+listenonion=0
+{{?}}
 {{? it.network === 'local' && it.externalIp }}
 whitelist={{=it.externalIp}}
 {{?}}

--- a/packages/dashmate/templates/core/tor/torrc.dot
+++ b/packages/dashmate/templates/core/tor/torrc.dot
@@ -1,0 +1,13 @@
+# Rendered by dashmate. The Tor container shares Core's network namespace, so
+# every address below is loopback from Core's point of view.
+DataDirectory /var/lib/tor
+Log notice stdout
+
+# Core dials onion peers through this proxy (dash.conf: onion=).
+SocksPort 127.0.0.1:9050
+
+# Core creates and publishes its own onion service over the control port
+# (dash.conf: torcontrol= / torpassword= / listenonion=1). The service key is
+# persisted by Core in its data directory, so the address survives restarts.
+ControlPort 127.0.0.1:9051
+HashedControlPassword {{= it.hashTorControlPassword(it.core.tor.control.password) }}

--- a/packages/dashmate/test/e2e/testnetEvonode.spec.js
+++ b/packages/dashmate/test/e2e/testnetEvonode.spec.js
@@ -62,6 +62,7 @@ describe('Testnet Evonode', function main() {
         preset,
         nodeType: getNodeTypeByName(NODE_TYPE_NAMES.FULLNODE),
         isHP: true,
+        enableTor: false,
         certificateProvider: SSL_PROVIDERS.FILE,
         tenderdashNodeKey: generateTenderdashNodeKey(),
         initialIpForm: {
@@ -83,6 +84,7 @@ describe('Testnet Evonode', function main() {
       expect(isConfigExists).to.be.true();
 
       config = configFile.getConfig(preset);
+      expect(config.get('core.tor.enabled')).to.be.false();
 
       if (process.env.DASHMATE_E2E_TESTS_SKIP_IMAGE_BUILD !== 'true') {
         config.set('dashmate.helper.docker.build.enabled', true);

--- a/packages/dashmate/test/e2e/testnetFullnode.spec.js
+++ b/packages/dashmate/test/e2e/testnetFullnode.spec.js
@@ -59,6 +59,7 @@ describe('Testnet Fullnode', function main() {
         preset,
         nodeType: getNodeTypeByName(NODE_TYPE_NAMES.FULLNODE),
         isHP: false,
+        enableTor: true,
         certificateProvider: SSL_PROVIDERS.FILE,
         tenderdashNodeKey: generateTenderdashNodeKey(),
         initialIpForm: {
@@ -80,6 +81,7 @@ describe('Testnet Fullnode', function main() {
       expect(isConfigExists).to.be.true();
 
       config = configFile.getConfig(preset);
+      expect(config.get('core.tor.enabled')).to.be.true();
 
       if (process.env.DASHMATE_E2E_TESTS_SKIP_IMAGE_BUILD !== 'true') {
         config.set('dashmate.helper.docker.build.enabled', true);

--- a/packages/dashmate/test/unit/config/configFile/ConfigFile.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/ConfigFile.spec.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import HomeDir from '../../../../src/config/HomeDir.js';
+import getBaseConfigFactory from '../../../../configs/defaults/getBaseConfigFactory.js';
+import ConfigFile from '../../../../src/config/configFile/ConfigFile.js';
+
+describe('ConfigFile', () => {
+  describe('#createConfig', () => {
+    it('should give a new config its own Tor control password', () => {
+      const base = getBaseConfigFactory(HomeDir.createTemp())();
+      const configFile = new ConfigFile([base], '4.2.0', null, null, null);
+
+      const created = configFile.createConfig('node', 'base');
+
+      const password = created.get('core.tor.control.password');
+      expect(password).to.match(/^[A-Za-z0-9]{12}$/);
+      expect(password).to.not.equal(base.get('core.tor.control.password'));
+      expect(configFile.createConfig('other', 'base').get('core.tor.control.password'))
+        .to.not.equal(password);
+    });
+  });
+});

--- a/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
@@ -59,8 +59,12 @@ describe('migrateConfigFileFactory', () => {
     );
 
     for (const [name, defaultConfig] of Object.entries(currentConfigFileData.configs)) {
-      // The Tor control password is generated per node, so it is the one
-      // value a migrated config is not expected to share with the default.
+      // Upgrades keep Tor disabled, while new configs default to enabled.
+      expect(migratedConfigFileData.configs[name].core.tor.enabled).to.equal(false);
+      expect(defaultConfig.core.tor.enabled).to.equal(true);
+      defaultConfig.core.tor.enabled = false;
+
+      // The Tor control password is generated per node.
       expect(migratedConfigFileData.configs[name].core.tor.control.password)
         .to.match(/^[A-Za-z0-9]{12}$/);
       migratedConfigFileData.configs[name].core.tor.control.password = defaultConfig
@@ -282,7 +286,7 @@ describe('migrateConfigFileFactory', () => {
     }
   });
 
-  it('should add and enable the Tor section on a 4.1.x config', async () => {
+  it('should add the Tor section disabled on a 4.1.x config', async () => {
     // Loading is what fails without it: the schema requires the section.
     const fromVersion = '4.1.1';
     const { version } = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT_DIR, 'package.json'), 'utf8'));
@@ -299,9 +303,8 @@ describe('migrateConfigFileFactory', () => {
 
     const passwords = new Set();
     for (const [name, options] of Object.entries(migrated.configs)) {
-      // Enabled for existing nodes too, with a password of their own rather
-      // than the placeholder the base config carries.
-      expect(options.core.tor.enabled, `Tor not enabled for ${name}`).to.equal(true);
+      // Existing nodes must opt in, with a password of their own ready to use.
+      expect(options.core.tor.enabled, `Tor silently enabled for ${name}`).to.equal(false);
       expect(options.core.tor.docker).to.deep.equal(baseConfig.get('core.tor.docker'));
       expect(options.core.tor.control.password).to.match(/^[A-Za-z0-9]{12}$/);
       expect(options.core.tor.control.password).to.not.equal(baseConfig.get('core.tor.control.password'));
@@ -309,6 +312,7 @@ describe('migrateConfigFileFactory', () => {
       expect(() => new Config(name, options), `migrated ${name} config does not load`).to.not.throw();
     }
     expect(passwords.size).to.equal(Object.keys(migrated.configs).length);
+    expect(baseConfig.get('core.tor.enabled')).to.equal(true);
   });
 
   it('should leave an existing Tor section alone when re-migrating', async () => {
@@ -321,6 +325,8 @@ describe('migrateConfigFileFactory', () => {
     configFileData.configFormatVersion = fromVersion;
     configFileData.configs.testnet.core.tor.enabled = false;
     configFileData.configs.testnet.core.tor.control.password = 'operator-chosen';
+    configFileData.configs.mainnet.core.tor.enabled = true;
+    configFileData.configs.mainnet.core.tor.control.password = 'operator-enabled';
 
     const migrated = migrateConfigFile(configFileData, fromVersion, version);
 
@@ -328,6 +334,11 @@ describe('migrateConfigFileFactory', () => {
       enabled: false,
       docker: baseConfig.get('core.tor.docker'),
       control: { password: 'operator-chosen' },
+    });
+    expect(migrated.configs.mainnet.core.tor).to.deep.equal({
+      enabled: true,
+      docker: baseConfig.get('core.tor.docker'),
+      control: { password: 'operator-enabled' },
     });
   });
 

--- a/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
@@ -59,6 +59,13 @@ describe('migrateConfigFileFactory', () => {
     );
 
     for (const [name, defaultConfig] of Object.entries(currentConfigFileData.configs)) {
+      // The Tor control password is generated per node, so it is the one
+      // value a migrated config is not expected to share with the default.
+      expect(migratedConfigFileData.configs[name].core.tor.control.password)
+        .to.match(/^[A-Za-z0-9]{12}$/);
+      migratedConfigFileData.configs[name].core.tor.control.password = defaultConfig
+        .core.tor.control.password;
+
       expect(defaultConfig).to.be.deep.equal(
         migratedConfigFileData.configs[name],
         `Migrated and default ${name} config do not match`,
@@ -275,7 +282,7 @@ describe('migrateConfigFileFactory', () => {
     }
   });
 
-  it('should add the Tor section to a config a development build stamped 4.2.0', async () => {
+  it('should add and enable the Tor section on a config a development build stamped 4.2.0', async () => {
     // Development builds of the 4.2.0 cycle stamp configs at 4.2.0, the newest
     // migration key at the time, so the section has to be added by a key above
     // it. Loading is what fails without it: the schema requires the section.
@@ -292,16 +299,21 @@ describe('migrateConfigFileFactory', () => {
 
     const migrated = migrateConfigFile(configFileData, fromVersion, version);
 
+    const passwords = new Set();
     for (const [name, options] of Object.entries(migrated.configs)) {
-      expect(options.core.tor).to.deep.equal(
-        baseConfig.get('core.tor'),
-        `Tor section was not added for ${name}`,
-      );
+      // Enabled for existing nodes too, with a password of their own rather
+      // than the placeholder the base config carries.
+      expect(options.core.tor.enabled, `Tor not enabled for ${name}`).to.equal(true);
+      expect(options.core.tor.docker).to.deep.equal(baseConfig.get('core.tor.docker'));
+      expect(options.core.tor.control.password).to.match(/^[A-Za-z0-9]{12}$/);
+      expect(options.core.tor.control.password).to.not.equal(baseConfig.get('core.tor.control.password'));
+      passwords.add(options.core.tor.control.password);
       expect(() => new Config(name, options), `migrated ${name} config does not load`).to.not.throw();
     }
+    expect(passwords.size).to.equal(Object.keys(migrated.configs).length);
   });
 
-  it('should leave an enabled Tor section alone when re-migrating', async () => {
+  it('should leave an existing Tor section alone when re-migrating', async () => {
     const fromVersion = '4.2.0';
     const { version } = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT_DIR, 'package.json'), 'utf8'));
 
@@ -309,13 +321,13 @@ describe('migrateConfigFileFactory', () => {
 
     const configFileData = createConfigFile().toObject();
     configFileData.configFormatVersion = fromVersion;
-    configFileData.configs.testnet.core.tor.enabled = true;
+    configFileData.configs.testnet.core.tor.enabled = false;
     configFileData.configs.testnet.core.tor.control.password = 'operator-chosen';
 
     const migrated = migrateConfigFile(configFileData, fromVersion, version);
 
     expect(migrated.configs.testnet.core.tor).to.deep.equal({
-      enabled: true,
+      enabled: false,
       docker: baseConfig.get('core.tor.docker'),
       control: { password: 'operator-chosen' },
     });

--- a/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
@@ -275,6 +275,50 @@ describe('migrateConfigFileFactory', () => {
     }
   });
 
+  it('should add the Tor section to a config a development build stamped 4.2.0', async () => {
+    // Development builds of the 4.2.0 cycle stamp configs at 4.2.0, the newest
+    // migration key at the time, so the section has to be added by a key above
+    // it. Loading is what fails without it: the schema requires the section.
+    const fromVersion = '4.2.0';
+    const { version } = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT_DIR, 'package.json'), 'utf8'));
+
+    const baseConfig = container.resolve('defaultConfigs').get('base');
+
+    const configFileData = createConfigFile().toObject();
+    configFileData.configFormatVersion = fromVersion;
+    for (const options of Object.values(configFileData.configs)) {
+      delete options.core.tor;
+    }
+
+    const migrated = migrateConfigFile(configFileData, fromVersion, version);
+
+    for (const [name, options] of Object.entries(migrated.configs)) {
+      expect(options.core.tor).to.deep.equal(
+        baseConfig.get('core.tor'),
+        `Tor section was not added for ${name}`,
+      );
+      expect(() => new Config(name, options), `migrated ${name} config does not load`).to.not.throw();
+    }
+  });
+
+  it('should leave an enabled Tor section alone when re-migrating', async () => {
+    const fromVersion = '4.2.0';
+    const { version } = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT_DIR, 'package.json'), 'utf8'));
+
+    const configFileData = createConfigFile().toObject();
+    configFileData.configFormatVersion = fromVersion;
+    configFileData.configs.testnet.core.tor.enabled = true;
+    configFileData.configs.testnet.core.tor.control.password = 'operator-chosen';
+
+    const migrated = migrateConfigFile(configFileData, fromVersion, version);
+
+    expect(migrated.configs.testnet.core.tor).to.deep.equal({
+      enabled: true,
+      docker: { image: 'osminogin/tor-simple:0.4.9.11' },
+      control: { password: 'operator-chosen' },
+    });
+  });
+
   it('should keep an operator image that predates the 4.0.0 re-pin', async () => {
     // Every config older than 4.0.0 crosses the unconditional re-pin in that
     // migration, so it is the first place operator intent can be respected. It

--- a/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
@@ -305,6 +305,8 @@ describe('migrateConfigFileFactory', () => {
     const fromVersion = '4.2.0';
     const { version } = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT_DIR, 'package.json'), 'utf8'));
 
+    const baseConfig = container.resolve('defaultConfigs').get('base');
+
     const configFileData = createConfigFile().toObject();
     configFileData.configFormatVersion = fromVersion;
     configFileData.configs.testnet.core.tor.enabled = true;
@@ -314,7 +316,7 @@ describe('migrateConfigFileFactory', () => {
 
     expect(migrated.configs.testnet.core.tor).to.deep.equal({
       enabled: true,
-      docker: { image: 'osminogin/tor-simple:0.4.9.11' },
+      docker: baseConfig.get('core.tor.docker'),
       control: { password: 'operator-chosen' },
     });
   });

--- a/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
@@ -282,11 +282,9 @@ describe('migrateConfigFileFactory', () => {
     }
   });
 
-  it('should add and enable the Tor section on a config a development build stamped 4.2.0', async () => {
-    // Development builds of the 4.2.0 cycle stamp configs at 4.2.0, the newest
-    // migration key at the time, so the section has to be added by a key above
-    // it. Loading is what fails without it: the schema requires the section.
-    const fromVersion = '4.2.0';
+  it('should add and enable the Tor section on a 4.1.x config', async () => {
+    // Loading is what fails without it: the schema requires the section.
+    const fromVersion = '4.1.1';
     const { version } = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT_DIR, 'package.json'), 'utf8'));
 
     const baseConfig = container.resolve('defaultConfigs').get('base');
@@ -314,7 +312,7 @@ describe('migrateConfigFileFactory', () => {
   });
 
   it('should leave an existing Tor section alone when re-migrating', async () => {
-    const fromVersion = '4.2.0';
+    const fromVersion = '4.1.1';
     const { version } = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT_DIR, 'package.json'), 'utf8'));
 
     const baseConfig = container.resolve('defaultConfigs').get('base');

--- a/packages/dashmate/test/unit/config/generateEnvsFactory.spec.js
+++ b/packages/dashmate/test/unit/config/generateEnvsFactory.spec.js
@@ -30,4 +30,9 @@ describe('generateEnvsFactory', () => {
     expect(envs.COMPOSE_FILE.split(':')).to.include('docker-compose.tor.yml');
     expect(envs.CORE_TOR_DOCKER_IMAGE).to.equal(config.get('core.tor.docker.image'));
   });
+
+  it('should pin the default Tor image by digest', () => {
+    // The image is published by a third party under a mutable tag.
+    expect(config.get('core.tor.docker.image')).to.match(/^osminogin\/tor-simple:[0-9.]+@sha256:[0-9a-f]{64}$/);
+  });
 });

--- a/packages/dashmate/test/unit/config/generateEnvsFactory.spec.js
+++ b/packages/dashmate/test/unit/config/generateEnvsFactory.spec.js
@@ -17,9 +17,9 @@ describe('generateEnvsFactory', () => {
   });
 
   it('should not include the Tor compose file when Tor is disabled', () => {
-    const { COMPOSE_FILE } = generateEnvs(config);
+    const envs = generateEnvs(config);
 
-    expect(COMPOSE_FILE.split(':')).to.not.include('docker-compose.tor.yml');
+    expect(envs.COMPOSE_FILE.split(':')).to.not.include('docker-compose.tor.yml');
   });
 
   it('should include the Tor compose file and image when Tor is enabled', () => {

--- a/packages/dashmate/test/unit/config/generateEnvsFactory.spec.js
+++ b/packages/dashmate/test/unit/config/generateEnvsFactory.spec.js
@@ -17,14 +17,14 @@ describe('generateEnvsFactory', () => {
   });
 
   it('should not include the Tor compose file when Tor is disabled', () => {
+    config.set('core.tor.enabled', false);
+
     const envs = generateEnvs(config);
 
     expect(envs.COMPOSE_FILE.split(':')).to.not.include('docker-compose.tor.yml');
   });
 
-  it('should include the Tor compose file and image when Tor is enabled', () => {
-    config.set('core.tor.enabled', true);
-
+  it('should include the Tor compose file and image by default', () => {
     const envs = generateEnvs(config);
 
     expect(envs.COMPOSE_FILE.split(':')).to.include('docker-compose.tor.yml');

--- a/packages/dashmate/test/unit/config/generateEnvsFactory.spec.js
+++ b/packages/dashmate/test/unit/config/generateEnvsFactory.spec.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import HomeDir from '../../../src/config/HomeDir.js';
+import getBaseConfigFactory from '../../../configs/defaults/getBaseConfigFactory.js';
+import generateEnvsFactory from '../../../src/config/generateEnvsFactory.js';
+import getConfigProfilesFactory from '../../../src/config/getConfigProfilesFactory.js';
+
+describe('generateEnvsFactory', () => {
+  let config;
+  let generateEnvs;
+
+  beforeEach(() => {
+    const homeDir = HomeDir.createTemp();
+    config = getBaseConfigFactory(homeDir)();
+
+    const configFile = { getProjectId: () => null };
+    generateEnvs = generateEnvsFactory(configFile, homeDir, getConfigProfilesFactory());
+  });
+
+  it('should not include the Tor compose file when Tor is disabled', () => {
+    const { COMPOSE_FILE } = generateEnvs(config);
+
+    expect(COMPOSE_FILE.split(':')).to.not.include('docker-compose.tor.yml');
+  });
+
+  it('should include the Tor compose file and image when Tor is enabled', () => {
+    config.set('core.tor.enabled', true);
+
+    const envs = generateEnvs(config);
+
+    expect(envs.COMPOSE_FILE.split(':')).to.include('docker-compose.tor.yml');
+    expect(envs.CORE_TOR_DOCKER_IMAGE).to.equal(config.get('core.tor.docker.image'));
+  });
+});

--- a/packages/dashmate/test/unit/docker/DockerCompose.spec.js
+++ b/packages/dashmate/test/unit/docker/DockerCompose.spec.js
@@ -1,0 +1,106 @@
+import sinon from 'sinon';
+import compose from '@dashevo/docker-compose';
+import DockerCompose from '../../../src/docker/DockerCompose.js';
+
+describe('DockerCompose Tor lifecycle', () => {
+  let sandbox;
+  let docker;
+  let sidecar;
+  let config;
+  let dockerCompose;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sidecar = {
+      stop: sandbox.stub().resolves(),
+      remove: sandbox.stub().resolves(),
+    };
+    docker = {
+      listContainers: sandbox.stub().resolves([{ Id: 'tor-container' }]),
+      getContainer: sandbox.stub().withArgs('tor-container').returns(sidecar),
+    };
+    config = { get: sandbox.stub().withArgs('core.tor.enabled').returns(false) };
+    dockerCompose = new DockerCompose(docker, null, null, () => ({
+      COMPOSE_PROJECT_NAME: 'dashmate_project_node',
+    }));
+    sandbox.stub(dockerCompose, 'throwErrorIfNotInstalled').resolves();
+    sandbox.stub(compose, 'upAll').resolves();
+    sandbox.stub(compose, 'stop').resolves();
+  });
+
+  afterEach(() => sandbox.restore());
+
+  ['up', 'stop'].forEach((operation) => {
+    describe(operation, () => {
+      it('should remove a disabled sidecar before operating on Core and retain its volumes', async () => {
+        await dockerCompose[operation](config);
+
+        expect(docker.listContainers).to.have.been.calledOnceWithExactly({
+          all: true,
+          filters: {
+            label: [
+              'com.docker.compose.project=dashmate_project_node',
+              'com.docker.compose.service=core_tor',
+            ],
+          },
+        });
+        expect(sidecar.stop).to.have.been.calledOnceWithExactly({ t: 30 });
+        expect(sidecar.remove).to.have.been.calledOnceWithExactly();
+        sinon.assert.callOrder(sidecar.stop, sidecar.remove, compose[operation === 'up' ? 'upAll' : 'stop']);
+      });
+
+      it('should leave an enabled sidecar alone', async () => {
+        config.get.withArgs('core.tor.enabled').returns(true);
+
+        await dockerCompose[operation](config);
+
+        expect(docker.listContainers).to.not.have.been.called();
+      });
+
+      it('should leave Core services alone during Platform-only operations', async () => {
+        await dockerCompose[operation](config, { profiles: ['platform', 'platform-dapi-rs'] });
+
+        expect(docker.listContainers).to.not.have.been.called();
+      });
+
+      it('should clean up when the core profile is explicitly selected', async () => {
+        await dockerCompose[operation](config, { profiles: ['core'] });
+
+        expect(sidecar.remove).to.have.been.calledOnce();
+      });
+
+      it('should succeed when no sidecar exists', async () => {
+        docker.listContainers.resolves([]);
+
+        await dockerCompose[operation](config);
+
+        expect(docker.getContainer).to.not.have.been.called();
+      });
+
+      it('should remove a sidecar that was already stopped', async () => {
+        sidecar.stop.rejects(Object.assign(new Error('already stopped'), { statusCode: 304 }));
+
+        await dockerCompose[operation](config);
+
+        expect(sidecar.remove).to.have.been.calledOnce();
+      });
+
+      ['stop', 'remove'].forEach((step) => {
+        it(`should tolerate a sidecar disappearing during ${step}`, async () => {
+          sidecar[step].rejects(Object.assign(new Error('not found'), { statusCode: 404 }));
+
+          await dockerCompose[operation](config);
+        });
+
+        it(`should report ${step} failures instead of silently leaving Tor running`, async () => {
+          sidecar[step].rejects(new Error('Docker unavailable'));
+
+          await expect(dockerCompose[operation](config)).to.be.rejectedWith('Docker unavailable');
+
+          expect(compose.upAll).to.not.have.been.called();
+          expect(compose.stop).to.not.have.been.called();
+        });
+      });
+    });
+  });
+});

--- a/packages/dashmate/test/unit/status/scopes/core.spec.js
+++ b/packages/dashmate/test/unit/status/scopes/core.spec.js
@@ -45,6 +45,7 @@ describe('getCoreScopeFactory', () => {
       config.get.withArgs('core.rpc.port').returns('8080');
       config.get.withArgs('core.p2p.port').returns('8081');
       config.get.withArgs('externalIp').returns('127.0.0.1');
+      config.get.withArgs('core.tor.enabled').returns(false);
 
       network = config.get('network');
       rpcService = `127.0.0.1:${config.get('core.rpc.port')}`;
@@ -91,6 +92,8 @@ describe('getCoreScopeFactory', () => {
         network,
         p2pService: '127.0.0.1:8081',
         rpcService: '127.0.0.1:8080',
+        torEnabled: false,
+        onionService: null,
         version: '0.17.0.3',
         chain: 'test',
         latestVersion: 'v1337-dev',
@@ -119,6 +122,8 @@ describe('getCoreScopeFactory', () => {
         network,
         p2pService,
         rpcService,
+        torEnabled: false,
+        onionService: null,
         version: null,
         chain: null,
         latestVersion: null,
@@ -148,6 +153,8 @@ describe('getCoreScopeFactory', () => {
         network,
         p2pService,
         rpcService,
+        torEnabled: false,
+        onionService: null,
         version: null,
         chain: null,
         latestVersion: null,
@@ -178,6 +185,8 @@ describe('getCoreScopeFactory', () => {
         network,
         p2pService,
         rpcService,
+        torEnabled: false,
+        onionService: null,
         version: null,
         chain: null,
         latestVersion: null,
@@ -232,6 +241,8 @@ describe('getCoreScopeFactory', () => {
         network,
         p2pService,
         rpcService,
+        torEnabled: false,
+        onionService: null,
         version: null,
         chain: null,
         latestVersion: 'v1337-dev',
@@ -282,6 +293,8 @@ describe('getCoreScopeFactory', () => {
         network,
         p2pService: '127.0.0.1:8081',
         rpcService: '127.0.0.1:8080',
+        torEnabled: false,
+        onionService: null,
         version: '0.17.0.3',
         chain: 'test',
         latestVersion: null,
@@ -299,6 +312,42 @@ describe('getCoreScopeFactory', () => {
       };
 
       expect(scope).to.deep.equal(expectedScope);
+    });
+
+    it('should report the onion service Core published when Tor is enabled', async function it() {
+      config.get.withArgs('core.tor.enabled').returns(true);
+
+      mockDockerCompose.isServiceRunning.resolves(true);
+      mockDetermineDockerStatus.returns(DockerStatusEnum.running);
+
+      mockRpcClient.mnsync.returns({
+        result: { AssetName: MasternodeSyncAssetEnum.MASTERNODE_SYNC_FINISHED },
+      });
+      mockRpcClient.getNetworkInfo.returns({
+        result: {
+          subversion: '/Dash Core:0.17.0.3/',
+          connections: 1,
+          localaddresses: [
+            { address: '1.2.3.4', port: 9999, score: 1 },
+            { address: 'yz5fl3xg2vhl5jldp7ncctolp7n5fpbwbc3enkzptuubn4lqm3q6xxad.onion', port: 9999, score: 4 },
+          ],
+        },
+      });
+      mockRpcClient.getBlockchainInfo.returns({
+        result: {
+          difficulty: 1, blocks: 2, headers: 3, chain: 'test', size_on_disk: 1337, verificationprogress: 1,
+        },
+      });
+
+      mockGithubProvider.rejects();
+      mockMNOWatchProvider.rejects();
+      mockInsightProvider.returns({ status: this.sinon.stub().rejects() });
+
+      const scope = await getCoreScope(config);
+
+      expect(scope.torEnabled).to.equal(true);
+      expect(scope.onionService)
+        .to.equal('yz5fl3xg2vhl5jldp7ncctolp7n5fpbwbc3enkzptuubn4lqm3q6xxad.onion:9999');
     });
   });
 });

--- a/packages/dashmate/test/unit/templates/torTemplates.spec.js
+++ b/packages/dashmate/test/unit/templates/torTemplates.spec.js
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import HomeDir from '../../../src/config/HomeDir.js';
+import getBaseConfigFactory from '../../../configs/defaults/getBaseConfigFactory.js';
+import renderTemplateFactory from '../../../src/templates/renderTemplateFactory.js';
+import renderServiceTemplatesFactory from '../../../src/templates/renderServiceTemplatesFactory.js';
+
+describe('Tor templates', () => {
+  let getBaseConfig;
+  let renderServiceTemplates;
+
+  beforeEach(() => {
+    getBaseConfig = getBaseConfigFactory(HomeDir.createTemp());
+    renderServiceTemplates = renderServiceTemplatesFactory(renderTemplateFactory());
+  });
+
+  it('should leave onion listening off and set no proxy when Tor is disabled', () => {
+    const config = getBaseConfig();
+
+    const dashConf = renderServiceTemplates(config)['core/dash.conf'];
+
+    expect(dashConf).to.match(/^listenonion=0$/m);
+    expect(dashConf).to.not.match(/^onion=/m);
+    expect(dashConf).to.not.match(/^torcontrol=/m);
+    expect(dashConf).to.not.match(/^proxy=/m);
+  });
+
+  it('should point Core at the sidecar on loopback when Tor is enabled', () => {
+    const config = getBaseConfig();
+    config.set('core.tor.enabled', true);
+    config.set('core.tor.control.password', 'dashmatetest');
+
+    const dashConf = renderServiceTemplates(config)['core/dash.conf'];
+
+    expect(dashConf).to.match(/^onion=127\.0\.0\.1:9050$/m);
+    expect(dashConf).to.match(/^listenonion=1$/m);
+    expect(dashConf).to.match(/^torcontrol=127\.0\.0\.1:9051$/m);
+    expect(dashConf).to.match(/^torpassword=dashmatetest$/m);
+    // Clearnet peers, and so quorum traffic, must not go through Tor.
+    expect(dashConf).to.not.match(/^proxy=/m);
+    expect(dashConf).to.not.match(/^onlynet=/m);
+  });
+
+  it('should render a torrc with loopback listeners and a hashed control password', () => {
+    const config = getBaseConfig();
+    config.set('core.tor.control.password', 'dashmatetest');
+
+    const torrc = renderServiceTemplates(config)['core/tor/torrc'];
+
+    expect(torrc).to.match(/^SocksPort 127\.0\.0\.1:9050$/m);
+    expect(torrc).to.match(/^ControlPort 127\.0\.0\.1:9051$/m);
+    expect(torrc).to.match(/^HashedControlPassword 16:[0-9A-F]{16}60[0-9A-F]{40}$/m);
+    expect(torrc).to.not.include('dashmatetest');
+  });
+});

--- a/packages/dashmate/test/unit/templates/torTemplates.spec.js
+++ b/packages/dashmate/test/unit/templates/torTemplates.spec.js
@@ -14,6 +14,8 @@ describe('Tor templates', () => {
   });
 
   it('should leave onion listening off and set no proxy when Tor is disabled', () => {
+    config.set('core.tor.enabled', false);
+
     const dashConf = renderServiceTemplates(config)['core/dash.conf'];
 
     expect(dashConf).to.match(/^listenonion=0$/m);
@@ -22,8 +24,7 @@ describe('Tor templates', () => {
     expect(dashConf).to.not.match(/^proxy=/m);
   });
 
-  it('should point Core at the sidecar on loopback when Tor is enabled', () => {
-    config.set('core.tor.enabled', true);
+  it('should point Core at the sidecar on loopback by default', () => {
     config.set('core.tor.control.password', 'dashmatetest');
 
     const dashConf = renderServiceTemplates(config)['core/dash.conf'];

--- a/packages/dashmate/test/unit/templates/torTemplates.spec.js
+++ b/packages/dashmate/test/unit/templates/torTemplates.spec.js
@@ -5,17 +5,15 @@ import renderTemplateFactory from '../../../src/templates/renderTemplateFactory.
 import renderServiceTemplatesFactory from '../../../src/templates/renderServiceTemplatesFactory.js';
 
 describe('Tor templates', () => {
-  let getBaseConfig;
+  let config;
   let renderServiceTemplates;
 
   beforeEach(() => {
-    getBaseConfig = getBaseConfigFactory(HomeDir.createTemp());
+    config = getBaseConfigFactory(HomeDir.createTemp())();
     renderServiceTemplates = renderServiceTemplatesFactory(renderTemplateFactory());
   });
 
   it('should leave onion listening off and set no proxy when Tor is disabled', () => {
-    const config = getBaseConfig();
-
     const dashConf = renderServiceTemplates(config)['core/dash.conf'];
 
     expect(dashConf).to.match(/^listenonion=0$/m);
@@ -25,7 +23,6 @@ describe('Tor templates', () => {
   });
 
   it('should point Core at the sidecar on loopback when Tor is enabled', () => {
-    const config = getBaseConfig();
     config.set('core.tor.enabled', true);
     config.set('core.tor.control.password', 'dashmatetest');
 
@@ -41,7 +38,6 @@ describe('Tor templates', () => {
   });
 
   it('should render a torrc with loopback listeners and a hashed control password', () => {
-    const config = getBaseConfig();
     config.set('core.tor.control.password', 'dashmatetest');
 
     const torrc = renderServiceTemplates(config)['core/tor/torrc'];

--- a/packages/dashmate/test/unit/tor/hashTorControlPassword.spec.js
+++ b/packages/dashmate/test/unit/tor/hashTorControlPassword.spec.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import hashTorControlPassword from '../../../src/tor/hashTorControlPassword.js';
+
+describe('hashTorControlPassword', () => {
+  it('should produce the same hash as tor --hash-password for a known salt', () => {
+    // Recorded from `tor --hash-password dashmatetest` (tor 0.4.9.11); the salt
+    // is the first 8 bytes of its output.
+    const salt = Buffer.from('A0C79FFFBAA5E730', 'hex');
+
+    expect(hashTorControlPassword('dashmatetest', salt))
+      .to.equal('16:A0C79FFFBAA5E73060ADD4E562A69F07771416D5EA11711DD1806D1901');
+  });
+
+  it('should use a fresh salt by default', () => {
+    const first = hashTorControlPassword('password');
+    const second = hashTorControlPassword('password');
+
+    expect(first).to.match(/^16:[0-9A-F]{16}60[0-9A-F]{40}$/);
+    expect(first).to.not.equal(second);
+  });
+
+  it('should reject a salt of the wrong length', () => {
+    expect(() => hashTorControlPassword('password', Buffer.alloc(4))).to.throw('8 bytes');
+  });
+});

--- a/packages/dashmate/test/unit/util/generateRandomString.spec.js
+++ b/packages/dashmate/test/unit/util/generateRandomString.spec.js
@@ -1,0 +1,9 @@
+import generateRandomString from '../../../src/util/generateRandomString.js';
+
+describe('generateRandomString', () => {
+  it('should generate a 12-character alphanumeric password without Math.random', function it() {
+    this.sinon.stub(Math, 'random').throws(new Error('Insecure randomness'));
+
+    expect(generateRandomString(12)).to.match(/^[A-Za-z0-9]{12}$/);
+  });
+});


### PR DESCRIPTION
## Issue being fixed or feature implemented

Dashmate-managed masternodes and evonodes have no way to take part in the Tor side of the Dash P2P network. This adds a Tor sidecar, offered with Yes selected by default during setup, so Core can reach `.onion` peers and publish an onion service of its own for inbound connections.

This is a dual-stack feature. The node keeps its public IPv4 address, and the ProTx address is unchanged. Dash Core requires an IPv4 address in the masternode registration and checks it against its local address at startup (`src/active/masternode.cpp`), peers only ever dial the primary `core_p2p` entry, Platform parses the masternode `service` as a `SocketAddr` and Tenderdash dials plain TCP. An onion-only masternode therefore needs Core, rust-dashcore, Drive and Tenderdash changes and V24 activation first. This PR gives operators the part that works today: onion connectivity on top of the IPv4 identity.

## What was done?

- New config section `core.tor` with `enabled` (default `true`), `docker.image` (`osminogin/tor-simple:0.4.9.11` pinned by its multi-arch index digest) and `control.password` (random on setup). Schema, base defaults, and a migration keyed `4.2.0` that backfills the section with `enabled: false` for existing configs. Upgrades do not silently enable Tor; any existing Tor settings are preserved.
- `docker-compose.tor.yml` overlay, included by `generateEnvs` when enabled. The `core_tor` service runs with `network_mode: service:core`, so Tor's SOCKS and control ports live on Core's loopback and nothing Tor-related is reachable from the host or other containers. Tor state is a named volume.
- `templates/core/tor/torrc.dot` renders `SocksPort 127.0.0.1:9050`, `ControlPort 127.0.0.1:9051` and a `HashedControlPassword`. The hash is computed in `src/tor/hashTorControlPassword.js` (Tor's iterated-salted S2K) and verified against `tor --hash-password` output in a unit test, so the plaintext never appears in torrc.
- `dash.conf` gains `onion=127.0.0.1:9050`, `listenonion=1`, `torcontrol=127.0.0.1:9051`, `torpassword=…` when enabled, and `listenonion=0` when disabled. `proxy=` and `onlynet=` are deliberately not set: clearnet peers and quorum traffic stay direct, so enabling Tor cannot cause PoSe penalties from exit latency. Core creates the onion service itself over the control port and persists the key in its data directory, so the address is stable across restarts.
- `dashmate status core` shows an `Onion service` row (from `getnetworkinfo.localaddresses`); the JSON output gains `torEnabled` and `onionService`.
- `dashmate config create` gives the new config its own control password instead of copying the source's.
- `dashmate setup` gains `--[no-]enable-tor`. The mainnet/testnet flow asks a yes/no question (default Yes) when the flag is absent; the local preset enables it unless `--no-enable-tor` is given. Opt out on a running node with `dashmate config set core.tor.enabled false` and `dashmate restart`.
- Docs: `docs/config/core.md` (new Tor section) and `docs/services/core.md`.

Image audit: the `osminogin/tor-simple` Dockerfile is `apk add --no-cache curl tor` on `alpine:edge` and nothing else; the repo's only changes in two years are `VERSION` bumps. The published amd64 layer contains no setuid files or scripts, and its `/usr/bin/tor` is byte-identical (sha256 `23ea7c64…`) to a fresh install of Alpine's `tor-0.4.9.11-r0` package. The image carries buildkit SLSA provenance naming the GitHub commit it was built from. It is not signed, so the digest pin is what makes it immutable.

## How Has This Been Tested?

Local validation after the migration change: all 828 Dashmate unit tests pass, including upgrades from 0.25.0 and 4.1.x that leave Tor disabled, distinct generated control passwords, preservation of existing enabled and disabled Tor settings, and unchanged enabled defaults for new configs. The Oclif CLI manifest builds successfully. Targeted ESLint passes with no errors (one pre-existing unused-disable warning). Generated workspace dependencies were restored from this PR's successful CI build.

Previously completed end-to-end validation of the sidecar (not rerun for this migration-only update):

End to end on a fresh 4-node local network set up with `dashmate setup local --enable-tor` and started with `dashmate group start`:

- All four `core_tor` sidecars reached `Bootstrapped 100%` and reported healthy.
- Every Core logged `Authentication successful` and `ADD_ONION successful` and published a v3 address, visible in `getnetworkinfo.localaddresses` and in `dashmate status core`.
- `getnetworkinfo.networks` shows `onion reachable=true proxy=127.0.0.1:9050`; IPv4 has no proxy.
- `addnode <local_2 onion>:19899 onetry` from `local_1` produced a peer with `network=onion` on `local_1` and an inbound `network=onion` peer on `local_2`, with `subver=/Dash Core:23.1.8/` and headers synced on both sides. Nodes then found each other over Tor on their own (`local_1` ended with two outbound onion peers and two inbound).
- All three masternodes stayed `READY` and the chain kept advancing.
- `dashmate restart --config local_1` republished the same onion address.
- With Tor disabled the rendered `dash.conf` differs from the previous template by exactly one line, `listenonion=0`.

Upgrade behavior: the migration adds `core.tor` with `enabled: false` when the section is absent, so starting an upgraded node does not launch the Tor sidecar. Operators can opt in with `dashmate config set core.tor.enabled true` followed by `dashmate restart`. Configurations that already contain Tor settings retain them. The regression tests cover these choices; the earlier end-to-end upgrade test enabled Tor automatically and no longer describes this PR's behavior.

Supersedes #4617 (same branch from a fork, where the image build and Dashmate E2E jobs were skipped for lack of repository secrets). Both CodeRabbit findings from that PR are addressed here: the `config create` password fix in the last commit, and the migration clone concern was a false positive (`Config.getStored()` deep-clones).

## Breaking Changes

None. New mainnet/testnet setups ask whether to enable Tor with Yes selected by default; `--no-enable-tor` opts out. Local setups enable it unless explicitly disabled. Upgrades leave Tor disabled when adding the section and preserve existing choices.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Tor support for Core, including onion peer access and onion service publishing.
  * New setups enable Tor by default, with a setup option to disable it.
  * Added Tor and onion-service status information to Core status output.
  * Generated unique control passwords for each node.

* **Bug Fixes**
  * Existing configurations remain Tor-disabled during upgrades unless already configured.

* **Documentation**
  * Added configuration and Core service documentation for Tor setup and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->