### PR TITLE
style(drive-abci): rustfmt the keep-history deletion replay test

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
@@ -406,8 +406,10 @@ mod deletion_tests {
     }
 
     #[tokio::test]
-    async fn test_document_delete_on_document_type_that_keeps_history_replays_protocol_version_13() {
-        run_document_delete_on_document_type_that_keeps_history_at_protocol_version(13, false).await;
+    async fn test_document_delete_on_document_type_that_keeps_history_replays_protocol_version_13()
+    {
+        run_document_delete_on_document_type_that_keeps_history_at_protocol_version(13, false)
+            .await;
     }
 
     /// Exercises an already-deployed contradictory contract at both sides of


### PR DESCRIPTION
## Issue being fixed or feature implemented

`cargo fmt --all -- --check` currently fails on `v4.2-dev` itself. The
`Rust wallet tests (macOS)` job runs that check before the tests, so it exits 1
after ~14s and **every PR branched off `v4.2-dev` shows red** — including ones
that touch none of the affected code.

Reproduced on a pristine `v4.2-dev` checkout with nothing else applied:

```
Diff in packages/rs-drive-abci/src/execution/validation/state_transition/
state_transitions/batch/tests/document/deletion.rs:406
```

That is the only formatting violation in the whole workspace.

## What was done?

Ran `cargo fmt --all`. The test name
`test_document_delete_on_document_type_that_keeps_history_replays_protocol_version_13`
is long enough that rustfmt wants the opening brace on its own line and the
call broken before `.await`; the merged form kept both on one line.

Pure rustfmt output — no logic, no test semantics, one file, six lines.

Introduced by 88b0427816 (#4218).

## How Has This Been Tested?

- `cargo fmt --all -- --check` — **exit 1 before, exit 0 after** ✅

The change is whitespace only, so it cannot affect behaviour; the surrounding
`deletion_tests` module is unchanged otherwise.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**

- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted a document deletion test for improved readability.
  * No functional behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->