### PR TITLE
feat(sdk)!: pure DPNS and DashPay document builders shared with embedders

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -347,6 +347,7 @@ jobs:
             --package dpp \
             --package drive-abci \
             --package dash-sdk \
+            --package dash-platform-queries \
             --package dash-async \
             --package platform-value \
             --package rs-dapi \

--- a/packages/dash-platform-queries/Cargo.toml
+++ b/packages/dash-platform-queries/Cargo.toml
@@ -24,6 +24,8 @@ dapi-grpc = { path = "../dapi-grpc", default-features = false, features = [
 dash-context-provider = { path = "../rs-context-provider", default-features = false }
 dash-platform-macros = { path = "../rs-dash-platform-macros" }
 dpp = { path = "../rs-dpp", default-features = false, features = [
+  "dashpay-contract",
+  "dpns-contract",
   "platform-value-cbor",
   "state-transitions",
   "state-transition-validation",

--- a/packages/dash-platform-queries/src/dashpay.rs
+++ b/packages/dash-platform-queries/src/dashpay.rs
@@ -1,0 +1,254 @@
+//! Transport-free DashPay document assembly.
+//!
+//! The Sdk-bound DashPay surface (ECDH, encryption, fetching the recipient,
+//! broadcasting) lives in `dash-sdk`; this is the pure DIP-15 document
+//! assembly it shares with embedders that hold the encrypted material
+//! themselves. Field size bounds come from the DashPay contract schema, so
+//! the builder cannot drift from what the contract accepts.
+
+use crate::dpns_usernames::new_document;
+use crate::Error;
+use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
+use dpp::data_contract::document_type::DocumentTypeRef;
+use dpp::data_contract::errors::DataContractError;
+use dpp::document::Document;
+use dpp::platform_value::Value;
+use dpp::prelude::{DataContract, Identifier};
+use dpp::system_data_contracts::dashpay_contract::v1::document_types::contact_request;
+use std::collections::BTreeMap;
+
+/// Inputs of a DIP-15 `contactRequest` document. The encrypted fields are
+/// supplied already encrypted (ECDH, AES-CBC with a fresh IV prepended);
+/// see `dash-sdk`'s `create_contact_request` for the encryption itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContactRequestDocumentParams {
+    /// Identity sending the request; becomes the document owner.
+    pub sender_id: Identifier,
+    /// Identity receiving the request (`toUserId`).
+    pub recipient_id: Identifier,
+    /// Index of the sender's encryption key used for ECDH.
+    pub sender_key_index: u32,
+    /// Index of the recipient's key used for ECDH.
+    pub recipient_key_index: u32,
+    /// DashPay receiving-account reference.
+    pub account_reference: u32,
+    /// Encrypted DIP-15 compact extended public key (IV ‖ ciphertext).
+    pub encrypted_public_key: Vec<u8>,
+    /// Encrypted account label (IV ‖ ciphertext), if any.
+    pub encrypted_account_label: Option<Vec<u8>>,
+    /// Unencrypted auto-accept proof, if any.
+    pub auto_accept_proof: Option<Vec<u8>>,
+    /// Entropy the document id derives from; reuse it on the create
+    /// transition.
+    pub entropy: [u8; 32],
+}
+
+/// Assemble a `contactRequest` document, checking every byte-array field
+/// against the size bounds the contract schema declares for it.
+pub fn build_contact_request_document(
+    contract: &DataContract,
+    params: ContactRequestDocumentParams,
+) -> Result<Document, Error> {
+    let document_type = contract.document_type_for_name(contact_request::NAME)?;
+
+    check_byte_field(
+        document_type,
+        "encryptedPublicKey",
+        &params.encrypted_public_key,
+    )?;
+    if let Some(label) = &params.encrypted_account_label {
+        check_byte_field(document_type, "encryptedAccountLabel", label)?;
+    }
+    if let Some(proof) = &params.auto_accept_proof {
+        check_byte_field(document_type, "autoAcceptProof", proof)?;
+    }
+
+    let mut properties = BTreeMap::from([
+        (
+            contact_request::properties::TO_USER_ID.to_string(),
+            Value::Identifier(params.recipient_id.to_buffer()),
+        ),
+        (
+            "encryptedPublicKey".to_string(),
+            Value::Bytes(params.encrypted_public_key),
+        ),
+        (
+            "senderKeyIndex".to_string(),
+            Value::U32(params.sender_key_index),
+        ),
+        (
+            "recipientKeyIndex".to_string(),
+            Value::U32(params.recipient_key_index),
+        ),
+        (
+            "accountReference".to_string(),
+            Value::U32(params.account_reference),
+        ),
+    ]);
+    if let Some(label) = params.encrypted_account_label {
+        properties.insert("encryptedAccountLabel".to_string(), Value::Bytes(label));
+    }
+    if let Some(proof) = params.auto_accept_proof {
+        properties.insert("autoAcceptProof".to_string(), Value::Bytes(proof));
+    }
+
+    Ok(new_document(
+        contract,
+        document_type.name(),
+        params.sender_id,
+        params.entropy,
+        properties,
+    ))
+}
+
+/// Check `bytes` against the `minItems`/`maxItems` the contract declares for
+/// the byte-array property `field`.
+fn check_byte_field(
+    document_type: DocumentTypeRef,
+    field: &str,
+    bytes: &[u8],
+) -> Result<(), Error> {
+    let property = document_type.properties().get(field).ok_or_else(|| {
+        DataContractError::DocumentTypeFieldNotFound(format!(
+            "{} has no property {field}",
+            document_type.name()
+        ))
+    })?;
+    // Only `Array`/`VariableTypeArray` report no size, and dpp refuses those
+    // at contract creation ("only byte arrays are supported now"), so every
+    // property reachable here is sized and the defaults never apply.
+    let min = property.property_type.min_size().unwrap_or(0) as usize;
+    let max = property.property_type.max_size().unwrap_or(u16::MAX) as usize;
+    if bytes.len() < min || bytes.len() > max {
+        return Err(Error::Config(format!(
+            "{field} must be {min}-{max} bytes, got {}",
+            bytes.len()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::document::DocumentV0Getters;
+    use dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
+    use dpp::version::PlatformVersion;
+
+    fn params(encrypted_public_key: Vec<u8>) -> ContactRequestDocumentParams {
+        ContactRequestDocumentParams {
+            sender_id: Identifier::from([1u8; 32]),
+            recipient_id: Identifier::from([2u8; 32]),
+            sender_key_index: 1,
+            recipient_key_index: 2,
+            account_reference: 3,
+            encrypted_public_key,
+            encrypted_account_label: None,
+            auto_accept_proof: None,
+            entropy: [7u8; 32],
+        }
+    }
+
+    fn contract() -> DataContract {
+        load_system_data_contract(SystemDataContract::Dashpay, PlatformVersion::latest())
+            .expect("dashpay contract")
+    }
+
+    #[test]
+    fn should_derive_the_document_id_from_the_entropy() {
+        let contract = contract();
+        let document = build_contact_request_document(&contract, params(vec![0u8; 96]))
+            .expect("valid contact request");
+        assert_eq!(
+            document.id(),
+            Document::generate_document_id_v0(
+                &contract.id(),
+                &Identifier::from([1u8; 32]),
+                contact_request::NAME,
+                &[7u8; 32]
+            )
+        );
+        assert_eq!(document.owner_id(), Identifier::from([1u8; 32]));
+        assert_eq!(
+            document.get("toUserId"),
+            Some(&Value::Identifier([2u8; 32]))
+        );
+    }
+
+    #[test]
+    fn should_enforce_the_contract_byte_bounds() {
+        let contract = contract();
+        build_contact_request_document(&contract, params(vec![0u8; 95]))
+            .expect_err("encryptedPublicKey below the schema's 96 bytes");
+        let mut with_label = params(vec![0u8; 96]);
+        with_label.encrypted_account_label = Some(vec![0u8; 81]);
+        build_contact_request_document(&contract, with_label)
+            .expect_err("encryptedAccountLabel above the schema's 80 bytes");
+        let mut with_proof = params(vec![0u8; 96]);
+        with_proof.auto_accept_proof = Some(vec![0u8; 37]);
+        build_contact_request_document(&contract, with_proof)
+            .expect_err("autoAcceptProof below the schema's 38 bytes");
+    }
+
+    /// The optional fields are the ones a wire-format slip would silently
+    /// drop, so pin every property the document carries when both are set.
+    #[test]
+    fn should_carry_every_property_when_the_optional_fields_are_present() {
+        let contract = contract();
+        let mut with_optionals = params(vec![1u8; 96]);
+        with_optionals.encrypted_account_label = Some(vec![2u8; 64]);
+        with_optionals.auto_accept_proof = Some(vec![3u8; 40]);
+
+        let document = build_contact_request_document(&contract, with_optionals)
+            .expect("valid contact request");
+
+        assert_eq!(
+            document.get("toUserId"),
+            Some(&Value::Identifier([2u8; 32]))
+        );
+        assert_eq!(
+            document.get("encryptedPublicKey"),
+            Some(&Value::Bytes(vec![1u8; 96]))
+        );
+        assert_eq!(document.get("senderKeyIndex"), Some(&Value::U32(1)));
+        assert_eq!(document.get("recipientKeyIndex"), Some(&Value::U32(2)));
+        assert_eq!(document.get("accountReference"), Some(&Value::U32(3)));
+        assert_eq!(
+            document.get("encryptedAccountLabel"),
+            Some(&Value::Bytes(vec![2u8; 64]))
+        );
+        assert_eq!(
+            document.get("autoAcceptProof"),
+            Some(&Value::Bytes(vec![3u8; 40]))
+        );
+    }
+
+    /// A contract that declares no `contactRequest` surfaces dpp's
+    /// `DataContractError` through our `Error`, rather than panicking.
+    #[test]
+    fn should_refuse_a_contract_without_a_contact_request_type() {
+        let dpns = load_system_data_contract(SystemDataContract::DPNS, PlatformVersion::latest())
+            .expect("dpns contract");
+        let error = build_contact_request_document(&dpns, params(vec![0u8; 96]))
+            .expect_err("dpns declares no contactRequest document type");
+        assert!(
+            matches!(error, Error::Protocol(_)),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn should_refuse_a_field_the_document_type_does_not_declare() {
+        let contract = contract();
+        let document_type = contract
+            .document_type_for_name(contact_request::NAME)
+            .expect("contactRequest document type");
+        let error = check_byte_field(document_type, "notAProperty", &[])
+            .expect_err("contactRequest declares no such property");
+        assert!(
+            matches!(error, Error::Protocol(_)),
+            "unexpected error: {error:?}"
+        );
+    }
+}

--- a/packages/dash-platform-queries/src/dpns_usernames.rs
+++ b/packages/dash-platform-queries/src/dpns_usernames.rs
@@ -2,21 +2,27 @@
 //!
 //! The Sdk-bound DPNS surface (registration, availability checks, name
 //! resolution) lives in `dash-sdk`; these free functions are pure string
-//! validation/normalization shared with embedders.
+//! validation/normalization and document assembly shared with embedders.
+//! Normalization is dpp's consensus implementation
+//! ([`convert_to_homograph_safe_chars`]), the same one the DPNS data trigger
+//! checks `normalizedLabel` against.
 
-/// Convert a string to homograph-safe characters by replacing 'o', 'i', and 'l'
-/// with '0', '1', and '1' respectively to prevent homograph attacks
-pub fn convert_to_homograph_safe_chars(input: &str) -> String {
-    input
-        .chars()
-        .map(|c| match c {
-            'o' | 'O' => '0',
-            'i' | 'I' => '1',
-            'l' | 'L' => '1',
-            _ => c.to_ascii_lowercase(),
-        })
-        .collect()
-}
+use crate::Error;
+use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
+use dpp::document::{Document, DocumentV0};
+use dpp::platform_value::Value;
+use dpp::prelude::{DataContract, Identifier};
+use dpp::system_data_contracts::dpns_contract::v1::document_types::domain;
+use dpp::util::hash::hash_double;
+use std::collections::BTreeMap;
+
+/// Document type name of the DPNS preorder document.
+pub const PREORDER_DOCUMENT_TYPE: &str = "preorder";
+/// The only parent domain names can currently be registered under.
+pub const DASH_PARENT_DOMAIN: &str = "dash";
+
+pub use dpp::util::strings::convert_to_homograph_safe_chars;
 
 /// Check if a username is valid according to DPNS rules
 ///
@@ -97,9 +103,180 @@ pub fn is_contested_username(label: &str) -> bool {
         .all(|c| matches!(c, 'a'..='z' | '0' | '1' | '-'))
 }
 
+/// The DPNS `preorder` document that blinds `label`.dash behind `salt`.
+///
+/// `saltedDomainHash` is `sha256d(salt ‖ "<normalized label>.dash")` — the
+/// same preimage the DPNS data trigger recomputes when the paired `domain`
+/// document is created. The document id derives from `entropy`, which must
+/// be reused on the create transition.
+///
+/// Callers driving their own registration must draw `salt` from a CSPRNG and
+/// keep it, the label, and the domain document private until the preorder is
+/// confirmed, or the preorder's front-running protection is lost.
+pub fn build_dpns_preorder_document(
+    contract: &DataContract,
+    owner_id: Identifier,
+    label: &str,
+    salt: [u8; 32],
+    entropy: [u8; 32],
+) -> Result<Document, Error> {
+    let document_type = contract.document_type_for_name(PREORDER_DOCUMENT_TYPE)?;
+    let properties = BTreeMap::from([(
+        "saltedDomainHash".to_string(),
+        Value::Bytes32(salted_domain_hash(label, salt)),
+    )]);
+    Ok(new_document(
+        contract,
+        document_type.name(),
+        owner_id,
+        entropy,
+        properties,
+    ))
+}
+
+/// The DPNS `domain` document registering `label`.dash for `owner_id`, with
+/// the identity record pointing at the owner and subdomains disallowed.
+///
+/// `normalizedLabel` is the consensus normalization of `label`. The label is
+/// not validated here; the contract's label pattern is enforced by consensus
+/// when the domain document is created (see [`is_valid_username`] for a
+/// client-side pre-check).
+pub fn build_dpns_domain_document(
+    contract: &DataContract,
+    owner_id: Identifier,
+    label: &str,
+    salt: [u8; 32],
+    entropy: [u8; 32],
+) -> Result<Document, Error> {
+    let document_type = contract.document_type_for_name(domain::NAME)?;
+    let properties = BTreeMap::from([
+        (
+            domain::properties::PARENT_DOMAIN_NAME.to_string(),
+            Value::Text(DASH_PARENT_DOMAIN.to_string()),
+        ),
+        (
+            domain::properties::NORMALIZED_PARENT_DOMAIN_NAME.to_string(),
+            Value::Text(DASH_PARENT_DOMAIN.to_string()),
+        ),
+        (
+            domain::properties::LABEL.to_string(),
+            Value::Text(label.to_string()),
+        ),
+        (
+            domain::properties::NORMALIZED_LABEL.to_string(),
+            Value::Text(convert_to_homograph_safe_chars(label)),
+        ),
+        (
+            domain::properties::PREORDER_SALT.to_string(),
+            Value::Bytes32(salt),
+        ),
+        (
+            domain::properties::RECORDS.to_string(),
+            Value::Map(vec![(
+                Value::Text(domain::properties::IDENTITY.to_string()),
+                Value::Identifier(owner_id.to_buffer()),
+            )]),
+        ),
+        (
+            "subdomainRules".to_string(),
+            Value::Map(vec![(
+                Value::Text("allowSubdomains".to_string()),
+                Value::Bool(false),
+            )]),
+        ),
+    ]);
+    Ok(new_document(
+        contract,
+        document_type.name(),
+        owner_id,
+        entropy,
+        properties,
+    ))
+}
+
+/// `sha256d(salt ‖ "<normalized label>.dash")`: the preorder commitment the
+/// DPNS data trigger recomputes from the domain document.
+pub fn salted_domain_hash(label: &str, salt: [u8; 32]) -> [u8; 32] {
+    let mut preimage = salt.to_vec();
+    preimage.extend_from_slice(convert_to_homograph_safe_chars(label).as_bytes());
+    preimage.extend_from_slice(b".");
+    preimage.extend_from_slice(DASH_PARENT_DOMAIN.as_bytes());
+    hash_double(preimage)
+}
+
+/// A fresh document whose id derives from `entropy`, with every
+/// chain-assigned field left unset (they never enter a create transition).
+pub(crate) fn new_document(
+    contract: &DataContract,
+    document_type_name: &str,
+    owner_id: Identifier,
+    entropy: [u8; 32],
+    properties: BTreeMap<String, Value>,
+) -> Document {
+    Document::V0(DocumentV0 {
+        id: Document::generate_document_id_v0(
+            &contract.id(),
+            &owner_id,
+            document_type_name,
+            &entropy,
+        ),
+        owner_id,
+        properties,
+        ..Default::default()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn should_build_preorder_and_domain_documents_that_agree() {
+        use dpp::document::DocumentV0Getters;
+        use dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
+        use dpp::version::PlatformVersion;
+
+        let contract =
+            load_system_data_contract(SystemDataContract::DPNS, PlatformVersion::latest())
+                .expect("dpns contract");
+        let owner = Identifier::from([1u8; 32]);
+        let salt = [5u8; 32];
+        let entropy = [9u8; 32];
+
+        let preorder = build_dpns_preorder_document(&contract, owner, "Alice", salt, entropy)
+            .expect("preorder");
+        let domain =
+            build_dpns_domain_document(&contract, owner, "Alice", salt, entropy).expect("domain");
+
+        // The commitment in the preorder is the one the DPNS data trigger
+        // recomputes from the domain document's salt and normalized label.
+        assert_eq!(
+            preorder.get("saltedDomainHash"),
+            Some(&Value::Bytes32(salted_domain_hash("Alice", salt)))
+        );
+        assert_eq!(
+            domain.get(domain::properties::NORMALIZED_LABEL),
+            Some(&Value::Text("a11ce".to_string()))
+        );
+        assert_eq!(
+            domain.get(domain::properties::LABEL),
+            Some(&Value::Text("Alice".to_string()))
+        );
+        assert_eq!(
+            domain.get(domain::properties::PREORDER_SALT),
+            Some(&Value::Bytes32(salt))
+        );
+        assert_eq!(
+            preorder.id(),
+            Document::generate_document_id_v0(
+                &contract.id(),
+                &owner,
+                PREORDER_DOCUMENT_TYPE,
+                &entropy
+            )
+        );
+        assert_ne!(preorder.id(), domain.id());
+    }
 
     #[test]
     fn test_convert_to_homograph_safe_chars() {

--- a/packages/dash-platform-queries/src/error.rs
+++ b/packages/dash-platform-queries/src/error.rs
@@ -1,6 +1,7 @@
 //! Errors produced by the transport-free query core.
 
 use dpp::consensus::ConsensusError;
+use dpp::data_contract::errors::DataContractError;
 use dpp::validation::SimpleConsensusValidationResult;
 use dpp::ProtocolError;
 
@@ -21,6 +22,12 @@ pub enum Error {
     /// DPP error
     #[error("Protocol error: {0}")]
     Protocol(#[from] ProtocolError),
+}
+
+impl From<DataContractError> for Error {
+    fn from(value: DataContractError) -> Self {
+        Self::Protocol(ProtocolError::DataContractError(value))
+    }
 }
 
 impl From<ConsensusError> for Error {

--- a/packages/dash-platform-queries/src/lib.rs
+++ b/packages/dash-platform-queries/src/lib.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::result_large_err)]
 
 pub mod block_info_from_metadata;
+pub mod dashpay;
 pub mod documents;
 pub mod dpns_usernames;
 pub mod error;

--- a/packages/rs-sdk/src/platform/dashpay/contact_request.rs
+++ b/packages/rs-sdk/src/platform/dashpay/contact_request.rs
@@ -5,23 +5,23 @@
 use crate::platform::transition::put_document::PutDocument;
 use crate::platform::Document;
 use crate::{Error, Sdk};
+use dash_platform_queries::dashpay::{
+    build_contact_request_document, ContactRequestDocumentParams,
+};
 use dpp::dashcore::secp256k1::rand::rngs::StdRng;
 use dpp::dashcore::secp256k1::rand::{RngCore, SeedableRng};
 use dpp::dashcore::secp256k1::{PublicKey, SecretKey};
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
-use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
-use dpp::document::DocumentV0;
 use dpp::identity::accessors::IdentityGettersV0;
 use dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dpp::identity::identity_public_key::Purpose;
 use dpp::identity::signer::Signer;
 use dpp::identity::{Identity, IdentityPublicKey};
-use dpp::platform_value::{Bytes32, Value};
+use dpp::platform_value::Bytes32;
 use dpp::prelude::Identifier;
 use platform_encryption::{
     derive_shared_key_ecdh, encrypt_account_label, encrypt_extended_public_key, COMPACT_XPUB_LEN,
 };
-use std::collections::BTreeMap;
 
 /// ECDH provider for contact request encryption
 ///
@@ -105,13 +105,9 @@ pub struct ContactRequestInput {
 /// Result of creating a contact request document
 #[derive(Debug)]
 pub struct ContactRequestResult {
-    /// The document ID
-    pub id: Identifier,
-    /// The owner ID (sender identity ID)
-    pub owner_id: Identifier,
-    /// The document properties
-    pub properties: BTreeMap<String, Value>,
-    /// The entropy used to derive `id`.
+    /// The assembled `contactRequest` document (not yet broadcast).
+    pub document: Document,
+    /// The entropy used to derive the document id.
     ///
     /// This must be reused when broadcasting the document so that the
     /// document id computed at creation matches the id platform consensus
@@ -259,7 +255,10 @@ impl Sdk {
         H: FnOnce(u32) -> Hut,
         Hut: std::future::Future<Output = Result<Vec<u8>, Error>>,
     {
-        // Validate auto accept proof size if provided
+        // Validate auto accept proof size if provided. The shared builder
+        // re-checks this against the contract schema, but `autoAcceptProof` is
+        // raw caller input and the fetch below is a network round trip, so keep
+        // rejecting it up front rather than after paying for the lookup.
         if let Some(ref proof) = input.auto_accept_proof {
             if proof.len() < 38 || proof.len() > 102 {
                 return Err(Error::Generic(format!(
@@ -366,27 +365,12 @@ impl Sdk {
         let encrypted_public_key =
             encrypt_extended_public_key(&shared_key, &xpub_iv, &extended_public_key);
 
-        // Validate encrypted public key size (must be exactly 96 bytes: 16-byte IV + 80-byte encrypted data)
-        if encrypted_public_key.len() != 96 {
-            return Err(Error::Generic(format!(
-                "Encrypted public key size mismatch: expected 96 bytes, got {}",
-                encrypted_public_key.len()
-            )));
-        }
-
         // Encrypt the account label if provided (includes IV prepended)
         let encrypted_account_label = if let Some(ref label) = input.account_label {
             let mut label_iv = [0u8; 16];
             rng.fill_bytes(&mut label_iv);
             let encrypted = encrypt_account_label(&shared_key, &label_iv, label);
 
-            // Validate encrypted label size (48-80 bytes: 16-byte IV + 32-64 byte encrypted data)
-            if encrypted.len() < 48 || encrypted.len() > 80 {
-                return Err(Error::Generic(format!(
-                    "Encrypted account label size out of range: expected 48-80 bytes, got {}",
-                    encrypted.len()
-                )));
-            }
             Some(encrypted)
         } else {
             None
@@ -395,66 +379,28 @@ impl Sdk {
         // Fetch DashPay contract
         let dashpay_contract = self.fetch_dashpay_contract().await?;
 
-        // Get contactRequest document type
-        let contact_request_document_type = dashpay_contract
-            .document_type_for_name("contactRequest")
-            .map_err(|_| {
-                Error::Generic("DashPay contactRequest document type not found".to_string())
-            })?;
-
         // Generate entropy for document ID
         let mut rng = StdRng::from_entropy();
         let entropy = Bytes32::random_with_rng(&mut rng);
 
-        // Generate document ID
-        let sender_id = input.sender_identity.id().to_owned();
-        let document_id = Document::generate_document_id_v0(
-            &dashpay_contract.id(),
-            &sender_id,
-            contact_request_document_type.name(),
-            entropy.as_slice(),
-        );
+        let document = build_contact_request_document(
+            &dashpay_contract,
+            ContactRequestDocumentParams {
+                sender_id: input.sender_identity.id().to_owned(),
+                recipient_id: recipient_identity.id().to_owned(),
+                sender_key_index: input.sender_key_index,
+                recipient_key_index: input.recipient_key_index,
+                account_reference: input.account_reference,
+                encrypted_public_key,
+                encrypted_account_label,
+                auto_accept_proof: input.auto_accept_proof,
+                entropy: entropy.0,
+            },
+        )?;
 
-        // Build document properties
-        let mut properties = BTreeMap::new();
-        let recipient_id = recipient_identity.id().to_owned();
-        properties.insert(
-            "toUserId".to_string(),
-            Value::Identifier(recipient_id.to_buffer()),
-        );
-        properties.insert(
-            "encryptedPublicKey".to_string(),
-            Value::Bytes(encrypted_public_key),
-        );
-        properties.insert(
-            "senderKeyIndex".to_string(),
-            Value::U32(input.sender_key_index),
-        );
-        properties.insert(
-            "recipientKeyIndex".to_string(),
-            Value::U32(input.recipient_key_index),
-        );
-        properties.insert(
-            "accountReference".to_string(),
-            Value::U32(input.account_reference),
-        );
-
-        // Add optional fields
-        if let Some(label) = encrypted_account_label {
-            properties.insert("encryptedAccountLabel".to_string(), Value::Bytes(label));
-        }
-        if let Some(proof) = input.auto_accept_proof {
-            properties.insert("autoAcceptProof".to_string(), Value::Bytes(proof));
-        }
-
-        // Return the essential fields for the contact request, including the
-        // entropy that derived `document_id` so the broadcast path can reuse it.
-        Ok(ContactRequestResult {
-            id: document_id,
-            owner_id: sender_id,
-            properties,
-            entropy,
-        })
+        // Return the assembled document together with the entropy that
+        // derived its id so the broadcast path can reuse it.
+        Ok(ContactRequestResult { document, entropy })
     }
 
     /// Send a contact request to the platform
@@ -516,30 +462,10 @@ impl Sdk {
                 Error::Generic("DashPay contactRequest document type not found".to_string())
             })?;
 
-        // Reuse the entropy that derived result.id during creation. Platform
-        // consensus recomputes the document id from this entropy and rejects the
-        // create transition unless it matches result.id, so a freshly generated
-        // entropy here would always be rejected (InvalidDocumentTransitionIdError).
+        // Reuse the entropy that derived the document id during creation:
+        // consensus recomputes the id from it and rejects a mismatch.
         let entropy = result.entropy;
-
-        // Create the document from the result
-        let document = Document::V0(DocumentV0 {
-            contract_version: None,
-            id: result.id,
-            owner_id: result.owner_id,
-            properties: result.properties,
-            revision: None,
-            created_at: None,
-            updated_at: None,
-            transferred_at: None,
-            created_at_block_height: None,
-            updated_at_block_height: None,
-            transferred_at_block_height: None,
-            created_at_core_block_height: None,
-            updated_at_core_block_height: None,
-            transferred_at_core_block_height: None,
-            creator_id: None,
-        });
+        let document = result.document;
 
         // Submit the document to the platform
         let platform_document = document
@@ -634,47 +560,48 @@ mod tests {
 
     #[test]
     fn contact_request_result_entropy_derives_returned_id() {
-        // Regression for G2 entropy mismatch: the document id returned by
-        // create_contact_request must be derivable from the entropy carried in
-        // ContactRequestResult. send_contact_request reuses ContactRequestResult::entropy
-        // when broadcasting, and platform consensus rejects the create transition
-        // (InvalidDocumentTransitionIdError) unless
-        //   generate_document_id_v0(contract, owner, "contactRequest", entropy) == base.id.
-        //
-        // Without the `entropy` field on ContactRequestResult,
-        // send_contact_request would generate fresh entropy E2 != E1 and this
-        // invariant could not even be expressed. This test pins it.
+        // send_contact_request reuses ContactRequestResult::entropy when
+        // broadcasting; consensus recomputes the document id from it and
+        // rejects the create transition on mismatch. Pin that the shared
+        // builder derives the document id from exactly that entropy.
+        use dpp::document::DocumentV0Getters;
+        use dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
+        use dpp::version::PlatformVersion;
+
         let mut rng = StdRng::seed_from_u64(0x6732_4732); // deterministic, no network
         let entropy = Bytes32::random_with_rng(&mut rng);
-
-        let contract_id = Identifier::from([1u8; 32]);
+        let contract =
+            load_system_data_contract(SystemDataContract::Dashpay, PlatformVersion::latest())
+                .expect("dashpay contract");
         let owner_id = Identifier::from([2u8; 32]);
 
-        let id = Document::generate_document_id_v0(
-            &contract_id,
-            &owner_id,
-            "contactRequest",
-            entropy.as_slice(),
-        );
+        let document = build_contact_request_document(
+            &contract,
+            ContactRequestDocumentParams {
+                sender_id: owner_id,
+                recipient_id: Identifier::from([3u8; 32]),
+                sender_key_index: 0,
+                recipient_key_index: 0,
+                account_reference: 0,
+                encrypted_public_key: vec![0u8; 96],
+                encrypted_account_label: None,
+                auto_accept_proof: None,
+                entropy: entropy.0,
+            },
+        )
+        .expect("assemble contact request");
+        let result = ContactRequestResult { document, entropy };
 
-        let result = ContactRequestResult {
-            id,
-            owner_id,
-            properties: BTreeMap::new(),
-            entropy,
-        };
-
-        // The entropy that send_contact_request will broadcast must regenerate the
-        // exact id that was returned at creation time.
         let regenerated = Document::generate_document_id_v0(
-            &contract_id,
-            &result.owner_id,
+            &contract.id(),
+            &result.document.owner_id(),
             "contactRequest",
             result.entropy.as_slice(),
         );
         assert_eq!(
-            regenerated, result.id,
-            "entropy carried in ContactRequestResult must derive the returned document id"
+            regenerated,
+            result.document.id(),
+            "entropy carried in ContactRequestResult must derive the document id"
         );
     }
 

--- a/packages/rs-sdk/src/platform/dashpay/mod.rs
+++ b/packages/rs-sdk/src/platform/dashpay/mod.rs
@@ -12,6 +12,9 @@ pub use contact_request::{
     EcdhProvider, RecipientIdentity, SendContactRequestInput, SendContactRequestResult,
 };
 pub use contact_request_queries::ContactRequestDocuments;
+pub use dash_platform_queries::dashpay::{
+    build_contact_request_document, ContactRequestDocumentParams,
+};
 
 use crate::platform::Fetch;
 use crate::{Error, Sdk};

--- a/packages/rs-sdk/src/platform/dpns_usernames/mod.rs
+++ b/packages/rs-sdk/src/platform/dpns_usernames/mod.rs
@@ -3,7 +3,8 @@ mod queries;
 
 pub use contested_queries::ContestedDpnsUsername;
 pub use dash_platform_queries::dpns_usernames::{
-    convert_to_homograph_safe_chars, is_contested_username, is_valid_username,
+    build_dpns_domain_document, build_dpns_preorder_document, convert_to_homograph_safe_chars,
+    is_contested_username, is_valid_username, salted_domain_hash,
 };
 pub use queries::DpnsUsername;
 
@@ -14,14 +15,12 @@ use dash_context_provider::ContextProvider;
 use dpp::dashcore::secp256k1::rand::rngs::StdRng;
 use dpp::dashcore::secp256k1::rand::{Rng, SeedableRng};
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
-use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
-use dpp::document::{DocumentV0, DocumentV0Getters};
+use dpp::document::DocumentV0Getters;
 use dpp::identity::accessors::IdentityGettersV0;
 use dpp::identity::signer::Signer;
 use dpp::identity::{Identity, IdentityPublicKey};
 use dpp::platform_value::{Bytes32, Value};
 use dpp::prelude::Identifier;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 fn extract_dpns_label(name: &str) -> &str {
@@ -43,14 +42,6 @@ fn extract_dpns_label(name: &str) -> &str {
 /// (e.g. `"a11ce"`).
 fn normalize_dpns_label(input: &str) -> String {
     convert_to_homograph_safe_chars(extract_dpns_label(input))
-}
-
-/// Hash a buffer twice using SHA256 (double SHA256)
-fn hash_double(data: Vec<u8>) -> [u8; 32] {
-    use dpp::dashcore::hashes::{sha256d, Hash};
-    // sha256d already does double SHA256
-    let hash = sha256d::Hash::hash(&data);
-    hash.to_byte_array()
 }
 
 /// Callback type for preorder document
@@ -164,97 +155,17 @@ impl Sdk {
         let entropy = Bytes32::random_with_rng(&mut rng);
         let salt: [u8; 32] = rng.gen();
 
-        // Generate document IDs
         let identity_id = input.identity.id().to_owned();
-        let preorder_id = Document::generate_document_id_v0(
-            &dpns_contract.id(),
-            &identity_id,
-            preorder_document_type.name(),
-            entropy.as_slice(),
-        );
-        let domain_id = Document::generate_document_id_v0(
-            &dpns_contract.id(),
-            &identity_id,
-            domain_document_type.name(),
-            entropy.as_slice(),
-        );
-
-        // Create salted domain hash for preorder
+        let preorder_document = build_dpns_preorder_document(
+            &dpns_contract,
+            identity_id,
+            &input.label,
+            salt,
+            entropy.0,
+        )?;
+        let domain_document =
+            build_dpns_domain_document(&dpns_contract, identity_id, &input.label, salt, entropy.0)?;
         let normalized_label = convert_to_homograph_safe_chars(&input.label);
-        let mut salted_domain_buffer: Vec<u8> = vec![];
-        salted_domain_buffer.extend(salt);
-        salted_domain_buffer.extend((normalized_label.clone() + ".dash").as_bytes());
-        let salted_domain_hash = hash_double(salted_domain_buffer);
-
-        // Create preorder document
-        let preorder_document = Document::V0(DocumentV0 {
-            contract_version: None,
-            id: preorder_id,
-            owner_id: identity_id,
-            properties: BTreeMap::from([(
-                "saltedDomainHash".to_string(),
-                Value::Bytes32(salted_domain_hash),
-            )]),
-            revision: None,
-            created_at: None,
-            updated_at: None,
-            transferred_at: None,
-            created_at_block_height: None,
-            updated_at_block_height: None,
-            transferred_at_block_height: None,
-            created_at_core_block_height: None,
-            updated_at_core_block_height: None,
-            transferred_at_core_block_height: None,
-            creator_id: None,
-        });
-
-        // Create domain document
-        let domain_document = Document::V0(DocumentV0 {
-            contract_version: None,
-            id: domain_id,
-            owner_id: identity_id,
-            properties: BTreeMap::from([
-                (
-                    "parentDomainName".to_string(),
-                    Value::Text("dash".to_string()),
-                ),
-                (
-                    "normalizedParentDomainName".to_string(),
-                    Value::Text("dash".to_string()),
-                ),
-                ("label".to_string(), Value::Text(input.label.clone())),
-                (
-                    "normalizedLabel".to_string(),
-                    Value::Text(normalized_label.clone()),
-                ),
-                ("preorderSalt".to_string(), Value::Bytes32(salt)),
-                (
-                    "records".to_string(),
-                    Value::Map(vec![(
-                        Value::Text("identity".to_string()),
-                        Value::Identifier(identity_id.to_buffer()),
-                    )]),
-                ),
-                (
-                    "subdomainRules".to_string(),
-                    Value::Map(vec![(
-                        Value::Text("allowSubdomains".to_string()),
-                        Value::Bool(false),
-                    )]),
-                ),
-            ]),
-            revision: None,
-            created_at: None,
-            updated_at: None,
-            transferred_at: None,
-            created_at_block_height: None,
-            updated_at_block_height: None,
-            transferred_at_block_height: None,
-            created_at_core_block_height: None,
-            updated_at_core_block_height: None,
-            transferred_at_core_block_height: None,
-            creator_id: None,
-        });
 
         // Submit preorder document first
         let platform_preorder_document = preorder_document


### PR DESCRIPTION
## Issue being fixed or feature implemented

Carries forward the pure-builder half of #4619, without that PR's request-driven `FromProof<GetDocumentsRequest>` verifier, which the SDK-first C++ embedding (next PR in this series) no longer needs: the SDK retains the rich query it built and verifies against it, so no wire request is reconstructed from bytes.

`dash-sdk`'s `register_dpns_name` and `create_contact_request` assemble DPNS and DashPay documents inline. An embedder that signs with a wallet-held key (Dash Core's platform GUI) needs the same assembly as a pure function over caller-supplied entropy, salt and ciphertexts, and must not reimplement it in C++.

## What was done?

**Pure document builders, in `dash-platform-queries`:**
- `dpns_usernames::{build_dpns_preorder_document, build_dpns_domain_document, salted_domain_hash}` and `dashpay::build_contact_request_document`, the assembly halves of `dash-sdk`'s `register_dpns_name` / `create_contact_request` as pure functions. `dash-sdk`'s networked flows now call them.
- They reuse what exists rather than re-deriving it: normalization is dpp's consensus `convert_to_homograph_safe_chars` (the crate's ASCII-only copy is replaced by a re-export); the preorder commitment uses `dpp::util::hash::hash_double`; property names come from the `dpns-contract` / `dashpay-contract` constants; the DashPay byte bounds are read from the contract schema's `DocumentPropertyType` sizes instead of being hard-coded to the same numbers.

**This is a move, not a rewrite.** The documents the builders produce are byte for byte what the inline SDK code produced. The normalization swap is the only substitution, and the two implementations agree on every label the contract's ASCII-only pattern admits — they differ only on non-ASCII input, which consensus rejects anyway. The re-export additionally makes the crate agree with the DPNS data trigger.

## Deliberately not in this PR

Two behaviour changes were dropped to keep this reviewable as a pure extraction. Both are worth doing on their own:

- **No new label validation.** An earlier revision rejected labels via `is_valid_username` before the preorder was paid for. That helper is stricter than the DPNS contract — it also refuses consecutive hyphens, which the contract's `^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$` pattern admits — so it would have refused names Platform accepts, on paths (`wasm-sdk`, `platform-wallet`) that previously had no local check at all. Failing early on a bad label is a real improvement, but it should check the contract's actual pattern, and it belongs in its own PR alongside a fix to `is_valid_username`'s docstring, which currently claims the pattern forbids consecutive hyphens.
- **No entropy/document-id check in dpp.** `dash-sdk` keeps its existing private `ensure_entropy_matches_document_id`. Hoisting it into `DocumentCreateTransitionV0::from_document` so every caller (SDK, wasm, FFI, embedders) inherits it is a good change — it cannot change any outcome, since it only refuses transitions Drive would reject after the nonce bump — but it adds an error path to a shared crate and is separable from this move.

`packages/rs-dpp` and `put_document.rs` are therefore byte-identical to `v4.2-dev` in this PR.

The `autoAcceptProof` bound is still checked in `create_contact_request` before the recipient lookup. The shared builder re-checks it against the schema, but that field is raw caller input and the lookup is a network round trip, so the early rejection is preserved. The two checks on the SDK's own encryption output are dropped as unreachable code — the pre-existing `COMPACT_XPUB_LEN` guard forces the encrypted xpub to 96 bytes, and `fit_account_label` bounds the encrypted label to 48-80 — and the builder covers both for embedders doing their own encryption.

## How Has This Been Tested?

- `dash-platform-queries`: 60 lib tests pass, including builder tests against the real DPNS/DashPay system contracts (preorder commitment matches the domain document's salt+label, id derivation, schema byte-bound enforcement).
- `dash-sdk --lib`: 187 pass. `cargo check` clean for `platform-wallet`, `rs-sdk-ffi`, `strategy-tests`, `rs-scripts`. `cargo fmt --check` clean.
- Byte-parity check: a scratch test reproduced the pre-PR inline assembly verbatim (including the old ASCII normalizer and the old `sha256d` helper) and asserted document equality against the new builders, across several DPNS labels — including `alice--bob`, `-bad` and `ab`, which the dropped gate used to reject — and a contact request with every optional field populated. All equal. Not committed; it exists only to prove the extraction.
- Not done here: a live-network run of `register_dpns_name` / `send_contact_request`. The on-wire behaviour is byte-identical by construction and the unit tests pin the property maps.

## Breaking Changes

API shape on unreleased `v4.2-dev` (not on crates.io): `dash_sdk::platform::dashpay::ContactRequestResult` now carries the assembled `document` plus `entropy` instead of `id` / `owner_id` / `properties`. No consumer outside `rs-sdk` uses it. No behavioural breaking changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helpers for creating DashPay contact request documents with encrypted-field validation.
  * Added helpers for creating DPNS preorder and domain documents, including label normalization and salted hash generation.
  * Exposed document-building utilities through the DashPay and DPNS SDK modules.

* **Improvements**
  * Contact request and DPNS registration workflows now share document construction and validation.
  * Improved handling of data contract validation errors.

* **Tests**
  * Expanded automated coverage for contact requests and DPNS document creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->