### PR TITLE
build: make the workspace lockfile vendorable with --locked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,7 +3199,7 @@ version = "5.0.1"
 source = "git+https://github.com/dashpay/grovedb?rev=6fc7e1e82de27a56c3428c0d5dd15b5f6a0ea23e#6fc7e1e82de27a56c3428c0d5dd15b5f6a0ea23e"
 dependencies = [
  "thiserror 2.0.18",
- "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "versioned-feature-core",
 ]
 
 [[package]]
@@ -5219,7 +5219,7 @@ dependencies = [
  "bincode",
  "grovedb-version",
  "thiserror 2.0.18",
- "versioned-feature-core 1.0.0 (git+https://github.com/dashpay/versioned-feature-core)",
+ "versioned-feature-core",
 ]
 
 [[package]]
@@ -6893,16 +6893,6 @@ dependencies = [
 [[package]]
 name = "serde-wasm-bindgen"
 version = "0.5.0"
-source = "git+https://github.com/QuantumExplorer/serde-wasm-bindgen?branch=feat%2Fnot_human_readable#121d1f7fbf62cb97f74b91626a1b23851098cc82"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.5.0"
 source = "git+https://github.com/dashpay/serde-wasm-bindgen?branch=fix%2Fuint8array-to-bytes#0d3e1a8ff058b400bab3a8ececd2fb9581e8c287"
 dependencies = [
  "js-sys",
@@ -8539,11 +8529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "898c0ad500fdb1914df465a2c729fce33646ef65dfbbbd16a6d8050e0d2404df"
 
 [[package]]
-name = "versioned-feature-core"
-version = "1.0.0"
-source = "git+https://github.com/dashpay/versioned-feature-core#560157096c8405a46ce0f21a2e7e1bd11d6625b4"
-
-[[package]]
 name = "virtue"
 version = "0.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8761,7 +8746,7 @@ dependencies = [
  "num_enum 0.7.6",
  "pastey",
  "serde",
- "serde-wasm-bindgen 0.5.0 (git+https://github.com/QuantumExplorer/serde-wasm-bindgen?branch=feat%2Fnot_human_readable)",
+ "serde-wasm-bindgen 0.5.0",
  "serde_json",
  "thiserror 2.0.18",
  "wasm-bindgen",
@@ -8782,7 +8767,7 @@ dependencies = [
  "hex",
  "js-sys",
  "serde",
- "serde-wasm-bindgen 0.5.0 (git+https://github.com/dashpay/serde-wasm-bindgen?branch=fix%2Fuint8array-to-bytes)",
+ "serde-wasm-bindgen 0.5.0",
  "serde_json",
  "sha2",
  "thiserror 1.0.69",
@@ -8867,7 +8852,7 @@ dependencies = [
  "rs-dapi-client",
  "rs-sdk-trusted-context-provider",
  "serde",
- "serde-wasm-bindgen 0.5.0 (git+https://github.com/dashpay/serde-wasm-bindgen?branch=fix%2Fuint8array-to-bytes)",
+ "serde-wasm-bindgen 0.5.0",
  "serde_json",
  "sha2",
  "thiserror 2.0.18",

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 [dependencies]
 thiserror = { version = "2.0.12" }
 bincode = { version = "=2.0.1" }
-versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
+versioned-feature-core = "1.0.0"
 grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "6fc7e1e82de27a56c3428c0d5dd15b5f6a0ea23e" }
 
 [features]

--- a/packages/wasm-dpp/Cargo.toml
+++ b/packages/wasm-dpp/Cargo.toml
@@ -22,7 +22,7 @@ wasm-bindgen = { version = "=0.2.108" }
 js-sys = "0.3.64"
 web-sys = { version = "0.3.64", features = ["console"] }
 thiserror = { version = "2.0.17" }
-serde-wasm-bindgen = { git = "https://github.com/QuantumExplorer/serde-wasm-bindgen", branch = "feat/not_human_readable" }
+serde-wasm-bindgen = { git = "https://github.com/dashpay/serde-wasm-bindgen", branch = "fix/uint8array-to-bytes" }
 dpp = { path = "../rs-dpp", default-features = false, features = [
     "json-conversion",
     "state-transitions",


### PR DESCRIPTION
## Issue being fixed or feature implemented

`cargo vendor --locked` refuses the workspace on `v4.2-dev`:

```
found duplicate version of package `serde-wasm-bindgen v0.5.0` vendored from two sources:
    source 1: https://github.com/QuantumExplorer/serde-wasm-bindgen?branch=feat%2Fnot_human_readable#121d1f7f
    source 2: https://github.com/dashpay/serde-wasm-bindgen?branch=fix%2Fuint8array-to-bytes#0d3e1a8f
```

and, once that is resolved, the same for `versioned-feature-core 1.0.0` (crates.io through `grovedb-version`, git through `rs-platform-version`). Offline build systems that vendor the workspace cannot get past this. Dash Core's depends packaging of the C++ embedding crate (the follow-up to this PR, see dashpay/dash#7512) is the first consumer that needs it.

## What was done?

- `wasm-dpp` now pins `serde-wasm-bindgen` to the `dashpay` fork like `wasm-sdk` and `wasm-dpp2` already do. That branch is the `QuantumExplorer` branch plus the `Uint8Array` fix and the current `wasm-bindgen` pin, so nothing changes for `wasm-dpp` beyond the source.
- `rs-platform-version` now depends on `versioned-feature-core` from crates.io instead of the dashpay git repo. The git pin was the repo's only substantive commit, published as 1.0.0 two days after the pin was written; the two trees differ only in cargo's `Cargo.toml` normalization on publish. `grovedb-version` already depended on the crates.io release, so this collapses two identical copies into one. (Earlier revision used a workspace `[patch]` table for this; the manifest edit is the direct fix and does not rely on a root-level override.)
- `Cargo.lock` loses the two duplicate entries.

## Why the two source changes are safe

**`serde-wasm-bindgen`.** The dashpay branch is a descendant of the QuantumExplorer branch (`git merge-base --is-ancestor` confirms), adding two commits. Their source diff:
- `is_human_readable` becomes a per-deserializer flag with a `from_value_json` entry point. The default stays `false`, which is the value the QuantumExplorer branch hardcoded, and `from_value` (the only entry point `wasm-dpp` uses) still takes that default. The serializer side only gains a setter; `Serializer::json_compatible()` is unchanged.
- `deserialize_any` gains an `as_bytes()` arm so a `Uint8Array`/`ArrayBuffer` becomes `visit_byte_buf`. On the QuantumExplorer branch that input fell through every arm (typed arrays are not `Array::is_array`, and they carry `Symbol.iterator`, so the object arm rejects them) and returned an `invalid_type` error. The change turns an error into a value; no input that deserialized before deserializes differently now. Upstream `serde-wasm-bindgen` 0.6.5 has the same arm, so this brings the fork in line with upstream.
- `wasm-dpp` does not reach the changed arm: its JS→`platform_value` path stringifies through JSON (`utils.rs::with_serde_to_platform_value`), and its `from_value` targets are typed option structs and `serde_json::Value` maps, where a typed array errors both before and after (`serde_json::Value` has no bytes visitor).
- The `wasm-bindgen` pin the fork carries (`=0.2.108`) is the pin `wasm-dpp` already declares; the lockfile had 0.2.108 before and after.

Why they differed: `wasm-dpp` took the QuantumExplorer branch in 2023 (#809) for the non-human-readable mode; `wasm-sdk` moved from upstream 0.6.5 to the dashpay branch in 2025 (#2850) because it needed both that mode and the typed-array fix, and the new branch was cut from the old one. `wasm-dpp` was never moved along. Drift, not a deliberate split.

**`versioned-feature-core`.** `rs-platform-version` pinned the git repo on 2024-07-10 (#1938), the day the crate's only real commit landed; QuantumExplorer published 1.0.0 to crates.io on 2024-07-12. The git rev the lockfile held is that same tip commit. `src/lib.rs` is byte-identical between the two; the only difference is cargo's `Cargo.toml` normalization on publish. `grovedb-version` already depends on the crates.io release, so `drive-abci` was already compiling one copy from each source. Switching the manifest to the published release collapses them onto one with no source change.

## How Has This Been Tested?

- `cargo check --locked` for `platform-version`, `dash-platform-queries`, `dash-sdk`, `rs-sdk-ffi`, `drive-abci`.
- `cargo check --locked --target wasm32-unknown-unknown` for `wasm-dpp`, `wasm-sdk`, `wasm-dpp2`.
- The `tests-rs-workspace` transport-free guards (`hyper`/`rustls`/`tower` absent from the verifier trees) still pass.
- `cargo vendor --locked` now succeeds (829 crates).
- Note on coverage: `@dashevo/wasm-dpp`'s own JS tests are not in the PR matrix (nightly/`workflow_dispatch` only). `Build JS` compiled it and its consumers' suites ran on top of the built artifact; a `workflow_dispatch` run of the full matrix on this branch is linked below.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency sources and version resolution to improve build consistency.
  - Switched the WebAssembly serialization dependency to a DashPay-maintained repository and branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
