### PR TITLE
docs(platform): add coding conventions chapter and refresh versioning chapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Platform uses data contracts to define application data schemas:
 - Editor config: 2-space indent (4 for `*.rs`), LF, UTF‑8, final newline (`.editorconfig`).
 - JS/TS: ESLint (Airbnb/TypeScript rules via package configs). Use camelCase for variables/functions, PascalCase for classes; prefer kebab-case filenames within JS packages.
 - Rust: Follow rustfmt defaults; keep code clippy-clean. Modules `snake_case`, types `PascalCase`, constants `SCREAMING_SNAKE_CASE`.
+- Rust architecture rules live in The Dash Platform Book (`book/`). Read [book/src/contributing/coding-conventions.md](book/src/contributing/coding-conventions.md) before changing versioned behaviour, validation, errors, fees, or limits; it states each rule, why it exists, and links to the chapter with the mechanics. Key rules: shipped `vN` modules are frozen and new behaviour is a new `vN` selected only by the unreleased protocol version's tables; numbers go in `SystemLimits`, fees in named `FEE_VERSION*` schedules; `platform_version` is the last parameter; no `unwrap`/`expect` on block-execution paths (a panic halts the chain); imports at the top, no inline `crate::` paths; latest-generation tests use `PlatformVersion::latest()`.
 
 ## Testing Guidelines
 - Unit/integration tests live alongside each package (e.g., `packages/<name>/tests`). E2E lives in `packages/platform-test-suite`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,9 @@ belongs, error and panic policy, module layout, test placement) are written
 down in The Dash Platform Book under `book/`. Start with the
 [Coding Conventions](book/src/contributing/coding-conventions.md) chapter; it
 links to the chapters that explain each subsystem. Build the book locally with
-`mdbook serve book`, or read the rendered version published from the current
-dev branch by the `Deploy Book & API Docs` workflow.
+`mdbook serve book`, or read the rendered version at
+<https://dashpay.github.io/platform/>, which the `Deploy Book & API Docs`
+workflow publishes from the current dev branch.
 
 
 Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,14 @@ Please ensure that the code you write adheres to the code style adopted in the
 project, and that all linting checks are passing. We use [AirBnB
 style](https://github.com/airbnb/javascript) for JS code.
 
+For Rust, the architectural rules (protocol versioning, where validation
+belongs, error and panic policy, module layout, test placement) are written
+down in The Dash Platform Book under `book/`. Start with the
+[Coding Conventions](book/src/contributing/coding-conventions.md) chapter; it
+links to the chapters that explain each subsystem. Build the book locally with
+`mdbook serve book`, or read the rendered version published from the current
+dev branch by the `Deploy Book & API Docs` workflow.
+
 
 Testing
 -------

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ chapter in The Dash Platform Book.
   and pull requests
 - See [AGENTS.md](AGENTS.md) for a concise contributor guide covering repo
   structure, commands, style, and tests
+- Read The Dash Platform Book in [book/](book/) for the design philosophy and
+  conventions of the Rust codebase, starting with
+  [Coding Conventions](book/src/contributing/coding-conventions.md)
 - File issues and feature requests at
   [platform/issues](https://github.com/dashpay/platform/issues)
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -12,6 +12,10 @@
 - [Monorepo Overview](architecture/overview.md)
 - [Component Pipeline](architecture/component-pipeline.md)
 
+# Contributing
+
+- [Coding Conventions](contributing/coding-conventions.md)
+
 # Versioning
 
 - [Platform Version](versioning/platform-version.md)

--- a/book/src/architecture/overview.md
+++ b/book/src/architecture/overview.md
@@ -1,6 +1,6 @@
 # Monorepo Overview
 
-Dash Platform ships as a single Git repository containing 44 Rust crates, a
+Dash Platform ships as a single Git repository containing 47 Rust crates, a
 handful of JavaScript/TypeScript packages, and supporting tooling. This chapter
 maps the territory: what each crate owns, how they depend on one another, and
 where the boundaries are drawn.
@@ -17,7 +17,7 @@ a few critical external dependencies at the workspace level -- most notably
 dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "53d699c..." }
 ```
 
-The workspace version (`3.0.1` at time of writing, Rust edition 2021, MSRV
+The workspace version (`4.2.0-dev` at time of writing, Rust edition 2021, MSRV
 1.92) is shared by all member crates through `version.workspace = true`.
 
 ## The Core Dependency Chain
@@ -199,12 +199,12 @@ Several smaller crates provide cross-cutting infrastructure:
 
 The versioning backbone. Defines `PlatformVersion`, `ProtocolVersion`, and the
 version tables for every consensus-critical method across DPP, Drive, and
-Drive-ABCI. Currently tracks 12 protocol versions (v1 through v12).
+Drive-ABCI. Currently tracks 14 protocol versions (v1 through v14).
 
 ```rust
 // From packages/rs-platform-version/src/version/mod.rs
 pub type ProtocolVersion = u32;
-pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_12;
+pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_14;
 pub const INITIAL_PROTOCOL_VERSION: ProtocolVersion = 1;
 ```
 

--- a/book/src/contributing/coding-conventions.md
+++ b/book/src/contributing/coding-conventions.md
@@ -1,0 +1,496 @@
+# Coding Conventions
+
+The other chapters of this book explain how each subsystem works. This chapter
+is the prescriptive companion: the rules a change has to follow to keep the
+codebase maintainable, and the reason behind each one. Most of these rules were
+learned in code review rather than designed up front, so each entry says what
+goes wrong when the rule is skipped. Where a rule has mechanics, it links to the
+chapter that shows them.
+
+Read this before your first non-trivial PR. Skim the checklists at the end
+before every PR.
+
+## The one constraint behind every rule
+
+Dash Platform is a replicated state machine. Every masternode must produce a
+byte-identical state root for every block, including blocks from years ago that
+a fresh node replays from genesis. That means code that shipped inside a
+released protocol version must keep behaving exactly as it did on the day it
+shipped, forever, while the same binary also runs the newest behaviour for
+current blocks.
+
+Almost everything below follows from that constraint: why behaviour is split
+into frozen generations, why numbers live in version tables, why a stray
+`unwrap` is a network outage and not a bug report, and why a check has to sit
+in the right validation tier. When a rule here seems pedantic, the question to
+ask is "could two nodes disagree because of this?"
+
+## Where code goes
+
+The dependency chain is `platform-version` → `dpp` → `drive` → `drive-abci` →
+`dash-sdk`, and it only points one way (see the
+[Monorepo Overview](../architecture/overview.md)). Put a change in the lowest
+crate that has what the change needs, and no lower.
+
+| You are adding… | It lives in | Notes |
+|---|---|---|
+| A protocol type, its wire shape, or a pure-data invariant | `packages/rs-dpp` | Knows nothing about storage. Structural validation that needs only the data itself goes here. |
+| Storage layout, GroveDB operations, index maintenance, query lowering, proof generation | `packages/rs-drive` (`server` feature) | One method per directory with versioned dispatch. |
+| Proof verification a client runs | `packages/rs-drive/src/verify/` | Must compile with `--no-default-features --features verify`. |
+| A validation step that reads platform state, block execution, an ABCI handler | `packages/rs-drive-abci/src/execution/` | Handlers under `abci/` stay thin and delegate. |
+| A gRPC query handler | `packages/rs-drive-abci/src/query/<name>/` plus the proto in `packages/dapi-grpc` | Request version dispatch mirrors method version dispatch. |
+| A version number, a limit, a fee rate | `packages/rs-platform-version` | Never a literal in a method body. |
+| Client-side proof composition (`FromProof`, Tenderdash signature check) | `packages/rs-drive-proof-verifier` | Calls into `drive::verify`, never into GroveDB directly. |
+| A client API | `packages/rs-sdk` | Follow the query checklist in `packages/rs-sdk/README.md`. |
+| A JavaScript binding | `packages/wasm-dpp2`, `packages/wasm-sdk` | Mirror the Rust shape; never validate. See `packages/wasm-dpp2/CONVENTIONS.md`. |
+| Mobile orchestration (sync, identity registration, DashPay) | `packages/rs-platform-wallet` | The FFI crates and the Swift and Kotlin SDKs marshal; they do not decide. |
+
+Three boundaries are enforced by CI and worth knowing by name:
+
+- **The verify-only cut.** `packages/wasm-drive-verify` builds `drive` with
+  `default-features = false, features = ["verify"]`. Anything under
+  `src/verify/**` that reaches a `server`-gated helper breaks the JavaScript
+  build on a Rust-only PR. A helper both the prover and the verifier need goes
+  in `drive::util::common`, and the server-side code delegates to it.
+- **The transport-free cut.** `drive-proof-verifier`, `dash-platform-queries`,
+  and the wasm32 dependency trees of `dash-sdk` and `wasm-sdk` must not pull in
+  `hyper`, `rustls`, `tower`, or `mio`. Embedders with their own networking
+  consume verification through these crates, so a dependency added for
+  convenience in a shared crate can fail a job that has nothing to do with the
+  change.
+- **The wallet closure.** The wallet CI fast path compiles only the wallet
+  crates and their known dependents. Adding a dependency on a wallet crate from
+  a new place fails the build until the closure list in
+  `.github/scripts/check-wallet-closure.py` is updated deliberately.
+
+## Versioned behaviour
+
+The mechanics of `PlatformVersion`, feature version tables, and the dispatcher
+shape are covered in the [Versioning](../versioning/platform-version.md)
+chapters. The rules here are about what to do with those mechanics.
+
+### Shipped generations are frozen
+
+A behaviour change to a versioned method means a new `vN` module selected only
+by the tables of the unreleased protocol version. It never means editing a
+shipped `vN`, and that includes "harmless" edits: threading a new parameter
+through it, adding a version-table check inside it, or computing a gate that is
+always false for old versions. Inside the new generation the capability is a
+constant fact (`Index::try_from_value_map(map, true)`), not a runtime check.
+
+Why: replay safety becomes structural instead of something a reviewer has to
+prove about a diff. A dead version check inside `v1` misleads the next reader
+into thinking `v1` can take that path. Shipped files should stay byte-identical
+to what shipped.
+
+How: copy the previous generation into the new module, make the change there,
+move the tests that exercise the new behaviour into the new module, and bump
+the method's number in the new protocol version's tables only. Duplication
+between generations is the accepted cost; it is cheaper than a drift-prone
+flag.
+
+### Table versions follow protocol-version boundaries, not PRs
+
+Version-table constants (`DRIVE_ABCI_VALIDATION_VERSIONS_V10`,
+`CONTRACT_VERSIONS_V6`, `SYSTEM_LIMITS_V4`, and so on) exist to mark the point
+where a released protocol version froze them. If the unreleased protocol
+version already introduced a new table version, a second feature landing in
+the same protocol version amends that table in place. Adding another table
+version would leave one referenced by no `PLATFORM_V*` at all.
+
+Leaf implementation modules are different: each feature still gets its own new
+`vN` implementation module under the method directory. The rule is about the
+tables.
+
+### Shared helpers get a versioned method, not a capability flag
+
+When new behaviour lives in a helper reached from several generations (a value
+walker, a property-reference resolver, a shared insert path), the fix is the
+standard versioned-method pattern: an `OptionalFeatureVersion` field in the
+tables (`None` for versions that predate the feature, `Some(0)` to dispatch to
+a `_v0` implementation), and the helper takes `&PlatformVersion`. A
+`admit_property_references: bool` on a shared context struct is the wrong
+shape, because it moves the version decision away from the tables into
+whichever caller happened to set the flag.
+
+Generation-owned grammar constants may live on a per-generation struct. Feature
+gates reachable from more than one generation may not.
+
+### Numbers live in the version tables
+
+If a protocol version changes only a number (a cap, a floor, a count), the
+number goes into `SystemLimits` or the relevant `*_constants` table, and the
+versioned method reads it. Do not add a `vN` method module whose entire body is
+`return NEW_CONSTANT`.
+
+How: add the field with a doc comment naming the method version that reads it.
+Backfill every shipped `SYSTEM_LIMITS_V*` (and the mock tables under
+`version/mocks/`) with the old value so shipped protocol versions are
+behaviour-preserving. Add the next `SYSTEM_LIMITS_V{n+1}` for the unreleased
+protocol version with the new value. Keep a real method version only where the
+logic differs: in `packages/rs-dpp/src/withdrawal/daily_withdrawal_limit/`,
+`v0` computes a tiered percentage of total credits and `v2` reads
+`daily_withdrawal_limit_percent` and `max_daily_withdrawal_amount` from
+`SystemLimits`; that is a logic change and earns its own version. Raising the
+percentage later would be a table edit, not a `v3`.
+
+Why: reviewers look for limits in the tables. A constant hidden in a method
+module is a second place to check and a dead module per bump.
+
+### Fees change through named schedules
+
+A fee change for a new protocol version is a new named schedule
+(`FEE_VERSION2` in `packages/rs-platform-version/src/version/fee/v2.rs`, and
+the next one for the next protocol version) referenced from that
+`PLATFORM_V*`, with versioned fee-group constants where a group changed. Never
+inline a nested `FeeVersion { .. }` override inside the platform version
+constant. Preserve earlier schedules. If the unreleased protocol version
+already owns a new schedule, amend that schedule instead of creating another
+generation nobody references.
+
+`fee_version_number` is a separate concept from the schedule generation: it
+keys persisted fee history and storage-refund behaviour, and it is stored in
+platform state. Inspect its consumers before changing it. `FEE_VERSION1` and
+`FEE_VERSION2` both carry `fee_version_number: 1` because storage rates did not
+change between them, only a fee group did. See the
+[Fee System Overview](../fees/overview.md).
+
+### Consensus code reads the version from state
+
+`PlatformVersion::latest()` is what the binary supports. The active version is
+what the network agreed on, obtained from
+`platform_state.current_platform_version()`. During an upgrade window they
+differ. `latest()` belongs in tests and in client code that is choosing which
+format to emit; it never belongs on a path that decides what a block does.
+
+Serde-based conversions of `DataContract` read a process-wide current version
+set through `PlatformVersionCurrentVersion::set_current`. Tests that build
+platforms at different protocol versions race on it. Prefer the explicit
+`to_value(platform_version)` style API wherever a version is in hand.
+
+### Dispatcher shape
+
+The [Versioned Dispatch](../versioning/versioned-dispatch.md) chapter shows the
+canonical `match` and its rules. Three details that come up in review:
+
+- The implementation is `pub(super) fn name_v0` in `v0/mod.rs`, usually
+  `#[inline(always)]`. Nothing outside the method directory calls it.
+- The catch-all arm is `version => Err(...UnknownVersionMismatch { method,
+  known_versions, received: version })`, using the crate's own error
+  (`DriveError`, `ExecutionError`, `ProtocolError`). Optional stages add a
+  `None => Err(...VersionNotActive { .. })` arm.
+- `#[allow(clippy::too_many_arguments)]` on a dispatcher and its
+  implementations is accepted. Do not invent a one-off parameter struct only
+  to silence the lint.
+
+### `platform_version` is the last parameter
+
+The observed order in `drive` and `drive-abci` is: `&self`, domain inputs,
+`block_info`, mode flags (`apply`, `stateful`), the estimation map,
+`transaction`, the operations accumulator, `platform_version`. A new parameter
+goes up with the context items, never after `platform_version`. The same holds
+for fields on context structs such as parse contexts. The known exception is
+`previous_fee_versions`, which trails it on fee-returning methods.
+
+Why: readers of a few hundred versioned signatures expect the closing
+parameter to be the version. Appending after it breaks that scan.
+
+### Versioned types
+
+A protocol type that may evolve is an enum over per-version structs
+(`DataContract { V0(DataContractV0), V1(DataContractV1) }`) with accessor
+traits (`DataContractV0Getters`) implemented on the enum, so call sites never
+match on the variant. The serde tag for versioned enums is `$formatVersion`
+with variants renamed to `"0"`, `"1"`; `$version` is reserved for the legacy
+protocol-version fields and must not be reused. New variants are appended.
+
+The full pattern, including the derive stack and the round-trip test template,
+is in `docs/json-value-conversion-canonical-pattern.md` and the
+[Serialization](../serialization/platform-serialization.md) chapters.
+
+## Where a check belongs
+
+A new validation rule has exactly one correct tier, determined by what it needs
+to read. The [Validation Pipeline](../state-transitions/validation-pipeline.md)
+chapter walks the stages in order; this table is the placement guide.
+
+| Tier | Location | May read | Error class |
+|---|---|---|---|
+| Pure-data invariants | `rs-dpp` (`validate_basic_structure`, document type and contract self-validation) | The value itself and `PlatformVersion` | `BasicError` |
+| Basic structure | `drive-abci` `<transition>/basic_structure/vN/` | `Network` and `PlatformVersion` only | `BasicError` |
+| Signature and nonces | `drive-abci` processor traits | The signing identity, nonces | `SignatureError`, unpaid rejection |
+| Advanced structure | `drive-abci` `<transition>/advanced_structure/vN/` | The fetched `PartialIdentity`, still no Drive | `BasicError`, paid |
+| State | `drive-abci` `<transition>/state/vN/` | Drive through `PlatformRef` and the transaction | `StateError`, paid |
+| Execution | `drive` operations | GroveDB | Internal `Error` only |
+
+Rules that fall out of the table:
+
+- Basic structure runs inside `check_tx` on every mempool entry. Keep it cheap
+  and stateless. If a check needs the identity, it is advanced structure; if it
+  needs anything else from Drive, it is state.
+- Validation outcomes are `ConsensusValidationResult`, returned as `Ok`. A
+  `Result::Err` from a validation function means the node is broken, not that
+  the transition is invalid. The block loop converts it into an internal-error
+  result instead of halting, and `process_proposal` rejects any block that
+  contains one.
+- Validation lives once. `wasm-dpp2`, the SDKs, and the FFI layer never
+  duplicate a length, range, or count check that `rs-dpp` enforces, even when
+  the duplicate would give a friendlier early error. Two definitions of
+  "valid" drift the day one of them changes.
+- Consensus errors carry numeric codes in fixed bands
+  (`packages/rs-dpp/src/errors/consensus/codes.rs`): basic errors in
+  10000-19999, signature in 20000-29999, fee in 30000-39999, state in
+  40000-49999, with sub-bands per domain. A new error takes the next free code
+  in its band and is appended to its enum. See
+  [Consensus Errors](../error-handling/consensus-errors.md) and
+  [Error Codes](../error-handling/error-codes.md).
+
+## Errors, panics, and arithmetic
+
+### A panic in block execution halts the chain
+
+`packages/rs-drive-abci/src/main.rs` installs a panic hook that cancels the
+node, and there is no `catch_unwind` anywhere in the crate. A panic reachable
+from `process_proposal` or `finalize_block` is deterministic, so every
+validator hits it on the same block and the network stops. This is the
+strongest rule in the codebase:
+
+- On any path reachable from block execution, no `unwrap`, no `expect` without
+  a proof, no slice indexing without a bounds check, no `unreachable!`, no
+  division by a value that could be zero.
+- `expect` is allowed when the message states the invariant established
+  immediately above it, in the style the codebase already uses:
+  `.expect("check above enforces it exists")`,
+  `.expect("we have already shown there is 1 byte")`. If you cannot write that
+  sentence, return an error.
+- A condition that "cannot happen" but is reachable returns
+  `DriveError::CorruptedCodeExecution` (or `CriticalCorruptedState` when the
+  right response is to stall) or `ExecutionError::CorruptedCodeExecution`. See
+  [Drive Errors](../error-handling/drive-errors.md).
+- Action transformers under `state_transition_action/**/transformer.rs` run
+  before fee and funding checks, so they are the most exposed surface. Treat
+  every conversion there as untrusted input.
+
+The `*_blocking` accessors in `rs-platform-wallet` are a related hazard on the
+client side: `tokio::sync::RwLock::blocking_read` panics on a runtime worker,
+and the iOS profiles build with `panic = "abort"`. When the current thread
+may be inside a runtime, use `try_read` and return a typed busy error.
+
+### Integer arithmetic wraps in release
+
+The root `Cargo.toml` does not enable `overflow-checks`, so a release build
+wraps silently and a debug build panics. Neither is acceptable in credit, fee,
+or balance math. Use the checked forms and surface `Overflow`; `FeeResult`
+already exposes `checked_add_assign` for the common case.
+
+### Append-only structures are enforced by CI
+
+Structures marked `// @append_only` (the `drive-abci` error enums, the data
+contract error enums, document property types, storage key requirements,
+`CheckTxLevel`) accept new variants at the end and nothing else. Structures marked `// @immutable` (`Epoch`, `BlockInfo`) accept no
+change at all. The `Detect immutable structure changes` step in
+`.github/workflows/tests-rs-workspace.yml` diffs the tagged block against the
+base branch and fails the PR on a deletion or, for `@immutable`, any change.
+The reason is serialization: these types are encoded into proofs, responses,
+and stored state with positional discriminants. Reordering or removing a
+variant changes what old bytes mean.
+
+The same rule applies without a marker to anything with a `DO NOT CHANGE
+ORDER` banner, to `StateTransitionType` discriminants, and to
+`SystemDataContract` slots (note the reserved `FeatureFlags = 2`).
+
+### Consensus errors versus internal errors
+
+A `ConsensusError` is something two nodes must agree on: it is deterministic,
+carries a code, and is serialized to the client. A `ProtocolError`, `DriveError`
+or `ExecutionError` means the build is wrong, data is corrupt, or an API was
+misused. Never return a consensus error for an internal failure or an internal
+error for a user mistake; the block loop treats the two classes differently.
+
+## Module layout and style
+
+- **One method, one directory.** `method_name/mod.rs` holds the public
+  dispatcher and its doc comment; `method_name/v0/mod.rs` holds the
+  implementation. The dispatcher's doc comment has `# Parameters` and
+  `# Returns` sections. `drive` and `drive-abci` compile with
+  `#![deny(missing_docs)]`, so every public item needs a doc line.
+- **Drive's naming triad.** `*_operations` gathers `Vec<LowLevelDriveOperation>`
+  without applying anything and takes the `estimated_costs_only_with_layer_info`
+  map for dry runs; `*_apply_and_add_to_operations` appends into a caller-owned
+  accumulator and applies; the bare public method owns the accumulator and
+  returns a `FeeResult`. Keep new storage methods in this shape so cost
+  estimation and real execution share one code path. See
+  [Drive Operations](../state-transitions/drive-operations.md).
+- **Tests sit with the implementation.** A `#[cfg(test)] mod tests` block at
+  the bottom of `vN/mod.rs`, or `vN/tests/` when it outgrows the file. The
+  dispatcher's `mod.rs` may carry end-to-end tests that need every version.
+- **Imports at the top.** No fully qualified `crate::a::b::c::function(...)`
+  at a call site or in a signature. Add a `use` and call it bare, or keep at
+  most one module qualifier when the bare name would be ambiguous. Inline paths
+  are fine in doc comments and inside macros that cannot see imports.
+- **No unsafe.** `dpp`, `drive`, and `drive-abci` compile with
+  `#![forbid(unsafe_code)]`. Unsafe stays in the FFI crates and in
+  dependencies.
+- **Test-code lints are real lints.** CI runs
+  `cargo clippy --workspace --all-targets --all-features -- -D warnings`, so
+  `clippy::type_complexity` in a test helper or `&vec![..]` passed as a slice
+  in a test fails the build. `drive-abci` allows a fixed list of test lints at
+  the crate root; do not extend it for convenience.
+- **State access is snapshot-based.** `Platform.state` is an `ArcSwap`;
+  read with `load()` and pass `PlatformRef` or `PlatformStateRef` down. The
+  only locks are the ABCI application's `transaction` and
+  `block_execution_context`. In async code, a guard's scope, not a `drop()`
+  call, is what clears `clippy::await_holding_lock`; wrap the guard in a block
+  that ends before the first `.await`.
+
+## Tests
+
+- **The latest generation tests against `PlatformVersion::latest()`.** Only
+  frozen older generations pin an explicit version with
+  `PlatformVersion::get(n)`. When you introduce `v(N+1)`, that is the moment
+  to pin the now-frozen `vN` module's tests. Pinning the current generation to
+  today's number only creates churn when the next version lands.
+- **Test behaviour through the dispatcher, on both sides of the gate.** "PV13
+  rejects this query shape, PV14 accepts it" is a real test. "Slot `foo` is 0
+  in `PLATFORM_V13` and 1 in `PLATFORM_V14`" restates the table literal and
+  cannot fail without the edit being deliberate; do not write it. The
+  exception is a historical freeze test that guards a shipped on-chain table
+  with a replay rationale, like `historical_method_table_freeze` in the drive
+  document method versions.
+- **Names start with `should`**, unit tests never touch the network, and
+  randomness is seeded (`StdRng::seed_from_u64`). Platforms come from
+  `TestPlatformBuilder`; Drives come from
+  `setup_drive_with_initial_state_structure`. See
+  [Unit Tests](../testing/unit-tests.md).
+- **Multi-block behaviour is a strategy test.** Anything involving epochs,
+  upgrades, withdrawals over time, or proposer churn belongs in
+  `packages/rs-drive-abci/tests/strategy_tests/`. See
+  [Strategy Tests](../testing/strategy-tests.md).
+- **Fixtures are shared.** `rs-dpp` exposes its fixtures under the
+  `fixtures-and-mocks` feature; `rs-sdk` records test vectors from a devnet
+  and replays them offline. Add to those rather than hand-rolling payloads.
+- **Struct-literal churn is caught by `--all-targets`.** A new required field
+  compiles clean under a lib-only `cargo check` and then fails in a test module
+  in CI. After adding a field or changing a signature, run
+  `cargo check --workspace --all-targets`.
+
+## Client layers
+
+### Proof verification is layered
+
+`drive::verify` does the GroveDB work: each verifier is a method on the
+`Drive*Query` type, builds the path query with the same builder the prover
+uses, and returns `(RootHash, T)`. `drive-proof-verifier` takes the full
+`Proof` message, calls into that method, and layers the Tenderdash signature
+check on top; the `FromProof` impl is the SDK's entry point. Never call
+`GroveDb::verify_*` from the proof-verifier crate and never build the path
+query at the SDK call site; both create a "these bytes must match the prover"
+invariant that nothing checks. Entry types live in `drive` and are re-exported
+so SDK consumers need no direct `drive` dependency.
+
+### The wasm layer mirrors, it does not reshape
+
+`rs-dpp` serde defines the canonical wire shape and `wasm-dpp2` mirrors it one
+to one, differing only in primitive encoding (`Uint8Array` versus base64,
+`bigint` versus number-or-string). Sum types are internally tagged with `type`,
+never wrapped in `data`. Field-like accessors are properties, verbs are
+methods. The rules and their reasons are in `packages/wasm-dpp2/CONVENTIONS.md`
+and the [WASM](../wasm/binding-patterns.md) chapters.
+
+### FFI and mobile SDKs hold no business logic
+
+The FFI crates (`rs-sdk-ffi`, `rs-platform-wallet-ffi`, `key-wallet-ffi`) and
+the Swift and Kotlin SDKs do three things: persist Rust-emitted state, load it
+for views, and call a function that already exists in a Rust library. If the
+wrapper is deciding anything (an index, a derivation path, which key, how
+many), that decision moves into Rust, usually `rs-platform-wallet`. An FFI
+function is named for the user-facing verb (`sendContactRequest`,
+`sendToContact`), not for a cryptographic or wallet building block; DIP-14 and
+DIP-15 derivation primitives stay internal. The motivating case was a Swift
+view that iterated the gap limit, built the DIP-9 path, and pulled the mnemonic
+across the FFI twice to do what one `preview_identity_registration_keys` call
+now does.
+
+## Commits, pull requests, and what to run before pushing
+
+- **Conventional Commits, with the repository's own scope list.** Types and
+  scopes are enforced by `.github/workflows/pr.yml`. The subject starts
+  lowercase. A change that spans packages uses no scope rather than an
+  invented one (`deps` is not a scope; `rs-platform-wallet-ffi` changes use
+  `platform-wallet`).
+- **`!` means consensus-breaking.** `feat!:` and `fix!:` are reserved for
+  changes that would fork the network if rolled out unevenly: protocol rules,
+  state-transition shapes, the fee model, anything nodes must agree on.
+  Removing a public Swift symbol or an `extern "C"` function is ordinary
+  `feat:` or `refactor:` work described in the PR body.
+- **Design documents are working artifacts.** A spec or plan written to drive
+  a change stays in the working tree and is never staged. Stage with explicit
+  paths. Facts worth keeping after merge go into a code comment, a test name,
+  or the PR description.
+- **Local gate before pushing.** The exhaustive pass is CI's job; the local
+  pass is scoped to what changed:
+
+  ```bash
+  cargo fmt --all
+  cargo clippy -p <crate> --all-features --all-targets -- -D warnings
+  cargo check --workspace --all-targets          # after any field or signature change
+  cargo check -p drive --no-default-features --features verify   # when touching src/verify/**
+  cargo test -p <crate> <filter>                 # the tests for the change, not the suite
+  ```
+
+  Do not block a push on the full `drive-abci` suite; it runs for a quarter of
+  an hour and CI runs it anyway.
+
+## Checklists
+
+**Adding a new generation of a versioned method**
+
+1. Copy `vN/` to `v(N+1)/`, make the change there, leave `vN/` byte-identical.
+2. Add the `N+1 =>` arm to the dispatcher and extend `known_versions`.
+3. Bump the method's number in the unreleased protocol version's tables only.
+   If that protocol version already has a new table constant, amend it.
+4. Move or write the behaviour tests in `v(N+1)/` against
+   `PlatformVersion::latest()`; pin `vN/`'s tests to `PlatformVersion::get(n)`.
+5. Add a test that runs both versions through the dispatcher.
+
+**Changing a limit or a fee**
+
+1. A number: add or update the `SystemLimits` (or `*_constants`) field, backfill
+   shipped tables with the old value, add the next table for the unreleased
+   protocol version.
+2. A fee: add or amend the unreleased protocol version's named `FEE_VERSION*`
+   schedule; do not touch `fee_version_number` unless storage rates changed and
+   you have read its consumers.
+3. The method reads the table. No new `vN` unless the logic changed.
+
+**Adding a consensus error**
+
+1. New file under `errors/consensus/{basic,state,signature,fee}/<domain>/` with
+   the standard derive stack, private fields, `new()`, getters, and the
+   ordering banner.
+2. Append the variant to its sub-enum; add the `From` impl for
+   `ConsensusError`.
+3. Assign the next free code in the band in `codes.rs`.
+4. If JavaScript branches on it, mirror the code in
+   `packages/wasm-dpp2/src/consensus_error.rs`.
+
+**Adding a check to a state transition**
+
+1. Pick the tier from the table above by what the check reads.
+2. Put it in `<transition>/<tier>/v(N+1)/` if the transition has shipped, or
+   in the existing `vN` if that generation is still unreleased.
+3. Return it through `ConsensusValidationResult`; never `Err`.
+4. Test the rejection through `process_raw_state_transitions`, and test that
+   the previous protocol version still accepts the input.
+
+**Adding a query end to end**
+
+1. Proto message in `packages/dapi-grpc/protos/platform/v0/platform.proto`,
+   registered in `build.rs`'s versioned request and response lists.
+2. Drive query type and prover, then `drive::verify` method with its
+   `FeatureVersion` slot, with a prover-verifier round trip test.
+3. `drive-abci` handler under `query/<name>/{mod.rs,v0/}` dispatching on the
+   request version against `drive_abci.query` bounds.
+4. `drive-proof-verifier` `FromProof` wrapper, then the `rs-sdk` `Query` and
+   `Fetch`/`FetchMany` impls per the checklist in `packages/rs-sdk/README.md`.
+5. Genesis test data and a recorded test vector so the SDK test runs offline.

--- a/book/src/contributing/coding-conventions.md
+++ b/book/src/contributing/coding-conventions.md
@@ -27,8 +27,11 @@ ask is "could two nodes disagree because of this?"
 
 ## Where code goes
 
-The dependency chain is `platform-version` → `dpp` → `drive` → `drive-abci` →
-`dash-sdk`, and it only points one way (see the
+The crates are layered, and dependencies only point downward:
+`platform-version` at the bottom, then `dpp`, then `drive`. Above `drive` the
+graph forks: `drive-abci` (the node) and `dash-sdk` (the client) both depend on
+`drive`, the SDK with the `verify` feature only, and `dash-sdk` does not depend
+on `drive-abci` at all (see the
 [Monorepo Overview](../architecture/overview.md)). Put a change in the lowest
 crate that has what the change needs, and no lower.
 
@@ -483,7 +486,7 @@ now does.
 4. Test the rejection through `process_raw_state_transitions`, and test that
    the previous protocol version still accepts the input.
 
-**Adding a query end to end**
+**Adding a query end-to-end**
 
 1. Proto message in `packages/dapi-grpc/protos/platform/v0/platform.proto`,
    registered in `build.rs`'s versioned request and response lists.

--- a/book/src/contributing/coding-conventions.md
+++ b/book/src/contributing/coding-conventions.md
@@ -222,15 +222,31 @@ chapter walks the stages in order; this table is the placement guide.
 | Pure-data invariants | `rs-dpp` (`validate_basic_structure`, document type and contract self-validation) | The value itself and `PlatformVersion` | `BasicError` |
 | Basic structure | `drive-abci` `<transition>/basic_structure/vN/` | `Network` and `PlatformVersion` only | `BasicError` |
 | Signature and nonces | `drive-abci` processor traits | The signing identity, nonces | `SignatureError`, unpaid rejection |
-| Advanced structure | `drive-abci` `<transition>/advanced_structure/vN/` | The fetched `PartialIdentity`, still no Drive | `BasicError`, paid |
+| Advanced structure without state | `drive-abci` `<transition>/advanced_structure/vN/` (`validate_advanced_structure`) | The transition, the fetched `PartialIdentity`, and `PlatformVersion`; no Drive reads | `ConsensusError`, paid |
+| Advanced structure with state | `drive-abci` `batch/advanced_structure/vN/` and the per-action validators under `batch/action_validation/*/advanced_structure_vN/` (`validate_advanced_structure_from_state`) | The action produced by `transform_into_action`, including the contracts it fetched, plus block, network, and identity context; no further Drive reads in the validator | `ConsensusError`, paid |
 | State | `drive-abci` `<transition>/state/vN/` | Drive through `PlatformRef` and the transaction | `StateError`, paid |
 | Execution | `drive` operations | GroveDB | Internal `Error` only |
 
 Rules that fall out of the table:
 
 - Basic structure runs inside `check_tx` on every mempool entry. Keep it cheap
-  and stateless. If a check needs the identity, it is advanced structure; if it
-  needs anything else from Drive, it is state.
+  and stateless.
+- Advanced structure without state uses the transition and the already fetched
+  signing identity. Advanced structure with state uses data fetched by
+  `transform_into_action`, such as the contract schema carried by a document
+  action: the transformer performs the Drive reads, and the advanced validator
+  consumes the resulting action. A transition opts into the second variant
+  through `has_advanced_structure_validation_with_state`; today only `Batch`
+  does.
+- Checks that require additional Drive queries, such as uniqueness checks,
+  belong in state validation. Needing a fetched contract does not by itself
+  make a structural check a state-validation check.
+- Preserve mempool coverage. `Batch` runs advanced structure with state during
+  `check_tx`, while full state validation is skipped there
+  (`validates_full_state_on_check_tx` defaults to `false`; masternode votes
+  are the one transition that opts in, because they are unpaid). Moving a
+  contract-dependent structural check into state validation would remove that
+  rejection from mempool admission.
 - Validation outcomes are `ConsensusValidationResult`, returned as `Ok`. A
   `Result::Err` from a validation function means the node is broken, not that
   the transition is invalid. The block loop converts it into an internal-error

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -201,8 +201,8 @@ with `rs-` on disk but have shorter names in `Cargo.toml`:
 | `packages/rs-platform-serialization` | `platform-serialization` |
 | `packages/rs-drive-proof-verifier` | `drive-proof-verifier` |
 
-The workspace currently targets Rust 1.92 and protocol version 12 (as of
-v3.0.1). The workspace `Cargo.toml` lists 44 member crates, but the core
+The workspace currently targets Rust 1.92 and protocol version 14 (as of
+4.2.0-dev). The workspace `Cargo.toml` lists 47 member crates, but the core
 platform logic lives in the first eight listed above.
 
 Let's begin with the architecture.

--- a/book/src/versioning/feature-versions.md
+++ b/book/src/versioning/feature-versions.md
@@ -314,24 +314,57 @@ Compare with `state` and `transform_into_action` which are plain
 ## Non-Method Version Fields
 
 Some version structs contain values that are not method versions at all, but
-protocol parameters:
+protocol parameters. `SystemLimits` is the main one:
 
 ```rust
+// packages/rs-platform-version/src/version/system_limits/mod.rs
+
 #[derive(Clone, Debug, Default)]
 pub struct SystemLimits {
     pub estimated_contract_max_serialized_size: u16,
     pub max_field_value_size: u32,
+    /// `None` preserves the behavior of protocol versions that predate this limit.
+    pub max_document_value_depth: Option<u16>,
     pub max_state_transition_size: u64,
     pub max_transitions_in_documents_batch: u16,
     pub withdrawal_transactions_per_block_limit: u16,
+    pub retry_signing_expired_withdrawal_documents_per_block_limit: u16,
     pub max_withdrawal_amount: u64,
+    /// `None` for the protocol versions that predate the relative rule.
+    pub daily_withdrawal_limit_percent: Option<u8>,
+    pub max_daily_withdrawal_amount: Option<u64>,
+    pub min_withdrawal_amount: u64,
     pub max_contract_group_size: u16,
     pub max_token_redemption_cycles: u32,
-    // ...
+    pub max_shielded_transition_actions: u16,
+    pub max_time_range_overlap_factor: Option<u64>,
 }
 ```
 
+There are four `SYSTEM_LIMITS_V*` constants, one for each protocol version at
+which a limit changed. The `Option` fields show the idiom for a parameter that
+did not exist before some version: `None` in the tables of the versions that
+predate the rule, `Some(value)` from the version that introduced it. It is the
+parameter-shaped twin of `OptionalFeatureVersion`.
+
+The same shape recurs wherever a subsystem owns tunables:
+
 ```rust
+// drive_abci_versions/drive_abci_withdrawal_constants/mod.rs
+pub struct DriveAbciWithdrawalConstants {
+    pub core_expiration_blocks: u32,
+    pub cleanup_expired_locks_of_withdrawal_amounts_limit: u16,
+    pub total_credits_history_prune_limit: u16,
+}
+
+// drive_abci_versions/drive_abci_validation_versions/mod.rs
+pub struct PenaltyAmounts {
+    pub identity_id_not_correct: u64,
+    pub unique_key_already_present: u64,
+    // ...
+    pub shielded_proof_verification_failure: u64,
+}
+
 pub struct DriveAbciCoreChainLockMethodVersionsAndConstants {
     pub choose_quorum: FeatureVersion,
     pub verify_chain_lock: FeatureVersion,
@@ -343,7 +376,38 @@ pub struct DriveAbciCoreChainLockMethodVersionsAndConstants {
 The chain lock struct mixes method versions (`choose_quorum: FeatureVersion`)
 with protocol constants (`recent_block_count_amount: u32`). This is perfectly
 fine -- the version snapshot captures *all* protocol-specific values, whether
-they control dispatch or configure behavior.
+they control dispatch or configure behavior. Fee rates follow the same idea
+one level up: `FeeVersion` is a table of numbers, and a fee change is a new
+named `FEE_VERSION*` schedule referenced from the platform version, never an
+inline override inside `PLATFORM_V*`.
+
+### Changing a number
+
+Because parameters live in tables, changing one is a table edit and not a
+method version:
+
+1. If the field does not exist yet, add it to the struct with a doc comment
+   naming the method version that reads it.
+2. Backfill every shipped table constant (and the mock tables under
+   `version/mocks/`) with the old value, so released protocol versions keep
+   their behaviour. The compiler forces this step.
+3. Add the next table constant for the unreleased protocol version with the
+   new value, and point that version's `PLATFORM_V*` at it. If the unreleased
+   version already introduced a new table constant, edit that one in place
+   instead.
+4. Make the method read the field through `platform_version`. The method keeps
+   its version number: shipped versions read their old value from their own
+   table, so their behaviour is unchanged.
+
+Do not create a `vN` method module whose entire body returns the new
+constant. That hides a protocol parameter in an implementation file, which is
+the situation the tables exist to prevent, and it leaves a dead module behind
+every time the number moves. A new method version is warranted only when the
+*logic* changes. `daily_withdrawal_limit` in `rs-dpp` is the reference case:
+`v0` derives the limit from the current total credits, `v2` reads
+`daily_withdrawal_limit_percent` and `max_daily_withdrawal_amount` from
+`SystemLimits`. Raising the percentage later is a `SYSTEM_LIMITS_V5`, not a
+`v3`.
 
 ## How Subsystem Version Constants Compose
 
@@ -385,29 +449,82 @@ fields are `0` in every version. Larger, frequently-changing structs like
 `DRIVE_CONTRACT_METHOD_VERSIONS_V1` get their own named constant so they can
 be reused or overridden in later versions.
 
-When `DRIVE_VERSION_V6` (used in `PLATFORM_V12`) needs to change contract
-methods, it simply references `DRIVE_CONTRACT_METHOD_VERSIONS_V2` instead of
-`V1`:
+When `DRIVE_VERSION_V9` (used in `PLATFORM_V14`) needs new document method
+versions, it references `DRIVE_DOCUMENT_METHOD_VERSIONS_V4` where V8
+referenced V3, and annotates the slot:
 
 ```rust
-// packages/rs-platform-version/src/version/drive_versions/v6.rs
+// packages/rs-platform-version/src/version/drive_versions/v9.rs
 
-pub const DRIVE_VERSION_V6: DriveVersion = DriveVersion {
+pub const DRIVE_VERSION_V9: DriveVersion = DriveVersion {
     structure: DRIVE_STRUCTURE_V1,
     methods: DriveMethodVersions {
         // ...
-        contract: DRIVE_CONTRACT_METHOD_VERSIONS_V2,  // changed!
+        document: DRIVE_DOCUMENT_METHOD_VERSIONS_V4, // changed in v9: v2 index walkers + v1 update walker
+        contract: DRIVE_CONTRACT_METHOD_VERSIONS_V3, // changed in v8: count-tree-aware contract-insertion cost estimation
         // ...
-        state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V2, // also changed!
+        verify: DRIVE_VERIFY_METHOD_VERSIONS_V2, // changed in v8: compacted address-balance proof envelope
+        identity: DRIVE_IDENTITY_METHOD_VERSIONS_V2, // changed in v9: v1 withdrawal-by-transaction-index query builder
         // ...
     },
-    grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,  // unchanged
-    grove_version: GROVE_V2,  // changed!
+    grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,
+    // changed in v9: GROVE_V4 activates the indexed-tree batch cleanup
+    grove_version: GROVE_V4,
 };
 ```
 
-The unchanged parts reference the same V1 constants they always did. Only the
-parts that actually changed get new constants.
+The unchanged parts reference the same constants they always did. Only the
+parts that actually changed get new constants. `grove_version` is how GroveDB
+behaviour is versioned from Platform's side: a new `DRIVE_VERSION_V*` points
+at a new `GROVE_V*`, and every GroveDB call receives it.
+
+### Two ways to write a new table constant
+
+Older table files are full copies of the previous version with the changed
+slots edited. Newer ones use struct update syntax, so that the file *is* the
+diff:
+
+```rust
+// packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_query_versions/v3.rs
+
+/// Differs from v2 in exactly one slot:
+/// `document_query_helpers.compute_aggregate_mode_and_check_limit` is 2
+/// rather than 1. That is the boolean-`HAVING` routing gate. ...
+pub const DRIVE_ABCI_QUERY_VERSIONS_V3: DriveAbciQueryVersions = DriveAbciQueryVersions {
+    document_query_helpers: DriveAbciDocumentQueryHelperVersions {
+        compute_aggregate_mode_and_check_limit: 2,
+    },
+    ..DRIVE_ABCI_QUERY_VERSIONS_V2
+};
+```
+
+It nests, so one changed leaf deep in a table still reads as one line:
+
+```rust
+// packages/rs-platform-version/src/version/dpp_versions/dpp_validation_versions/v5.rs
+
+pub const DPP_VALIDATION_VERSIONS_V5: DPPValidationVersions = DPPValidationVersions {
+    document_type: DocumentTypeValidationVersions {
+        validate_update: 1,
+        ..DPP_VALIDATION_VERSIONS_V4.document_type
+    },
+    ..DPP_VALIDATION_VERSIONS_V4
+};
+```
+
+Use the struct update form for new table constants. Either way, the doc
+comment on the constant names the slots that differ from the previous table
+and why, in the same spirit as the `// changed:` comments on `PLATFORM_V*`.
+
+### When to create a new table constant
+
+Table constants mark the boundaries between released protocol versions. Create
+`DRIVE_ABCI_QUERY_VERSIONS_V4` when the constant you would otherwise edit is
+referenced by a *released* `PLATFORM_V*`. If the unreleased protocol version
+already introduced a new constant for that table, a second feature landing in
+the same protocol version amends it in place. Otherwise the crate accumulates
+table versions that no protocol version references, and the numbering stops
+saying anything about what shipped when.
 
 ## The File Layout
 
@@ -416,46 +533,72 @@ The version structs follow a consistent directory layout in
 
 ```
 version/
-  mod.rs                        # ProtocolVersion type alias, module declarations
+  mod.rs                        # ProtocolVersion type alias, LATEST_VERSION, module declarations
   protocol_version.rs           # PlatformVersion struct, PLATFORM_VERSIONS array, get()
-  v1.rs .. v12.rs               # PLATFORM_V* snapshot constants
+  consensus_versions.rs         # ConsensusVersions (Tenderdash consensus version)
+  feature_initial_protocol_versions.rs  # first protocol version of whole new transition kinds
+  v1.rs .. v14.rs               # PLATFORM_V* snapshot constants, one per protocol version
   drive_versions/
     mod.rs                      # DriveVersion, DriveMethodVersions, etc.
-    v1.rs .. v6.rs              # DRIVE_VERSION_V* constants
+    v1.rs .. v9.rs              # DRIVE_VERSION_V* constants
     drive_grove_method_versions/
       mod.rs                    # DriveGroveMethodVersions struct
       v1.rs                     # DRIVE_GROVE_METHOD_VERSIONS_V1
     drive_contract_method_versions/
       mod.rs                    # DriveContractMethodVersions struct
-      v1.rs, v2.rs              # versioned constants
+      v1.rs .. v3.rs            # versioned constants
+    drive_document_method_versions/
+      mod.rs
+      v1.rs .. v4.rs
+    drive_verify_method_versions/
+      mod.rs
+      v1.rs, v2.rs
     ...
   drive_abci_versions/
     mod.rs                      # DriveAbciVersion struct
     drive_abci_method_versions/
       mod.rs                    # DriveAbciMethodVersions and sub-structs
-      v1.rs .. v7.rs            # versioned constants
+      v1.rs .. v10.rs           # versioned constants
     drive_abci_validation_versions/
-      mod.rs                    # DriveAbciValidationVersions struct
-      v1.rs .. v7.rs
-    ...
+      mod.rs                    # DriveAbciValidationVersions, PenaltyAmounts, validation constants
+      v1.rs .. v10.rs
+    drive_abci_query_versions/
+      mod.rs
+      v0.rs .. v3.rs
+    drive_abci_withdrawal_constants/
+      mod.rs                    # DriveAbciWithdrawalConstants (parameters, not method versions)
+      v1.rs .. v3.rs
+    drive_abci_structure_versions/      v1.rs
+    drive_abci_checkpoint_parameters/   v1.rs
   dpp_versions/
     mod.rs                      # DPPVersion struct
     dpp_contract_versions/
       mod.rs                    # DPPContractVersions struct
-      v1.rs, v2.rs, v3.rs
+      v1.rs .. v6.rs
+    dpp_validation_versions/
+      mod.rs
+      v1.rs .. v5.rs
     ...
   fee/
-    mod.rs                      # FeeVersion struct
-    v1.rs, v2.rs
-    storage.rs, signature.rs, ...
+    mod.rs                      # FeeVersion struct, FEE_VERSIONS
+    v1.rs, v2.rs                # FEE_VERSION* schedules
+    storage/, signature/, processing/, ...   # per-group tables, each with its own v*.rs
   system_limits/
     mod.rs                      # SystemLimits struct
-    v1.rs
+    v1.rs .. v4.rs
+  system_data_contract_versions/
+    mod.rs
+    v1.rs .. v3.rs
+  mocks/
+    v2_test.rs, v3_test.rs      # TEST_PLATFORM_V* behind the mock-versions feature
 ```
 
 The pattern is: `mod.rs` defines the struct, and `v*.rs` files define the
 concrete constants. The struct definition is the *schema*. The version files
-are the *data*.
+are the *data*. Note that each table's `v*` numbering is its own:
+`DRIVE_VERSION_V9` is what `PLATFORM_V14` uses, and `SYSTEM_LIMITS_V4`
+likewise. The number says how many times that table has changed, not which
+protocol version it belongs to.
 
 ## Rules
 
@@ -465,7 +608,14 @@ are the *data*.
   in every `v*.rs` constant -- the compiler will force you.
 - Use `OptionalFeatureVersion` for features that are being introduced in a
   non-initial protocol version. Set them to `None` in earlier versions and
-  `Some(0)` in the version that introduces the feature.
+  `Some(0)` in the version that introduces the feature. Use an `Option` field
+  the same way for a parameter that did not exist before some version.
+- Declare every protocol parameter that might change (limits, penalties,
+  retention windows, fee rates) as a table field and read it through
+  `platform_version`. Change a number by adding a table version, not a method
+  version.
+- Write new table constants with struct update syntax (`..PREVIOUS`) and a doc
+  comment naming the slots that differ and why.
 - Group related methods into their own sub-struct when the parent struct
   grows too large. Follow the existing naming pattern:
   `Drive<Category>MethodVersions`.
@@ -480,3 +630,9 @@ are the *data*.
   `DRIVE_CONTRACT_METHOD_VERSIONS_V1` means something, creating a V2 that
   changes one field is correct. Silently modifying V1 is not -- it would change
   the behavior of every platform version that references it.
+- Never create a new table constant for a second change landing in the same
+  unreleased protocol version. Table versions mark released boundaries; amend
+  the unreleased version's own constant in place.
+- Never leave a `const` in an implementation file that a future protocol
+  version might want to change. Move it to the tables the first time it is
+  touched.

--- a/book/src/versioning/platform-version.md
+++ b/book/src/versioning/platform-version.md
@@ -59,19 +59,19 @@ function version so that execution is deterministic.
 ## The Version Array
 
 Each protocol version gets its own constant, defined in a separate file. At
-the time of writing, the platform has twelve versions:
+the time of writing, the platform has fourteen versions:
 
 ```rust
 // packages/rs-platform-version/src/version/mod.rs
 
 pub type ProtocolVersion = u32;
 
-pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_12;
+pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_14;
 pub const INITIAL_PROTOCOL_VERSION: ProtocolVersion = 1;
 pub const ALL_VERSIONS: RangeInclusive<ProtocolVersion> = 1..=LATEST_VERSION;
 ```
 
-These twelve snapshots are collected into a single static array in
+These fourteen snapshots are collected into a single static array in
 `protocol_version.rs`:
 
 ```rust
@@ -88,15 +88,25 @@ pub const PLATFORM_VERSIONS: &[PlatformVersion] = &[
     PLATFORM_V10,
     PLATFORM_V11,
     PLATFORM_V12,
+    PLATFORM_V13,
+    PLATFORM_V14,
 ];
 
-pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V12;
+pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V14;
 pub const DESIRED_PLATFORM_VERSION: &PlatformVersion = LATEST_PLATFORM_VERSION;
 ```
 
 The array is indexed by protocol version number minus one (since versions are
-1-indexed). `PLATFORM_V1` sits at index 0, `PLATFORM_V12` at index 11. This
+1-indexed). `PLATFORM_V1` sits at index 0, `PLATFORM_V14` at index 13. This
 simple layout is what makes the `get` function so fast.
+
+One file, one protocol version. `v14.rs` was created when the first consensus
+change after version 13 shipped needed somewhere to live, and every later
+change destined for version 14 amends that same file. The day version 14 is
+released the file freezes: from then on it is part of the chain's historical
+record, and the next consensus change creates `v15.rs`. There is never a
+`v14.rs` that means one thing on a node built last month and another on a node
+built today.
 
 ## What a Version Snapshot Looks Like
 
@@ -143,49 +153,105 @@ pub const PLATFORM_V1: PlatformVersion = PlatformVersion {
 };
 ```
 
-Now compare with `PLATFORM_V12`, the latest at the time of writing:
+Now compare with `PLATFORM_V14`, the latest at the time of writing. Every slot
+that differs from `PLATFORM_V13` carries a trailing `// changed:` comment
+saying what changed; the slots without one are inherited unchanged:
 
 ```rust
-// packages/rs-platform-version/src/version/v12.rs
+// packages/rs-platform-version/src/version/v14.rs
 
-pub const PLATFORM_V12: PlatformVersion = PlatformVersion {
-    protocol_version: PROTOCOL_VERSION_12,
-    drive: DRIVE_VERSION_V6,          // was V1
+pub const PLATFORM_V14: PlatformVersion = PlatformVersion {
+    protocol_version: PROTOCOL_VERSION_14,
+    drive: DRIVE_VERSION_V9, // changed: drive document method versions v4 (v2 index walkers, detect_ranked_mode slot)
     drive_abci: DriveAbciVersion {
         structs: DRIVE_ABCI_STRUCTURE_VERSIONS_V1,
-        methods: DRIVE_ABCI_METHOD_VERSIONS_V7,   // was V1
-        validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V7, // was V1
-        withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2,     // was V1
-        query: DRIVE_ABCI_QUERY_VERSIONS_V1,
+        methods: DRIVE_ABCI_METHOD_VERSIONS_V10, // changed: records the per-block total credits history
+        validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V10, // changed: contested-index cross-check + refersTo validation
+        withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V3, // changed: prune bound for the total credits history
+        query: DRIVE_ABCI_QUERY_VERSIONS_V3, // changed: ranked + boolean-HAVING routing gate
         checkpoints: DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1,
     },
     dpp: DPPVersion {
         costs: DPP_COSTS_VERSIONS_V1,
-        validation: DPP_VALIDATION_VERSIONS_V2,  // was V1
-        state_transitions: STATE_TRANSITION_VERSIONS_V3, // was V1
-        contract_versions: CONTRACT_VERSIONS_V3,         // was V1
-        document_versions: DOCUMENT_VERSIONS_V3,         // was V1
-        // ... other fields, some still V1, some bumped
-        methods: DPP_METHOD_VERSIONS_V2,                 // was V1
+        validation: DPP_VALIDATION_VERSIONS_V5,
+        state_transition_serialization_versions: STATE_TRANSITION_SERIALIZATION_VERSIONS_V3, // changed: documentIndexOnlyDelete joins the wire
+        state_transition_conversion_versions: STATE_TRANSITION_CONVERSION_VERSIONS_V2,
+        state_transition_method_versions: STATE_TRANSITION_METHOD_VERSIONS_V1,
+        state_transitions: STATE_TRANSITION_VERSIONS_V3,
+        contract_versions: CONTRACT_VERSIONS_V6, // changed: v3 document meta-schema (ranked, refersTo, requiredSince, timeRange)
+        document_versions: DOCUMENT_VERSIONS_V4, // changed: document serialization format 3
+        identity_versions: IDENTITY_VERSIONS_V1,
+        voting_versions: VOTING_VERSION_V2,
+        token_versions: TOKEN_VERSIONS_V2,
+        asset_lock_versions: DPP_ASSET_LOCK_VERSIONS_V1,
+        methods: DPP_METHOD_VERSIONS_V3, // changed: daily_withdrawal_limit v2
         factory_versions: DPP_FACTORY_VERSIONS_V1,
-        // ...
     },
-    fee_version: FEE_VERSION2,   // was VERSION1
+    system_data_contracts: SYSTEM_DATA_CONTRACT_VERSIONS_V3, // changed: DashPay v2 profile payment address fields
+    fee_version: FEE_VERSION2,
+    system_limits: SYSTEM_LIMITS_V4, // changed: relative daily withdrawal limit + time-range overlap cap
     consensus: ConsensusVersions {
-        tenderdash_consensus_version: 1,  // was 0
+        tenderdash_consensus_version: 1,
     },
-    // ...
 };
 ```
 
-Notice how only some subsystem versions change between V1 and V12. The query
-versions stayed at V1 across all twelve protocol versions because the query
-logic never changed. The ABCI method versions, on the other hand, went from
-V1 all the way to V7 -- seven revisions of the block processing logic.
+Notice how only some subsystem versions change between V1 and V14. The ABCI
+structure versions and checkpoint parameters are still at V1 because nothing
+in them ever changed. The ABCI method versions, on the other hand, went from
+V1 to V10 -- ten revisions of the block processing logic -- and the query
+versions from V1 to V3.
 
 This is the power of the snapshot model: **each subsystem version evolves at
 its own pace.** A new protocol version does not require bumping everything. You
 only change the sub-constants that actually differ.
+
+Two annotation conventions make a version file reviewable:
+
+- **The file's doc comment is the changelog.** `v14.rs` opens with a numbered
+  list of every consensus change the version hosts, each with a paragraph on
+  what it does and why it needed a protocol version. A change landing in the
+  unreleased version adds an item there.
+- **Every bumped slot gets a `// changed:` comment** saying what the new
+  sub-constant does differently. A reviewer reading `PLATFORM_V14` top to
+  bottom sees every behaviour difference from `PLATFORM_V13` without opening
+  another file.
+
+## What Belongs in the Snapshot
+
+The snapshot holds three kinds of values, and the third is the one people
+forget:
+
+1. **Method versions.** `FeatureVersion` numbers that select a `v0`, `v1`, ...
+   implementation. The next two chapters are about these.
+2. **Format bounds.** `FeatureVersionBounds` for serialized structures: which
+   structure versions a node accepts and which one it writes.
+3. **Protocol parameters.** Plain numbers the code reads at runtime: size
+   caps, per-block limits, penalty amounts, fee rates, retention windows,
+   expiry heights. `SystemLimits`, `FeeVersion`,
+   `DriveAbciWithdrawalConstants`, `DriveAbciValidationConstants` and
+   `PenaltyAmounts` are all tables of these.
+
+The rule for the third kind: **a constant that might change in a future
+protocol version is declared in the version tables, not in an implementation
+file.** Code reads it through `platform_version`. A `const MAX_SOMETHING: u16 =
+50;` at the top of a Drive module is a value that cannot change without
+editing shipped code, which is exactly what the versioning system exists to
+avoid. A field on `SystemLimits` can change at a protocol-version boundary
+with the old value preserved for replay.
+
+Two consequences:
+
+- Changing a number never creates a new method version. You change the table,
+  and the method that reads the table keeps its version. See
+  [Non-Method Version Fields](feature-versions.md#non-method-version-fields)
+  for the recipe.
+- Constants that genuinely cannot change stay in code: key and hash lengths,
+  encoding widths, tree key bytes, anything whose change would be a new
+  storage format rather than a new parameter. The test is whether a future
+  protocol version could plausibly want a different value. If it could, it
+  belongs in the tables from the start; moving it later means touching shipped
+  code.
 
 ## The Get Dispatch
 
@@ -209,8 +275,8 @@ impl PlatformVersion {
 }
 ```
 
-This is a simple array lookup. Protocol version 1 maps to index 0, version 12
-to index 11. If the version number is out of range, you get a clear error. No
+This is a simple array lookup. Protocol version 1 maps to index 0, version 14
+to index 13. If the version number is out of range, you get a clear error. No
 hash maps, no runtime registration, no dynamic dispatch -- just a static array
 of compile-time constants.
 
@@ -324,28 +390,39 @@ Three reasons:
 
 The cost is verbosity. Each new platform version file is large and repetitive.
 But this is a deliberate trade-off: the system favors **correctness and
-auditability** over conciseness. When you read `PLATFORM_V12`, you can see
+auditability** over conciseness. When you read `PLATFORM_V14`, you can see
 every single version number in one place. There is no mystery about what
-version 12 means.
+version 14 means.
 
 ## Rules
 
 **Do:**
 - Always pass `&PlatformVersion` (or `&DriveVersion`, etc.) to functions that
   have versioned behavior. Never hardcode a version number at a call site.
-- Use `PlatformVersion::latest()` for tests that do not care about a specific
-  version. Use `PlatformVersion::first()` when you need to test the initial
-  protocol behavior.
-- When creating a new platform version, copy the previous version file and
-  change only the constants that differ. The compiler will catch any missing
-  fields.
+- Use `PlatformVersion::latest()` for tests of the current generation. Pin an
+  explicit version with `PlatformVersion::get(n)` only for tests of a frozen,
+  older generation, and use `PlatformVersion::first()` when you need the
+  initial protocol behavior.
+- Create `vN.rs` once, when the first consensus change after version N-1
+  ships needs a home: copy the previous version file and change only the
+  constants that differ. Every later change destined for version N amends
+  that file: add a numbered item to its doc comment and a `// changed:`
+  comment on each slot it bumps.
+- Declare any constant that might change in a future protocol version in the
+  version tables (`SystemLimits`, `FeeVersion`, the `*Constants` structs) and
+  read it through `platform_version`. Keep only genuinely invariant values as
+  `const` items in implementation files.
 
 **Do not:**
 - Never mutate platform version data at runtime. The constants are `const` for
   a reason.
+- Never edit a released `vN.rs`, or any table constant it references. Once a
+  protocol version has run on the network its snapshot is part of the chain's
+  history; a change there makes a fresh node replay history differently from
+  every node that was there at the time.
 - Never add a new field to `PlatformVersion` without also updating every
   `PLATFORM_V*` constant. The compiler will enforce this, but be aware that
-  the fix is updating twelve files, not one.
+  the fix is updating fourteen files, not one.
 - Never use `PlatformVersion::latest()` in consensus-critical code paths.
   Always use the version from the current platform state, obtained via
   `platform_state.current_platform_version()`. The "latest" version is what

--- a/book/src/versioning/platform-version.md
+++ b/book/src/versioning/platform-version.md
@@ -153,9 +153,12 @@ pub const PLATFORM_V1: PlatformVersion = PlatformVersion {
 };
 ```
 
-Now compare with `PLATFORM_V14`, the latest at the time of writing. Every slot
-that differs from `PLATFORM_V13` carries a trailing `// changed:` comment
-saying what changed; the slots without one are inherited unchanged:
+Now compare with `PLATFORM_V14`, the latest at the time of writing. By
+convention, each sub-constant slot that was bumped carries a trailing
+`// changed:` comment saying what changed. The `protocol_version` field is the
+snapshot's identity and is never annotated. One bumped slot in this snapshot,
+`validation` (`DPP_VALIDATION_VERSIONS_V4` to `V5`), is missing its comment,
+which is exactly the omission the convention exists to prevent:
 
 ```rust
 // packages/rs-platform-version/src/version/v14.rs

--- a/book/src/versioning/versioned-dispatch.md
+++ b/book/src/versioning/versioned-dispatch.md
@@ -630,8 +630,8 @@ Three things to take from this:
   message. That is deliberate: a node that cannot run the agreed protocol must
   stop rather than produce a divergent state root.
 - **`perform_events_on_first_block_of_protocol_change` is where state
-  migrations live.** Anything a new protocol version needs done to the tree
-  once, before its first state transition runs, goes here: creating a new
+  migrations live.** Anything that needs to be done to the tree once for a new
+  protocol version, before its first state transition runs, goes here: creating a new
   root-tree subtree, rewriting a system contract, back-filling a sum tree.
 
 The migration hook is itself a versioned method

--- a/book/src/versioning/versioned-dispatch.md
+++ b/book/src/versioning/versioned-dispatch.md
@@ -222,6 +222,41 @@ Notice the visibility: `pub(super)`. The v0 function is only visible to its
 parent module (the dispatch file). External code calls the public dispatch
 method, never the versioned implementation directly.
 
+The layout is the versioning contract made physical, and three rules follow
+from it:
+
+- **One directory per generation, always.** A behaviour change to a versioned
+  method is a new `v1/` (or `v2/`, ...) directory with its own `mod.rs`, plus
+  a new match arm. It is never an edit inside `v0/`. That includes edits that
+  look harmless: threading a new parameter through `v0`, adding an
+  `if platform_version.protocol_version >= 14` inside it, or computing a
+  version-table gate that is always false for old versions. A shipped `vN/`
+  stays byte-identical to what shipped, so a reviewer never has to prove that
+  an in-place diff is inert for old blocks.
+- **Inside a generation, a capability is a constant fact, not a check.** If
+  `v1` admits a new keyword, `v1` admits it unconditionally
+  (`Index::try_from_value_map(map, true)`). The decision of whether the
+  keyword is allowed was made by the table that selected `v1`. Old
+  generations cannot reach the new path at all, so there is nothing for them
+  to check.
+- **Start the new generation as a copy of the old one.** Duplicate `v0/` into
+  `v1/`, rename the function, make the change, and move the tests that
+  exercise the new behaviour across. Duplication between generations is the
+  accepted cost; a shared helper with a flag is the thing it replaces.
+
+When new behaviour lives in a helper reached from several generations (a
+value walker, a property-reference resolver), the helper itself becomes a
+versioned method: an `OptionalFeatureVersion` slot in the tables (`None` for
+versions that predate the feature, `Some(0)` to dispatch to `_v0`), and the
+helper takes `&PlatformVersion`. A `bool` on a shared context struct is the
+wrong shape, because it moves the version decision from the tables to whoever
+set the flag. Per-generation grammar constants may live on a generation-owned
+struct; feature gates reachable from more than one generation may not.
+
+Tests live with the generation they test: a `#[cfg(test)] mod tests` at the
+bottom of `vN/mod.rs`, or `vN/tests/` when it grows. The dispatcher's `mod.rs`
+may carry end-to-end tests that need every generation.
+
 For state transitions in Drive ABCI, the same pattern applies but with trait
 implementations:
 
@@ -359,96 +394,141 @@ impl Drive {
 }
 ```
 
-### Step 3: Create a new subsystem version constant
+### Step 3: Bump the slot in the unreleased protocol version's tables
 
-If this is the first change in this subsystem version, create a new constant.
-For example, if grove method versions were at V1:
+The new arm is dead until a table selects it. Which table you edit depends on
+whether the unreleased protocol version already owns one.
+
+At the time of writing the latest released version is 13 and version 14 is in
+development. `PLATFORM_V14` already references `DRIVE_VERSION_V9`, which was
+created for version 14, so a version-14 change edits `v9.rs` in place:
+
+```rust
+// drive_versions/v9.rs  (existing file, amended)
+
+pub const DRIVE_VERSION_V9: DriveVersion = DriveVersion {
+    // ...
+    grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V2, // changed in v9: my_grove_operation v1
+    // ...
+};
+```
+
+`DRIVE_GROVE_METHOD_VERSIONS_V1` is referenced by released versions, so it
+cannot be edited. Create the next one with struct update syntax:
 
 ```rust
 // drive_grove_method_versions/v2.rs  (NEW file)
 
+/// Differs from v1 in one slot: `basic.my_grove_operation` is 1 rather
+/// than 0. v1 of the operation <what changed and why>.
 pub const DRIVE_GROVE_METHOD_VERSIONS_V2: DriveGroveMethodVersions =
     DriveGroveMethodVersions {
         basic: DriveGroveBasicMethodVersions {
-            my_grove_operation: 1,  // CHANGED from 0 to 1
-            grove_get_raw: 0,       // unchanged
-            grove_delete: 0,        // unchanged
-            // ... all other fields unchanged
+            my_grove_operation: 1,
+            ..DRIVE_GROVE_METHOD_VERSIONS_V1.basic
         },
-        // ... rest unchanged
+        ..DRIVE_GROVE_METHOD_VERSIONS_V1
     };
 ```
 
-### Step 4: Create a new DriveVersion constant
+Had `DRIVE_VERSION_V9` also been shared with a released version, the same
+logic would apply one level up: a new `drive_versions/v10.rs` pointing at
+`DRIVE_GROVE_METHOD_VERSIONS_V2`, and `PLATFORM_V14` pointing at
+`DRIVE_VERSION_V10`. The rule at every level is the same: **edit in place if
+the constant belongs only to the unreleased version; create the next constant
+if a released version references it.**
 
-Create a new `DriveVersion` that references the updated subsystem version:
+### Step 4: Annotate the platform version file
+
+Add or extend the `// changed:` comment on the affected slot of the unreleased
+`PLATFORM_V*`, and add a numbered item to the file's doc comment describing
+the consensus change. That doc comment is the release changelog for the
+protocol version.
+
+### Step 5: If this is the first change after a release, create the version
+
+Only the *first* consensus change after a release creates a new protocol
+version. If version 14 had already shipped, the change above would start
+version 15:
 
 ```rust
-// drive_versions/v7.rs  (NEW file)
+// version/v15.rs  (NEW file, copied from v14.rs)
 
-pub const DRIVE_VERSION_V7: DriveVersion = DriveVersion {
-    grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V2,  // CHANGED
-    // ... everything else unchanged from V6
+pub const PROTOCOL_VERSION_15: ProtocolVersion = 15;
+
+/// v15 hosts one consensus change so far:
+///
+/// 1. **my_grove_operation v1**: ...
+pub const PLATFORM_V15: PlatformVersion = PlatformVersion {
+    protocol_version: PROTOCOL_VERSION_15,
+    drive: DRIVE_VERSION_V10, // changed: my_grove_operation v1
+    // ... everything else unchanged from V14
 };
 ```
 
-### Step 5: Create a new PlatformVersion
-
-Create the new platform version snapshot that references the new drive version:
-
-```rust
-// version/v13.rs  (NEW file)
-
-pub const PROTOCOL_VERSION_13: ProtocolVersion = 13;
-
-pub const PLATFORM_V13: PlatformVersion = PlatformVersion {
-    protocol_version: PROTOCOL_VERSION_13,
-    drive: DRIVE_VERSION_V7,  // CHANGED
-    // ... everything else unchanged from V12
-};
-```
-
-### Step 6: Register the new version
-
-Add `PLATFORM_V13` to the `PLATFORM_VERSIONS` array and update the version
-constants:
+Then register it:
 
 ```rust
 // version/mod.rs
-pub mod v13;
+pub mod v15;
+pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_15;
 
 // version/protocol_version.rs
 pub const PLATFORM_VERSIONS: &[PlatformVersion] = &[
     PLATFORM_V1,
     // ...
-    PLATFORM_V12,
-    PLATFORM_V13,  // NEW
+    PLATFORM_V14,
+    PLATFORM_V15,  // NEW
 ];
 
-pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V13;
+pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V15;
 ```
 
-### Step 7: Write tests
+A test in `system_limits/mod.rs` asserts that `PLATFORM_VERSIONS.len()`
+equals `LATEST_VERSION`, so a version that is declared but not registered
+fails the test run rather than silently resolving to the previous one. Every
+subsequent change destined for version 15 amends `v15.rs` and the constants it
+introduced, as in step 3.
 
-Test both the old and new behavior:
+### Step 6: Write tests
+
+Test both generations through the dispatcher, and put each test with the
+generation it exercises:
 
 ```rust
-#[test]
-fn test_my_grove_operation_v0() {
-    let platform_version = PlatformVersion::first();
-    // ... assert v0 behavior
+// my_grove_operation/v1/mod.rs
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn should_apply_new_behaviour() {
+        let platform_version = PlatformVersion::latest();
+        // ... drive.my_grove_operation(..., &platform_version.drive)
+    }
 }
 
-#[test]
-fn test_my_grove_operation_v1() {
-    let platform_version = PlatformVersion::latest();
-    // ... assert v1 behavior
+// my_grove_operation/v0/mod.rs
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn should_keep_old_behaviour() {
+        // frozen generation: pin the last protocol version that selected it
+        let platform_version = PlatformVersion::get(13).expect("known version");
+        // ...
+    }
 }
 ```
+
+The current generation tests against `PlatformVersion::latest()` so it keeps
+tracking the tip; the moment `v1` is introduced is the moment `v0`'s tests get
+pinned to an explicit version. Do not write a test that merely asserts the
+table slot's value (`assert_eq!(PLATFORM_V14.drive.grove_methods.basic.my_grove_operation, 1)`);
+it restates the literal and cannot fail without the edit being deliberate. A
+behaviour test that runs both versions through the dispatcher pins the gate
+meaningfully.
 
 This is a lot of steps, but each one is mechanical and the compiler guides you
 through most of it. If you add a field to a version struct and forget to set it
-in one of the twelve (now thirteen) platform version constants, the build fails.
+in one of the fourteen platform version constants, the build fails.
 
 ## Passing Version References
 
@@ -477,10 +557,10 @@ Here is how the version flows through a real execution path:
 Block arrives from Tenderdash
     |
     v
-PlatformState has the current protocol_version (e.g., 12)
+PlatformState has the current protocol_version (e.g., 14)
     |
     v
-PlatformVersion::get(12) -> &PLATFORM_V12
+PlatformVersion::get(14) -> &PLATFORM_V14
     |
     v
 process_raw_state_transitions(&platform_version)
@@ -506,6 +586,105 @@ The protocol version number enters at the top and the correct implementation
 is selected at every level. No function chooses its own version -- it is always
 determined by the version reference passed from above.
 
+## The First Block of a New Protocol Version
+
+The version flow above assumes the protocol version is already known. The
+switch itself happens in `run_block_proposal`
+(`packages/rs-drive-abci/src/execution/engine/run_block_proposal/mod.rs`).
+On the first block of an epoch, if the protocol version the network locked in
+during the previous epoch differs from the one in consensus, the block runs
+under the new version:
+
+```rust
+// abbreviated
+let block_platform_version = if epoch_info.is_epoch_change_but_not_genesis()
+    && platform_state.next_epoch_protocol_version()
+        != platform_state.current_protocol_version_in_consensus()
+{
+    let next_protocol_version = platform_state.next_epoch_protocol_version();
+
+    // We should panic if this node is not supported a new protocol version
+    let Ok(next_platform_version) = PlatformVersion::get(next_protocol_version) else {
+        panic!("Failed to upgrade the network protocol version {next_protocol_version}. ...");
+    };
+
+    let old_protocol_version = block_platform_state.current_protocol_version_in_consensus();
+    block_platform_state.set_current_protocol_version_in_consensus(next_protocol_version);
+
+    // This is for events like adding stuff to the root tree, or making structural changes/fixes
+    self.perform_events_on_first_block_of_protocol_change(
+        platform_state, &block_info, transaction, old_protocol_version, next_platform_version,
+    )?;
+
+    next_platform_version
+} else {
+    last_committed_platform_version
+};
+```
+
+Three things to take from this:
+
+- **Epoch info is computed with the old version**, before the switch. The new
+  version applies to everything after it.
+- **A binary that does not know the new version panics** with an upgrade
+  message. That is deliberate: a node that cannot run the agreed protocol must
+  stop rather than produce a divergent state root.
+- **`perform_events_on_first_block_of_protocol_change` is where state
+  migrations live.** Anything a new protocol version needs done to the tree
+  once, before its first state transition runs, goes here: creating a new
+  root-tree subtree, rewriting a system contract, back-filling a sum tree.
+
+The migration hook is itself a versioned method
+(`drive_abci.methods.protocol_upgrade.perform_events_on_first_block_of_protocol_change`:
+`None` in the earliest method tables, `Some(0)` once the first migration
+existed, `Some(1)` in the two most recent tables). Its `v0` is a ladder of
+guarded rungs, one per protocol version that needed a migration:
+
+```rust
+// packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/
+//   perform_events_on_first_block_of_protocol_change/v0/mod.rs
+
+if previous_protocol_version < 4 && platform_version.protocol_version >= 4 {
+    self.transition_to_version_4(platform_state, block_info, transaction, platform_version)?;
+}
+if previous_protocol_version < 6 && platform_version.protocol_version >= 6 {
+    self.transition_to_version_6(block_info, transaction, platform_version)?;
+}
+// ... 8, 9, 11, 12, 13 ...
+if previous_protocol_version < 14 && platform_version.protocol_version >= 14 {
+    self.transition_to_version_14(block_info, transaction, platform_version)?;
+}
+```
+
+The guard shape matters. A node can cross more than one protocol version in a
+single switch (a network that skipped a version, or a devnet started at an old
+one), and the `previous < N && new >= N` form runs every rung it crossed, in
+order. A rung written as `new == N` would be skipped by such a node, and its
+state tree would be missing a subtree every other node has.
+
+`v1` exists because the migrations write system contracts through a path that
+bypasses the drive operation batch's cache invalidation; it runs the same
+ladder and then refreshes the cached contract definitions so that a validator
+with a warm cache and one with a cold cache serialize the same bytes. Read its
+doc comment before touching the hook: it is a worked example of a
+consensus-critical cache bug.
+
+To add a migration for a new protocol version: add a rung at the bottom of the
+ladder in the current generation of the hook, guarded by that version, with a
+`transition_to_version_N` helper next to the others. A failure in a rung
+returns `Err` from block processing on every node, so a rung either succeeds
+deterministically or halts the network. The version 8 rung's `or_else` that
+logs and continues is the exception for a migration that does not touch the
+state structure, not a pattern to copy.
+
+Whole new state transition kinds are gated separately, by the `is_allowed`
+stage of the validation pipeline reading the constants in
+`feature_initial_protocol_versions.rs`
+(`ADDRESS_FUNDS_INITIAL_PROTOCOL_VERSION = 11`,
+`SHIELDED_POOL_INITIAL_PROTOCOL_VERSION = 12`). A transition submitted before
+its initial version is rejected with a `StateTransitionNotActiveError` rather
+than an unknown-version dispatch error.
+
 ## Rules
 
 **Do:**
@@ -517,8 +696,15 @@ determined by the version reference passed from above.
   version 2, the vector should be `vec![0, 1, 2]`.
 - Make versioned implementation methods `pub(super)` -- visible to the dispatch
   module but not to external code.
-- Keep v0 code intact when adding v1. Never modify an existing version's
-  implementation. Copy it, rename it, and make your changes in the new version.
+- Put every new generation in its own `vN/` directory, started as a copy of
+  the previous one, with its tests inside it.
+- Bump the slot in the unreleased protocol version's tables only: amend a
+  constant that only the unreleased version references, create the next
+  constant when a released version references it.
+- Test the current generation against `PlatformVersion::latest()` and pin the
+  previous generation's tests to the last protocol version that selected it.
+- Put one-time state changes a protocol version needs in a guarded rung of
+  `perform_events_on_first_block_of_protocol_change`.
 
 **Do not:**
 - Never call a versioned implementation directly (e.g., `grove_get_raw_v0`).
@@ -530,6 +716,11 @@ determined by the version reference passed from above.
 - Never use `_ =>` as the catch-all arm in a version dispatch. Always use
   `version =>` so the variable is available for the error message. And never
   silently ignore unknown versions -- always return an error.
-- Never change the signature of an existing version's function after it has
-  been released to the network. If v0 takes five parameters and v1 needs six,
-  that is fine -- v0 keeps its original signature forever.
+- Never modify a shipped generation, not even by threading a parameter or a
+  version check through it. If v0 takes five parameters and v1 needs six,
+  that is fine -- v0 keeps its original signature and body forever.
+- Never gate new behaviour with a `bool` on a shared context struct. A helper
+  reached from several generations gets an `OptionalFeatureVersion` slot and
+  takes `&PlatformVersion`.
+- Never write a test that only asserts a table slot's value. Test the
+  behaviour through the dispatcher on both sides of the gate.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,15 +1,17 @@
 # Repository documentation
 
 Several of the packages in this repository contain developer documentation. This
-folder is used to aggregate docs from several packages and then produce a
-consolidated [GitHub Pages site](https://dashpay.github.io/platform/) using
-MkDocs. The GitHub workflow described in [docs.yml](/.github/workflows/docs.yml)
-builds the documents and publishes them.
+folder is used to aggregate docs from several packages into one MkDocs site
+that can be served locally (see below).
 
-The architecture and conventions guide for the Rust codebase is a separate
-mdBook under [`book/`](/book/), published by
-[book.yml](/.github/workflows/book.yml). Contributors should start with its
-[Coding Conventions](/book/src/contributing/coding-conventions.md) chapter.
+The published [GitHub Pages site](https://dashpay.github.io/platform/) is built
+by [book.yml](/.github/workflows/book.yml) from the current dev branch. It
+serves The Dash Platform Book, the architecture and conventions guide for the
+Rust codebase (source under [`book/`](/book/)), at its root, with the generated
+Rust, gRPC and JavaScript API references under `/api/`. Contributors should
+start with the book's
+[Coding Conventions](https://dashpay.github.io/platform/contributing/coding-conventions.html)
+chapter (source: [`book/src/contributing/coding-conventions.md`](/book/src/contributing/coding-conventions.md)).
 
 ## Viewing documentation locally
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,11 @@ consolidated [GitHub Pages site](https://dashpay.github.io/platform/) using
 MkDocs. The GitHub workflow described in [docs.yml](/.github/workflows/docs.yml)
 builds the documents and publishes them.
 
+The architecture and conventions guide for the Rust codebase is a separate
+mdBook under [`book/`](/book/), published by
+[book.yml](/.github/workflows/book.yml). Contributors should start with its
+[Coding Conventions](/book/src/contributing/coding-conventions.md) chapter.
+
 ## Viewing documentation locally
 
 You can use [MkDocs](https://www.mkdocs.org/getting-started/) to serve the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Dash Platform Book under `book/` is the codebase's architecture and conventions guide, but nothing in `README.md`, `CONTRIBUTING.md`, `AGENTS.md` or `docs/README.md` links to it, so contributors do not find it. It also had two gaps:

- No prescriptive chapter for the rules that are enforced in review (frozen `vN` generations, where limits and fees live, validation tier placement, panic policy, test placement). Those rules existed only as review history.
- The versioning chapters were written at protocol version 12, and their "how to add a new version" walkthrough told readers to create a new table constant and a new `PLATFORM_V*` on every change, which contradicts current practice of amending the unreleased protocol version's tables in place.

## What was done?
<!--- Describe your changes in detail -->

**New chapter: `book/src/contributing/coding-conventions.md`** (registered in `SUMMARY.md` under a new Contributing section)
- Where code goes: crate placement table plus the three CI-enforced cuts (verify-only `drive`, transport-free proof verification, wallet closure).
- Versioned behaviour: shipped `vN` modules are frozen and new behaviour is a new `vN`; table versions follow protocol-version boundaries, not PRs; shared helpers get an `OptionalFeatureVersion` slot, not a capability flag; numbers live in `SystemLimits`; fees change through named `FEE_VERSION*` schedules; consensus code reads the version from state; `platform_version` is the last parameter.
- Where a check belongs: validation tier table (dpp structural, basic structure, advanced structure, state) with what each may read and its error class.
- Errors, panics and arithmetic: a panic in block execution halts the chain, `expect` only with a stated invariant, wrapping arithmetic in release, `@append_only` / `@immutable` CI gate.
- Module layout, tests, client layers (proof verification layering, wasm mirror rule, no business logic in FFI or mobile SDKs), commit and PR conventions, the local pre-push gate, and five checklists.

**Versioning chapters refreshed to protocol version 14**
- `platform-version.md`: fourteen-version array, `PLATFORM_V14` with its real `// changed:` annotations, the doc-comment-as-changelog convention, and a new section stating that any constant which might change in a future protocol version is declared in the version tables rather than in an implementation file.
- `feature-versions.md`: current `SystemLimits` and the `Option` idiom for parameters that predate a rule, the other `*Constants` tables, a "changing a number" recipe (backfill shipped tables, add the next table, method reads it, no `vN` that returns a constant), the struct-update form for new table constants (`..PREVIOUS`), when to create a new table constant, and the current file layout.
- `versioned-dispatch.md`: the directory convention now states one `vN/` directory per generation with no edits to shipped ones; the walkthrough's steps 3 to 5 reconciled with the table rule using `DRIVE_VERSION_V9` / version 14 as the worked example; a new section on the first block of a new protocol version (`run_block_proposal` switch, the upgrade panic, the guarded migration ladder in `perform_events_on_first_block_of_protocol_change`, `feature_initial_protocol_versions.rs`); tests: current generation on `PlatformVersion::latest()`, frozen generation pinned, no table-literal tests.
- `introduction.md` and `architecture/overview.md`: protocol version, workspace version and crate count brought current.

**Discoverability**
- `CONTRIBUTING.md`, `README.md`, `AGENTS.md` (`CLAUDE.md` is a symlink to it) and `docs/README.md` now link to the book and the new chapter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Documentation only; no code changes.

- `mdbook build book` succeeds, and every cross-chapter link plus the new intra-book anchor resolves in the built output.
- Every file path, constant name, version-table slot and behaviour cited in the new and updated chapters was checked against the tree at this commit.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a Coding Conventions chapter covering Rust architecture, versioning, validation, errors, testing, and contribution practices.
  - Updated contributor guidance and repository documentation to link to the architecture and conventions guide.
  - Expanded versioning documentation with guidance for platform versions, immutable generations, limits, fees, migrations, and testing.
  - Updated architecture references to reflect protocol version 14, workspace version 4.2.0-dev, and 47 crates.
  - Clarified documentation site structure, published resources, and generated API references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->