### PR TITLE
fix(platform-wallet): support HASH160 DashPay profile signing keys

### DIFF
--- a/packages/rs-platform-wallet/src/wallet/identity/network/profile.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/profile.rs
@@ -6,9 +6,9 @@ use dpp::document::DocumentV0Getters;
 use dpp::identity::accessors::IdentityGettersV0;
 use dpp::identity::identity_public_key::Purpose;
 use dpp::identity::signer::Signer;
-use dpp::identity::IdentityPublicKey;
 use dpp::identity::KeyType;
 use dpp::identity::SecurityLevel;
+use dpp::identity::{Identity, IdentityPublicKey};
 use dpp::platform_value::Value;
 use dpp::prelude::Identifier;
 
@@ -16,6 +16,17 @@ use super::*;
 use crate::broadcaster::TransactionBroadcaster;
 use crate::error::PlatformWalletError;
 use crate::wallet::identity::{ContactProfileEntry, DashPayProfile};
+
+// Profile documents require HIGH or CRITICAL authentication; MASTER is reserved
+// for identity operations and cannot authorize an ordinary document write.
+fn profile_signing_key(identity: &Identity) -> Option<&IdentityPublicKey> {
+    identity.get_first_public_key_matching(
+        Purpose::AUTHENTICATION,
+        [SecurityLevel::HIGH, SecurityLevel::CRITICAL].into(),
+        [KeyType::ECDSA_SECP256K1, KeyType::ECDSA_HASH160].into(),
+        false,
+    )
+}
 
 // ---------------------------------------------------------------------------
 // Sync profiles
@@ -109,8 +120,8 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
     ///
     /// Mirrors [`Self::create_profile`] but signing is routed through
     /// the supplied `&S: Signer<IdentityPublicKey>`. The signing key
-    /// is still resolved from the identity's `public_keys` map (first
-    /// AUTHENTICATION key, matching the legacy variant) — the signer
+    /// is resolved from the identity's active HIGH or CRITICAL ECDSA
+    /// authentication keys (full public key or HASH160) — the signer
     /// is responsible for producing a signature for whatever key is
     /// picked.
     ///
@@ -172,20 +183,7 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
                 .identity_manager
                 .managed_identity(identity_id)
                 .ok_or(PlatformWalletError::IdentityNotFound(*identity_id))?;
-            managed
-                .identity
-                // DashPay profile create/update writes a document state
-                // transition, which DPP requires to be signed by a
-                // HIGH-or-stricter authentication key. MASTER is
-                // intentionally excluded — it's reserved for identity
-                // self-modification (update / key rotation /
-                // withdrawal) and rejected on document writes.
-                .get_first_public_key_matching(
-                    Purpose::AUTHENTICATION,
-                    [SecurityLevel::HIGH, SecurityLevel::CRITICAL].into(),
-                    [KeyType::ECDSA_SECP256K1].into(),
-                    false,
-                )
+            profile_signing_key(&managed.identity)
                 .cloned()
                 .ok_or_else(|| {
                     PlatformWalletError::InvalidIdentityData(
@@ -334,20 +332,7 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
                 .identity_manager
                 .managed_identity(identity_id)
                 .ok_or(PlatformWalletError::IdentityNotFound(*identity_id))?;
-            managed
-                .identity
-                // DashPay profile create/update writes a document state
-                // transition, which DPP requires to be signed by a
-                // HIGH-or-stricter authentication key. MASTER is
-                // intentionally excluded — it's reserved for identity
-                // self-modification (update / key rotation /
-                // withdrawal) and rejected on document writes.
-                .get_first_public_key_matching(
-                    Purpose::AUTHENTICATION,
-                    [SecurityLevel::HIGH, SecurityLevel::CRITICAL].into(),
-                    [KeyType::ECDSA_SECP256K1].into(),
-                    false,
-                )
+            profile_signing_key(&managed.identity)
                 .cloned()
                 .ok_or_else(|| {
                     PlatformWalletError::InvalidIdentityData(
@@ -800,6 +785,86 @@ mod tests {
     use super::*;
     use crate::wallet::identity::ProfileUpdate;
     use std::collections::BTreeMap;
+
+    use dpp::identity::identity_public_key::v0::IdentityPublicKeyV0;
+    use dpp::version::PlatformVersion;
+
+    fn profile_key(key_type: KeyType, security_level: SecurityLevel) -> IdentityPublicKeyV0 {
+        IdentityPublicKeyV0 {
+            id: 1,
+            purpose: Purpose::AUTHENTICATION,
+            security_level,
+            key_type,
+            data: vec![1; key_type.default_size()].into(),
+            ..Default::default()
+        }
+    }
+
+    fn identity_with_key(key: IdentityPublicKeyV0) -> Identity {
+        let mut identity = Identity::default_versioned(PlatformVersion::latest()).unwrap();
+        identity.add_public_key(key.into());
+        identity
+    }
+
+    #[test]
+    fn should_select_high_and_critical_ecdsa_profile_keys() {
+        for key_type in [KeyType::ECDSA_SECP256K1, KeyType::ECDSA_HASH160] {
+            for level in [SecurityLevel::HIGH, SecurityLevel::CRITICAL] {
+                let identity = identity_with_key(profile_key(key_type, level));
+                assert!(
+                    profile_signing_key(&identity).is_some(),
+                    "{key_type:?}/{level:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn should_reject_ineligible_profile_keys() {
+        let empty = Identity::default_versioned(PlatformVersion::latest()).unwrap();
+        assert!(profile_signing_key(&empty).is_none());
+        for key_type in [
+            KeyType::BLS12_381,
+            KeyType::BIP13_SCRIPT_HASH,
+            KeyType::EDDSA_25519_HASH160,
+        ] {
+            assert!(profile_signing_key(&identity_with_key(profile_key(
+                key_type,
+                SecurityLevel::HIGH
+            )))
+            .is_none());
+        }
+        for key_type in [KeyType::ECDSA_SECP256K1, KeyType::ECDSA_HASH160] {
+            for level in [SecurityLevel::MASTER, SecurityLevel::MEDIUM] {
+                assert!(
+                    profile_signing_key(&identity_with_key(profile_key(key_type, level))).is_none()
+                );
+            }
+            let mut key = profile_key(key_type, SecurityLevel::HIGH);
+            key.disabled_at = Some(1);
+            assert!(profile_signing_key(&identity_with_key(key)).is_none());
+            let mut key = profile_key(key_type, SecurityLevel::CRITICAL);
+            key.purpose = Purpose::TRANSFER;
+            assert!(profile_signing_key(&identity_with_key(key)).is_none());
+        }
+    }
+
+    #[test]
+    fn should_select_high_hash160_from_reported_identity_layout() {
+        let mut identity =
+            identity_with_key(profile_key(KeyType::ECDSA_HASH160, SecurityLevel::HIGH));
+        let mut master = profile_key(KeyType::ECDSA_HASH160, SecurityLevel::MASTER);
+        master.id = 0;
+        identity.add_public_key(master.into());
+        let mut transfer = profile_key(KeyType::ECDSA_HASH160, SecurityLevel::CRITICAL);
+        transfer.id = 2;
+        transfer.purpose = Purpose::TRANSFER;
+        identity.add_public_key(transfer.into());
+        assert_eq!(
+            profile_signing_key(&identity),
+            identity.public_keys().get(&1)
+        );
+    }
 
     fn existing_full() -> BTreeMap<String, Value> {
         let mut m = BTreeMap::new();


### PR DESCRIPTION
## TL;DR

Allow users whose identity uses hashed ECDSA keys to create and update their DashPay profile.

## User story

As a wallet user, I can save my profile with my existing identity keys.

## Scenario

An identity has a master authentication key, a high-security authentication key, and a transfer key, all stored as public-key hashes. Profile writes currently fail with a missing-authentication-key error. The high-security key should authorize the write.

## Detailed discussion

### Issue being fixed or feature implemented

Related to dashpay/dash-evo-tool#760. The platform-wallet external-signer profile paths restrict eligible keys to ECDSA_SECP256K1, excluding ECDSA_HASH160 before invoking the signer.

### Specification rationale and DIP scope

[DIP-15, Creating a Profile](https://github.com/dashpay/dips/blob/master/dip-0015.md#creating-a-profile) calls for the normal procedure of:

> creating and publishing a document create transition

[Updating a Profile](https://github.com/dashpay/dips/blob/master/dip-0015.md#updating-a-profile) likewise refers to:

> creating and publishing a document replace transition

These sections delegate profile publication to Platform's document-transition rules; they introduce no profile-specific signing-key type restriction.

[DIP-11, Encryption Keys](https://github.com/dashpay/dips/blob/master/dip-0011.md#encryption-keys) distinguishes signing from encryption:

> Encryption and decryption keys are not valid for document signing.

The secp256k1 ECDH requirements in [DIP-15, Creating a Contact Request, steps 3–5](https://github.com/dashpay/dips/blob/master/dip-0015.md#creating-a-contact-request) concern the keys used to establish a shared encryption secret. Step 10 separately requires signing the completed transition. This PR changes profile authentication-key selection; it does not change contact ECDH key selection.

**Historical limitation of DIP-11:** its [Identity Public Key / data section](https://github.com/dashpay/dips/blob/master/dip-0011.md#identity-public-key) explicitly says:

> a raw public key is used instead of a public key hash

That older data model lists only EC secp256k1 and BLS. Consequently, these DIPs must not be cited as an explicit requirement to support `ECDSA_HASH160`. The direct basis for accepting it is the [current Identity protocol reference](https://docs.dash.org/projects/platform/en/stable/docs/protocol-ref/identity.html#public-key-type), which defines type 2 as ECDSA secp256k1 Hash160, and the [Platform signature validator at revision 63cf57f](https://github.com/dashpay/platform/blob/63cf57f40d0000bf3b2b26026c8fa1c71162852d/packages/rs-drive-abci/src/execution/validation/state_transition/common/validate_state_transition_identity_signed/v0/mod.rs#L35), which explicitly includes `ECDSA_HASH160` among supported types and separately validates purpose, security level, enabled status, and signature.

The change therefore removes a wallet-library restriction beyond Platform's supported authentication-key types while retaining the profile paths' HIGH/CRITICAL authentication policy.

### What was done?

Both profile creation and replacement use one selector accepting ECDSA_SECP256K1 and ECDSA_HASH160. It continues to require enabled AUTHENTICATION keys at HIGH or CRITICAL security. The supplied signer remains responsible for the selected key.

### How Has This Been Tested?

- Regression tests failed with the original type restriction and pass with HASH160 enabled.
- `cargo test -p platform-wallet --lib wallet::identity::network::profile::tests --locked`: 10 passed. Covers both ECDSA types at HIGH/CRITICAL, the reported three-key identity, and rejection of disabled, MASTER, MEDIUM, TRANSFER, unsupported-type, and absent keys.
- `cargo fmt -p platform-wallet -- --check`: passed.
- `cargo clippy -p platform-wallet --all-targets --all-features --locked -- --no-deps -D warnings`: passed (existing dependency warning in Drive).
- Self-reviewed the shared selector's use by both write paths and the SDK handoff. No iOS or live network end-to-end test was run.

### Breaking Changes

None.

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation if needed
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - External-signed profile creation and updates now support eligible HASH160 authentication keys in addition to supported ECDSA keys.
  - Signing keys are selected only when they meet the required security level, purpose, type, and enabled-status criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->