### PR TITLE
fix(platform): resolve fee versions by registered number and price refunds at the storage epoch rate

### DIFF
--- a/book/src/fees/overview.md
+++ b/book/src/fees/overview.md
@@ -219,6 +219,15 @@ out to proposers.
 There is a **dust limit**: refunds below 32 bytes worth of storage credits are
 discarded to prevent micro-refund spam.
 
+A refund is priced at the storage table that was active when the bytes were
+written. `FeeRefunds::from_storage_removal` resolves that rate through the fee
+history at the storage epoch (the epoch recorded in the element's storage
+flags), never at the epoch of the removal. The current epoch only fixes how many
+era shares of the original fee were already paid out to proposers. Every
+schedule shipped so far carries the same storage table, so this distinction
+first becomes observable when a schedule with new storage rates is registered
+under a new fee version number.
+
 ## Epoch-Based Fee Distribution
 
 Fees do not go directly to the block proposer. Instead, they accumulate in
@@ -291,6 +300,27 @@ pub struct FeeVersion {
 Fee versions are stored in the `FEE_VERSIONS` array and looked up by number. The
 `uses_version_fee_multiplier_permille` field allows a global scaling factor
 (permille = divide by 1000; a value of 1000 means no change).
+
+`fee_version_number` names a fee-history generation: the set of values the
+persisted fee history can serve through `KnownCostItem` (storage, processing,
+hashing and signature costs). It is what the epoch change hook records in
+platform state and what saved state stores. `FEE_VERSIONS` is the registry of
+those generations, keyed by that number; `FeeVersion::get` resolves a number by
+matching it, never by array position, and a number that is not registered is an
+error. A saved state that stores an unknown number therefore fails to load with
+a descriptive error instead of aborting the node.
+
+Several schedules may share one number when they differ only in groups the
+history never serves: `FEE_VERSION1` and `FEE_VERSION2` both carry number 1
+because only `data_contract_registration` changed between them. A schedule that
+changes storage rates must be registered under a new number, because that
+number is what prices refunds of bytes written while it was active. Unit tests
+in `rs-platform-version` pin that every schedule a protocol version references
+is registered and agrees with the registered generation on every served value.
+
+An empty fee history resolves to the first registered generation. This is
+deliberate: the hook records a generation only on the first non-genesis epoch
+change, so genesis epoch costs always take that path.
 
 ## Key Source Files
 

--- a/book/src/fees/overview.md
+++ b/book/src/fees/overview.md
@@ -219,14 +219,17 @@ out to proposers.
 There is a **dust limit**: refunds below 32 bytes worth of storage credits are
 discarded to prevent micro-refund spam.
 
-A refund is priced at the storage table that was active when the bytes were
-written. `FeeRefunds::from_storage_removal` resolves that rate through the fee
-history at the storage epoch (the epoch recorded in the element's storage
-flags), never at the epoch of the removal. The current epoch only fixes how many
-era shares of the original fee were already paid out to proposers. Every
-schedule shipped so far carries the same storage table, so this distinction
-first becomes observable when a schedule with new storage rates is registered
-under a new fee version number.
+Refund pricing is versioned through `Drive::calculate_fee`. Generation 0, which
+every released protocol version selects, prices every removed byte at the storage
+rate active at the removal epoch (`FeeRefunds::from_storage_removal`). Generation
+1 prices each removed epoch at the storage table that was active when the bytes
+were written: `FeeRefunds::from_storage_removal_v1` resolves that rate through
+the fee history at the storage epoch (the epoch recorded in the element's storage
+flags), and the current epoch only fixes how many era shares of the original fee
+were already paid out to proposers. Every schedule shipped so far carries the same
+storage table, so the two generations agree on every reachable input; generation
+1 is switched on by the unreleased protocol version that registers a schedule
+with new storage rates under a new fee version number.
 
 ## Epoch-Based Fee Distribution
 

--- a/packages/rs-dpp/src/fee/default_costs/mod.rs
+++ b/packages/rs-dpp/src/fee/default_costs/mod.rs
@@ -162,3 +162,134 @@ impl EpochCosts for Epoch {
         cost_item.lookup_cost_on_epoch(self, cached_fee_version)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use platform_version::version::fee::storage::FeeStorageVersion;
+    use platform_version::version::fee::v1::FEE_VERSION1;
+    use platform_version::version::PLATFORM_VERSIONS;
+
+    /// A second generation that is not registered anywhere, so a boundary in the fee history is
+    /// observable through the storage rate it carries.
+    static SYNTHETIC_FEE_VERSION_2: FeeVersion = FeeVersion {
+        fee_version_number: 2,
+        storage: FeeStorageVersion {
+            storage_disk_usage_credit_per_byte: 54000,
+            ..FEE_VERSION1.storage
+        },
+        ..FEE_VERSION1
+    };
+
+    /// Every `KnownCostItem` variant, with a few sizes for the two sized variants.
+    fn every_known_cost_item() -> Vec<KnownCostItem> {
+        let mut items = vec![
+            KnownCostItem::StorageDiskUsageCreditPerByte,
+            KnownCostItem::StorageProcessingCreditPerByte,
+            KnownCostItem::StorageLoadCreditPerByte,
+            KnownCostItem::NonStorageLoadCreditPerByte,
+            KnownCostItem::StorageSeekCost,
+            KnownCostItem::FetchIdentityBalanceProcessingCost,
+            KnownCostItem::FetchSingleIdentityKeyProcessingCost,
+            KnownCostItem::VerifySignatureEcdsaSecp256k1,
+            KnownCostItem::VerifySignatureBLS12_381,
+            KnownCostItem::VerifySignatureEcdsaHash160,
+            KnownCostItem::VerifySignatureBip13ScriptHash,
+            KnownCostItem::VerifySignatureEddsa25519Hash160,
+        ];
+        for size in [0, 1, 64] {
+            items.push(KnownCostItem::SingleSHA256(size));
+            items.push(KnownCostItem::Blake3(size));
+        }
+        items
+    }
+
+    fn epoch(index: EpochIndex) -> Epoch {
+        Epoch::new(index).expect("epoch index fits")
+    }
+
+    #[test]
+    fn should_use_the_first_fee_version_when_the_history_is_empty() {
+        // The epoch change hook only records a generation on the first non-genesis epoch change,
+        // so genesis epoch refunds always resolve through an empty history. That must land on
+        // the first registered generation, which is number 1.
+        let empty = CachedEpochIndexFeeVersions::default();
+        for index in [0, 1, 500] {
+            let resolved = epoch(index).active_fee_version(&empty);
+            assert_eq!(resolved, FeeVersion::first());
+            assert_eq!(
+                resolved,
+                FeeVersion::get(1).expect("number 1 is registered")
+            );
+        }
+    }
+
+    #[test]
+    fn should_use_the_exact_epoch_entry_when_present() {
+        let history: CachedEpochIndexFeeVersions = BTreeMap::from([
+            (0, FeeVersion::get(1).expect("registered")),
+            (10, &SYNTHETIC_FEE_VERSION_2),
+        ]);
+        assert_eq!(epoch(0).active_fee_version(&history).fee_version_number, 1);
+        assert_eq!(epoch(10).active_fee_version(&history).fee_version_number, 2);
+        assert_eq!(
+            epoch(10)
+                .cost_for_known_cost_item(&history, KnownCostItem::StorageDiskUsageCreditPerByte),
+            54000
+        );
+    }
+
+    #[test]
+    fn should_use_the_nearest_lower_epoch_entry() {
+        let history: CachedEpochIndexFeeVersions = BTreeMap::from([
+            (0, FeeVersion::get(1).expect("registered")),
+            (10, &SYNTHETIC_FEE_VERSION_2),
+        ]);
+        assert_eq!(epoch(9).active_fee_version(&history).fee_version_number, 1);
+        assert_eq!(epoch(11).active_fee_version(&history).fee_version_number, 2);
+        assert_eq!(
+            epoch(u16::MAX - 300)
+                .active_fee_version(&history)
+                .fee_version_number,
+            2
+        );
+    }
+
+    #[test]
+    fn should_use_the_first_fee_version_before_the_earliest_entry() {
+        let history: CachedEpochIndexFeeVersions = BTreeMap::from([(10, &SYNTHETIC_FEE_VERSION_2)]);
+        let resolved = epoch(3).active_fee_version(&history);
+        assert_eq!(resolved, FeeVersion::first());
+        assert_eq!(
+            epoch(3)
+                .cost_for_known_cost_item(&history, KnownCostItem::StorageDiskUsageCreditPerByte),
+            FEE_VERSION1.storage.storage_disk_usage_credit_per_byte
+        );
+    }
+
+    #[test]
+    fn should_agree_with_the_registered_entry_on_every_known_cost_item_for_every_platform_version()
+    {
+        // The fee history stores a number and serves values through KnownCostItem. For the stored
+        // number to resolve to the intended table, the registered generation must return the same
+        // value as the schedule the platform version actually carries, for every item.
+        for platform_version in PLATFORM_VERSIONS {
+            let schedule = &platform_version.fee_version;
+            let registered = FeeVersion::get(schedule.fee_version_number).unwrap_or_else(|error| {
+                panic!(
+                    "protocol version {} references an unregistered fee version: {error}",
+                    platform_version.protocol_version
+                )
+            });
+            for item in every_known_cost_item() {
+                assert_eq!(
+                    item.lookup_cost(schedule),
+                    item.lookup_cost(registered),
+                    "protocol version {} disagrees with registered fee version {} on a cost item",
+                    platform_version.protocol_version,
+                    schedule.fee_version_number
+                );
+            }
+        }
+    }
+}

--- a/packages/rs-dpp/src/fee/fee_result/refunds.rs
+++ b/packages/rs-dpp/src/fee/fee_result/refunds.rs
@@ -35,12 +35,66 @@ pub struct FeeRefunds(pub CreditsPerEpochByIdentifier);
 impl FeeRefunds {
     /// Create fee refunds from GroveDB's StorageRemovalPerEpochByIdentifier
     ///
+    /// Shipped generation: every removed epoch is priced at the storage rate active at the
+    /// current epoch. Selected by `calculate_fee` version 0, which every released protocol
+    /// version uses. Frozen; see `from_storage_removal_v1` for the corrected rule.
+    pub fn from_storage_removal<I, C, E>(
+        storage_removal: I,
+        current_epoch_index: EpochIndex,
+        epochs_per_era: u16,
+        previous_fee_versions: &CachedEpochIndexFeeVersions,
+    ) -> Result<Self, ProtocolError>
+    where
+        I: IntoIterator<Item = ([u8; 32], C)>,
+        C: IntoIterator<Item = (E, u32)>,
+        E: TryInto<u16>,
+    {
+        let refunds_per_epoch_by_identifier = storage_removal
+            .into_iter()
+            .map(|(identifier, bytes_per_epochs)| {
+                bytes_per_epochs
+                    .into_iter()
+                    .filter(|(_, bytes)| bytes >= &MIN_REFUND_LIMIT_BYTES)
+                    .map(|(encoded_epoch_index, bytes)| {
+                        let epoch_index : u16 = encoded_epoch_index.try_into().map_err(|_| ProtocolError::Overflow("can't fit u64 epoch index from StorageRemovalPerEpochByIdentifier to u16 EpochIndex"))?;
+
+                        // TODO Add in multipliers once they have been made
+
+                        let credits: Credits = (bytes as Credits)
+                            .checked_mul(Epoch::new(current_epoch_index)?.cost_for_known_cost_item(previous_fee_versions, StorageDiskUsageCreditPerByte))
+                            .ok_or(ProtocolError::Overflow("storage written bytes cost overflow"))?;
+
+                        let (amount, _) = calculate_storage_fee_refund_amount_and_leftovers(
+                            credits,
+                            epoch_index,
+                            current_epoch_index,
+                            epochs_per_era,
+                        )?;
+
+                        Ok((epoch_index, amount))
+                    })
+                    .collect::<Result<CreditsPerEpoch, ProtocolError>>()
+                    .map(|credits_per_epochs| (identifier, credits_per_epochs))
+            })
+            .collect::<Result<CreditsPerEpochByIdentifier, ProtocolError>>()?;
+
+        Ok(Self(refunds_per_epoch_by_identifier))
+    }
+
+    /// Create fee refunds from GroveDB's StorageRemovalPerEpochByIdentifier, pricing each
+    /// removed epoch at the storage rate that was active when the bytes were stored.
+    ///
     /// A refund is the unpaid remainder of the storage fee originally charged for the removed
     /// bytes. That fee was priced with the storage table active when the bytes were written, so
     /// the rate is resolved at the storage epoch (the key of each removal entry) through the fee
     /// history. The current epoch only decides how many era shares of that fee were already paid
     /// out to proposers.
-    pub fn from_storage_removal<I, C, E>(
+    ///
+    /// Generation 1 of the refund pricing rule, selected by `calculate_fee` version 1. No
+    /// released protocol version selects it yet; the protocol version that registers a schedule
+    /// under a new fee version number is the boundary at which it takes effect. Until then every
+    /// registered generation shares one storage table, so both rules produce identical refunds.
+    pub fn from_storage_removal_v1<I, C, E>(
         storage_removal: I,
         current_epoch_index: EpochIndex,
         epochs_per_era: u16,
@@ -232,7 +286,17 @@ mod tests {
             amount
         }
 
+        /// Which generation of the pricing rule a test drives.
+        #[derive(Clone, Copy)]
+        enum Generation {
+            /// `from_storage_removal`: the shipped rule, priced at the current epoch.
+            Shipped,
+            /// `from_storage_removal_v1`: priced at the storage epoch.
+            V1,
+        }
+
         fn refunds_for_one_identity(
+            generation: Generation,
             bytes_per_epoch: IntMap<u16, u32>,
             current_epoch: EpochIndex,
             fee_history: &CachedEpochIndexFeeVersions,
@@ -241,16 +305,25 @@ mod tests {
             let storage_removal =
                 BytesPerEpochByIdentifier::from_iter([(identity_id, bytes_per_epoch)]);
 
-            FeeRefunds::from_storage_removal(
-                storage_removal,
-                current_epoch,
-                EPOCHS_PER_ERA,
-                fee_history,
-            )
-            .expect("should create fee refunds")
-            .get(&identity_id)
-            .expect("identity has refunds")
-            .clone()
+            let refunds = match generation {
+                Generation::Shipped => FeeRefunds::from_storage_removal(
+                    storage_removal,
+                    current_epoch,
+                    EPOCHS_PER_ERA,
+                    fee_history,
+                ),
+                Generation::V1 => FeeRefunds::from_storage_removal_v1(
+                    storage_removal,
+                    current_epoch,
+                    EPOCHS_PER_ERA,
+                    fee_history,
+                ),
+            };
+            refunds
+                .expect("should create fee refunds")
+                .get(&identity_id)
+                .expect("identity has refunds")
+                .clone()
         }
 
         #[test]
@@ -261,18 +334,56 @@ mod tests {
             let storage_removal =
                 BytesPerEpochByIdentifier::from_iter([(identity_id, bytes_per_epoch)]);
 
-            let fee_refunds = FeeRefunds::from_storage_removal(
-                storage_removal,
-                3,
-                20,
-                &EPOCH_CHANGE_FEE_VERSION_TEST,
-            )
-            .expect("should create fee refunds");
+            for fee_refunds in [
+                FeeRefunds::from_storage_removal(
+                    storage_removal.clone(),
+                    3,
+                    20,
+                    &EPOCH_CHANGE_FEE_VERSION_TEST,
+                )
+                .expect("should create fee refunds"),
+                FeeRefunds::from_storage_removal_v1(
+                    storage_removal.clone(),
+                    3,
+                    20,
+                    &EPOCH_CHANGE_FEE_VERSION_TEST,
+                )
+                .expect("should create fee refunds"),
+            ] {
+                let credits_per_epoch = fee_refunds.get(&identity_id).expect("should exists");
 
-            let credits_per_epoch = fee_refunds.get(&identity_id).expect("should exists");
+                assert!(credits_per_epoch.get(&0).is_none());
+                assert!(credits_per_epoch.get(&1).is_some());
+            }
+        }
 
-            assert!(credits_per_epoch.get(&0).is_none());
-            assert!(credits_per_epoch.get(&1).is_some());
+        #[test]
+        fn should_keep_pricing_every_removed_epoch_at_the_current_epoch_rate_in_the_shipped_generation(
+        ) {
+            // Frozen replay behaviour of `from_storage_removal`: the rate is the one active at
+            // the removal epoch, whatever epoch the bytes were stored in. Selected by
+            // `calculate_fee` version 0 on every released protocol version.
+            let fee_history: CachedEpochIndexFeeVersions = BTreeMap::from([
+                (0, FeeVersion::get(1).expect("registered")),
+                (10, &SYNTHETIC_FEE_VERSION_2),
+            ]);
+            let current_epoch = 15;
+
+            let refunds = refunds_for_one_identity(
+                Generation::Shipped,
+                IntMap::from_iter([(5, 100), (12, 100)]),
+                current_epoch,
+                &fee_history,
+            );
+
+            assert_eq!(
+                refunds.get(&5).copied(),
+                Some(expected_refund(100, SYNTHETIC_RATE, 5, current_epoch))
+            );
+            assert_eq!(
+                refunds.get(&12).copied(),
+                Some(expected_refund(100, SYNTHETIC_RATE, 12, current_epoch))
+            );
         }
 
         #[test]
@@ -287,6 +398,7 @@ mod tests {
             let current_epoch = 15;
 
             let refunds = refunds_for_one_identity(
+                Generation::V1,
                 IntMap::from_iter([(5, 100), (12, 100)]),
                 current_epoch,
                 &fee_history,
@@ -321,6 +433,7 @@ mod tests {
             let current_epoch = 12;
 
             let refunds = refunds_for_one_identity(
+                Generation::V1,
                 IntMap::from_iter([(3, 100)]),
                 current_epoch,
                 &fee_history,
@@ -342,8 +455,8 @@ mod tests {
         {
             // Every shipped input: an empty history (the fee version number 1 path in Drive) or a
             // history whose entries all resolve to number 1. The storage epoch and the current
-            // epoch then resolve to the same rate, so the result is identical to what pricing at
-            // the current epoch produced before the rule changed.
+            // epoch then resolve to the same rate, so both generations of the rule produce the
+            // same refunds.
             let same_table_histories: [CachedEpochIndexFeeVersions; 2] = [
                 BTreeMap::default(),
                 BTreeMap::from([
@@ -354,11 +467,19 @@ mod tests {
             let current_epoch = 9;
 
             for fee_history in &same_table_histories {
-                let refunds = refunds_for_one_identity(
+                let shipped = refunds_for_one_identity(
+                    Generation::Shipped,
                     IntMap::from_iter([(2, 100), (8, 100)]),
                     current_epoch,
                     fee_history,
                 );
+                let refunds = refunds_for_one_identity(
+                    Generation::V1,
+                    IntMap::from_iter([(2, 100), (8, 100)]),
+                    current_epoch,
+                    fee_history,
+                );
+                assert_eq!(shipped, refunds, "both generations agree on shipped inputs");
                 let current_epoch_rate = Epoch::new(current_epoch)
                     .expect("epoch")
                     .cost_for_known_cost_item(fee_history, StorageDiskUsageCreditPerByte);

--- a/packages/rs-dpp/src/fee/fee_result/refunds.rs
+++ b/packages/rs-dpp/src/fee/fee_result/refunds.rs
@@ -34,6 +34,12 @@ pub struct FeeRefunds(pub CreditsPerEpochByIdentifier);
 
 impl FeeRefunds {
     /// Create fee refunds from GroveDB's StorageRemovalPerEpochByIdentifier
+    ///
+    /// A refund is the unpaid remainder of the storage fee originally charged for the removed
+    /// bytes. That fee was priced with the storage table active when the bytes were written, so
+    /// the rate is resolved at the storage epoch (the key of each removal entry) through the fee
+    /// history. The current epoch only decides how many era shares of that fee were already paid
+    /// out to proposers.
     pub fn from_storage_removal<I, C, E>(
         storage_removal: I,
         current_epoch_index: EpochIndex,
@@ -56,8 +62,11 @@ impl FeeRefunds {
 
                         // TODO Add in multipliers once they have been made
 
+                        let storage_rate = Epoch::new(epoch_index)?
+                            .cost_for_known_cost_item(previous_fee_versions, StorageDiskUsageCreditPerByte);
+
                         let credits: Credits = (bytes as Credits)
-                            .checked_mul(Epoch::new(current_epoch_index)?.cost_for_known_cost_item(previous_fee_versions, StorageDiskUsageCreditPerByte))
+                            .checked_mul(storage_rate)
                             .ok_or(ProtocolError::Overflow("storage written bytes cost overflow"))?;
 
                         let (amount, _) = calculate_storage_fee_refund_amount_and_leftovers(
@@ -177,15 +186,72 @@ impl IntoIterator for FeeRefunds {
 mod tests {
     use super::*;
     use once_cell::sync::Lazy;
+    use platform_version::version::fee::storage::FeeStorageVersion;
+    use platform_version::version::fee::v1::FEE_VERSION1;
     use platform_version::version::fee::FeeVersion;
 
     static EPOCH_CHANGE_FEE_VERSION_TEST: Lazy<CachedEpochIndexFeeVersions> =
         Lazy::new(|| BTreeMap::from([(0, FeeVersion::first())]));
 
+    /// Storage rate of the first registered generation, which priced every byte written so far.
+    const FIRST_GENERATION_RATE: Credits = 27000;
+
+    /// A second storage table that is not registered anywhere. It exists only so a rate boundary
+    /// in the fee history is observable in these tests.
+    const SYNTHETIC_RATE: Credits = 54000;
+
+    static SYNTHETIC_FEE_VERSION_2: FeeVersion = FeeVersion {
+        fee_version_number: 2,
+        storage: FeeStorageVersion {
+            storage_disk_usage_credit_per_byte: SYNTHETIC_RATE,
+            ..FEE_VERSION1.storage
+        },
+        ..FEE_VERSION1
+    };
+
     mod from_storage_removal {
         use super::*;
         use nohash_hasher::IntMap;
         use std::iter::FromIterator;
+
+        const EPOCHS_PER_ERA: u16 = 20;
+
+        fn expected_refund(
+            bytes: u32,
+            rate: Credits,
+            storage_epoch: EpochIndex,
+            current_epoch: EpochIndex,
+        ) -> Credits {
+            let (amount, _) = calculate_storage_fee_refund_amount_and_leftovers(
+                bytes as Credits * rate,
+                storage_epoch,
+                current_epoch,
+                EPOCHS_PER_ERA,
+            )
+            .expect("refund amount");
+            amount
+        }
+
+        fn refunds_for_one_identity(
+            bytes_per_epoch: IntMap<u16, u32>,
+            current_epoch: EpochIndex,
+            fee_history: &CachedEpochIndexFeeVersions,
+        ) -> CreditsPerEpoch {
+            let identity_id = [7; 32];
+            let storage_removal =
+                BytesPerEpochByIdentifier::from_iter([(identity_id, bytes_per_epoch)]);
+
+            FeeRefunds::from_storage_removal(
+                storage_removal,
+                current_epoch,
+                EPOCHS_PER_ERA,
+                fee_history,
+            )
+            .expect("should create fee refunds")
+            .get(&identity_id)
+            .expect("identity has refunds")
+            .clone()
+        }
 
         #[test]
         fn should_filter_out_refunds_under_the_limit() {
@@ -207,6 +273,109 @@ mod tests {
 
             assert!(credits_per_epoch.get(&0).is_none());
             assert!(credits_per_epoch.get(&1).is_some());
+        }
+
+        #[test]
+        fn should_price_each_removed_epoch_at_the_storage_table_active_when_the_bytes_were_stored()
+        {
+            // Rate boundary at epoch 10: bytes written before it were charged at the first
+            // generation's rate, bytes written from it on at the synthetic rate.
+            let fee_history: CachedEpochIndexFeeVersions = BTreeMap::from([
+                (0, FeeVersion::get(1).expect("registered")),
+                (10, &SYNTHETIC_FEE_VERSION_2),
+            ]);
+            let current_epoch = 15;
+
+            let refunds = refunds_for_one_identity(
+                IntMap::from_iter([(5, 100), (12, 100)]),
+                current_epoch,
+                &fee_history,
+            );
+
+            assert_eq!(
+                refunds.get(&5).copied(),
+                Some(expected_refund(
+                    100,
+                    FIRST_GENERATION_RATE,
+                    5,
+                    current_epoch
+                )),
+                "bytes stored before the boundary refund at the rate they were charged"
+            );
+            assert_eq!(
+                refunds.get(&12).copied(),
+                Some(expected_refund(100, SYNTHETIC_RATE, 12, current_epoch)),
+                "bytes stored after the boundary refund at the new rate"
+            );
+            assert_ne!(
+                refunds.get(&5).copied(),
+                Some(expected_refund(100, SYNTHETIC_RATE, 5, current_epoch)),
+                "pre-boundary bytes must not be re-priced at the current epoch's rate"
+            );
+        }
+
+        #[test]
+        fn should_price_removals_before_the_earliest_history_entry_with_the_first_generation() {
+            let fee_history: CachedEpochIndexFeeVersions =
+                BTreeMap::from([(10, &SYNTHETIC_FEE_VERSION_2)]);
+            let current_epoch = 12;
+
+            let refunds = refunds_for_one_identity(
+                IntMap::from_iter([(3, 100)]),
+                current_epoch,
+                &fee_history,
+            );
+
+            assert_eq!(
+                refunds.get(&3).copied(),
+                Some(expected_refund(
+                    100,
+                    FIRST_GENERATION_RATE,
+                    3,
+                    current_epoch
+                ))
+            );
+        }
+
+        #[test]
+        fn should_match_the_current_epoch_rate_whenever_every_generation_shares_one_storage_table()
+        {
+            // Every shipped input: an empty history (the fee version number 1 path in Drive) or a
+            // history whose entries all resolve to number 1. The storage epoch and the current
+            // epoch then resolve to the same rate, so the result is identical to what pricing at
+            // the current epoch produced before the rule changed.
+            let same_table_histories: [CachedEpochIndexFeeVersions; 2] = [
+                BTreeMap::default(),
+                BTreeMap::from([
+                    (0, FeeVersion::get(1).expect("registered")),
+                    (7, FeeVersion::get(1).expect("registered")),
+                ]),
+            ];
+            let current_epoch = 9;
+
+            for fee_history in &same_table_histories {
+                let refunds = refunds_for_one_identity(
+                    IntMap::from_iter([(2, 100), (8, 100)]),
+                    current_epoch,
+                    fee_history,
+                );
+                let current_epoch_rate = Epoch::new(current_epoch)
+                    .expect("epoch")
+                    .cost_for_known_cost_item(fee_history, StorageDiskUsageCreditPerByte);
+                assert_eq!(current_epoch_rate, FIRST_GENERATION_RATE);
+
+                for storage_epoch in [2, 8] {
+                    assert_eq!(
+                        refunds.get(&storage_epoch).copied(),
+                        Some(expected_refund(
+                            100,
+                            current_epoch_rate,
+                            storage_epoch,
+                            current_epoch
+                        ))
+                    );
+                }
+            }
         }
     }
 }

--- a/packages/rs-drive-abci/src/execution/platform_events/block_processing_end_events/tests.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_processing_end_events/tests.rs
@@ -861,9 +861,13 @@ mod refund_tests {
 
         let mut platform_state = platform.state.load().clone().deref().clone();
 
-        platform_state
-            .previous_fee_versions_mut()
-            .insert(5, platform_version_with_higher_fees.fee_version.as_static());
+        platform_state.previous_fee_versions_mut().insert(
+            5,
+            platform_version_with_higher_fees
+                .fee_version
+                .as_static()
+                .expect("registered fee version"),
+        );
 
         let (mut fee_results, _) = process_state_transitions(
             &platform,

--- a/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
@@ -245,7 +245,7 @@ impl TryFromPlatformVersioned<PlatformStateForSaving> for PlatformState {
             }
             PlatformStateForSaving::V1(v1) => {
                 match platform_version.drive_abci.structs.platform_state_structure {
-                    0 => Ok(PlatformState::from(v1)),
+                    0 => PlatformState::try_from(v1),
                     version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
                         method:
                             "PlatformState::try_from_platform_versioned(PlatformStateForSavingV1)"
@@ -268,9 +268,62 @@ mod tests {
         use crate::test::fixture::platform_state::{
             PLATFORM_STATE_V3_TESTNET, PLATFORM_STATE_V8_DEVNET,
         };
+        use dpp::block::epoch::{Epoch, EpochIndex};
+        use dpp::fee::default_costs::{EpochCosts, KnownCostItem};
+        use dpp::version::fee::{FeeVersion, FEE_VERSIONS};
         use platform_version::version::v3::PLATFORM_V3;
         use platform_version::version::v9::PLATFORM_V9;
+        use platform_version::version::LATEST_VERSION;
         use std::ops::Deref;
+
+        /// Every `KnownCostItem` variant, with a few sizes for the two sized variants.
+        fn every_known_cost_item() -> Vec<KnownCostItem> {
+            let mut items = vec![
+                KnownCostItem::StorageDiskUsageCreditPerByte,
+                KnownCostItem::StorageProcessingCreditPerByte,
+                KnownCostItem::StorageLoadCreditPerByte,
+                KnownCostItem::NonStorageLoadCreditPerByte,
+                KnownCostItem::StorageSeekCost,
+                KnownCostItem::FetchIdentityBalanceProcessingCost,
+                KnownCostItem::FetchSingleIdentityKeyProcessingCost,
+                KnownCostItem::VerifySignatureEcdsaSecp256k1,
+                KnownCostItem::VerifySignatureBLS12_381,
+                KnownCostItem::VerifySignatureEcdsaHash160,
+                KnownCostItem::VerifySignatureBip13ScriptHash,
+                KnownCostItem::VerifySignatureEddsa25519Hash160,
+            ];
+            for size in [0, 1, 64] {
+                items.push(KnownCostItem::SingleSHA256(size));
+                items.push(KnownCostItem::Blake3(size));
+            }
+            items
+        }
+
+        fn latest_state() -> PlatformState {
+            PlatformState::default_with_protocol_versions(
+                LATEST_VERSION,
+                LATEST_VERSION,
+                &PlatformConfig::default_testnet(),
+            )
+            .expect("default state")
+        }
+
+        fn round_trip(state: &PlatformState) -> PlatformState {
+            let bytes = state.serialize_to_bytes().expect("serialize state");
+            PlatformState::versioned_deserialize(&bytes, PlatformVersion::latest())
+                .expect("deserialize state")
+        }
+
+        fn assert_every_entry_is_fee_version_one(state: &PlatformState) {
+            let registered = FeeVersion::get(1).expect("number 1 is registered");
+            for (epoch_index, fee_version) in state.previous_fee_versions() {
+                assert_eq!(
+                    fee_version.fee_version_number, 1,
+                    "epoch {epoch_index} must resolve to fee version number 1"
+                );
+                assert_eq!(*fee_version, registered);
+            }
+        }
 
         #[test]
         fn should_deserialize_state_stored_in_version_0_from_testnet() {
@@ -288,6 +341,109 @@ mod tests {
 
             PlatformState::versioned_deserialize(&serialized_state, &PLATFORM_V9)
                 .expect("failed to deserialize state");
+        }
+
+        #[test]
+        fn should_still_load_legacy_v0_states_as_fee_version_one() {
+            // The pre-1.4 format stored whole fee version structs. Only number 1 existed then,
+            // so every stored epoch maps to the first registered generation.
+            let serialized_state =
+                hex::decode(PLATFORM_STATE_V3_TESTNET.deref()).expect("failed to decode hex");
+            let state = PlatformState::versioned_deserialize(&serialized_state, &PLATFORM_V3)
+                .expect("failed to deserialize state");
+
+            assert_every_entry_is_fee_version_one(&state);
+        }
+
+        #[test]
+        fn should_resolve_stored_numbers_in_v1_states_to_registered_fee_versions() {
+            let serialized_state =
+                hex::decode(PLATFORM_STATE_V8_DEVNET.deref()).expect("failed to decode hex");
+            let state = PlatformState::versioned_deserialize(&serialized_state, &PLATFORM_V9)
+                .expect("failed to deserialize state");
+
+            assert_every_entry_is_fee_version_one(&state);
+        }
+
+        #[test]
+        fn should_round_trip_every_registered_fee_version_number_through_saved_state() {
+            let mut state = latest_state();
+            for registered in FEE_VERSIONS {
+                let epoch_index = registered.fee_version_number as EpochIndex;
+                state
+                    .previous_fee_versions_mut()
+                    .insert(epoch_index, registered);
+            }
+
+            let reloaded = round_trip(&state);
+
+            assert_eq!(
+                reloaded.previous_fee_versions().len(),
+                FEE_VERSIONS.len(),
+                "every registered number survives the round trip"
+            );
+            for (epoch_index, fee_version) in state.previous_fee_versions() {
+                let reloaded_fee_version = reloaded
+                    .previous_fee_versions()
+                    .get(epoch_index)
+                    .expect("epoch entry survives the round trip");
+                assert_eq!(
+                    reloaded_fee_version.fee_version_number,
+                    fee_version.fee_version_number
+                );
+                assert_eq!(*reloaded_fee_version, *fee_version);
+                assert_eq!(
+                    *reloaded_fee_version,
+                    FeeVersion::get(fee_version.fee_version_number).expect("registered")
+                );
+            }
+        }
+
+        #[test]
+        fn should_agree_with_the_in_memory_fee_history_on_every_known_cost_item_after_reload() {
+            // The epoch change hook stores a reference into the platform version table, not the
+            // registry entry. After a reload the map holds the registry entry. Both must serve
+            // the same values for every epoch and every cost item.
+            let mut state = latest_state();
+            state
+                .previous_fee_versions_mut()
+                .insert(1, &PlatformVersion::latest().fee_version);
+
+            let reloaded = round_trip(&state);
+
+            assert_eq!(
+                reloaded.previous_fee_versions().keys().collect::<Vec<_>>(),
+                state.previous_fee_versions().keys().collect::<Vec<_>>()
+            );
+            for epoch_index in 0..=3 {
+                let epoch = Epoch::new(epoch_index).expect("epoch");
+                for item in every_known_cost_item() {
+                    assert_eq!(
+                        epoch.cost_for_known_cost_item(state.previous_fee_versions(), item),
+                        epoch.cost_for_known_cost_item(reloaded.previous_fee_versions(), item),
+                        "epoch {epoch_index} disagrees after reload"
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn should_reject_a_saved_state_that_stores_an_unknown_fee_version_number() {
+            let state = latest_state();
+            let mut saving = PlatformStateForSavingV1::try_from(state).expect("saving form");
+            saving.previous_fee_versions.insert(3, 99);
+            let config = config::standard().with_big_endian().with_no_limit();
+            let bytes = bincode::encode_to_vec(PlatformStateForSaving::V1(saving), config)
+                .expect("encode saving form");
+
+            let error = PlatformState::versioned_deserialize(&bytes, PlatformVersion::latest())
+                .expect_err("an unknown fee version number must not load");
+            let message = error.to_string();
+            assert!(message.contains("99"), "error names the number: {message}");
+            assert!(
+                message.contains("epoch 3"),
+                "error names the epoch: {message}"
+            );
         }
     }
 }

--- a/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/mod.rs
@@ -271,6 +271,9 @@ mod tests {
         use dpp::block::epoch::{Epoch, EpochIndex};
         use dpp::fee::default_costs::{EpochCosts, KnownCostItem};
         use dpp::version::fee::{FeeVersion, FEE_VERSIONS};
+        use dpp::version::mocks::fee_test::{
+            TEST_FEE_VERSION_DOUBLED_STORAGE_RATE, TEST_FEE_VERSION_NUMBER_DOUBLED_STORAGE_RATE,
+        };
         use platform_version::version::v3::PLATFORM_V3;
         use platform_version::version::v9::PLATFORM_V9;
         use platform_version::version::LATEST_VERSION;
@@ -397,6 +400,62 @@ mod tests {
                     FeeVersion::get(fee_version.fee_version_number).expect("registered")
                 );
             }
+        }
+
+        #[test]
+        fn should_round_trip_a_fee_version_number_that_is_not_a_registry_position() {
+            // The mock generation's number lives above the test shift, so it is never a position
+            // in the shipped registry. It must come back from saved state through a lookup by
+            // carried number, and the reloaded entry must price storage at its own rate.
+            let mut state = latest_state();
+            let mock = TEST_FEE_VERSION_DOUBLED_STORAGE_RATE
+                .as_static()
+                .expect("mock generation is registered");
+            state
+                .previous_fee_versions_mut()
+                .insert(0, FeeVersion::get(1).expect("registered"));
+            state.previous_fee_versions_mut().insert(10, mock);
+
+            let saving = PlatformStateForSavingV1::try_from(state.clone()).expect("saving form");
+            assert_eq!(
+                saving.previous_fee_versions.get(&10).copied(),
+                Some(TEST_FEE_VERSION_NUMBER_DOUBLED_STORAGE_RATE),
+                "the stored number is the carried number, not a position"
+            );
+
+            let reloaded = round_trip(&state);
+            let reloaded_mock = reloaded
+                .previous_fee_versions()
+                .get(&10)
+                .expect("boundary entry survives the round trip");
+            assert_eq!(
+                reloaded_mock.fee_version_number,
+                TEST_FEE_VERSION_NUMBER_DOUBLED_STORAGE_RATE
+            );
+            assert_eq!(*reloaded_mock, mock);
+            for epoch_index in [9, 10, 11] {
+                let epoch = Epoch::new(epoch_index).expect("epoch");
+                assert_eq!(
+                    epoch.cost_for_known_cost_item(
+                        reloaded.previous_fee_versions(),
+                        KnownCostItem::StorageDiskUsageCreditPerByte
+                    ),
+                    epoch.cost_for_known_cost_item(
+                        state.previous_fee_versions(),
+                        KnownCostItem::StorageDiskUsageCreditPerByte
+                    ),
+                    "epoch {epoch_index} prices storage the same before and after reload"
+                );
+            }
+            assert_eq!(
+                Epoch::new(10).expect("epoch").cost_for_known_cost_item(
+                    reloaded.previous_fee_versions(),
+                    KnownCostItem::StorageDiskUsageCreditPerByte
+                ),
+                TEST_FEE_VERSION_DOUBLED_STORAGE_RATE
+                    .storage
+                    .storage_disk_usage_credit_per_byte
+            );
         }
 
         #[test]

--- a/packages/rs-drive-abci/src/platform_types/platform_state/platform_state_for_saving/v1/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform_state/platform_state_for_saving/v1/mod.rs
@@ -1,3 +1,4 @@
+use crate::error::execution::ExecutionError;
 use crate::error::Error;
 use crate::platform_types::masternode::Masternode;
 use crate::platform_types::platform_state::accessors::PlatformStateV0Methods;
@@ -106,9 +107,28 @@ impl TryFrom<PlatformState> for PlatformStateForSavingV1 {
     }
 }
 
-impl From<PlatformStateForSavingV1> for PlatformState {
-    fn from(value: PlatformStateForSavingV1) -> Self {
-        PlatformState {
+impl TryFrom<PlatformStateForSavingV1> for PlatformState {
+    type Error = Error;
+
+    /// Restores the in-memory state, resolving every stored fee version number through the fee
+    /// version registry. A number this build does not know is a load error, never a fallback to
+    /// another generation, because the refund rates it stands for would be wrong.
+    fn try_from(value: PlatformStateForSavingV1) -> Result<Self, Self::Error> {
+        let previous_fee_versions = value
+            .previous_fee_versions
+            .into_iter()
+            .map(|(epoch_index, fee_version_number)| {
+                FeeVersion::get(fee_version_number)
+                    .map(|fee_version| (epoch_index, fee_version))
+                    .map_err(|_| {
+                        Error::Execution(ExecutionError::CorruptedCachedState(format!(
+                            "platform state stores fee version {fee_version_number} for epoch {epoch_index}, which this build does not know"
+                        )))
+                    })
+            })
+            .collect::<Result<_, Error>>()?;
+
+        Ok(PlatformState {
             genesis_block_info: value.genesis_block_info,
             last_committed_block_info: value.last_committed_block_info,
             current_protocol_version_in_consensus: value.current_protocol_version_in_consensus,
@@ -136,17 +156,7 @@ impl From<PlatformStateForSavingV1> for PlatformState {
                 .into_iter()
                 .map(|(k, v)| (ProTxHash::from_byte_array(k.to_buffer()), v.into()))
                 .collect(),
-            previous_fee_versions: value
-                .previous_fee_versions
-                .into_iter()
-                .map(|(epoch_index, fee_version_number)| {
-                    (
-                        epoch_index,
-                        FeeVersion::get(fee_version_number)
-                            .expect("expected fee version number to exist"),
-                    )
-                })
-                .collect(),
-        }
+            previous_fee_versions,
+        })
     }
 }

--- a/packages/rs-drive/src/fees/calculate_fee/mod.rs
+++ b/packages/rs-drive/src/fees/calculate_fee/mod.rs
@@ -61,6 +61,10 @@ mod tests {
     use super::*;
     use crate::fees::op::LowLevelDriveOperation::CalculatedCostOperation;
     use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
+    use dpp::fee::epoch::distribution::calculate_storage_fee_refund_amount_and_leftovers;
+    use dpp::fee::Credits;
+    use dpp::version::mocks::fee_test::TEST_FEE_VERSION_DOUBLED_STORAGE_RATE;
+    use dpp::version::mocks::v2_test::TEST_PLATFORM_V2;
     use grovedb_costs::storage_cost::removal::StorageRemovedBytes::SectionedStorageRemoval;
     use grovedb_costs::storage_cost::StorageCost;
     use grovedb_costs::OperationCost;
@@ -69,31 +73,82 @@ mod tests {
     use platform_version::version::PlatformVersion;
     use std::collections::BTreeMap;
 
+    const EPOCHS_PER_ERA: u16 = 20;
+    const CURRENT_EPOCH: u16 = 15;
+    const IDENTITY: [u8; 32] = [9; 32];
+
+    /// One identity removing 100 bytes stored at epoch 5 and 100 bytes stored at epoch 12,
+    /// plus 10 freshly added bytes.
+    fn removal_operation() -> LowLevelDriveOperation {
+        let mut removal = BTreeMap::new();
+        removal.insert(
+            IDENTITY,
+            IntMap::from_iter([(5u16, 100u32), (12u16, 100u32)]),
+        );
+        CalculatedCostOperation(OperationCost {
+            storage_cost: StorageCost {
+                added_bytes: 10,
+                replaced_bytes: 0,
+                removed_bytes: SectionedStorageRemoval(removal),
+            },
+            ..Default::default()
+        })
+    }
+
+    /// Fee history with a storage-rate boundary at epoch 10.
+    fn boundary_history() -> CachedEpochIndexFeeVersions {
+        BTreeMap::from([
+            (0, FeeVersion::get(1).expect("registered")),
+            (
+                10,
+                TEST_FEE_VERSION_DOUBLED_STORAGE_RATE
+                    .as_static()
+                    .expect("mock generation is registered"),
+            ),
+        ])
+    }
+
+    /// A mock platform version whose schedule is the mock generation, so the dispatcher must
+    /// hand the fee history through for refunds to be priced at all.
+    fn platform_version_with_doubled_storage_rate() -> PlatformVersion {
+        PlatformVersion {
+            fee_version: TEST_FEE_VERSION_DOUBLED_STORAGE_RATE,
+            ..TEST_PLATFORM_V2
+        }
+    }
+
+    fn expected_refund(bytes: u32, rate: Credits, storage_epoch: u16) -> Credits {
+        let (amount, _) = calculate_storage_fee_refund_amount_and_leftovers(
+            bytes as Credits * rate,
+            storage_epoch,
+            CURRENT_EPOCH,
+            EPOCHS_PER_ERA,
+        )
+        .expect("refund amount");
+        amount
+    }
+
+    fn refunds_of(fee_result: &FeeResult) -> BTreeMap<u16, Credits> {
+        fee_result
+            .fee_refunds
+            .get(&IDENTITY)
+            .expect("identity has refunds")
+            .iter()
+            .map(|(epoch_index, credits)| (*epoch_index, *credits))
+            .collect()
+    }
+
     #[test]
     fn should_forward_the_platform_fee_schedule_and_the_fee_history_to_the_implementation() {
         let platform_version = PlatformVersion::latest();
-        let identity = [9; 32];
-        let operation = || {
-            let mut removal = BTreeMap::new();
-            removal.insert(identity, IntMap::from_iter([(2u16, 200u32)]));
-            CalculatedCostOperation(OperationCost {
-                storage_cost: StorageCost {
-                    added_bytes: 10,
-                    replaced_bytes: 0,
-                    removed_bytes: SectionedStorageRemoval(removal),
-                },
-                ..Default::default()
-            })
-        };
-        let epoch = Epoch::new(6).expect("epoch");
-        let history: CachedEpochIndexFeeVersions =
-            BTreeMap::from([(0, FeeVersion::get(1).expect("registered"))]);
+        let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+        let history = boundary_history();
 
         let through_dispatcher = Drive::calculate_fee(
             None,
-            Some(vec![operation()]),
+            Some(vec![removal_operation()]),
             &epoch,
-            20,
+            EPOCHS_PER_ERA,
             platform_version,
             Some(&history),
         )
@@ -101,9 +156,9 @@ mod tests {
 
         let expected = Drive::calculate_fee_v0(
             None,
-            Some(vec![operation()]),
+            Some(vec![removal_operation()]),
             &epoch,
-            20,
+            EPOCHS_PER_ERA,
             &platform_version.fee_version,
             Some(&history),
         )
@@ -117,6 +172,62 @@ mod tests {
                 .storage
                 .storage_disk_usage_credit_per_byte
         );
-        assert!(through_dispatcher.fee_refunds.get(&identity).is_some());
+        assert!(through_dispatcher.fee_refunds.get(&IDENTITY).is_some());
+    }
+
+    #[test]
+    fn should_price_refunds_across_a_rate_boundary_through_the_dispatcher_for_a_later_generation() {
+        let platform_version = platform_version_with_doubled_storage_rate();
+        let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+        let history = boundary_history();
+        let first_rate = FeeVersion::get(1)
+            .expect("registered")
+            .storage
+            .storage_disk_usage_credit_per_byte;
+        let doubled_rate = TEST_FEE_VERSION_DOUBLED_STORAGE_RATE
+            .storage
+            .storage_disk_usage_credit_per_byte;
+        assert_ne!(first_rate, doubled_rate);
+
+        let fee_result = Drive::calculate_fee(
+            None,
+            Some(vec![removal_operation()]),
+            &epoch,
+            EPOCHS_PER_ERA,
+            &platform_version,
+            Some(&history),
+        )
+        .expect("history supplied through the dispatcher");
+
+        assert_eq!(fee_result.storage_fee, 10 * doubled_rate);
+        assert_eq!(
+            refunds_of(&fee_result),
+            BTreeMap::from([
+                (5, expected_refund(100, first_rate, 5)),
+                (12, expected_refund(100, doubled_rate, 12)),
+            ]),
+            "bytes stored on each side of the boundary refund at the rate they were charged"
+        );
+    }
+
+    #[test]
+    fn should_reject_a_missing_fee_history_through_the_dispatcher_for_a_later_generation() {
+        let platform_version = platform_version_with_doubled_storage_rate();
+        let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+
+        let error = Drive::calculate_fee(
+            None,
+            Some(vec![removal_operation()]),
+            &epoch,
+            EPOCHS_PER_ERA,
+            &platform_version,
+            None,
+        )
+        .expect_err("a later generation cannot price refunds without the history");
+
+        assert!(
+            matches!(error, Error::Drive(DriveError::CorruptedCodeExecution(_))),
+            "unexpected error {error}"
+        );
     }
 }

--- a/packages/rs-drive/src/fees/calculate_fee/mod.rs
+++ b/packages/rs-drive/src/fees/calculate_fee/mod.rs
@@ -9,6 +9,7 @@ use dpp::version::PlatformVersion;
 use enum_map::EnumMap;
 
 mod v0;
+mod v1;
 
 impl Drive {
     /// Calculates fees for the given operations. Returns the storage and processing costs.
@@ -47,9 +48,17 @@ impl Drive {
                 &platform_version.fee_version,
                 previous_fee_versions,
             ),
+            1 => Self::calculate_fee_v1(
+                base_operations,
+                drive_operations,
+                epoch,
+                epochs_per_era,
+                &platform_version.fee_version,
+                previous_fee_versions,
+            ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "Drive::calculate_fee".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             })),
         }
@@ -69,6 +78,8 @@ mod tests {
     use grovedb_costs::storage_cost::StorageCost;
     use grovedb_costs::OperationCost;
     use intmap::IntMap;
+    use platform_version::version::drive_versions::DriveFeesMethodVersions;
+    use platform_version::version::drive_versions::{DriveMethodVersions, DriveVersion};
     use platform_version::version::fee::FeeVersion;
     use platform_version::version::PlatformVersion;
     use std::collections::BTreeMap;
@@ -109,12 +120,33 @@ mod tests {
     }
 
     /// A mock platform version whose schedule is the mock generation, so the dispatcher must
-    /// hand the fee history through for refunds to be priced at all.
-    fn platform_version_with_doubled_storage_rate() -> PlatformVersion {
+    /// hand the fee history through for refunds to be priced at all, running the requested
+    /// `calculate_fee` generation.
+    fn platform_version_with_doubled_storage_rate(calculate_fee: u16) -> PlatformVersion {
         PlatformVersion {
             fee_version: TEST_FEE_VERSION_DOUBLED_STORAGE_RATE,
+            drive: DriveVersion {
+                methods: DriveMethodVersions {
+                    fees: DriveFeesMethodVersions { calculate_fee },
+                    ..TEST_PLATFORM_V2.drive.methods
+                },
+                ..TEST_PLATFORM_V2.drive
+            },
             ..TEST_PLATFORM_V2
         }
+    }
+
+    fn first_rate() -> Credits {
+        FeeVersion::get(1)
+            .expect("registered")
+            .storage
+            .storage_disk_usage_credit_per_byte
+    }
+
+    fn doubled_rate() -> Credits {
+        TEST_FEE_VERSION_DOUBLED_STORAGE_RATE
+            .storage
+            .storage_disk_usage_credit_per_byte
     }
 
     fn expected_refund(bytes: u32, rate: Credits, storage_epoch: u16) -> Credits {
@@ -176,18 +208,13 @@ mod tests {
     }
 
     #[test]
-    fn should_price_refunds_across_a_rate_boundary_through_the_dispatcher_for_a_later_generation() {
-        let platform_version = platform_version_with_doubled_storage_rate();
+    fn should_price_every_removed_epoch_at_the_current_epoch_rate_through_generation_zero() {
+        // Shipped rule, selected by every released protocol version: the rate active at the
+        // removal epoch (15, after the boundary) prices every removed epoch.
+        let platform_version = platform_version_with_doubled_storage_rate(0);
         let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
         let history = boundary_history();
-        let first_rate = FeeVersion::get(1)
-            .expect("registered")
-            .storage
-            .storage_disk_usage_credit_per_byte;
-        let doubled_rate = TEST_FEE_VERSION_DOUBLED_STORAGE_RATE
-            .storage
-            .storage_disk_usage_credit_per_byte;
-        assert_ne!(first_rate, doubled_rate);
+        assert_ne!(first_rate(), doubled_rate());
 
         let fee_result = Drive::calculate_fee(
             None,
@@ -199,20 +226,114 @@ mod tests {
         )
         .expect("history supplied through the dispatcher");
 
-        assert_eq!(fee_result.storage_fee, 10 * doubled_rate);
+        assert_eq!(fee_result.storage_fee, 10 * doubled_rate());
         assert_eq!(
             refunds_of(&fee_result),
             BTreeMap::from([
-                (5, expected_refund(100, first_rate, 5)),
-                (12, expected_refund(100, doubled_rate, 12)),
+                (5, expected_refund(100, doubled_rate(), 5)),
+                (12, expected_refund(100, doubled_rate(), 12)),
             ]),
-            "bytes stored on each side of the boundary refund at the rate they were charged"
+            "generation 0 prices both epochs at the current epoch's rate"
+        );
+    }
+
+    #[test]
+    fn should_price_refunds_across_a_rate_boundary_through_generation_one() {
+        let platform_version = platform_version_with_doubled_storage_rate(1);
+        let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+        let history = boundary_history();
+
+        let fee_result = Drive::calculate_fee(
+            None,
+            Some(vec![removal_operation()]),
+            &epoch,
+            EPOCHS_PER_ERA,
+            &platform_version,
+            Some(&history),
+        )
+        .expect("history supplied through the dispatcher");
+
+        assert_eq!(fee_result.storage_fee, 10 * doubled_rate());
+        assert_eq!(
+            refunds_of(&fee_result),
+            BTreeMap::from([
+                (5, expected_refund(100, first_rate(), 5)),
+                (12, expected_refund(100, doubled_rate(), 12)),
+            ]),
+            "generation 1 refunds each epoch at the rate its bytes were charged"
+        );
+    }
+
+    #[test]
+    fn should_agree_across_generations_whenever_every_generation_shares_one_storage_table() {
+        // Every input reachable on a released protocol version: a history where every entry is
+        // number 1. Both generations then resolve the same rate at every epoch.
+        let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+        let history: CachedEpochIndexFeeVersions = BTreeMap::from([
+            (0, FeeVersion::get(1).expect("registered")),
+            (10, FeeVersion::get(1).expect("registered")),
+        ]);
+        let results: Vec<FeeResult> = [0, 1]
+            .into_iter()
+            .map(|calculate_fee| {
+                let platform_version = PlatformVersion {
+                    drive: DriveVersion {
+                        methods: DriveMethodVersions {
+                            fees: DriveFeesMethodVersions { calculate_fee },
+                            ..TEST_PLATFORM_V2.drive.methods
+                        },
+                        ..TEST_PLATFORM_V2.drive
+                    },
+                    ..TEST_PLATFORM_V2
+                };
+                Drive::calculate_fee(
+                    None,
+                    Some(vec![removal_operation()]),
+                    &epoch,
+                    EPOCHS_PER_ERA,
+                    &platform_version,
+                    Some(&history),
+                )
+                .expect("dispatches")
+            })
+            .collect();
+
+        assert_eq!(results[0], results[1]);
+        assert_eq!(
+            refunds_of(&results[1]),
+            BTreeMap::from([
+                (5, expected_refund(100, first_rate(), 5)),
+                (12, expected_refund(100, first_rate(), 12)),
+            ])
         );
     }
 
     #[test]
     fn should_reject_a_missing_fee_history_through_the_dispatcher_for_a_later_generation() {
-        let platform_version = platform_version_with_doubled_storage_rate();
+        for calculate_fee in [0, 1] {
+            let platform_version = platform_version_with_doubled_storage_rate(calculate_fee);
+            let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+
+            let error = Drive::calculate_fee(
+                None,
+                Some(vec![removal_operation()]),
+                &epoch,
+                EPOCHS_PER_ERA,
+                &platform_version,
+                None,
+            )
+            .expect_err("a later generation cannot price refunds without the history");
+
+            assert!(
+                matches!(error, Error::Drive(DriveError::CorruptedCodeExecution(_))),
+                "calculate_fee {calculate_fee}: unexpected error {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_reject_an_unknown_calculate_fee_version() {
+        let platform_version = platform_version_with_doubled_storage_rate(2);
         let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
 
         let error = Drive::calculate_fee(
@@ -223,10 +344,13 @@ mod tests {
             &platform_version,
             None,
         )
-        .expect_err("a later generation cannot price refunds without the history");
+        .expect_err("version 2 is not known");
 
         assert!(
-            matches!(error, Error::Drive(DriveError::CorruptedCodeExecution(_))),
+            matches!(
+                error,
+                Error::Drive(DriveError::UnknownVersionMismatch { received: 2, .. })
+            ),
             "unexpected error {error}"
         );
     }

--- a/packages/rs-drive/src/fees/calculate_fee/mod.rs
+++ b/packages/rs-drive/src/fees/calculate_fee/mod.rs
@@ -55,3 +55,68 @@ impl Drive {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fees::op::LowLevelDriveOperation::CalculatedCostOperation;
+    use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
+    use grovedb_costs::storage_cost::removal::StorageRemovedBytes::SectionedStorageRemoval;
+    use grovedb_costs::storage_cost::StorageCost;
+    use grovedb_costs::OperationCost;
+    use intmap::IntMap;
+    use platform_version::version::fee::FeeVersion;
+    use platform_version::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn should_forward_the_platform_fee_schedule_and_the_fee_history_to_the_implementation() {
+        let platform_version = PlatformVersion::latest();
+        let identity = [9; 32];
+        let operation = || {
+            let mut removal = BTreeMap::new();
+            removal.insert(identity, IntMap::from_iter([(2u16, 200u32)]));
+            CalculatedCostOperation(OperationCost {
+                storage_cost: StorageCost {
+                    added_bytes: 10,
+                    replaced_bytes: 0,
+                    removed_bytes: SectionedStorageRemoval(removal),
+                },
+                ..Default::default()
+            })
+        };
+        let epoch = Epoch::new(6).expect("epoch");
+        let history: CachedEpochIndexFeeVersions =
+            BTreeMap::from([(0, FeeVersion::get(1).expect("registered"))]);
+
+        let through_dispatcher = Drive::calculate_fee(
+            None,
+            Some(vec![operation()]),
+            &epoch,
+            20,
+            platform_version,
+            Some(&history),
+        )
+        .expect("latest platform version dispatches calculate_fee");
+
+        let expected = Drive::calculate_fee_v0(
+            None,
+            Some(vec![operation()]),
+            &epoch,
+            20,
+            &platform_version.fee_version,
+            Some(&history),
+        )
+        .expect("direct implementation call");
+
+        assert_eq!(through_dispatcher, expected);
+        assert_eq!(
+            through_dispatcher.storage_fee,
+            10 * platform_version
+                .fee_version
+                .storage
+                .storage_disk_usage_credit_per_byte
+        );
+        assert!(through_dispatcher.fee_refunds.get(&identity).is_some());
+    }
+}

--- a/packages/rs-drive/src/fees/calculate_fee/v1/mod.rs
+++ b/packages/rs-drive/src/fees/calculate_fee/v1/mod.rs
@@ -1,0 +1,56 @@
+use crate::drive::Drive;
+use crate::error::fee::FeeError;
+use crate::error::Error;
+use crate::fees::op::{BaseOp, LowLevelDriveOperation};
+use dpp::block::epoch::Epoch;
+use dpp::fee::fee_result::FeeResult;
+
+use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
+use enum_map::EnumMap;
+use platform_version::version::fee::FeeVersion;
+
+impl Drive {
+    /// Calculates fees for the given operations. Returns the storage and processing costs.
+    ///
+    /// Generation 1 differs from generation 0 only in refund pricing: removed bytes are refunded
+    /// at the storage rate active when they were stored (`consume_to_fees_v1`), not at the rate
+    /// active when they are removed. No released protocol version selects this generation; the
+    /// unreleased protocol version that registers a schedule under a new fee version number is
+    /// where it is switched on.
+    #[inline(always)]
+    pub(crate) fn calculate_fee_v1(
+        base_operations: Option<EnumMap<BaseOp, u64>>,
+        drive_operations: Option<Vec<LowLevelDriveOperation>>,
+        epoch: &Epoch,
+        epochs_per_era: u16,
+        fee_version: &FeeVersion,
+        previous_fee_versions: Option<&CachedEpochIndexFeeVersions>,
+    ) -> Result<FeeResult, Error> {
+        let mut aggregate_fee_result = FeeResult::default();
+        if let Some(base_operations) = base_operations {
+            for (base_op, count) in base_operations.iter() {
+                match base_op.cost().checked_mul(*count) {
+                    None => return Err(Error::Fee(FeeError::Overflow("overflow error"))),
+                    Some(cost) => match aggregate_fee_result.processing_fee.checked_add(cost) {
+                        None => return Err(Error::Fee(FeeError::Overflow("overflow error"))),
+                        Some(value) => aggregate_fee_result.processing_fee = value,
+                    },
+                }
+            }
+        }
+
+        if let Some(drive_operations) = drive_operations {
+            for drive_fee_result in LowLevelDriveOperation::consume_to_fees_v1(
+                drive_operations,
+                epoch,
+                epochs_per_era,
+                fee_version,
+                previous_fee_versions,
+            )? {
+                aggregate_fee_result.checked_add_assign(drive_fee_result)?;
+            }
+        }
+
+        Ok(aggregate_fee_result)
+    }
+}

--- a/packages/rs-drive/src/fees/op.rs
+++ b/packages/rs-drive/src/fees/op.rs
@@ -312,6 +312,81 @@ impl LowLevelDriveOperation {
             .collect()
     }
 
+    /// Returns a list of the costs of the Drive operations, refunding removed bytes at the
+    /// storage rate active when they were stored.
+    /// Should only be used by Calculate fee (generation 1).
+    ///
+    /// Identical to `consume_to_fees_v0` except that refunds go through
+    /// `FeeRefunds::from_storage_removal_v1`. The fee version number 1 arm keeps pricing against
+    /// an empty history, so on every schedule shipped so far the two generations agree.
+    pub fn consume_to_fees_v1(
+        drive_operations: Vec<LowLevelDriveOperation>,
+        epoch: &Epoch,
+        epochs_per_era: u16,
+        fee_version: &FeeVersion,
+        previous_fee_versions: Option<&CachedEpochIndexFeeVersions>,
+    ) -> Result<Vec<FeeResult>, Error> {
+        drive_operations
+            .into_iter()
+            .map(|operation| match operation {
+                PreCalculatedFeeResult(f) => Ok(f),
+                FunctionOperation(op) => Ok(FeeResult {
+                    processing_fee: op.cost(fee_version),
+                    ..Default::default()
+                }),
+                _ => {
+                    let cost = operation.operation_cost()?;
+                    // There is no need for a checked multiply here because added bytes are u64 and
+                    // storage disk usage credit per byte should never be high enough to cause an overflow
+                    let storage_fee = cost.storage_cost.added_bytes as u64 * fee_version.storage.storage_disk_usage_credit_per_byte;
+                    let processing_fee = cost.ephemeral_cost(fee_version)?;
+                    let (fee_refunds, removed_bytes_from_system) =
+                        match cost.storage_cost.removed_bytes {
+                            NoStorageRemoval => (FeeRefunds::default(), 0),
+                            BasicStorageRemoval(amount) => {
+                                // this is not always considered an error
+                                (FeeRefunds::default(), amount)
+                            }
+                            SectionedStorageRemoval(mut removal_per_epoch_by_identifier) => {
+
+                                let system_amount = removal_per_epoch_by_identifier
+                                    .remove(&Identifier::default())
+                                    .map_or(0, |a| a.values().sum());
+                                if fee_version.fee_version_number == 1 {
+                                    (
+                                        FeeRefunds::from_storage_removal_v1(
+                                            removal_per_epoch_by_identifier,
+                                            epoch.index,
+                                            epochs_per_era,
+                                            &BTreeMap::default(),
+                                        )?,
+                                        system_amount,
+                                    )
+                                } else {
+                                    let previous_fee_versions = previous_fee_versions.ok_or(Error::Drive(DriveError::CorruptedCodeExecution("expected previous epoch index fee versions to be able to offer refunds")))?;
+                                    (
+                                        FeeRefunds::from_storage_removal_v1(
+                                            removal_per_epoch_by_identifier,
+                                            epoch.index,
+                                            epochs_per_era,
+                                            previous_fee_versions,
+                                        )?,
+                                        system_amount,
+                                    )
+                                }
+                            }
+                        };
+                    Ok(FeeResult {
+                        storage_fee,
+                        processing_fee,
+                        fee_refunds,
+                        removed_bytes_from_system,
+                    })
+                }
+            })
+            .collect()
+    }
+
     /// Returns the cost of this operation
     pub fn operation_cost(self) -> Result<OperationCost, Error> {
         match self {
@@ -2654,10 +2729,10 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // 9. consume_to_fees_v0 — refunds and the fee history requirement
+    // 9. consume_to_fees_v0 / consume_to_fees_v1 — refunds and the fee history requirement
     // ---------------------------------------------------------------
 
-    mod consume_to_fees_v0 {
+    mod consume_to_fees {
         use super::*;
         use dpp::fee::epoch::distribution::calculate_storage_fee_refund_amount_and_leftovers;
         use intmap::IntMap;
@@ -2734,62 +2809,90 @@ mod tests {
                 .collect()
         }
 
+        /// Runs the requested generation of `consume_to_fees`.
+        fn consume(
+            generation: u16,
+            fee_version: &FeeVersion,
+            previous_fee_versions: Option<&CachedEpochIndexFeeVersions>,
+        ) -> Result<FeeResult, Error> {
+            let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+            let results = match generation {
+                0 => LowLevelDriveOperation::consume_to_fees_v0(
+                    vec![removal_operation()],
+                    &epoch,
+                    EPOCHS_PER_ERA,
+                    fee_version,
+                    previous_fee_versions,
+                ),
+                1 => LowLevelDriveOperation::consume_to_fees_v1(
+                    vec![removal_operation()],
+                    &epoch,
+                    EPOCHS_PER_ERA,
+                    fee_version,
+                    previous_fee_versions,
+                ),
+                other => panic!("no consume_to_fees generation {other}"),
+            }?;
+            Ok(results
+                .into_iter()
+                .next()
+                .expect("one operation, one result"))
+        }
+
         #[test]
         fn should_refund_through_the_legacy_empty_history_path_when_the_fee_version_number_is_one()
         {
-            let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
-            let mut results = LowLevelDriveOperation::consume_to_fees_v0(
-                vec![removal_operation()],
-                &epoch,
-                EPOCHS_PER_ERA,
-                &FEE_VERSION1,
-                None,
-            )
-            .expect("number 1 never needs the fee history");
-            let fee_result = results.remove(0);
+            for generation in [0, 1] {
+                let fee_result = consume(generation, &FEE_VERSION1, None)
+                    .expect("number 1 never needs the fee history");
 
-            assert_eq!(fee_result.removed_bytes_from_system, 40);
-            assert_eq!(fee_result.storage_fee, 0);
+                assert_eq!(fee_result.removed_bytes_from_system, 40);
+                assert_eq!(fee_result.storage_fee, 0);
+                assert_eq!(
+                    refunds_of(&fee_result),
+                    BTreeMap::from([
+                        (5, expected_refund(100, FIRST_GENERATION_RATE, 5)),
+                        (12, expected_refund(100, FIRST_GENERATION_RATE, 12)),
+                    ]),
+                    "generation {generation}"
+                );
+            }
+        }
+
+        #[test]
+        fn should_require_fee_history_when_the_fee_version_number_is_not_one() {
+            for generation in [0, 1] {
+                let error = consume(generation, &SYNTHETIC_FEE_VERSION_2, None)
+                    .expect_err("a later generation cannot price refunds without the history");
+                assert!(
+                    matches!(error, Error::Drive(DriveError::CorruptedCodeExecution(_))),
+                    "generation {generation}: unexpected error {error}"
+                );
+            }
+        }
+
+        #[test]
+        fn should_price_every_removed_epoch_at_the_current_epoch_rate_in_generation_zero() {
+            // Shipped rule: the rate active at the removal epoch (15, past the boundary) prices
+            // every removed epoch, including bytes stored at epoch 5 before the boundary.
+            let history = boundary_history();
+            let fee_result =
+                consume(0, &SYNTHETIC_FEE_VERSION_2, Some(&history)).expect("history supplied");
+
             assert_eq!(
                 refunds_of(&fee_result),
                 BTreeMap::from([
-                    (5, expected_refund(100, FIRST_GENERATION_RATE, 5)),
-                    (12, expected_refund(100, FIRST_GENERATION_RATE, 12)),
+                    (5, expected_refund(100, SYNTHETIC_RATE, 5)),
+                    (12, expected_refund(100, SYNTHETIC_RATE, 12)),
                 ])
             );
         }
 
         #[test]
-        fn should_require_fee_history_when_the_fee_version_number_is_not_one() {
-            let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
-            let error = LowLevelDriveOperation::consume_to_fees_v0(
-                vec![removal_operation()],
-                &epoch,
-                EPOCHS_PER_ERA,
-                &SYNTHETIC_FEE_VERSION_2,
-                None,
-            )
-            .expect_err("a later generation cannot price refunds without the history");
-            assert!(
-                matches!(error, Error::Drive(DriveError::CorruptedCodeExecution(_))),
-                "unexpected error {error}"
-            );
-        }
-
-        #[test]
-        fn should_refund_at_the_storage_epoch_rate_across_a_history_boundary_when_the_fee_version_number_is_not_one(
-        ) {
-            let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+        fn should_refund_at_the_storage_epoch_rate_across_a_history_boundary_in_generation_one() {
             let history = boundary_history();
-            let mut results = LowLevelDriveOperation::consume_to_fees_v0(
-                vec![removal_operation()],
-                &epoch,
-                EPOCHS_PER_ERA,
-                &SYNTHETIC_FEE_VERSION_2,
-                Some(&history),
-            )
-            .expect("history supplied");
-            let fee_result = results.remove(0);
+            let fee_result =
+                consume(1, &SYNTHETIC_FEE_VERSION_2, Some(&history)).expect("history supplied");
 
             assert_eq!(
                 refunds_of(&fee_result),
@@ -2804,26 +2907,22 @@ mod tests {
         #[test]
         fn should_ignore_fee_history_when_the_fee_version_number_is_one() {
             // Shipped replay path: every schedule a released protocol version references
-            // carries number 1, and that branch prices refunds against an empty history.
-            let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+            // carries number 1, and that branch prices refunds against an empty history in
+            // both generations.
             let history = boundary_history();
-            let mut results = LowLevelDriveOperation::consume_to_fees_v0(
-                vec![removal_operation()],
-                &epoch,
-                EPOCHS_PER_ERA,
-                &FEE_VERSION1,
-                Some(&history),
-            )
-            .expect("number 1 accepts but does not read the history");
-            let fee_result = results.remove(0);
+            for generation in [0, 1] {
+                let fee_result = consume(generation, &FEE_VERSION1, Some(&history))
+                    .expect("number 1 accepts but does not read the history");
 
-            assert_eq!(
-                refunds_of(&fee_result),
-                BTreeMap::from([
-                    (5, expected_refund(100, FIRST_GENERATION_RATE, 5)),
-                    (12, expected_refund(100, FIRST_GENERATION_RATE, 12)),
-                ])
-            );
+                assert_eq!(
+                    refunds_of(&fee_result),
+                    BTreeMap::from([
+                        (5, expected_refund(100, FIRST_GENERATION_RATE, 5)),
+                        (12, expected_refund(100, FIRST_GENERATION_RATE, 12)),
+                    ]),
+                    "generation {generation}"
+                );
+            }
         }
     }
 }

--- a/packages/rs-drive/src/fees/op.rs
+++ b/packages/rs-drive/src/fees/op.rs
@@ -2652,4 +2652,178 @@ mod tests {
             "expected overflow error when summing large components"
         );
     }
+
+    // ---------------------------------------------------------------
+    // 9. consume_to_fees_v0 — refunds and the fee history requirement
+    // ---------------------------------------------------------------
+
+    mod consume_to_fees_v0 {
+        use super::*;
+        use dpp::fee::epoch::distribution::calculate_storage_fee_refund_amount_and_leftovers;
+        use intmap::IntMap;
+        use platform_version::version::fee::v1::FEE_VERSION1;
+
+        const EPOCHS_PER_ERA: u16 = 20;
+        const CURRENT_EPOCH: u16 = 15;
+        const IDENTITY: [u8; 32] = [3; 32];
+
+        /// Storage rate of the first registered generation.
+        const FIRST_GENERATION_RATE: Credits = 27000;
+
+        /// A second storage table that is not registered anywhere, so a rate boundary in the
+        /// fee history is observable. Its number is not 1, which makes Drive require the
+        /// history to price refunds.
+        const SYNTHETIC_RATE: Credits = 54000;
+        static SYNTHETIC_FEE_VERSION_2: FeeVersion = FeeVersion {
+            fee_version_number: 2,
+            storage: FeeStorageVersion {
+                storage_disk_usage_credit_per_byte: SYNTHETIC_RATE,
+                ..FEE_VERSION1.storage
+            },
+            ..FEE_VERSION1
+        };
+
+        /// Fee history with a rate boundary at epoch 10.
+        fn boundary_history() -> CachedEpochIndexFeeVersions {
+            BTreeMap::from([
+                (0, FeeVersion::get(1).expect("registered")),
+                (10, &SYNTHETIC_FEE_VERSION_2),
+            ])
+        }
+
+        /// One identity removing 100 bytes stored at epoch 5 and 100 bytes stored at epoch 12,
+        /// plus 40 system bytes with an unknown storage epoch.
+        fn removal_operation() -> LowLevelDriveOperation {
+            let mut removal = BTreeMap::new();
+            removal.insert(
+                IDENTITY,
+                IntMap::from_iter([(5u16, 100u32), (12u16, 100u32)]),
+            );
+            removal.insert(
+                Identifier::default(),
+                IntMap::from_iter([(u16::MAX, 40u32)]),
+            );
+            CalculatedCostOperation(OperationCost {
+                storage_cost: StorageCost {
+                    added_bytes: 0,
+                    replaced_bytes: 0,
+                    removed_bytes: SectionedStorageRemoval(removal),
+                },
+                ..Default::default()
+            })
+        }
+
+        fn expected_refund(bytes: u32, rate: Credits, storage_epoch: u16) -> Credits {
+            let (amount, _) = calculate_storage_fee_refund_amount_and_leftovers(
+                bytes as Credits * rate,
+                storage_epoch,
+                CURRENT_EPOCH,
+                EPOCHS_PER_ERA,
+            )
+            .expect("refund amount");
+            amount
+        }
+
+        fn refunds_of(fee_result: &FeeResult) -> BTreeMap<u16, Credits> {
+            fee_result
+                .fee_refunds
+                .get(&IDENTITY)
+                .expect("identity has refunds")
+                .iter()
+                .map(|(epoch_index, credits)| (*epoch_index, *credits))
+                .collect()
+        }
+
+        #[test]
+        fn should_refund_through_the_legacy_empty_history_path_when_the_fee_version_number_is_one()
+        {
+            let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+            let mut results = LowLevelDriveOperation::consume_to_fees_v0(
+                vec![removal_operation()],
+                &epoch,
+                EPOCHS_PER_ERA,
+                &FEE_VERSION1,
+                None,
+            )
+            .expect("number 1 never needs the fee history");
+            let fee_result = results.remove(0);
+
+            assert_eq!(fee_result.removed_bytes_from_system, 40);
+            assert_eq!(fee_result.storage_fee, 0);
+            assert_eq!(
+                refunds_of(&fee_result),
+                BTreeMap::from([
+                    (5, expected_refund(100, FIRST_GENERATION_RATE, 5)),
+                    (12, expected_refund(100, FIRST_GENERATION_RATE, 12)),
+                ])
+            );
+        }
+
+        #[test]
+        fn should_require_fee_history_when_the_fee_version_number_is_not_one() {
+            let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+            let error = LowLevelDriveOperation::consume_to_fees_v0(
+                vec![removal_operation()],
+                &epoch,
+                EPOCHS_PER_ERA,
+                &SYNTHETIC_FEE_VERSION_2,
+                None,
+            )
+            .expect_err("a later generation cannot price refunds without the history");
+            assert!(
+                matches!(error, Error::Drive(DriveError::CorruptedCodeExecution(_))),
+                "unexpected error {error}"
+            );
+        }
+
+        #[test]
+        fn should_refund_at_the_storage_epoch_rate_across_a_history_boundary_when_the_fee_version_number_is_not_one(
+        ) {
+            let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+            let history = boundary_history();
+            let mut results = LowLevelDriveOperation::consume_to_fees_v0(
+                vec![removal_operation()],
+                &epoch,
+                EPOCHS_PER_ERA,
+                &SYNTHETIC_FEE_VERSION_2,
+                Some(&history),
+            )
+            .expect("history supplied");
+            let fee_result = results.remove(0);
+
+            assert_eq!(
+                refunds_of(&fee_result),
+                BTreeMap::from([
+                    (5, expected_refund(100, FIRST_GENERATION_RATE, 5)),
+                    (12, expected_refund(100, SYNTHETIC_RATE, 12)),
+                ]),
+                "each epoch refunds at the rate its bytes were charged"
+            );
+        }
+
+        #[test]
+        fn should_ignore_fee_history_when_the_fee_version_number_is_one() {
+            // Shipped replay path: every schedule a released protocol version references
+            // carries number 1, and that branch prices refunds against an empty history.
+            let epoch = Epoch::new(CURRENT_EPOCH).expect("epoch");
+            let history = boundary_history();
+            let mut results = LowLevelDriveOperation::consume_to_fees_v0(
+                vec![removal_operation()],
+                &epoch,
+                EPOCHS_PER_ERA,
+                &FEE_VERSION1,
+                Some(&history),
+            )
+            .expect("number 1 accepts but does not read the history");
+            let fee_result = results.remove(0);
+
+            assert_eq!(
+                refunds_of(&fee_result),
+                BTreeMap::from([
+                    (5, expected_refund(100, FIRST_GENERATION_RATE, 5)),
+                    (12, expected_refund(100, FIRST_GENERATION_RATE, 12)),
+                ])
+            );
+        }
+    }
 }

--- a/packages/rs-platform-version/src/version/fee/mod.rs
+++ b/packages/rs-platform-version/src/version/fee/mod.rs
@@ -29,7 +29,43 @@ pub mod vote_resolution_fund_fees;
 
 pub type FeeVersionNumber = u32;
 
+/// The registry of fee-history generations, keyed by `fee_version_number`.
+///
+/// A fee-history generation is the set of values the persisted fee history can be asked for
+/// through `KnownCostItem`: the storage, processing, hashing and signature groups. The epoch
+/// change hook records the number of the active schedule in platform state, and saved state
+/// stores that number, so every number that was ever recorded must stay registered here.
+///
+/// Entries are ordered by number, starting at 1 and without gaps. A schedule that changes any
+/// value the fee history serves (storage rates in particular, because they price refunds) must
+/// be registered under a new number. A schedule that only changes a group the history never
+/// serves (for example `FEE_VERSION2`, which changed only `data_contract_registration`) keeps
+/// the number of the generation it agrees with.
 pub const FEE_VERSIONS: &[FeeVersion] = &[FEE_VERSION1];
+
+const _: () = assert!(
+    !FEE_VERSIONS.is_empty(),
+    "the fee version registry must hold at least one generation"
+);
+
+const _: () = assert!(
+    registry_numbers_are_contiguous_from_one(FEE_VERSIONS),
+    "fee version numbers must be registered in order, starting at 1 and without gaps"
+);
+
+/// Returns true when the registry entries carry the numbers 1, 2, ... in order.
+///
+/// Evaluated at compile time so a mis-numbered entry cannot be built into a node.
+const fn registry_numbers_are_contiguous_from_one(registry: &[FeeVersion]) -> bool {
+    let mut index = 0;
+    while index < registry.len() {
+        if registry[index].fee_version_number != index as FeeVersionNumber + 1 {
+            return false;
+        }
+        index += 1;
+    }
+    true
+}
 
 #[derive(Clone, Debug, Encode, Decode, Default, PartialEq, Eq)]
 pub struct FeeVersion {
@@ -47,37 +83,46 @@ pub struct FeeVersion {
 }
 
 impl FeeVersion {
-    pub fn as_static(&self) -> &'static FeeVersion {
-        FeeVersion::get(self.fee_version_number).expect("expected fee version to exist")
+    /// Returns the registered fee-history generation this schedule's number names.
+    ///
+    /// The registered entry agrees with this schedule on every value the fee history serves,
+    /// but it is not necessarily the same schedule constant: several schedules may share one
+    /// number when they differ only in groups the history never reads. Fails when the number
+    /// is not registered.
+    pub fn as_static(&self) -> Result<&'static FeeVersion, PlatformVersionError> {
+        FeeVersion::get(self.fee_version_number)
     }
+
+    /// Resolves a fee version number to its registered generation.
+    ///
+    /// Lookup is by number, never by position in the registry. Zero and any unregistered number
+    /// are errors.
     pub fn get<'a>(version: FeeVersionNumber) -> Result<&'a Self, PlatformVersionError> {
-        if version > 0 {
-            FEE_VERSIONS.get(version as usize - 1).ok_or_else(|| {
-                PlatformVersionError::UnknownVersionError(format!("no fee version {version}"))
-            })
-        } else {
-            Err(PlatformVersionError::UnknownVersionError(format!(
-                "no fee version {version}"
-            )))
-        }
+        FeeVersion::get_optional(version).ok_or_else(|| {
+            PlatformVersionError::UnknownVersionError(format!("no fee version {version}"))
+        })
     }
 
+    /// Resolves a fee version number to its registered generation, or `None` when the number
+    /// is zero or not registered.
     pub fn get_optional<'a>(version: FeeVersionNumber) -> Option<&'a Self> {
-        if version > 0 {
-            FEE_VERSIONS.get(version as usize - 1)
-        } else {
-            None
-        }
+        FEE_VERSIONS
+            .iter()
+            .find(|fee_version| fee_version.fee_version_number == version)
     }
 
+    /// The earliest registered generation. This is what an empty fee history resolves to.
     pub fn first<'a>() -> &'a Self {
         FEE_VERSIONS
             .first()
-            .expect("expected to have a fee version")
+            .expect("the compile time assertion above proves the registry is not empty")
     }
 
+    /// The most recently registered generation.
     pub fn latest<'a>() -> &'a Self {
-        FEE_VERSIONS.last().expect("expected to have a fee version")
+        FEE_VERSIONS
+            .last()
+            .expect("the compile time assertion above proves the registry is not empty")
     }
 }
 
@@ -113,6 +158,161 @@ impl From<FeeVersionFieldsBeforeVersion4> for FeeVersion {
                 value.state_transition_min_fees,
             ),
             vote_resolution_fund_fees: value.vote_resolution_fund_fees,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "mock-versions")]
+    use crate::version::mocks::v2_test::TEST_PLATFORM_V2;
+    #[cfg(feature = "mock-versions")]
+    use crate::version::mocks::v3_test::TEST_PLATFORM_V3;
+    use crate::version::PLATFORM_VERSIONS;
+
+    /// Every schedule a platform version references, plus the mock schedules when they are
+    /// compiled in.
+    fn referenced_schedules() -> Vec<(&'static str, &'static FeeVersion)> {
+        let shipped = PLATFORM_VERSIONS
+            .iter()
+            .map(|platform_version| ("shipped platform version", &platform_version.fee_version));
+        #[cfg(feature = "mock-versions")]
+        let mocks = [
+            ("TEST_PLATFORM_V2", &TEST_PLATFORM_V2.fee_version),
+            ("TEST_PLATFORM_V3", &TEST_PLATFORM_V3.fee_version),
+        ];
+        #[cfg(not(feature = "mock-versions"))]
+        let mocks: [(&'static str, &'static FeeVersion); 0] = [];
+        shipped.chain(mocks).collect()
+    }
+
+    #[test]
+    fn should_resolve_every_registered_number_to_the_entry_with_that_number() {
+        for registered in FEE_VERSIONS {
+            let number = registered.fee_version_number;
+            let resolved = FeeVersion::get(number).expect("registered number resolves");
+            assert_eq!(
+                resolved.fee_version_number, number,
+                "lookup must return the entry carrying the requested number"
+            );
+            assert_eq!(resolved, registered);
+            assert_eq!(FeeVersion::get_optional(number), Some(registered));
+        }
+    }
+
+    #[test]
+    fn should_reject_zero_and_unregistered_numbers() {
+        let unregistered = [0, FEE_VERSIONS.len() as FeeVersionNumber + 1, u32::MAX];
+        for number in unregistered {
+            let error = FeeVersion::get(number).expect_err("unregistered number is an error");
+            assert!(
+                error.to_string().contains(&number.to_string()),
+                "error names the unknown number: {error}"
+            );
+            assert!(FeeVersion::get_optional(number).is_none());
+        }
+    }
+
+    #[test]
+    fn should_keep_registered_numbers_unique_and_contiguous_from_one() {
+        let numbers: Vec<FeeVersionNumber> = FEE_VERSIONS
+            .iter()
+            .map(|fee_version| fee_version.fee_version_number)
+            .collect();
+        let expected: Vec<FeeVersionNumber> =
+            (1..=FEE_VERSIONS.len() as FeeVersionNumber).collect();
+        assert_eq!(numbers, expected);
+        assert!(registry_numbers_are_contiguous_from_one(FEE_VERSIONS));
+
+        let skipped = [
+            FEE_VERSION1,
+            FeeVersion {
+                fee_version_number: 3,
+                ..FEE_VERSION1
+            },
+        ];
+        assert!(!registry_numbers_are_contiguous_from_one(&skipped));
+        let duplicated = [FEE_VERSION1, FEE_VERSION1];
+        assert!(!registry_numbers_are_contiguous_from_one(&duplicated));
+        let starting_at_zero = [FeeVersion {
+            fee_version_number: 0,
+            ..FEE_VERSION1
+        }];
+        assert!(!registry_numbers_are_contiguous_from_one(&starting_at_zero));
+    }
+
+    #[test]
+    fn should_register_the_number_every_platform_version_references() {
+        for (origin, schedule) in referenced_schedules() {
+            let registered = FeeVersion::get(schedule.fee_version_number).unwrap_or_else(|error| {
+                panic!(
+                    "{origin} references fee version number {} which is not registered: {error}",
+                    schedule.fee_version_number
+                )
+            });
+            // The registered generation must agree with the schedule on every group the fee
+            // history can serve. A schedule that changes one of these needs a new number.
+            assert_eq!(
+                registered.storage, schedule.storage,
+                "{origin}: storage group"
+            );
+            assert_eq!(
+                registered.processing, schedule.processing,
+                "{origin}: processing group"
+            );
+            assert_eq!(
+                registered.hashing, schedule.hashing,
+                "{origin}: hashing group"
+            );
+            assert_eq!(
+                registered.signature, schedule.signature,
+                "{origin}: signature group"
+            );
+        }
+    }
+
+    #[test]
+    fn should_keep_fee_version_one_storage_rates_frozen_for_replay() {
+        // Every storage byte written on the network so far was priced with these rates, and
+        // every refund of those bytes is priced with them again through the fee history.
+        // Changing them under number 1 would re-price historical refunds during replay, so a
+        // change in storage rates must be registered under a new number instead.
+        let storage = &FeeVersion::get(1)
+            .expect("fee version 1 is registered")
+            .storage;
+        assert_eq!(storage.storage_disk_usage_credit_per_byte, 27000);
+        assert_eq!(storage.storage_processing_credit_per_byte, 400);
+        assert_eq!(storage.storage_load_credit_per_byte, 20);
+        assert_eq!(storage.non_storage_load_credit_per_byte, 10);
+        assert_eq!(storage.storage_seek_cost, 2000);
+    }
+
+    #[test]
+    fn should_return_the_registered_entry_from_as_static() {
+        for (origin, schedule) in referenced_schedules() {
+            let registered = schedule
+                .as_static()
+                .unwrap_or_else(|error| panic!("{origin}: {error}"));
+            assert_eq!(registered.fee_version_number, schedule.fee_version_number);
+            assert_eq!(
+                registered,
+                FeeVersion::get(schedule.fee_version_number).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn should_error_from_as_static_for_an_unregistered_number() {
+        for number in [0, 99] {
+            let schedule = FeeVersion {
+                fee_version_number: number,
+                ..FEE_VERSION1
+            };
+            let error = schedule
+                .as_static()
+                .expect_err("an unregistered number cannot resolve");
+            assert!(error.to_string().contains(&number.to_string()));
         }
     }
 }

--- a/packages/rs-platform-version/src/version/fee/mod.rs
+++ b/packages/rs-platform-version/src/version/fee/mod.rs
@@ -14,6 +14,8 @@ use crate::version::fee::state_transition_min_fees::{
 use crate::version::fee::storage::FeeStorageVersion;
 use crate::version::fee::v1::FEE_VERSION1;
 use crate::version::fee::vote_resolution_fund_fees::VoteResolutionFundFees;
+#[cfg(feature = "mock-versions")]
+use crate::version::mocks::fee_test::FEE_TEST_VERSIONS;
 use bincode::{Decode, Encode};
 
 pub mod data_contract_registration;
@@ -67,6 +69,17 @@ const fn registry_numbers_are_contiguous_from_one(registry: &[FeeVersion]) -> bo
     true
 }
 
+/// Finds the entry that carries `number` in a registry slice.
+///
+/// Only the carried number is compared. The position of an entry in the slice is never used,
+/// so a registry whose numbers do not line up with positions still resolves correctly and a
+/// number that no entry carries is `None`.
+fn find_registered(registry: &[FeeVersion], number: FeeVersionNumber) -> Option<&FeeVersion> {
+    registry
+        .iter()
+        .find(|fee_version| fee_version.fee_version_number == number)
+}
+
 #[derive(Clone, Debug, Encode, Decode, Default, PartialEq, Eq)]
 pub struct FeeVersion {
     pub fee_version_number: FeeVersionNumber,
@@ -105,10 +118,15 @@ impl FeeVersion {
 
     /// Resolves a fee version number to its registered generation, or `None` when the number
     /// is zero or not registered.
+    ///
+    /// With the `mock-versions` feature the mock generations are consulted after the shipped
+    /// registry. Their numbers live above the test shift, so they can never shadow a shipped one.
     pub fn get_optional<'a>(version: FeeVersionNumber) -> Option<&'a Self> {
-        FEE_VERSIONS
-            .iter()
-            .find(|fee_version| fee_version.fee_version_number == version)
+        #[cfg(feature = "mock-versions")]
+        if let Some(mock_fee_version) = find_registered(FEE_TEST_VERSIONS, version) {
+            return Some(mock_fee_version);
+        }
+        find_registered(FEE_VERSIONS, version)
     }
 
     /// The earliest registered generation. This is what an empty fee history resolves to.
@@ -166,6 +184,10 @@ impl From<FeeVersionFieldsBeforeVersion4> for FeeVersion {
 mod tests {
     use super::*;
     #[cfg(feature = "mock-versions")]
+    use crate::version::mocks::fee_test::{
+        TEST_FEE_VERSION_DOUBLED_STORAGE_RATE, TEST_FEE_VERSION_NUMBER_DOUBLED_STORAGE_RATE,
+    };
+    #[cfg(feature = "mock-versions")]
     use crate::version::mocks::v2_test::TEST_PLATFORM_V2;
     #[cfg(feature = "mock-versions")]
     use crate::version::mocks::v3_test::TEST_PLATFORM_V3;
@@ -199,6 +221,75 @@ mod tests {
             assert_eq!(resolved, registered);
             assert_eq!(FeeVersion::get_optional(number), Some(registered));
         }
+    }
+
+    #[test]
+    fn should_find_entries_by_carried_number_regardless_of_position() {
+        // A registry whose numbers do not line up with positions: number 3 sits at position 0
+        // and number 1 at position 1. Position-based lookup would return the wrong entry for 1
+        // and nothing for 3; matching on the carried number must find both and reject 2.
+        let registry = [
+            FeeVersion {
+                fee_version_number: 3,
+                ..FEE_VERSION1
+            },
+            FeeVersion {
+                fee_version_number: 1,
+                ..FEE_VERSION1
+            },
+        ];
+
+        let found_one = find_registered(&registry, 1).expect("number 1 is carried");
+        assert!(std::ptr::eq(found_one, &registry[1]));
+        let found_three = find_registered(&registry, 3).expect("number 3 is carried");
+        assert!(std::ptr::eq(found_three, &registry[0]));
+        assert!(find_registered(&registry, 2).is_none());
+        assert!(find_registered(&registry, 0).is_none());
+
+        // The contrast a position-based lookup would have produced.
+        assert_ne!(registry[1 - 1].fee_version_number, 1);
+        assert!(registry.get(3 - 1).is_none());
+    }
+
+    #[cfg(feature = "mock-versions")]
+    #[test]
+    fn should_resolve_a_mock_generation_whose_number_is_not_a_registry_position() {
+        let number = TEST_FEE_VERSION_NUMBER_DOUBLED_STORAGE_RATE;
+        // The mock number lives above the test shift, so no position in the shipped registry
+        // corresponds to it; only a lookup by carried number can find it.
+        assert!(FEE_VERSIONS.get(number as usize - 1).is_none());
+        assert!(!FEE_VERSIONS.contains(&TEST_FEE_VERSION_DOUBLED_STORAGE_RATE));
+
+        let resolved = FeeVersion::get(number).expect("mock generation is registered");
+        assert_eq!(resolved.fee_version_number, number);
+        assert_eq!(*resolved, TEST_FEE_VERSION_DOUBLED_STORAGE_RATE);
+        assert_eq!(
+            FeeVersion::get_optional(number),
+            Some(&TEST_FEE_VERSION_DOUBLED_STORAGE_RATE)
+        );
+        assert_eq!(
+            TEST_FEE_VERSION_DOUBLED_STORAGE_RATE
+                .as_static()
+                .expect("mock generation resolves"),
+            resolved
+        );
+        assert_eq!(
+            resolved.storage.storage_disk_usage_credit_per_byte,
+            2 * FeeVersion::get(1)
+                .expect("registered")
+                .storage
+                .storage_disk_usage_credit_per_byte
+        );
+
+        // Neighbours of the mock number are not registered, and the mock never becomes the
+        // first or latest shipped generation.
+        assert!(FeeVersion::get(number - 1).is_err());
+        assert!(FeeVersion::get(number + 1).is_err());
+        assert_eq!(FeeVersion::first().fee_version_number, 1);
+        assert_eq!(
+            FeeVersion::latest(),
+            FEE_VERSIONS.last().expect("non-empty")
+        );
     }
 
     #[test]

--- a/packages/rs-platform-version/src/version/mocks/fee_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/fee_test.rs
@@ -1,0 +1,49 @@
+use crate::version::fee::storage::FeeStorageVersion;
+use crate::version::fee::v1::FEE_VERSION1;
+use crate::version::fee::{FeeVersion, FeeVersionNumber};
+use crate::version::mocks::TEST_PROTOCOL_VERSION_SHIFT_BYTES;
+
+/// Number of the mock fee-history generation.
+///
+/// Test identifiers live above the same shift as test protocol versions, so a mock number can
+/// never collide with a number a released network persisted, and it is never a position in the
+/// shipped registry.
+pub const TEST_FEE_VERSION_NUMBER_DOUBLED_STORAGE_RATE: FeeVersionNumber =
+    (1 << TEST_PROTOCOL_VERSION_SHIFT_BYTES) + 1;
+
+/// A fee-history generation whose disk usage rate is twice the shipped one.
+///
+/// It exists so tests can put a storage-rate boundary into the fee history and observe it
+/// through every consumer: the registry lookup, Drive's refund pricing and the saved-state
+/// round trip. It is registered only when the `mock-versions` feature is on.
+pub const TEST_FEE_VERSION_DOUBLED_STORAGE_RATE: FeeVersion = FeeVersion {
+    fee_version_number: TEST_FEE_VERSION_NUMBER_DOUBLED_STORAGE_RATE,
+    storage: FeeStorageVersion {
+        storage_disk_usage_credit_per_byte: FEE_VERSION1.storage.storage_disk_usage_credit_per_byte
+            * 2,
+        ..FEE_VERSION1.storage
+    },
+    ..FEE_VERSION1
+};
+
+/// Mock generations consulted by `FeeVersion::get` after the shipped registry.
+///
+/// Never part of a release build: `mock-versions` is a development-only feature.
+pub const FEE_TEST_VERSIONS: &[FeeVersion] = &[TEST_FEE_VERSION_DOUBLED_STORAGE_RATE];
+
+const _: () = assert!(
+    every_number_is_above_the_test_shift(FEE_TEST_VERSIONS),
+    "mock fee version numbers must live above the test shift so they cannot collide with shipped numbers"
+);
+
+/// Returns true when every mock entry carries a number above the test shift.
+const fn every_number_is_above_the_test_shift(registry: &[FeeVersion]) -> bool {
+    let mut index = 0;
+    while index < registry.len() {
+        if registry[index].fee_version_number >> TEST_PROTOCOL_VERSION_SHIFT_BYTES == 0 {
+            return false;
+        }
+        index += 1;
+    }
+    true
+}

--- a/packages/rs-platform-version/src/version/mocks/mod.rs
+++ b/packages/rs-platform-version/src/version/mocks/mod.rs
@@ -1,3 +1,4 @@
+pub mod fee_test;
 pub mod v2_test;
 pub mod v3_test;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of the smart-contract plan in dashpay/platform#4626 (task R12-01, fees workstream). The fee version registry and its consumers had four gaps that the plan's fee-version integrity work requires closed before new fee schedules can be introduced:

- `FeeVersion::get` and `FeeVersion::get_optional` resolved a `fee_version_number` by array position (`FEE_VERSIONS[n - 1]`), not by the number the entry carries. That only works while the registry happens to be numbered contiguously, and nothing enforced it.
- `FeeVersion::as_static` called `expect` on the lookup, and the saved-state loader (`PlatformStateForSavingV1` into `PlatformState`) did the same, so a persisted state holding a fee version number this build does not know aborted the node at start instead of failing with a descriptive error.
- `FeeRefunds::from_storage_removal` prices every removed byte at the storage rate active at the removal epoch. A refund is the unpaid remainder of the fee originally charged, and that fee was priced at the rate active when the bytes were written, so the rate must be resolved at the storage epoch through the fee history. The corrected rule is a new generation behind the `calculate_fee` method version, not an edit to the shipped one.
- None of this had tests: the registry module, the epoch fee-history resolution and the refund path in Drive had no coverage, and the two saved-state fixture tests only asserted that decoding succeeds.

Refs #4675

## What was done?
<!--- Describe your changes in detail -->

**`packages/rs-platform-version/src/version/fee/mod.rs`**
- `FeeVersion::get` and `get_optional` resolve by matching `fee_version_number` in `FEE_VERSIONS`; zero and any unregistered number are `PlatformVersionError::UnknownVersionError` (same message text as before).
- `FeeVersion::as_static` now returns `Result<&'static FeeVersion, PlatformVersionError>`.
- Two compile-time assertions: the registry is non-empty (so `first()` and `latest()` cannot panic) and the entries are numbered 1, 2, ... in order (`registry_numbers_are_contiguous_from_one`, a `const fn`). A mis-numbered or duplicated entry no longer compiles.
- Doc comment on `FEE_VERSIONS` defining a fee-history generation and when a schedule needs a new number.
- Lookup by carried number is factored into `find_registered`, and with the `mock-versions` feature `get_optional` consults `FEE_TEST_VERSIONS` after the shipped registry.
- Nine tests: every registered number resolves to the entry carrying it, `find_registered` against a registry whose numbers do not line up with positions (number 3 at position 0, number 1 at position 1), the mock generation resolves through `get`, `get_optional` and `as_static` although no registry position corresponds to its number, zero and unregistered numbers are rejected on every entry point, the numbering guard, every schedule referenced by `PLATFORM_VERSIONS` (and `TEST_PLATFORM_V2` / `TEST_PLATFORM_V3` under `mock-versions`) is registered and agrees with the registered generation on the storage, processing, hashing and signature groups, the number 1 storage rates are frozen with a replay rationale, and `as_static` on both sides.

**`packages/rs-platform-version/src/version/mocks/fee_test.rs`** (new, `mock-versions` feature only)
- `TEST_FEE_VERSION_DOUBLED_STORAGE_RATE`: a fee-history generation with twice the shipped disk usage rate, numbered `(1 << TEST_PROTOCOL_VERSION_SHIFT_BYTES) + 1` so it can never collide with a number a released network persisted and is never a position in the shipped registry. A compile-time assertion keeps every mock number above the shift. `mock-versions` is a dev-dependency feature of `drive`, `drive-abci` and `strategy-tests`; release builds never enable it.

**`packages/rs-dpp/src/fee/fee_result/refunds.rs`**
- `FeeRefunds::from_storage_removal` (generation 0) is byte-identical to the shipped body; its doc comment now states it is frozen and selected by `calculate_fee` version 0.
- New `FeeRefunds::from_storage_removal_v1`: the same function with the storage rate resolved with `Epoch::new(epoch_index)` (the storage epoch, the key of each removal entry) instead of `Epoch::new(current_epoch_index)`. The dust filter, era arithmetic and error mapping are unchanged. Doc comment explains the rule and which method version selects it.
- Tests with a synthetic number 2 generation (54000 credits per byte, not registered anywhere): the shipped generation keeps pricing both sides of a boundary at the current epoch's rate (frozen replay pin); generation 1 prices removals on both sides of a rate boundary at the rate their bytes were charged and uses the first generation before the earliest history entry; on every input reachable today (empty history, or a history where every entry is number 1) both generations produce identical refunds; the dust filter holds in both.

**`packages/rs-dpp/src/fee/default_costs/mod.rs`** (tests only)
- Five tests for `EpochCosts::active_fee_version`: empty history resolves to the first registered generation (the genesis-epoch fallback the epoch-change hook relies on), exact epoch match, nearest lower entry, before the earliest entry, and a consumer-level check that for every `PlatformVersion` and every `KnownCostItem` variant the referenced schedule and the registered generation return the same cost.

**`packages/rs-drive/src/fees/calculate_fee/v1/mod.rs`** (new), **`calculate_fee/mod.rs`** and **`packages/rs-drive/src/fees/op.rs`**
- `Drive::calculate_fee_v1`: a copy of `calculate_fee_v0` that calls `LowLevelDriveOperation::consume_to_fees_v1`. The dispatcher gains the `1 =>` arm and `known_versions: vec![0, 1]`. `calculate_fee_v0` and `consume_to_fees_v0` are byte-identical to the base branch.
- `LowLevelDriveOperation::consume_to_fees_v1`: a copy of `consume_to_fees_v0` whose two refund arms call `from_storage_removal_v1`. The fee version number 1 arm still prices against an empty history, so both generations agree on every shipped schedule.
- No `DRIVE_VERSION_V*` table selects `calculate_fee: 1` yet. Every `PLATFORM_V*` keeps `calculate_fee: 0`, and the mock versions too. The unreleased protocol version that registers a schedule under a new fee version number sets `calculate_fee: 1` in its drive table; that is the explicit version boundary.
- Tests in `op.rs` run both generations: number 1 refunds through the legacy empty-history path with `None` history and ignores a supplied history (both generations); any other number requires the history (`DriveError::CorruptedCodeExecution`, both generations); with a boundary history, generation 0 prices every epoch at the current epoch's rate and generation 1 at the storage-epoch rate; system bytes land in `removed_bytes_from_system`.
- Tests in `calculate_fee/mod.rs` go through the public dispatcher with a `TEST_PLATFORM_V2` clone carrying the mock generation and an explicit `calculate_fee` slot: generation 0 and generation 1 produce their respective pricing across a boundary, both agree when every history entry is number 1, both reject a missing history, and slot 2 is `UnknownVersionMismatch`.

**`packages/rs-drive-abci/src/platform_types/platform_state/platform_state_for_saving/v1/mod.rs`** and **`platform_state/mod.rs`**
- `From<PlatformStateForSavingV1> for PlatformState` became `TryFrom` with `Error`. An unknown stored number produces `ExecutionError::CorruptedCachedState("platform state stores fee version {n} for epoch {e}, which this build does not know")`. The struct, its derive stack and its bincode encoding are unchanged. The V1 arm of `TryFromPlatformVersioned<PlatformStateForSaving>` calls `try_from`. The V0 arm (legacy pre-1.4 format, every entry mapped to the first generation) is unchanged. `fetch_platform_state_v0`, the checkpoint loader and the `verify` subcommand all go through this path.
- Tests: the two existing fixture tests are kept, and new ones assert that both the V0 testnet fixture and the V1 devnet fixture resolve every entry to number 1, that every registered number round-trips through `serialize_to_bytes` and `versioned_deserialize`, that the mock generation's number (not a registry position) is what gets stored and comes back resolved to the mock entry with storage priced identically before and after reload, that a map built the way the epoch-change hook builds it (a reference into `PLATFORM_VERSIONS`) and the reloaded map agree on every `KnownCostItem` for epochs 0 to 3, and that a V1 state carrying number 99 for epoch 3 fails to load with an error naming both.

**`packages/rs-drive-abci/src/execution/platform_events/block_processing_end_events/tests.rs`**
- The single `as_static()` call site uses the fallible signature.

**`book/src/fees/overview.md`**
- Refunds section: the rate is resolved at the storage epoch through the fee history; the current epoch only fixes how many era shares were already paid. Fee Versioning section: what `fee_version_number` names, lookup by number, unknown numbers are load errors, why `FEE_VERSION1` and `FEE_VERSION2` share number 1, and why the empty-history fallback is deliberate.

Not changed: every `FEE_VERSION*` and fee-group constant, every `PLATFORM_V*` and mock version, `consume_to_fees_v0`, `EpochCosts::active_fee_version`, `upgrade_protocol_version_on_epoch_change_v0`, both `PlatformStateForSaving` layouts, the V0 legacy mapping, `SystemLimits`, proto and SDK surfaces.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Local gate, each command's output captured to a log file and its exit code checked (macOS, Rust 1.92):

```
cargo fmt --all -- --check
cargo clippy -p platform-version -p dpp -p drive -p drive-abci --all-features --all-targets -- -D warnings
cargo clippy -p platform-version --all-targets -- -D warnings
cargo check --workspace --all-targets
cargo test -p platform-version --all-features fee::
cargo test -p platform-version fee::
cargo test -p dpp --lib fee::
cargo test -p drive --lib fees::
cargo test -p drive --lib fees::calculate_fee
cargo test -p drive-abci --lib platform_types::platform_state
cargo test -p drive-abci --lib test_document_refund
cargo test -p drive-abci --lib protocol_upgrade::upgrade_protocol_version
```

Compile-time guard verified negatively: registering `FEE_VERSION1` twice fails `cargo check -p platform-version` with "fee version numbers must be registered in order, starting at 1 and without gaps".

No verify-only cut needed (no `src/verify/**` change). Full `drive-abci` suite and strategy tests are left to CI.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None on any shipped protocol version, so no `!`.

The refund rule correction (rate at the storage epoch instead of the removal epoch) lives in a new generation: `FeeRefunds::from_storage_removal_v1`, `consume_to_fees_v1` and `Drive::calculate_fee_v1`, selected only by `calculate_fee: 1`, which no `DRIVE_VERSION_V*` table sets. Generation 0 is byte-identical to the base branch. Every released protocol version therefore runs exactly the code it shipped with. The tests also show the two generations agree on every input reachable today (every registered schedule shares one storage table), so switching the slot to 1 in the unreleased protocol version alongside a new fee version number is where the correction first becomes observable.

In-workspace Rust API: `FeeVersion::as_static` is now fallible and `PlatformStateForSavingV1` converts to `PlatformState` through `TryFrom`. Each had one in-tree caller, both updated. No client crate uses either.

## Decisions taken (provisional values)

- **`FEE_VERSION2` keeps `fee_version_number: 1` and is not registered separately.** `fee_version_number` names a fee-history generation: the set of values `KnownCostItem` can read (storage, processing, hashing, signature). The two schedules differ only in `data_contract_registration`, which the history never serves, so both resolve to the same generation. Renumbering would flip protocol versions 9 to 14 onto the map-driven refund branch of `consume_to_fees_v0` for historical blocks, and several block-lifecycle callers (withdrawal cleanup, epoch change, masternode identity updates at init chain) pass `None` history to Drive and would hit `CorruptedCodeExecution`. That caller audit belongs to the next task in this workstream; it is recorded here so the reviewer sees it was considered.
- **Unknown stored number is an internal load error, not a consensus error.** It means the binary is older than the state it is loading. The error class is `ExecutionError::CorruptedCachedState`, surfaced through `ProtocolError::Generic` by `versioned_deserialize`, which is the existing path for load failures.
- **The registry numbering guard is a compile-time assertion rather than a runtime check**, so the constraint cannot be violated in a running node and the `expect` in `first()` and `latest()` has a proof.
- **A mock fee generation lives under `mock-versions`, not in the shipped registry.** The review asked for a lookup that cannot be satisfied by array position. Adding a real second generation would be a consensus change (it needs a protocol version and the caller audit). The mock generation follows the existing test protocol version pattern: its number sits above `TEST_PROTOCOL_VERSION_SHIFT_BYTES`, it is consulted after the shipped registry, and release builds never compile it.
- **The refund correction is a new `calculate_fee` generation, not an in-place edit.** The first revision changed `from_storage_removal` in place on the argument that the change is unobservable on shipped versions; review pointed out the conventions freeze shipped generations regardless, so generation 0 is restored byte-identical and the corrected rule is `calculate_fee_v1` / `consume_to_fees_v1` / `from_storage_removal_v1`. No version table selects it in this PR: the slot flips to 1 in the unreleased protocol version that also introduces a new fee version number, so both changes share one boundary. The registry change is a lookup repair with identical results for every currently registered input, and the saved-state change only turns an abort into an error; neither alters versioned behaviour.
- **Provisional numbers:** none. This task introduces no new fee rates, limits or constants. The synthetic number 2 generation with 54000 credits per byte exists only inside test modules.

Findings recorded for follow-up tasks in the workstream (no code change here):
- The block-lifecycle callers that pass `None` fee history to Drive are safe while every registered number is 1; the tests in `op.rs` pin that a later number requires the history on those paths.
- An end-to-end replay-versus-saved-state comparison across a live rate boundary at the ABCI level can now use `TEST_FEE_VERSION_DOUBLED_STORAGE_RATE` on a mock protocol version through `replace_test_versions`; this PR covers the boundary at the Drive dispatcher and the saved-state layers. `test_document_refund_after_10_epochs_on_different_fee_version_increasing_fees` cannot observe a boundary today because its "higher fees" version is a clone of the latest schedule (number 1).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

Dash-Tasks: R12-01

---
🤖 Posted autonomously by DashVM (Claude Fable 5.1) on behalf of pasta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new fee calculation version that refunds removed storage using the rate active when data was stored.
  * Fee versions are now resolved by their registered version number, improving consistency across fee schedules and saved platform state.

* **Bug Fixes**
  * Invalid or unknown fee versions in restored state are now rejected with clear errors instead of causing unexpected failures.

* **Documentation**
  * Expanded fee documentation covering refund calculation generations and fee-version history behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->