### PR TITLE
fix(platform-wallet): serialize pending crypto writes with identity removal

### DIFF
--- a/packages/rs-platform-wallet-storage/src/sqlite/schema/identities.rs
+++ b/packages/rs-platform-wallet-storage/src/sqlite/schema/identities.rs
@@ -543,7 +543,7 @@ fn managed_identity_from_entry(
 /// Insert a stub identity row (test helper) so identity_keys /
 /// dashpay_profiles can reference it via their FK. The stub carries a
 /// `null`-encoded `IdentityEntry` so `entry_blob` always decodes; real data
-/// overwrites via [`apply`].
+/// overwrites via [`apply_upserts`].
 #[cfg(any(test, feature = "__test-helpers"))]
 pub fn ensure_exists(
     conn: &Connection,

--- a/packages/rs-platform-wallet/src/wallet/identity/network/contact_info.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/contact_info.rs
@@ -381,23 +381,19 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
             op: PendingContactCryptoOp::ContactInfoDecrypt,
             enqueued_at_ms,
         };
-        {
-            let mut wm = self.wallet_manager.write().await;
-            let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) else {
-                return;
-            };
-            let Some(managed) = info.identity_manager.managed_identity_mut(owner_id) else {
-                tracing::warn!(
-                    owner = %owner_id,
-                    "contactInfo-decrypt enqueue for a non-resident identity; dropping"
-                );
-                return;
-            };
-            upsert_pending_contact_crypto(
-                managed.dashpay_pending_contact_crypto_mut(),
-                entry.clone(),
+        // Serialize the queue write with identity removal under the same guard.
+        let mut wm = self.wallet_manager.write().await;
+        let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) else {
+            return;
+        };
+        let Some(managed) = info.identity_manager.managed_identity_mut(owner_id) else {
+            tracing::warn!(
+                owner = %owner_id,
+                "contactInfo-decrypt enqueue for a non-resident identity; dropping"
             );
-        }
+            return;
+        };
+        upsert_pending_contact_crypto(managed.dashpay_pending_contact_crypto_mut(), entry.clone());
         let changeset = PlatformWalletChangeSet {
             pending_contact_crypto_added: vec![entry],
             ..Default::default()
@@ -776,5 +772,18 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
             "Published contactInfo document"
         );
         Ok(ContactInfoPublishOutcome::Published)
+    }
+}
+
+#[cfg(test)]
+mod pending_enqueue_tests {
+    #[tokio::test]
+    async fn should_serialize_contact_info_enqueue_with_identity_removal() {
+        let (iw, owner, backend) = super::super::pending_crypto_tests::fixture().await;
+        iw.dashpay().enqueue_contact_info_decrypt(&owner).await;
+        assert_eq!(backend.writes.load(std::sync::atomic::Ordering::SeqCst), 1);
+        super::super::pending_crypto_tests::remove_owner(&iw, &owner).await;
+        iw.dashpay().enqueue_contact_info_decrypt(&owner).await;
+        assert_eq!(backend.writes.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/identity/network/contact_requests.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/contact_requests.rs
@@ -1807,24 +1807,23 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
             })
             .collect();
 
-        {
-            let mut wm = self.wallet_manager.write().await;
-            let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) else {
-                return;
-            };
-            let Some(managed) = info.identity_manager.managed_identity_mut(identity_id) else {
-                tracing::warn!(
-                    owner = %identity_id,
-                    "auto-accept enqueue for a non-resident identity; dropping"
-                );
-                return;
-            };
-            for entry in &entries {
-                upsert_pending_contact_crypto(
-                    managed.dashpay_pending_contact_crypto_mut(),
-                    entry.clone(),
-                );
-            }
+        // Serialize the queue write with identity removal under the same guard.
+        let mut wm = self.wallet_manager.write().await;
+        let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) else {
+            return;
+        };
+        let Some(managed) = info.identity_manager.managed_identity_mut(identity_id) else {
+            tracing::warn!(
+                owner = %identity_id,
+                "auto-accept enqueue for a non-resident identity; dropping"
+            );
+            return;
+        };
+        for entry in &entries {
+            upsert_pending_contact_crypto(
+                managed.dashpay_pending_contact_crypto_mut(),
+                entry.clone(),
+            );
         }
         let changeset = PlatformWalletChangeSet {
             pending_contact_crypto_added: entries,
@@ -1996,26 +1995,23 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
             },
         ];
 
-        // In-memory upsert onto the owner identity's queue, under the write
-        // lock (released before persisting). All entries share this owner.
-        {
-            let mut wm = self.wallet_manager.write().await;
-            let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) else {
-                return;
-            };
-            let Some(managed) = info.identity_manager.managed_identity_mut(identity_id) else {
-                tracing::warn!(
-                    identity = %identity_id, contact = %candidate.contact_id,
-                    "deferred contact-crypto enqueue for a non-resident identity; dropping"
-                );
-                return;
-            };
-            for entry in &entries {
-                upsert_pending_contact_crypto(
-                    managed.dashpay_pending_contact_crypto_mut(),
-                    entry.clone(),
-                );
-            }
+        // Serialize the queue write with identity removal under the same guard.
+        let mut wm = self.wallet_manager.write().await;
+        let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) else {
+            return;
+        };
+        let Some(managed) = info.identity_manager.managed_identity_mut(identity_id) else {
+            tracing::warn!(
+                identity = %identity_id, contact = %candidate.contact_id,
+                "deferred contact-crypto enqueue for a non-resident identity; dropping"
+            );
+            return;
+        };
+        for entry in &entries {
+            upsert_pending_contact_crypto(
+                managed.dashpay_pending_contact_crypto_mut(),
+                entry.clone(),
+            );
         }
 
         // Persist the add-delta so the queue survives a restart. Best-effort:
@@ -5817,5 +5813,54 @@ mod drain_budget_tests {
         })
         .await;
         assert_eq!(result, None, "the step outlasted the budget");
+    }
+}
+
+#[cfg(test)]
+mod pending_enqueue_tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    #[tokio::test]
+    async fn should_serialize_deferred_enqueue_with_identity_removal() {
+        let (iw, owner, backend) = super::super::pending_crypto_tests::fixture().await;
+        let candidate = AccountBuildCandidate {
+            contact_id: Identifier::from([0xBB; 32]),
+            encrypted_public_key: vec![0; 96],
+            our_decryption_key_index: 0,
+            contact_encryption_key_index: 1,
+        };
+        iw.dashpay()
+            .enqueue_deferred_contact_crypto(&owner, &candidate)
+            .await;
+        assert_eq!(backend.writes.load(Ordering::SeqCst), 2);
+        super::super::pending_crypto_tests::remove_owner(&iw, &owner).await;
+        iw.dashpay()
+            .enqueue_deferred_contact_crypto(&owner, &candidate)
+            .await;
+        assert_eq!(backend.writes.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn should_serialize_auto_accept_enqueue_with_identity_removal() {
+        let (iw, owner, backend) = super::super::pending_crypto_tests::fixture().await;
+        let sender = Identifier::from([0xBB; 32]);
+        let mut request = ContactRequest::new(sender, owner, 0, 0, 0, vec![0; 96], 100, 0);
+        request.auto_accept_proof = Some(vec![0; 70]);
+        {
+            let mut wm = iw.wallet_manager.write().await;
+            wm.get_wallet_info_mut(&iw.wallet_id)
+                .unwrap()
+                .identity_manager
+                .managed_identity_mut(&owner)
+                .unwrap()
+                .add_incoming_contact_request(request, &iw.persister)
+                .unwrap();
+        }
+        iw.dashpay().enqueue_pending_auto_accepts(&owner).await;
+        assert_eq!(backend.writes.load(Ordering::SeqCst), 1);
+        super::super::pending_crypto_tests::remove_owner(&iw, &owner).await;
+        iw.dashpay().enqueue_pending_auto_accepts(&owner).await;
+        assert_eq!(backend.writes.load(Ordering::SeqCst), 1);
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/identity/network/mod.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/mod.rs
@@ -125,3 +125,6 @@ pub(crate) fn dashpay_contract(
     let _ = CONTRACT.set(std::sync::Arc::clone(&arc));
     Ok(CONTRACT.get().map(std::sync::Arc::clone).unwrap_or(arc))
 }
+
+#[cfg(test)]
+mod pending_crypto_tests;

--- a/packages/rs-platform-wallet/src/wallet/identity/network/pending_crypto_tests.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/pending_crypto_tests.rs
@@ -1,0 +1,109 @@
+use super::IdentityWallet;
+use crate::broadcaster::SpvBroadcaster;
+use crate::changeset::{
+    ClientStartState, PersistenceError, PlatformWalletChangeSet, PlatformWalletPersistence,
+};
+use crate::events::{EventHandler, PlatformEventHandler};
+use crate::wallet::persister::WalletPersister;
+use dpp::identity::{v0::IdentityV0, Identity};
+use dpp::prelude::Identifier;
+use key_wallet::wallet::initialization::WalletAccountCreationOptions;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+pub(super) struct CheckedPersistence {
+    check: Mutex<Option<Box<dyn Fn() + Send + Sync>>>,
+    pub writes: AtomicUsize,
+}
+
+impl PlatformWalletPersistence for CheckedPersistence {
+    fn store(
+        &self,
+        _: [u8; 32],
+        changeset: PlatformWalletChangeSet,
+    ) -> Result<(), PersistenceError> {
+        if !changeset.pending_contact_crypto_added.is_empty() {
+            self.check
+                .lock()
+                .unwrap()
+                .as_ref()
+                .expect("installed check")();
+            self.writes.fetch_add(
+                changeset.pending_contact_crypto_added.len(),
+                Ordering::SeqCst,
+            );
+        }
+        Ok(())
+    }
+    fn flush(&self, _: [u8; 32]) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+    fn load(&self) -> Result<ClientStartState, PersistenceError> {
+        Ok(ClientStartState::default())
+    }
+}
+
+struct NoopEvents;
+impl EventHandler for NoopEvents {}
+impl PlatformEventHandler for NoopEvents {}
+
+pub(super) async fn fixture() -> (
+    IdentityWallet<SpvBroadcaster>,
+    Identifier,
+    Arc<CheckedPersistence>,
+) {
+    let backend = Arc::new(CheckedPersistence::default());
+    let manager = crate::PlatformWalletManager::new(
+        Arc::new(dash_sdk::SdkBuilder::new_mock().build().unwrap()),
+        backend.clone(),
+        Arc::new(NoopEvents),
+    );
+    let wallet = manager
+        .create_wallet_from_seed_bytes(
+            key_wallet::Network::Testnet,
+            &[42; 64],
+            WalletAccountCreationOptions::None,
+            Some(0),
+        )
+        .await
+        .unwrap();
+    let iw = wallet.identity().clone();
+    let owner = Identifier::from([0xAA; 32]);
+    {
+        let mut wm = iw.wallet_manager.write().await;
+        wm.get_wallet_info_mut(&iw.wallet_id)
+            .unwrap()
+            .identity_manager
+            .add_identity(
+                Identity::V0(IdentityV0 {
+                    id: owner,
+                    public_keys: Default::default(),
+                    balance: 0,
+                    revision: 0,
+                }),
+                0,
+                iw.wallet_id,
+                &WalletPersister::new(iw.wallet_id, backend.clone()),
+            )
+            .unwrap();
+    }
+    let wm = Arc::downgrade(&iw.wallet_manager);
+    *backend.check.lock().unwrap() = Some(Box::new(move || {
+        // Removal needs this same write guard before it can persist the delete.
+        assert!(
+            wm.upgrade().unwrap().try_write().is_err(),
+            "identity removal must not overtake pending-crypto persistence"
+        );
+    }));
+    (iw, owner, backend)
+}
+
+pub(super) async fn remove_owner(iw: &IdentityWallet<SpvBroadcaster>, owner: &Identifier) {
+    let mut wm = iw.wallet_manager.write().await;
+    wm.get_wallet_info_mut(&iw.wallet_id)
+        .unwrap()
+        .identity_manager
+        .remove_identity(owner, &iw.persister)
+        .unwrap();
+}


### PR DESCRIPTION
Prevent background DashPay queue writes from leaving stale records after an identity is removed. Also repair the storage writer's rustdoc link. Follow-up to #4496.

## Issue being fixed or feature implemented

A queue write could reach storage after a concurrent identity removal had finished its cleanup. This race predates #4496; the separate documentation issue comes from the writer rename in that PR.

## What was done?

- Keep the wallet manager write guard through synchronous persistence for contact-info decrypt, auto-accept, and deferred account-build enqueue operations.
- Add deterministic tests for all three paths: removal cannot acquire the guard during queue persistence, and enqueue attempts after owner removal do not write entries.
- Point `ensure_exists` documentation to `apply_upserts`.

## How Has This Been Tested?

- Three new wallet regression tests: failed against the old guard scopes and pass with the fix.
- All 13 `sqlite_identity_hard_delete` tests pass, including V018 migration with foreign keys enabled and disabled.
- `cargo fmt -p platform-wallet -p platform-wallet-storage -- --check`
- `cargo clippy -p platform-wallet -p platform-wallet-storage --all-targets --all-features --locked -- --no-deps -D warnings`

The concurrency tests use a mock SDK and a checking persistence backend; no network is required.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing pending contact information and contact requests during identity removal.
  - Prevented stale pending-crypto updates from being written after the associated owner identity has been removed.
  - Ensured queued contact updates are processed safely and consistently during concurrent wallet operations.

- **Tests**
  - Added coverage for identity removal and pending contact-crypto persistence interactions.

- **Documentation**
  - Updated test-helper documentation to reference the current operation name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->