### PR TITLE
chore: bump rust-dashcore to dev head (#1000 merged: a known transaction is not announced new twice)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 dependencies = [
  "dash-network",
 ]
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1797,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1823,12 +1823,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1841,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2925,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 
 [[package]]
 name = "glob"
@@ -4137,7 +4137,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 dependencies = [
  "aes",
  "async-trait",
@@ -4166,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd#93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7e315af582bc6ec9c088447a7699099b5fbf0f96#7e315af582bc6ec9c088447a7699099b5fbf0f96"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,14 +53,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "93260bf39bac5d9d09e89bfb45e9ea3ff7fdcbcd" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "7e315af582bc6ec9c088447a7699099b5fbf0f96" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "7e315af582bc6ec9c088447a7699099b5fbf0f96" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "7e315af582bc6ec9c088447a7699099b5fbf0f96" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "7e315af582bc6ec9c088447a7699099b5fbf0f96" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "7e315af582bc6ec9c088447a7699099b5fbf0f96" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "7e315af582bc6ec9c088447a7699099b5fbf0f96" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "7e315af582bc6ec9c088447a7699099b5fbf0f96" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "7e315af582bc6ec9c088447a7699099b5fbf0f96" }
 tokio-metrics = "0.5"
 
 # Size-tuned profile for the iOS `rs-unified-sdk-ffi` staticlib, which


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The pin has been one commit behind `rust-dashcore`'s `dev` since #4560 landed, and the
commit it is missing is a sync-accounting fix worth having: dashpay/rust-dashcore#1000.

Upstream's `is_new` polled only `affected_accounts`. That set is not stable across
deliveries — an account that matched solely because the transaction spent its coin drops
out of it on every later delivery, the coin having left `utxos` when the spend was
recorded. Once the account holding the record stops matching, the remaining candidates
have no record, and a transaction the wallet has held all along is announced as new a
second time. The counter is fed `new_txids`, so the transaction total a sync reports
disagreed between runs whose wallet state was identical.

Upstream measured 13-14 double counts per full mainnet restore — a reported total of 6800
or 6801 over the same 6787 transactions. With the fix the total is 6787 on every run.

## What was done?
<!--- Describe your changes in detail -->

- Moved the `rust-dashcore` pin from `93260bf3` (dashpay/rust-dashcore#998) to `7e315af5`,
  the current head of `dev`, across all eight crates in the workspace `Cargo.toml`:
  `dashcore`, `dash-network-seeds`, `dash-spv`, `key-wallet`, `key-wallet-ffi`,
  `key-wallet-manager`, `dash-network`, `dashcore-rpc`.
- Refreshed `Cargo.lock`.

The delta is dashpay/rust-dashcore#1000 alone, touching one file
(`key-wallet/src/transaction_checking/wallet_checker.rs`): `is_new` now asks every account
rather than only the matched ones, behind the existing relevance early-return, so it runs
only for transactions that already matched.

No platform code changes. Nothing here reads `is_new_transaction` outside two assertions
in `packages/rs-platform-wallet/src/test_support.rs`, both of which cover a first delivery
and are unaffected by the change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `cargo check -p platform-wallet -p platform-wallet-ffi -p platform-wallet-storage --tests` — clean.
- `cargo test -p platform-wallet -p platform-wallet-ffi -p platform-wallet-storage` — 1744 passed, 0 failed.

The upstream change ships with its own regression test
(`known_transaction_is_not_new_again_when_its_holder_stops_matching`), which runs in
rust-dashcore's suite rather than here.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None. The delta carries no API change — the modified function is internal to
`wallet_checker`, and its signature and return type are unchanged.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated underlying Dash components to newer revisions.
  - No direct user-facing features or behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->