### PR TITLE
ci: verify preinstalled macOS build dependencies

### DIFF
--- a/.github/workflows/tests-rs-wallet.yml
+++ b/.github/workflows/tests-rs-wallet.yml
@@ -88,13 +88,27 @@ jobs:
             rm -rf target
           fi
 
-      - name: Install build dependencies
+      - name: Verify build dependencies (macOS)
         run: |
-          echo "/opt/homebrew/bin" >> $GITHUB_PATH
-          echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
-          brew list cmake &>/dev/null || brew install cmake
-          brew list gmp &>/dev/null || brew install gmp
-          brew list llvm &>/dev/null || brew install llvm
+          # Persistent runners must be provisioned before accepting CI jobs.
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/opt/homebrew/opt/llvm/bin" >> "$GITHUB_PATH"
+          export PATH="/opt/homebrew/opt/llvm/bin:/opt/homebrew/bin:$PATH"
+
+          missing=0
+          for tool in cmake llvm-config; do
+            if ! "$tool" --version >/dev/null 2>&1; then
+              echo "::error::Missing or unusable $tool. Provision this dependency on the runner before running CI."
+              missing=1
+            fi
+          done
+          for library in /opt/homebrew/opt/gmp/include/gmp.h /opt/homebrew/opt/gmp/lib/libgmp.dylib /opt/homebrew/opt/llvm/lib/libclang.dylib; do
+            if [ ! -r "$library" ]; then
+              echo "::error::Missing or unreadable $library. Provision this dependency on the runner before running CI."
+              missing=1
+            fi
+          done
+          exit "$missing"
 
       - name: Setup Rust
         uses: ./.github/actions/rust

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -92,15 +92,28 @@ jobs:
             rm -rf target
           fi
 
-      - name: Install build dependencies (macOS)
+      - name: Verify build dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          echo "/opt/homebrew/bin" >> $GITHUB_PATH
-          echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
-          brew list cmake &>/dev/null || brew install cmake
-          brew list gmp &>/dev/null || brew install gmp
-          brew list llvm &>/dev/null || brew install llvm
-          brew list gnupg &>/dev/null || brew install gnupg
+          # Persistent runners must be provisioned before accepting CI jobs.
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          echo "/opt/homebrew/opt/llvm/bin" >> "$GITHUB_PATH"
+          export PATH="/opt/homebrew/opt/llvm/bin:/opt/homebrew/bin:$PATH"
+
+          missing=0
+          for tool in cmake llvm-config gpg; do
+            if ! "$tool" --version >/dev/null 2>&1; then
+              echo "::error::Missing or unusable $tool. Provision this dependency on the runner before running CI."
+              missing=1
+            fi
+          done
+          for library in /opt/homebrew/opt/gmp/include/gmp.h /opt/homebrew/opt/gmp/lib/libgmp.dylib /opt/homebrew/opt/llvm/lib/libclang.dylib; do
+            if [ ! -r "$library" ]; then
+              echo "::error::Missing or unreadable $library. Provision this dependency on the runner before running CI."
+              missing=1
+            fi
+          done
+          exit "$missing"
 
       # clang, llvm and libsnappy are installed by ./.github/actions/rust on
       # Linux; this covers what the rest of the job needs and what a bare


### PR DESCRIPTION
## Issue being fixed or feature implemented

Rust CI on persistent macOS runners runs `brew list ... || brew install ...` before testing. On `mac-runner-1b`, Homebrew fails with `Permission denied @ dir_initialize - /opt/homebrew/Library/Taps`, stopping the job before compilation. CI should verify dependencies provisioned on the runner without invoking Homebrew.

## What was done?

Replace Homebrew checks and installation fallbacks in both the workspace and wallet Rust test workflows with checks that CMake and LLVM tools run and GMP headers/libraries and libclang are readable. The workspace workflow also checks GnuPG for Codecov. Preserve Homebrew tool paths for subsequent steps and export them for the checks themselves. Missing or unusable dependencies produce explicit errors asking for runner provisioning.

## How Has This Been Tested?

- Executed both exact replacement step scripts locally on macOS with installed dependencies: passed.
- Exercised temporary fixtures for provisioned dependencies, an unusable tool, and a missing library; verified success/failure and error messages without invoking Homebrew.
- Both step scripts pass `bash -n` and ShellCheck.
- Both workflows pass actionlint with its ShellCheck integration disabled. With ShellCheck enabled, only four existing SC1083 warnings in unrelated workspace commands remain; confirmed against the base revision.
- `git diff --check` and code-review-validator review: passed.
- Verified this host is the Mac Studio registered as `mac-runner-1b`: CMake 4.4.0, LLVM 22.1.8, GnuPG 2.5.21, and GMP 6.3.0 are installed. Required executables/libraries and their directory paths permit other-user access, with no denying ACLs found. libclang loads successfully, and a C program compiled/linked with LLVM and GMP runs successfully. These execution checks ran as `dcg`; direct SSH authentication as `githubrunner` was unavailable.
- Confirmed the original failure source: `/opt/homebrew/Library/Taps` is owned by `dcg` with mode `700`, excluding the dedicated runner account. The new checks do not access that directory.
- Workflow-only change; no Rust source or build configuration changed. PR CI passed its triggered checks but skipped the Rust jobs, so execution under the runner account remains unverified.

## Breaking Changes

None. macOS runners must have their build dependencies provisioned before accepting jobs.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

This pull request was created by Codex.
