### PR TITLE
feat(kotlin-sdk): bind the ordered wallet bring-up (startWalletSubsystems) over JNI

### DIFF
--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/WalletManagerNative.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/WalletManagerNative.kt
@@ -700,4 +700,49 @@ internal object WalletManagerNative {
         accountIndex: Int,
         coreFeePerByte: Int,
     ): String?
+
+    // ── Ordered wallet bring-up ───────────────────────────────────────
+
+    /**
+     * Ordered wallet bring-up — identity → contacts → contact-account
+     * drain — run as ONE bounded call so the host can start Core SPV
+     * knowing the DIP-15 contact addresses exist and will be in the first
+     * filter set. Wraps `platform_wallet_manager_start_wallet_subsystems`;
+     * iOS binds the same call (`PlatformWalletManagerStartup.swift`), and
+     * the ordering / retry / budget policy lives Rust-side in
+     * `platform_wallet::manager::startup`.
+     *
+     * Blocks until the sequence finishes or its budget expires — call from
+     * a background dispatcher. Throws [DashSDKException] only for a
+     * malformed request (bad handle, unknown wallet, bad argument); an
+     * unreachable Platform, a failed sync pass or an unfinished drain are
+     * all reported through the returned blob's status, because the host
+     * must be able to start Core SPV regardless.
+     *
+     * @param managerHandle the raw manager handle ([nativeManagerHandle]).
+     * @param walletId the 32-byte wallet id.
+     * @param mnemonicResolverHandle Keychain mnemonic resolver, or 0 for a
+     *   wallet holding resident keys. Without it the drain is skipped and
+     *   the pending count reported.
+     * @param identitySignerHandle identity signer for the DIP-15
+     *   auto-accept pass, or 0 to skip it.
+     * @param budgetSecs ceiling for the whole sequence; 0 = SDK default
+     *   (20s). Never unbounded — this call gates Core SPV.
+     * @param gapLimit identity-discovery gap limit; 0 = SDK default.
+     * @return a fixed 57-byte big-endian outcome blob, decoded by
+     *   `WalletStartupOutcome.decode` (the layouts must match the JNI
+     *   side): offset 0 status (1B), 1 hasIdentityId (1B), 2 identityId
+     *   (32B), 34 discoveryAttempts (u32), 38 dashPaySyncRan (1B),
+     *   39 seedBindingUnverified (1B), 40 identityScanIncomplete (1B),
+     *   41 contactAccountsDrained (u32), 45 contactAccountsPending (u32),
+     *   49 elapsedMs (u64).
+     */
+    external fun startWalletSubsystems(
+        managerHandle: Long,
+        walletId: ByteArray,
+        mnemonicResolverHandle: Long,
+        identitySignerHandle: Long,
+        budgetSecs: Long,
+        gapLimit: Int,
+    ): ByteArray
 }

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
@@ -2387,24 +2387,36 @@ class PlatformWalletManager(
         require(budgetSecs >= 0) { "budgetSecs must be non-negative, got $budgetSecs" }
         require(gapLimit >= 0) { "gapLimit must be non-negative, got $gapLimit" }
         withContext(Dispatchers.IO) {
+            // Each handle is guarded from the moment it exists: the signer's
+            // constructor can throw (Keystore unlock, DAO access), and a single
+            // try covering both would leak the resolver's native handle when it
+            // does. Closed in reverse construction order.
             val startupResolver = MnemonicResolverAndPersister(walletStorage)
-            val startupSigner =
-                KeystoreSigner(walletStorage, network, biometricGate, database.platformAddressDao())
             try {
-                val blob = mapNativeErrors {
-                    WalletManagerNative.startWalletSubsystems(
-                        managerHandle,
-                        walletId,
-                        startupResolver.nativeHandle,
-                        startupSigner.nativeHandle,
-                        budgetSecs,
-                        gapLimit,
+                val startupSigner =
+                    KeystoreSigner(
+                        walletStorage,
+                        network,
+                        biometricGate,
+                        database.platformAddressDao(),
                     )
+                try {
+                    val blob = mapNativeErrors {
+                        WalletManagerNative.startWalletSubsystems(
+                            managerHandle,
+                            walletId,
+                            startupResolver.nativeHandle,
+                            startupSigner.nativeHandle,
+                            budgetSecs,
+                            gapLimit,
+                        )
+                    }
+                    WalletStartupOutcome.decode(blob)
+                } finally {
+                    runCatching { startupSigner.close() }
                 }
-                WalletStartupOutcome.decode(blob)
             } finally {
                 runCatching { startupResolver.close() }
-                runCatching { startupSigner.close() }
             }
         }
     }

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
@@ -2341,6 +2341,74 @@ class PlatformWalletManager(
         }
     }
 
+    // ── Ordered wallet bring-up ───────────────────────────────────────
+
+    /**
+     * Bring one wallet's DashPay state up in dependency order — identity →
+     * contacts → contact-account drain — then return so the caller can
+     * start Core SPV. Port of Swift's `startWalletSubsystems`
+     * (`PlatformWalletManagerStartup.swift`); the ordering, the retry
+     * policy and the budget all live Rust-side
+     * (`platform_wallet::manager::startup`) — this is a thin bridge.
+     *
+     * A contact's DIP-15 payment addresses are derived from its contact
+     * account, and an address the wallet is not watching when the
+     * compact-filter scan passes its funding height produces no
+     * transaction at all. Call this once per wallet load, immediately
+     * before [startSpv], so the first filter set already covers them —
+     * a restored wallet then needs no receival-payment rescan at all.
+     *
+     * Budget expiry is reported in the outcome, never thrown: Core sync is
+     * the wallet's primary function and must not be held hostage to
+     * Platform being slow. Start SPV regardless of the returned status;
+     * inspect [WalletStartupOutcome.contactAccountsPending] for
+     * diagnostics.
+     *
+     * Key material follows the drain's per-call contract: the mnemonic
+     * resolver and identity signer are built for this call and closed when
+     * it returns — Rust borrows and never retains them. An auth-gated
+     * signing failure (identity keys are biometric-gated on Android)
+     * leaves the affected entries queued; the recurring sweep self-heals.
+     *
+     * Throws only for a malformed request (bad wallet id, negative
+     * arguments, unknown wallet, torn-down manager).
+     *
+     * @param walletId the 32-byte wallet id.
+     * @param budgetSecs ceiling for the whole sequence in seconds; 0 = SDK
+     *   default (20s). Never unbounded — this call gates Core SPV.
+     * @param gapLimit identity-discovery gap limit; 0 = SDK default.
+     */
+    suspend fun startWalletSubsystems(
+        walletId: ByteArray,
+        budgetSecs: Long = 0,
+        gapLimit: Int = 0,
+    ): WalletStartupOutcome = teardownGate.op {
+        require(walletId.size == 32) { "walletId must be 32 bytes, got ${walletId.size}" }
+        require(budgetSecs >= 0) { "budgetSecs must be non-negative, got $budgetSecs" }
+        require(gapLimit >= 0) { "gapLimit must be non-negative, got $gapLimit" }
+        withContext(Dispatchers.IO) {
+            val startupResolver = MnemonicResolverAndPersister(walletStorage)
+            val startupSigner =
+                KeystoreSigner(walletStorage, network, biometricGate, database.platformAddressDao())
+            try {
+                val blob = mapNativeErrors {
+                    WalletManagerNative.startWalletSubsystems(
+                        managerHandle,
+                        walletId,
+                        startupResolver.nativeHandle,
+                        startupSigner.nativeHandle,
+                        budgetSecs,
+                        gapLimit,
+                    )
+                }
+                WalletStartupOutcome.decode(blob)
+            } finally {
+                runCatching { startupResolver.close() }
+                runCatching { startupSigner.close() }
+            }
+        }
+    }
+
     // ── Lifecycle ─────────────────────────────────────────────────────
 
     val isClosed: Boolean get() = bundleRef.get() == 0L

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/WalletStartup.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/WalletStartup.kt
@@ -1,0 +1,205 @@
+package org.dashfoundation.dashsdk.wallet
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Why a wallet bring-up stopped where it did — Kotlin mirror of the Rust
+ * `WalletStartupStatus` (and of Swift's `WalletStartupStatus`). Raw values
+ * are the `WalletStartupStatusFFI` ABI discriminants: append, never
+ * renumber.
+ *
+ * Every case is a normal result. A host starts Core SPV on all of them —
+ * the partial cases just mean the DIP-15 rescan has work left to do.
+ */
+enum class WalletStartupStatus(val raw: Int) {
+    /**
+     * Identity resolved, contacts synced, no contact-account builds left
+     * queued. Everything a contact payment needs is in place.
+     */
+    READY(0),
+
+    /**
+     * Platform answered that this seed owns no identity. Terminal, and not
+     * a failure — there is nothing to sync and nothing to drain.
+     */
+    NO_IDENTITY(1),
+
+    /**
+     * The identity scan never reached Platform inside the budget. The
+     * wallet may well own one; we do not know yet, and asking again may
+     * answer it.
+     */
+    PARTIAL_NO_IDENTITY(2),
+
+    /**
+     * Identity resolved and synced, but contact-account builds are still
+     * queued — the budget ran out, the drain failed on some entries, or no
+     * contact-crypto provider was available.
+     */
+    PARTIAL_ACCOUNTS_PENDING(3),
+
+    /**
+     * Discovery failed locally — a wallet or persistence fault, not a
+     * reachability problem. Another scan will not answer it: the same
+     * fault is still there.
+     */
+    DISCOVERY_FAILED(4),
+
+    /**
+     * The contact-crypto provider does not resolve the seed that owns this
+     * wallet, so the contact-account drain was skipped without deriving
+     * anything. Not about Platform being slow: the signer handed to the
+     * call belongs to a different wallet, and deriving anyway would write
+     * contact receiving addresses from the wrong seed that no later
+     * correct-seed pass would ever revisit. The queued work is intact; a
+     * rerun with the right signer completes it.
+     */
+    SEED_BINDING_UNVERIFIED(5),
+
+    /**
+     * An identity is known and every later step ran, but the gap-limit
+     * identity scan is on record as having left indices unanswered. The
+     * identity reported is real; it may not be the only one. The verdict
+     * stays on record, so the next launch re-scans instead of taking the
+     * warm shortcut.
+     */
+    IDENTITY_SCAN_INCOMPLETE(6),
+    ;
+
+    /**
+     * Whether another discovery scan could change the answer: true for
+     * [PARTIAL_NO_IDENTITY] (Platform was never reached) and
+     * [IDENTITY_SCAN_INCOMPLETE] (reached, but not for every index). The
+     * others are terminal for this launch.
+     */
+    val discoveryWorthRetrying: Boolean
+        get() = this == PARTIAL_NO_IDENTITY || this == IDENTITY_SCAN_INCOMPLETE
+
+    /**
+     * Whether the identity question has an answer. Not the inverse of
+     * [discoveryWorthRetrying]: [DISCOVERY_FAILED] leaves the question
+     * open AND is not worth retrying, while [IDENTITY_SCAN_INCOMPLETE]
+     * has an answer that is merely known to be partial. Use this to
+     * decide what to show, and [discoveryWorthRetrying] to decide whether
+     * to scan again.
+     */
+    val identityIsSettled: Boolean
+        get() = this != PARTIAL_NO_IDENTITY && this != DISCOVERY_FAILED
+
+    companion object {
+        fun fromRaw(raw: Int): WalletStartupStatus =
+            entries.firstOrNull { it.raw == raw }
+                ?: throw IllegalArgumentException("unknown WalletStartupStatus discriminant $raw")
+    }
+}
+
+/**
+ * What a wallet bring-up did — Kotlin mirror of the Rust
+ * `WalletStartupOutcome` (and of Swift's `WalletStartupOutcome`).
+ */
+data class WalletStartupOutcome(
+    val status: WalletStartupStatus,
+    /** The wallet's identity, when one is known by the time this returned. */
+    val identityId: ByteArray?,
+    /**
+     * Discovery scans performed; 0 when a local identity was already known
+     * and no network scan was needed.
+     */
+    val discoveryAttempts: Int,
+    /**
+     * Whether the inline contact-request pass ran TO COMPLETION. False when
+     * it was skipped, failed, ran out of budget, or came back degraded — a
+     * pass that could not read some identities' contact documents left
+     * their account builds unenqueued, so an empty pending count does not
+     * mean their addresses are ready.
+     */
+    val dashPaySyncRan: Boolean,
+    /**
+     * The drain was skipped because the contact-crypto provider does not
+     * resolve this wallet's seed. Nothing was derived and nothing written;
+     * the queued work is intact.
+     */
+    val seedBindingUnverified: Boolean,
+    /**
+     * The wallet's identity scan is on record as having left indices
+     * unanswered and this launch did not close the gap. Carried separately
+     * from [status] because a pending contact queue outranks it there.
+     */
+    val identityScanIncomplete: Boolean,
+    /** Contact-crypto entries the drain completed. */
+    val contactAccountsDrained: Int,
+    /**
+     * Contact-account builds still queued on return. Non-zero means the
+     * DIP-15 rescan will have to backfill those contacts' payments.
+     */
+    val contactAccountsPending: Int,
+    /** Wall-clock duration of the whole sequence, in milliseconds. */
+    val elapsedMs: Long,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is WalletStartupOutcome) return false
+        return status == other.status &&
+            (identityId?.contentEquals(other.identityId) ?: (other.identityId == null)) &&
+            discoveryAttempts == other.discoveryAttempts &&
+            dashPaySyncRan == other.dashPaySyncRan &&
+            seedBindingUnverified == other.seedBindingUnverified &&
+            identityScanIncomplete == other.identityScanIncomplete &&
+            contactAccountsDrained == other.contactAccountsDrained &&
+            contactAccountsPending == other.contactAccountsPending &&
+            elapsedMs == other.elapsedMs
+    }
+
+    override fun hashCode(): Int {
+        var result = status.hashCode()
+        result = 31 * result + (identityId?.contentHashCode() ?: 0)
+        result = 31 * result + discoveryAttempts
+        result = 31 * result + dashPaySyncRan.hashCode()
+        result = 31 * result + seedBindingUnverified.hashCode()
+        result = 31 * result + identityScanIncomplete.hashCode()
+        result = 31 * result + contactAccountsDrained
+        result = 31 * result + contactAccountsPending
+        result = 31 * result + elapsedMs.hashCode()
+        return result
+    }
+
+    companion object {
+        /** Size of the JNI outcome blob; must match the Rust serializer. */
+        const val BLOB_SIZE: Int = 57
+
+        /**
+         * Decode the fixed-layout big-endian blob produced by
+         * `WalletManagerNative.startWalletSubsystems` — the layout table
+         * lives on both the JNI wrapper and the external declaration, and
+         * the three must stay in lockstep.
+         */
+        fun decode(blob: ByteArray): WalletStartupOutcome {
+            require(blob.size == BLOB_SIZE) {
+                "startup outcome blob must be $BLOB_SIZE bytes, got ${blob.size}"
+            }
+            val buf = ByteBuffer.wrap(blob).order(ByteOrder.BIG_ENDIAN)
+            val status = WalletStartupStatus.fromRaw(buf.get().toInt() and 0xFF)
+            val hasIdentity = buf.get().toInt() != 0
+            val identity = ByteArray(32).also { buf.get(it) }
+            val discoveryAttempts = buf.int
+            val dashPaySyncRan = buf.get().toInt() != 0
+            val seedBindingUnverified = buf.get().toInt() != 0
+            val identityScanIncomplete = buf.get().toInt() != 0
+            val drained = buf.int
+            val pending = buf.int
+            val elapsedMs = buf.long
+            return WalletStartupOutcome(
+                status = status,
+                identityId = if (hasIdentity) identity else null,
+                discoveryAttempts = discoveryAttempts,
+                dashPaySyncRan = dashPaySyncRan,
+                seedBindingUnverified = seedBindingUnverified,
+                identityScanIncomplete = identityScanIncomplete,
+                contactAccountsDrained = drained,
+                contactAccountsPending = pending,
+                elapsedMs = elapsedMs,
+            )
+        }
+    }
+}

--- a/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/wallet/WalletStartupTest.kt
+++ b/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/wallet/WalletStartupTest.kt
@@ -1,0 +1,131 @@
+package org.dashfoundation.dashsdk.wallet
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the 57-byte outcome blob ABI shared with the JNI serializer in
+ * `rs-unified-sdk-jni/src/wallet_manager.rs` — the layout table lives on
+ * both sides and this test is the Kotlin half of the contract.
+ */
+class WalletStartupTest {
+
+    private fun blob(
+        status: Int = 0,
+        hasIdentity: Boolean = true,
+        identity: ByteArray = ByteArray(32) { it.toByte() },
+        discoveryAttempts: Int = 3,
+        dashPaySyncRan: Boolean = true,
+        seedBindingUnverified: Boolean = false,
+        identityScanIncomplete: Boolean = false,
+        drained: Int = 4,
+        pending: Int = 0,
+        elapsedMs: Long = 12_345L,
+    ): ByteArray {
+        val buf = ByteBuffer.allocate(WalletStartupOutcome.BLOB_SIZE).order(ByteOrder.BIG_ENDIAN)
+        buf.put(status.toByte())
+        buf.put(if (hasIdentity) 1 else 0)
+        buf.put(identity)
+        buf.putInt(discoveryAttempts)
+        buf.put(if (dashPaySyncRan) 1 else 0)
+        buf.put(if (seedBindingUnverified) 1 else 0)
+        buf.put(if (identityScanIncomplete) 1 else 0)
+        buf.putInt(drained)
+        buf.putInt(pending)
+        buf.putLong(elapsedMs)
+        return buf.array()
+    }
+
+    @Test
+    fun decodesEveryFieldOfAReadyOutcome() {
+        val identity = ByteArray(32) { (it * 3).toByte() }
+        val outcome = WalletStartupOutcome.decode(
+            blob(
+                status = 0,
+                hasIdentity = true,
+                identity = identity,
+                discoveryAttempts = 2,
+                dashPaySyncRan = true,
+                seedBindingUnverified = false,
+                identityScanIncomplete = false,
+                drained = 5,
+                pending = 1,
+                elapsedMs = 9_876L,
+            ),
+        )
+        assertEquals(WalletStartupStatus.READY, outcome.status)
+        assertArrayEquals(identity, outcome.identityId)
+        assertEquals(2, outcome.discoveryAttempts)
+        assertTrue(outcome.dashPaySyncRan)
+        assertFalse(outcome.seedBindingUnverified)
+        assertFalse(outcome.identityScanIncomplete)
+        assertEquals(5, outcome.contactAccountsDrained)
+        assertEquals(1, outcome.contactAccountsPending)
+        assertEquals(9_876L, outcome.elapsedMs)
+    }
+
+    @Test
+    fun absentIdentityDecodesToNullEvenWhenBytesAreSet() {
+        // The JNI side zeroes the array when has_identity_id is false, but
+        // the decoder must key on the flag, not the bytes.
+        val outcome = WalletStartupOutcome.decode(
+            blob(status = 1, hasIdentity = false, identity = ByteArray(32) { 7 }),
+        )
+        assertEquals(WalletStartupStatus.NO_IDENTITY, outcome.status)
+        assertNull(outcome.identityId)
+    }
+
+    @Test
+    fun everyAbiDiscriminantRoundTrips() {
+        for (status in WalletStartupStatus.entries) {
+            val outcome = WalletStartupOutcome.decode(blob(status = status.raw))
+            assertEquals(status, outcome.status)
+        }
+    }
+
+    @Test
+    fun unknownDiscriminantThrows() {
+        assertThrows(IllegalArgumentException::class.java) {
+            WalletStartupOutcome.decode(blob(status = 200))
+        }
+    }
+
+    @Test
+    fun wrongBlobSizeThrows() {
+        assertThrows(IllegalArgumentException::class.java) {
+            WalletStartupOutcome.decode(ByteArray(WalletStartupOutcome.BLOB_SIZE - 1))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            WalletStartupOutcome.decode(ByteArray(WalletStartupOutcome.BLOB_SIZE + 1))
+        }
+    }
+
+    @Test
+    fun statusHelperSemanticsMatchTheSwiftBinding() {
+        // discoveryWorthRetrying: only the two "Platform not fully asked" cases.
+        assertTrue(WalletStartupStatus.PARTIAL_NO_IDENTITY.discoveryWorthRetrying)
+        assertTrue(WalletStartupStatus.IDENTITY_SCAN_INCOMPLETE.discoveryWorthRetrying)
+        assertFalse(WalletStartupStatus.READY.discoveryWorthRetrying)
+        assertFalse(WalletStartupStatus.NO_IDENTITY.discoveryWorthRetrying)
+        assertFalse(WalletStartupStatus.DISCOVERY_FAILED.discoveryWorthRetrying)
+        assertFalse(WalletStartupStatus.SEED_BINDING_UNVERIFIED.discoveryWorthRetrying)
+        assertFalse(WalletStartupStatus.PARTIAL_ACCOUNTS_PENDING.discoveryWorthRetrying)
+        // identityIsSettled: not the inverse — DISCOVERY_FAILED is unsettled
+        // AND not worth retrying; IDENTITY_SCAN_INCOMPLETE is settled AND
+        // worth retrying.
+        assertFalse(WalletStartupStatus.PARTIAL_NO_IDENTITY.identityIsSettled)
+        assertFalse(WalletStartupStatus.DISCOVERY_FAILED.identityIsSettled)
+        assertTrue(WalletStartupStatus.IDENTITY_SCAN_INCOMPLETE.identityIsSettled)
+        assertTrue(WalletStartupStatus.READY.identityIsSettled)
+        assertTrue(WalletStartupStatus.NO_IDENTITY.identityIsSettled)
+        assertTrue(WalletStartupStatus.SEED_BINDING_UNVERIFIED.identityIsSettled)
+        assertTrue(WalletStartupStatus.PARTIAL_ACCOUNTS_PENDING.identityIsSettled)
+    }
+}

--- a/packages/rs-unified-sdk-jni/src/wallet_manager.rs
+++ b/packages/rs-unified-sdk-jni/src/wallet_manager.rs
@@ -3899,3 +3899,111 @@ fn throw_pwffi(env: &mut JNIEnv, result: &mut PlatformWalletFFIResult) {
     throw_sdk_exception(env, result.code as i32 + PWFFI_CODE_OFFSET, &message);
     unsafe { platform_wallet_ffi_result_free(result) };
 }
+
+/// Ordered wallet bring-up: identity → contacts → contact-account drain, run
+/// as one bounded call so the host can start Core SPV knowing the DIP-15
+/// contact addresses exist and will be in the first filter set — the JNI
+/// bridge over `platform_wallet_manager_start_wallet_subsystems`. The
+/// ordering, retry policy and budget all live Rust-side
+/// (`platform_wallet::manager::startup`); iOS binds the same call as
+/// `PlatformWalletManagerStartup.swift`.
+///
+/// `mnemonicResolverHandle` is nullable (0): required for a Keychain-backed
+/// external-signable wallet; 0 means the wallet holds resident keys. Without
+/// it the drain is skipped and the pending count reported.
+/// `identitySignerHandle` is nullable (0): 0 skips the DIP-15 auto-accept
+/// pass. `budgetSecs` 0 selects the crate default (20s) — the call always
+/// terminates, because it gates Core SPV. `gapLimit` 0 selects the default.
+///
+/// Returns the outcome as a fixed 57-byte big-endian blob (decoded by
+/// `WalletStartupOutcome.decode` in Kotlin — the layouts must match):
+///
+/// | offset | size | field |
+/// |---|---|---|
+/// | 0  | 1  | status (`WalletStartupStatusFFI` discriminant) |
+/// | 1  | 1  | hasIdentityId (0/1) |
+/// | 2  | 32 | identityId (valid only when hasIdentityId=1) |
+/// | 34 | 4  | discoveryAttempts (u32) |
+/// | 38 | 1  | dashpaySyncRan (0/1) |
+/// | 39 | 1  | seedBindingUnverified (0/1) |
+/// | 40 | 1  | identityScanIncomplete (0/1) |
+/// | 41 | 4  | contactAccountsDrained (u32) |
+/// | 45 | 4  | contactAccountsPending (u32) |
+/// | 49 | 8  | elapsedMs (u64) |
+///
+/// Throws only for a malformed request (bad handle, unknown wallet, bad
+/// argument) — an unreachable Platform, a failed sync pass or an unfinished
+/// drain all come back through the blob's status, because the host must be
+/// able to start Core SPV regardless.
+#[no_mangle]
+pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_WalletManagerNative_startWalletSubsystems(
+    mut env: JNIEnv,
+    _class: JClass,
+    manager_handle: jlong,
+    wallet_id: JByteArray,
+    mnemonic_resolver_handle: jlong,
+    identity_signer_handle: jlong,
+    budget_secs: jlong,
+    gap_limit: jint,
+) -> jbyteArray {
+    guard(&mut env, std::ptr::null_mut(), |env| {
+        let Some(wallet_id) = read_id32(env, &wallet_id) else {
+            return std::ptr::null_mut();
+        };
+        if budget_secs < 0 {
+            throw_sdk_exception(env, 1, "budgetSecs must be non-negative");
+            return std::ptr::null_mut();
+        }
+        if gap_limit < 0 {
+            throw_sdk_exception(env, 1, "gapLimit must be non-negative");
+            return std::ptr::null_mut();
+        }
+
+        let mut outcome = platform_wallet_ffi::wallet_startup::WalletStartupOutcomeFFI {
+            status: 0,
+            has_identity_id: false,
+            identity_id: [0u8; 32],
+            discovery_attempts: 0,
+            dashpay_sync_ran: false,
+            seed_binding_unverified: false,
+            identity_scan_incomplete: false,
+            contact_accounts_drained: 0,
+            contact_accounts_pending: 0,
+            elapsed_ms: 0,
+        };
+        let result = unsafe {
+            platform_wallet_ffi::wallet_startup::platform_wallet_manager_start_wallet_subsystems(
+                manager_handle as Handle,
+                wallet_id.as_ptr(),
+                mnemonic_resolver_handle as *mut rs_sdk_ffi::MnemonicResolverHandle,
+                identity_signer_handle as *mut rs_sdk_ffi::SignerHandle,
+                budget_secs as u64,
+                gap_limit as u32,
+                &mut outcome,
+            )
+        };
+        if take_pwffi_error(env, result) {
+            return std::ptr::null_mut();
+        }
+
+        let mut blob = [0u8; 57];
+        blob[0] = outcome.status;
+        blob[1] = outcome.has_identity_id as u8;
+        blob[2..34].copy_from_slice(&outcome.identity_id);
+        blob[34..38].copy_from_slice(&outcome.discovery_attempts.to_be_bytes());
+        blob[38] = outcome.dashpay_sync_ran as u8;
+        blob[39] = outcome.seed_binding_unverified as u8;
+        blob[40] = outcome.identity_scan_incomplete as u8;
+        blob[41..45].copy_from_slice(&outcome.contact_accounts_drained.to_be_bytes());
+        blob[45..49].copy_from_slice(&outcome.contact_accounts_pending.to_be_bytes());
+        blob[49..57].copy_from_slice(&outcome.elapsed_ms.to_be_bytes());
+        match env.byte_array_from_slice(&blob) {
+            Ok(array) => array.into_raw(),
+            Err(_) => {
+                let _ = env.exception_clear();
+                throw_sdk_exception(env, 99, "startup outcome blob allocation failed");
+                std::ptr::null_mut()
+            }
+        }
+    })
+}


### PR DESCRIPTION
## Issue being fixed

`platform-wallet` already owns the DashPay startup ordering (#4359, gated on seed ownership by #4368) and
Swift already drives it. Kotlin has no binding, so Android clients cannot run the ordered bring-up at all.

The consequence on a restored wallet is missed money. DashPay contact accounts only start watching their
addresses once they are registered. If Core SPV starts first, the scan passes the heights that fund those
addresses while nothing is watching them, and the coins are never seen. A later rescan does not help: the
addresses were not in the filter query when those blocks were tested.

Measured on a restored CoinJoin-heavy testnet wallet before this binding existed: 12 receiving-chain coins
worth 0.0836 DASH simply absent, plus a class of contact payments whose records were never built.

## What was done

- `rs-unified-sdk-jni/src/wallet_manager.rs`: JNI entry point that resolves the mnemonic and signer, calls
  `PlatformWalletManager::start_wallet_subsystems`, and returns a packed outcome blob.
- `WalletStartup.kt`: `WalletStartupStatus` (the status codes the Rust side reports) and
  `WalletStartupOutcome` (status, discovery count, whether DashPay sync ran, drained and pending counts,
  elapsed ms).
- `PlatformWalletManager.startWalletSubsystems(walletId, budgetSecs = 0, gapLimit = 0)`: suspending, runs on
  the IO dispatcher behind the teardown gate, validates its arguments, and maps native errors. The budget is
  never unbounded because this call gates Core SPV.
- `WalletManagerNative`: the native declaration.
- `WalletStartupTest`: 6 tests over the outcome decoding and the status mapping.

No behaviour change for any existing caller: this only adds a binding to an API that already exists.

## How this was tested

- `kotlin-sdk :sdk:testDebugUnitTest` — **435 tests, 0 failures** (6 of them the new class).
- `cargo check -p rs-unified-sdk-jni` clean; `cargo fmt --check` and `clippy` clean for the touched file.
- **Device-verified** through a downstream Android wallet build that calls this binding before `startSpv`,
  over eight successive test builds on two large restored testnet wallets:
  - 7,324-transaction CoinJoin wallet: balance exact to the duff against a dashj wallet of the same seed,
    zero coins missing, 14 contact accounts registered before the scan began.
  - 3,269-transaction wallet: balance exact, and a contact payment that had gone missing in 4 of 6 restore
    sessions before the ordered bring-up is now present in every run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wallet startup orchestration that initializes identity, contacts, and contact accounts in dependency order.
  * Added detailed startup results covering status, identity, discovery, synchronization, and contact-account progress.
  * Added configurable startup time budgets and contact-account gap limits.
  * Added status indicators for ready, partial, incomplete, and retryable startup conditions.

* **Tests**
  * Added coverage for startup outcome decoding, status handling, missing identities, and invalid results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->