### PR TITLE
test(dpp): stabilize distribution evaluator tests

### DIFF
--- a/packages/rs-dpp/src/data_contract/associated_token/token_perpetual_distribution/distribution_function/evaluate.rs
+++ b/packages/rs-dpp/src/data_contract/associated_token/token_perpetual_distribution/distribution_function/evaluate.rs
@@ -822,10 +822,10 @@ mod tests {
         }
     }
 
-    /// Off-boundary inputs agree between v0 and v1 on this host, documenting that v1 is a
-    /// rounding-boundary fix rather than a behaviour change in practice.
+    /// Both math versions accept ordinary inputs. Their exact results are intentionally
+    /// not compared: v0 delegates to the host libm and can differ from v1 across targets.
     #[test]
-    fn v0_and_v1_agree_off_boundary() {
+    fn v0_and_v1_accept_off_boundary_inputs() {
         let mut v0 = PlatformVersion::latest().clone();
         v0.dpp.token_versions.distribution_function_evaluate_version = 0;
         let v1 = latest();
@@ -835,11 +835,8 @@ mod tests {
         );
         for f in transcendental_variants() {
             for x in [1u64, 2, 10, 100, 1000] {
-                assert_eq!(
-                    f.evaluate(0, x, &v0).unwrap(),
-                    f.evaluate(0, x, v1).unwrap(),
-                    "{f:?} at {x}"
-                );
+                assert!(f.evaluate(0, x, &v0).is_ok(), "v0 rejected {f:?} at {x}");
+                assert!(f.evaluate(0, x, v1).is_ok(), "v1 rejected {f:?} at {x}");
             }
         }
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
The distribution evaluator test `v0_and_v1_agree_off_boundary` compares legacy host `libm` math with deterministic pure-Rust `libm` and assumes the results are identical. That assumption is architecture-dependent; CI on another target observed a valid `0` versus `1` difference.

## What was done?
Replaced the exact cross-version equality assertion with checks that both evaluators accept the ordinary input vectors. Deterministic v1 behavior remains covered by the existing golden-bit and boundary tests.

## How Has This Been Tested?
- `cargo test -p dpp --features all_features --lib associated_token` (632 passed)
- `cargo fmt --all`

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains one
- [ ] I have made corresponding changes to the documentation if needed

This pull request was created by Codex.
