### PR TITLE
ci: label pull requests with merge conflicts

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,0 +1,36 @@
+name: Label Merge Conflicts
+
+on:
+  # Recheck PRs targeting any branch that receives a push.
+  push:
+    branches: ['**']
+  # Allow label and comment updates for fork PRs without running their code.
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+# Each PR event scans all open PRs; serialize runs to avoid duplicate comments.
+concurrency:
+  group: label-merge-conflicts
+  cancel-in-progress: false
+
+jobs:
+  label-merge-conflicts:
+    if: github.repository == 'dashpay/platform'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update merge conflict labels
+        uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
+        with:
+          dirtyLabel: needs rebase
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          commentOnDirty: |
+            This pull request has conflicts, please rebase.
+
+            ---
+            🤖 Posted autonomously by Codex on behalf of pasta.


### PR DESCRIPTION
## Issue being fixed or feature implemented
Pull requests with conflicts against their base branch are not automatically marked in Platform. Add the same `needs rebase` labeling and rebase reminder used by Dash Core.

## What was done?
- Use Dash Core's `eps1lon/actions-label-merge-conflict` v3.1.0 action, pinned to its commit.
- Check PRs after base-branch pushes and when PRs are opened, reopened, updated, or edited; support manual scans.
- Add `needs rebase` and a comment when conflicts appear, and remove the label when resolved. Serialize scans to avoid duplicate comments from overlapping runs.
- Restrict execution to `dashpay/platform`, grant only content-read and PR/issue-write permissions, and never check out or execute PR code.
- Created the repository's `needs rebase` label using Dash Core's `ededed` color.

The workflow becomes active after merging into `v4.2-dev`.

## How Has This Been Tested?
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/label-merge-conflicts.yml` passed locally.
- `git diff --check` passed.
- Inspected the pinned action's inputs and implementation to verify base-branch filtering, label addition/removal, and comments only when adding the label.
- Verified the label exists through the GitHub API. Live labeling requires the workflow to land on the base branch.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

This pull request was created by Codex.
