### PR TITLE
feat(platform)!: require fee history for storage refunds and credit their recorded owners

### DIFF
--- a/book/src/fees/overview.md
+++ b/book/src/fees/overview.md
@@ -219,6 +219,34 @@ out to proposers.
 There is a **dust limit**: refunds below 32 bytes worth of storage credits are
 discarded to prevent micro-refund spam.
 
+### Fee history and refund ownership (protocol version 15 onward)
+
+A refund is priced with the fee history of the block that removes the bytes:
+the `previous_fee_versions` map platform state carries, which the epoch change
+hook extends whenever the fee version number changes. `Drive::calculate_fee`
+v1 (`DRIVE_VERSION_V10`) consults that history for every owner-attributed
+storage removal, on every fee version number, and returns an internal error
+when a caller passes none. Earlier generations priced fee version number 1
+against an empty history, so a caller that forgot the history silently
+refunded at the first generation's storage rates; from protocol version 15
+that omission halts instead of mispricing. Every shipped schedule shares fee
+version number 1 and the same storage rates, so the credits themselves are
+unchanged for every shipped input.
+
+Refunds follow the recorded owner in the element's storage flags.
+`Drive::credit_storage_refunds_to_owners_operations` credits each owner that
+has a balance element without consulting any key or permission, so a frozen
+but existing owner still receives its bookkeeping refund, and reports the
+amount whose owner has no balance element (the native stand-in for a wiped
+owner) for the caller to move into the current epoch's processing pool with a
+single pool write. The caller records every refund against its storage epoch
+in the pending epoch refunds, so the credit conservation check stays balanced.
+Block lifecycle paths that remove owner-attributed bytes settle their refunds
+this way in the block that removes them. The protocol 12 schema migration,
+which shrank stored contracts without refunding the stripped bytes, ran once
+at that activation and is the recorded historical exception; it replays
+exactly as executed.
+
 ## Epoch-Based Fee Distribution
 
 Fees do not go directly to the block proposer. Instead, they accumulate in
@@ -291,6 +319,15 @@ pub struct FeeVersion {
 Fee versions are stored in the `FEE_VERSIONS` array and looked up by number. The
 `uses_version_fee_multiplier_permille` field allows a global scaling factor
 (permille = divide by 1000; a value of 1000 means no change).
+
+`fee_version_number` keys the persisted fee history that refunds are priced
+against. A schedule that changes storage rates needs a new number, because the
+refund code resolves the schedule for an epoch through the history and (in
+generations before protocol version 15) shortcut number 1 to the first
+generation's rates. `FEE_VERSION1` and `FEE_VERSION2` share number 1 because
+only a non-storage group changed between them; a test in `rs-drive`'s fee
+operation module pins that every shipped schedule keeps the first generation's
+storage rates.
 
 ## Key Source Files
 

--- a/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/ranked_index_e2e_tests.rs
+++ b/packages/rs-drive/src/drive/contract/insert/insert_contract/v0/tests/ranked_index_e2e_tests.rs
@@ -67,12 +67,15 @@ use dpp::block::block_info::BlockInfo;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::document_type::random_document::CreateRandomDocument;
 use dpp::document::{Document, DocumentV0Getters, DocumentV0Setters};
+use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
 use dpp::platform_value::Value;
 use dpp::prelude::DataContract;
 use dpp::tests::json_document::json_document_to_contract;
+use dpp::version::fee::FeeVersion;
 use dpp::version::PlatformVersion;
 use grovedb::element::indexed::AVG_FIXED_POINT_SCALE;
 use grovedb::Element;
+use std::collections::BTreeMap;
 
 /// The one index property every doctype in the fixture ranks by.
 const GROUP_PROPERTY: &str = "restaurantId";
@@ -1331,6 +1334,10 @@ fn estimated_and_actual_update_fees(
         .document_type_for_name(document_type_name)
         .unwrap_or_else(|_| panic!("{document_type_name} doctype exists"));
     let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+    // The replaced element carries epoch flags, so pricing its removal needs
+    // the fee history of the removing block, as every production caller
+    // passes.
+    let fee_history: CachedEpochIndexFeeVersions = BTreeMap::from([(0, FeeVersion::first())]);
 
     let run = |apply: bool| {
         drive
@@ -1344,7 +1351,7 @@ fn estimated_and_actual_update_fees(
                 storage_flags.clone(),
                 None,
                 pv,
-                None,
+                Some(&fee_history),
             )
             .unwrap_or_else(|e| {
                 panic!("expected the {document_type_name} update (apply={apply}) to succeed: {e}")

--- a/packages/rs-drive/src/drive/contract/migration/strip_unknown_document_schema_properties.rs
+++ b/packages/rs-drive/src/drive/contract/migration/strip_unknown_document_schema_properties.rs
@@ -214,3 +214,204 @@ impl Drive {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::storage_flags::StorageFlags;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::data_contract::accessors::v0::DataContractV0Getters;
+    use dpp::identity::accessors::{IdentityGettersV0, IdentitySettersV0};
+    use dpp::identity::Identity;
+    use dpp::platform_value::Value;
+    use dpp::tests::json_document::json_document_to_contract_with_ids;
+    use dpp::version::PlatformVersion;
+
+    const OWNER_BALANCE: u64 = 5_000_000;
+
+    /// The protocol 12 schema migration rewrote every stored user contract
+    /// whose document schemas carried top-level properties the v1 document
+    /// meta-schema forbids. It kept each element's storage flags and applied
+    /// the rewrite with a discarded cost vector, so the storage fee share of
+    /// the stripped bytes was never refunded to the contract owner and no
+    /// pending epoch refund was recorded. That is what every node executed
+    /// at the protocol 12 activation, and replay from genesis must reproduce
+    /// it byte for byte: the stripped byte counts were never recorded, so a
+    /// retroactive settlement is impossible, and the migration never runs
+    /// again, so there is nothing at a later version left to correct. The
+    /// storage refund invariant that applies from protocol version 15 names
+    /// this migration as its recorded historical exception; this test pins
+    /// the shipped behaviour so the exception stays exactly what it was.
+    #[test]
+    fn should_keep_the_protocol_12_schema_strip_frozen_without_refunding_stripped_bytes() {
+        let platform_version = PlatformVersion::get(12).expect("protocol version 12");
+        let drive = setup_drive_with_initial_state_structure(Some(platform_version));
+        let transaction = drive.grove.start_transaction();
+
+        // The contract owner exists with a balance, so a refund would be
+        // observable as a balance change.
+        let mut owner =
+            Identity::random_identity(2, Some(12), platform_version).expect("expected an identity");
+        owner.set_balance(OWNER_BALANCE);
+        drive
+            .add_new_identity(
+                owner.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to insert the owner");
+        drive
+            .add_to_system_credits(OWNER_BALANCE, Some(&transaction), platform_version)
+            .expect("expected to record the system credits");
+
+        // A user contract stored the way protocol version 12 stores it: the
+        // element carries the owner's storage flags.
+        let contract = json_document_to_contract_with_ids(
+            "tests/supporting_files/contract/family/family-contract.json",
+            None,
+            Some(owner.id()),
+            false,
+            platform_version,
+        )
+        .expect("expected the family contract");
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to insert the contract");
+
+        let contract_id = contract.id();
+        let contract_path = contract_root_path(contract_id.as_slice());
+        let stored_element = drive
+            .grove_get_raw(
+                (&contract_path).into(),
+                &[0],
+                DirectQueryType::StatefulDirectQuery,
+                Some(&transaction),
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("expected to read the contract element")
+            .expect("expected the contract element to exist");
+        let (clean_bytes, flags) = match stored_element {
+            Element::Item(bytes, flags) => (bytes, flags),
+            other => panic!("expected an item, got {:?}", other),
+        };
+        let owner_flags = StorageFlags::from_element_flags_ref(
+            flags
+                .as_ref()
+                .expect("a user contract carries storage flags"),
+        )
+        .expect("expected valid flags")
+        .expect("expected owner flags");
+        assert_eq!(
+            owner_flags.owner_id(),
+            Some(&owner.id().to_buffer()),
+            "the contract bytes are attributed to the owner"
+        );
+
+        // Rewrite the stored bytes the way a pre-v12 contract could look:
+        // with a top-level document schema property the v1 meta-schema does
+        // not allow. The element keeps its flags and grows.
+        let bincode_config = bincode::config::standard()
+            .with_big_endian()
+            .with_no_limit();
+        let (mut serialization_format, _): (DataContractInSerializationFormat, usize) =
+            bincode::borrow_decode_from_slice(&clean_bytes, bincode_config)
+                .expect("expected to decode the stored contract");
+        let person_schema = serialization_format
+            .document_schemas_mut()
+            .get_mut("person")
+            .expect("expected the person document type");
+        person_schema
+            .insert("legacyUnknownProperty".to_string(), Value::Bool(true))
+            .expect("expected to add the unknown property");
+        let inflated_bytes = bincode::encode_to_vec(&serialization_format, bincode_config)
+            .expect("expected to encode the inflated contract");
+        assert!(inflated_bytes.len() > clean_bytes.len());
+        drive
+            .grove_insert(
+                (&contract_path).into(),
+                &[0],
+                Element::Item(inflated_bytes.clone(), flags.clone()),
+                Some(&transaction),
+                None,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("expected to store the inflated contract");
+        drive.cache.data_contracts.clear();
+
+        let pending_refunds_before = drive
+            .fetch_pending_epoch_refunds(Some(&transaction), &platform_version.drive)
+            .expect("expected the pending refunds");
+        assert!(pending_refunds_before.is_empty());
+
+        // The migration, exactly as the protocol 12 activation ran it.
+        drive
+            .strip_unknown_document_schema_properties(&transaction, &platform_version.drive)
+            .expect("expected the migration to succeed");
+
+        let migrated_element = drive
+            .grove_get_raw(
+                (&contract_path).into(),
+                &[0],
+                DirectQueryType::StatefulDirectQuery,
+                Some(&transaction),
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("expected to read the migrated element")
+            .expect("expected the migrated element to exist");
+        let (migrated_bytes, migrated_flags) = match migrated_element {
+            Element::Item(bytes, flags) => (bytes, flags),
+            other => panic!("expected an item, got {:?}", other),
+        };
+        assert!(
+            migrated_bytes.len() < inflated_bytes.len(),
+            "the migration strips the unknown property, so the element shrinks"
+        );
+        assert_eq!(
+            migrated_bytes, clean_bytes,
+            "the migration restores the bytes the contract had without the property"
+        );
+        assert_eq!(
+            migrated_flags, flags,
+            "the element keeps the owner's storage flags byte for byte"
+        );
+
+        // The stripped bytes were owner-paid, yet nothing was refunded: the
+        // owner's balance and the pending epoch refunds are untouched and the
+        // credit sum stays balanced.
+        assert_eq!(
+            drive
+                .fetch_identity_balance(
+                    owner.id().to_buffer(),
+                    Some(&transaction),
+                    platform_version
+                )
+                .expect("expected the owner's balance"),
+            Some(OWNER_BALANCE)
+        );
+        assert!(drive
+            .fetch_pending_epoch_refunds(Some(&transaction), &platform_version.drive)
+            .expect("expected the pending refunds")
+            .is_empty());
+        let total = drive
+            .calculate_total_credits_balance(Some(&transaction), &platform_version.drive)
+            .expect("expected the total credits balance");
+        assert!(
+            total.ok().expect("expected a well-formed balance"),
+            "no credits move during the migration: {:?}",
+            total
+        );
+    }
+}

--- a/packages/rs-drive/src/drive/document/update/mod.rs
+++ b/packages/rs-drive/src/drive/document/update/mod.rs
@@ -3476,7 +3476,7 @@ mod tests {
                 storage_flags,
                 None,
                 platform_version,
-                None,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
             )
             .expect("key-changing update on aggregate index must succeed");
 

--- a/packages/rs-drive/src/drive/group/mod.rs
+++ b/packages/rs-drive/src/drive/group/mod.rs
@@ -14,6 +14,10 @@ mod queries;
 #[cfg(feature = "server")]
 mod tests {
     use crate::drive::Drive;
+    use crate::error::drive::DriveError;
+    use crate::error::Error;
+    use crate::util::batch::drive_op_batch::GroupOperationType;
+    use crate::util::batch::DriveOperation;
     use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
     use dpp::block::block_info::BlockInfo;
     use dpp::data_contract::accessors::v0::DataContractV0Getters;
@@ -25,6 +29,8 @@ mod tests {
     use dpp::data_contract::group::Group;
     use dpp::data_contract::v1::DataContractV1;
     use dpp::data_contract::DataContract;
+    use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
+    use dpp::fee::fee_result::FeeResult;
     use dpp::group::action_event::GroupActionEvent;
     use dpp::group::group_action::v0::GroupActionV0;
     use dpp::group::group_action::GroupAction;
@@ -34,8 +40,51 @@ mod tests {
     use dpp::identity::Identity;
     use dpp::serialization::PlatformDeserializable;
     use dpp::tokens::token_event::TokenEvent;
+    use dpp::version::fee::FeeVersion;
     use dpp::version::PlatformVersion;
     use std::collections::BTreeMap;
+
+    /// Closing a group action moves signer-flagged items out of the active
+    /// tree, and pricing that removal needs the fee history of the removing
+    /// block. Production reaches the closing branch only through
+    /// `apply_drive_operations`, which forwards the block's history; the
+    /// tests below use the same funnel.
+    fn fee_history() -> CachedEpochIndexFeeVersions {
+        BTreeMap::from([(0, FeeVersion::first())])
+    }
+
+    /// Closes `action_id` the way production does: as a group operation
+    /// applied through `apply_drive_operations` with the fee history.
+    #[allow(clippy::too_many_arguments)]
+    fn close_group_action_through_production_funnel(
+        drive: &Drive,
+        contract_id: Identifier,
+        initialize_with_insert_action_info: Option<GroupAction>,
+        action_id: Identifier,
+        signer_identity_id: Identifier,
+        signer_power: u32,
+        platform_version: &PlatformVersion,
+    ) -> Result<FeeResult, Error> {
+        let history = fee_history();
+        drive.apply_drive_operations(
+            vec![DriveOperation::GroupOperation(
+                GroupOperationType::AddGroupAction {
+                    contract_id,
+                    group_contract_position: 0,
+                    initialize_with_insert_action_info,
+                    action_id,
+                    signer_identity_id,
+                    signer_power,
+                    closes_group_action: true,
+                },
+            )],
+            true,
+            &BlockInfo::default(),
+            None,
+            platform_version,
+            Some(&history),
+        )
+    }
 
     /// Helper to create a standard test contract with groups and tokens.
     fn create_test_contract_with_groups(
@@ -573,22 +622,18 @@ mod tests {
         let platform_version = PlatformVersion::latest();
 
         // Add second signer to bring total power to 3 (meets required_power)
-        // and close the action
-        drive
-            .add_group_action(
-                contract_id,
-                0,
-                None, // no new action info, existing one will be moved
-                true, // closes_group_action
-                action_id,
-                identity_2_id,
-                2,
-                &BlockInfo::default(),
-                true,
-                None,
-                platform_version,
-            )
-            .expect("expected to close group action");
+        // and close the action. Closing moves signer-flagged items, so it goes
+        // through the production funnel that carries the fee history.
+        close_group_action_through_production_funnel(
+            &drive,
+            contract_id,
+            None, // no new action info, existing one will be moved
+            action_id,
+            identity_2_id,
+            2,
+            platform_version,
+        )
+        .expect("expected to close group action");
 
         // Verify the action is now closed
         let is_closed = drive
@@ -676,6 +721,104 @@ mod tests {
             *closed_action, expected_action,
             "closed action info should match the originally inserted action"
         );
+    }
+
+    #[test]
+    fn should_refund_signer_bytes_when_a_group_action_closes() {
+        let (drive, contract_id, identity_1_id, identity_2_id, action_id) =
+            setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        // identity_1 opened the action: its signer sum item and the action
+        // info are flagged with identity_1 at epoch 0. Closing moves both out
+        // of the active tree into unflagged closed items, so identity_1 is
+        // refunded for the removed flagged bytes; identity_2's closing signer
+        // item is written unflagged and never refundable.
+        let fee_result = close_group_action_through_production_funnel(
+            &drive,
+            contract_id,
+            None,
+            action_id,
+            identity_2_id,
+            2,
+            platform_version,
+        )
+        .expect("expected to close group action");
+
+        let identity_1_refunds = fee_result
+            .fee_refunds
+            .get(identity_1_id.as_bytes())
+            .expect("the opening signer's flagged bytes must be refunded");
+        assert!(
+            identity_1_refunds
+                .get(&0)
+                .is_some_and(|credits| *credits > 0),
+            "the refund is recorded against the storage epoch of the moved items: {:?}",
+            identity_1_refunds
+        );
+        assert!(
+            fee_result
+                .fee_refunds
+                .get(identity_2_id.as_bytes())
+                .is_none(),
+            "the closing signer never stored flagged bytes"
+        );
+    }
+
+    #[test]
+    fn should_reject_closing_a_group_action_through_the_bare_wrapper_without_fee_history() {
+        // The bare fee-returning wrapper passes no fee history. Production
+        // never closes an action through it (the state transition funnel
+        // forwards the block's history), so from protocol version 15 a
+        // closing call through the wrapper is a misuse the strict refund rule
+        // surfaces; the frozen generation keeps pricing at the first
+        // generation's rates.
+        let (drive, contract_id, _identity_1_id, identity_2_id, action_id) =
+            setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        let result = drive.add_group_action(
+            contract_id,
+            0,
+            None,
+            true,
+            action_id,
+            identity_2_id,
+            2,
+            &BlockInfo::default(),
+            true,
+            None,
+            platform_version,
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(Error::Drive(DriveError::CorruptedCodeExecution(_)))
+            ),
+            "closing without fee history must be rejected at the latest version, got {:?}",
+            result
+        );
+
+        let (drive, contract_id, _identity_1_id, identity_2_id, action_id) =
+            setup_drive_with_contract_and_action();
+        let frozen_platform_version = PlatformVersion::get(14).expect("protocol version 14");
+
+        drive
+            .add_group_action(
+                contract_id,
+                0,
+                None,
+                true,
+                action_id,
+                identity_2_id,
+                2,
+                &BlockInfo::default(),
+                true,
+                None,
+                frozen_platform_version,
+            )
+            .expect("protocol version 14 prices the shipped shortcut without a history");
     }
 
     #[test]

--- a/packages/rs-drive/src/drive/identity/update/methods/credit_storage_refunds_to_owners_operations/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/methods/credit_storage_refunds_to_owners_operations/mod.rs
@@ -1,0 +1,77 @@
+mod v0;
+
+use crate::drive::identity::update::storage_refund_credit_outcome::StorageRefundCreditOutcome;
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use crate::fees::op::LowLevelDriveOperation;
+use dpp::fee::fee_result::refunds::FeeRefunds;
+use dpp::version::PlatformVersion;
+use grovedb::TransactionArg;
+
+impl Drive {
+    /// Credits storage refunds to their recorded owners and reports what could
+    /// not be routed.
+    ///
+    /// For every owner in `fee_refunds` except `skip_owner`, the owner's
+    /// per-epoch credits are summed with checked arithmetic. An owner with a
+    /// balance element is credited through `add_to_identity_balance_operations`;
+    /// no key, signature or permission is consulted, so a frozen but existing
+    /// owner receives its bookkeeping refund. An owner without a balance
+    /// element (the native proxy for a wiped owner) is not credited and its
+    /// amount is reported as `routed_to_processing_pool`, for the caller to
+    /// settle into the current epoch's processing pool with one pool write.
+    /// The primitive records no pending refunds; the caller does, so the block
+    /// keeps a single pending-refund and pool write per batch.
+    ///
+    /// # Parameters
+    ///
+    /// * `fee_refunds` - The refunds to settle, per owner and storage epoch.
+    /// * `skip_owner` - An owner whose refund the caller settles itself (a
+    ///   state transition payer, whose refund folds into its balance change);
+    ///   `None` on lifecycle paths.
+    /// * `transaction` - The current transaction.
+    /// * `drive_operations` - The accumulator the balance operations are
+    ///   appended to; the caller applies them.
+    /// * `platform_version` - The platform version.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(StorageRefundCreditOutcome)` - The owners credited and the amount
+    ///   routed to the processing pool.
+    /// * `Err(Error)` - On overflow, a corrupted balance element, or when the
+    ///   method is not active for the platform version.
+    pub fn credit_storage_refunds_to_owners_operations(
+        &self,
+        fee_refunds: &FeeRefunds,
+        skip_owner: Option<[u8; 32]>,
+        transaction: TransactionArg,
+        drive_operations: &mut Vec<LowLevelDriveOperation>,
+        platform_version: &PlatformVersion,
+    ) -> Result<StorageRefundCreditOutcome, Error> {
+        match platform_version
+            .drive
+            .methods
+            .identity
+            .update
+            .credit_storage_refunds_to_owners
+        {
+            Some(0) => self.credit_storage_refunds_to_owners_operations_v0(
+                fee_refunds,
+                skip_owner,
+                transaction,
+                drive_operations,
+                platform_version,
+            ),
+            Some(version) => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "credit_storage_refunds_to_owners_operations".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+            None => Err(Error::Drive(DriveError::VersionNotActive {
+                method: "credit_storage_refunds_to_owners_operations".to_string(),
+                known_versions: vec![0],
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/identity/update/methods/credit_storage_refunds_to_owners_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/methods/credit_storage_refunds_to_owners_operations/v0/mod.rs
@@ -1,0 +1,82 @@
+use crate::drive::identity::update::storage_refund_credit_outcome::StorageRefundCreditOutcome;
+use crate::drive::Drive;
+use crate::error::Error;
+use crate::fees::op::LowLevelDriveOperation;
+use dpp::fee::fee_result::refunds::FeeRefunds;
+use dpp::fee::Credits;
+use dpp::prelude::Identifier;
+use dpp::version::PlatformVersion;
+use dpp::ProtocolError;
+use grovedb::batch::KeyInfoPath;
+use grovedb::{EstimatedLayerInformation, TransactionArg};
+use std::collections::{BTreeMap, HashMap};
+
+impl Drive {
+    /// Credits each recorded refund owner that has a balance element and
+    /// reports the rest as routed to the processing pool. See the dispatcher.
+    #[inline(always)]
+    pub(super) fn credit_storage_refunds_to_owners_operations_v0(
+        &self,
+        fee_refunds: &FeeRefunds,
+        skip_owner: Option<[u8; 32]>,
+        transaction: TransactionArg,
+        drive_operations: &mut Vec<LowLevelDriveOperation>,
+        platform_version: &PlatformVersion,
+    ) -> Result<StorageRefundCreditOutcome, Error> {
+        let mut credited: BTreeMap<Identifier, Credits> = BTreeMap::new();
+        let mut routed_to_processing_pool: Credits = 0;
+
+        for (owner_id, credits_per_epoch) in fee_refunds.iter() {
+            if skip_owner.as_ref() == Some(owner_id) {
+                continue;
+            }
+
+            let credits = credits_per_epoch
+                .values()
+                .try_fold(0u64, |sum, epoch_credits| sum.checked_add(*epoch_credits))
+                .ok_or(ProtocolError::Overflow(
+                    "storage refund credits for one owner overflow",
+                ))?;
+
+            if credits == 0 {
+                continue;
+            }
+
+            // A stateful read: `None` means the balance element does not exist, which
+            // is the only signal Drive has today that the owner is gone.
+            let existing_balance = self.fetch_identity_balance_operations(
+                *owner_id,
+                true,
+                transaction,
+                drive_operations,
+                platform_version,
+            )?;
+
+            if existing_balance.is_some() {
+                let mut estimated_costs_only_with_layer_info =
+                    None::<HashMap<KeyInfoPath, EstimatedLayerInformation>>;
+
+                drive_operations.extend(self.add_to_identity_balance_operations(
+                    *owner_id,
+                    credits,
+                    &mut estimated_costs_only_with_layer_info,
+                    transaction,
+                    platform_version,
+                )?);
+
+                credited.insert(Identifier::from(*owner_id), credits);
+            } else {
+                routed_to_processing_pool = routed_to_processing_pool.checked_add(credits).ok_or(
+                    ProtocolError::Overflow(
+                        "storage refund credits routed to the processing pool overflow",
+                    ),
+                )?;
+            }
+        }
+
+        Ok(StorageRefundCreditOutcome {
+            credited,
+            routed_to_processing_pool,
+        })
+    }
+}

--- a/packages/rs-drive/src/drive/identity/update/methods/credit_storage_refunds_to_owners_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/methods/credit_storage_refunds_to_owners_operations/v0/mod.rs
@@ -97,6 +97,9 @@ mod tests {
     const IDENTITY_BALANCE: Credits = 10_000_000;
     const PROCESSING_POOL_SEED: Credits = 1_000_000;
 
+    /// Refund credits per storage epoch, per owner.
+    type RefundsByOwner<'a> = [([u8; 32], &'a [(u16, Credits)])];
+
     fn insert_identity(
         drive: &Drive,
         seed: u64,
@@ -119,7 +122,7 @@ mod tests {
         identity
     }
 
-    fn refunds(entries: &[([u8; 32], &[(u16, Credits)])]) -> FeeRefunds {
+    fn refunds(entries: &RefundsByOwner) -> FeeRefunds {
         let mut fee_refunds = FeeRefunds::default();
         for (owner, credits_per_epoch) in entries {
             let mut epochs = CreditsPerEpoch::default();

--- a/packages/rs-drive/src/drive/identity/update/methods/credit_storage_refunds_to_owners_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/methods/credit_storage_refunds_to_owners_operations/v0/mod.rs
@@ -80,3 +80,401 @@ impl Drive {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::drive::DriveError;
+    use crate::util::batch::DriveOperation;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::block::epoch::Epoch;
+    use dpp::fee::epoch::CreditsPerEpoch;
+    use dpp::identity::accessors::{IdentityGettersV0, IdentitySettersV0};
+    use dpp::identity::Identity;
+    use grovedb::Transaction;
+
+    const IDENTITY_BALANCE: Credits = 10_000_000;
+    const PROCESSING_POOL_SEED: Credits = 1_000_000;
+
+    fn insert_identity(
+        drive: &Drive,
+        seed: u64,
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+    ) -> Identity {
+        let mut identity = Identity::random_identity(3, Some(seed), platform_version)
+            .expect("expected a random identity");
+        identity.set_balance(IDENTITY_BALANCE);
+        drive
+            .add_new_identity(
+                identity.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                Some(transaction),
+                platform_version,
+            )
+            .expect("expected to insert the identity");
+        identity
+    }
+
+    fn refunds(entries: &[([u8; 32], &[(u16, Credits)])]) -> FeeRefunds {
+        let mut fee_refunds = FeeRefunds::default();
+        for (owner, credits_per_epoch) in entries {
+            let mut epochs = CreditsPerEpoch::default();
+            for (epoch_index, credits) in credits_per_epoch.iter() {
+                epochs.insert(*epoch_index, *credits);
+            }
+            fee_refunds.0.insert(*owner, epochs);
+        }
+        fee_refunds
+    }
+
+    fn apply(
+        drive: &Drive,
+        operations: Vec<LowLevelDriveOperation>,
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+    ) {
+        drive
+            .apply_batch_low_level_drive_operations(
+                None,
+                Some(transaction),
+                operations,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("expected to apply the operations");
+    }
+
+    fn balance(
+        drive: &Drive,
+        identity_id: [u8; 32],
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+    ) -> Option<Credits> {
+        drive
+            .fetch_identity_balance(identity_id, Some(transaction), platform_version)
+            .expect("expected to fetch the balance")
+    }
+
+    #[test]
+    fn should_credit_each_recorded_owner_by_the_sum_of_its_epochs() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let transaction = drive.grove.start_transaction();
+
+        let first = insert_identity(&drive, 1, &transaction, platform_version);
+        let second = insert_identity(&drive, 2, &transaction, platform_version);
+        let first_id = first.id().to_buffer();
+        let second_id = second.id().to_buffer();
+
+        let fee_refunds = refunds(&[
+            (first_id, &[(0, 300), (4, 700), (9, 1)]),
+            (second_id, &[(2, 5_000)]),
+        ]);
+
+        let mut operations = vec![];
+        let outcome = drive
+            .credit_storage_refunds_to_owners_operations(
+                &fee_refunds,
+                None,
+                Some(&transaction),
+                &mut operations,
+                platform_version,
+            )
+            .expect("expected to credit the owners");
+        apply(&drive, operations, &transaction, platform_version);
+
+        assert_eq!(
+            outcome,
+            StorageRefundCreditOutcome {
+                credited: BTreeMap::from([(first.id(), 1_001), (second.id(), 5_000)]),
+                routed_to_processing_pool: 0,
+            }
+        );
+        assert_eq!(
+            balance(&drive, first_id, &transaction, platform_version),
+            Some(IDENTITY_BALANCE + 1_001)
+        );
+        assert_eq!(
+            balance(&drive, second_id, &transaction, platform_version),
+            Some(IDENTITY_BALANCE + 5_000)
+        );
+    }
+
+    #[test]
+    fn should_report_refunds_for_an_owner_without_a_balance_instead_of_failing() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let transaction = drive.grove.start_transaction();
+
+        let existing = insert_identity(&drive, 3, &transaction, platform_version);
+        let existing_id = existing.id().to_buffer();
+        let missing_id = [0xAB; 32];
+        assert_eq!(
+            balance(&drive, missing_id, &transaction, platform_version),
+            None
+        );
+
+        let fee_refunds = refunds(&[
+            (existing_id, &[(1, 400)]),
+            (missing_id, &[(1, 250), (3, 50)]),
+        ]);
+
+        let mut operations = vec![];
+        let outcome = drive
+            .credit_storage_refunds_to_owners_operations(
+                &fee_refunds,
+                None,
+                Some(&transaction),
+                &mut operations,
+                platform_version,
+            )
+            .expect("an owner without a balance is reported, not an error");
+        apply(&drive, operations, &transaction, platform_version);
+
+        assert_eq!(
+            outcome,
+            StorageRefundCreditOutcome {
+                credited: BTreeMap::from([(existing.id(), 400)]),
+                routed_to_processing_pool: 300,
+            }
+        );
+        assert_eq!(outcome.total(), Some(700));
+        assert_eq!(
+            balance(&drive, existing_id, &transaction, platform_version),
+            Some(IDENTITY_BALANCE + 400)
+        );
+        assert_eq!(
+            balance(&drive, missing_id, &transaction, platform_version),
+            None,
+            "no balance element is created for the missing owner"
+        );
+    }
+
+    #[test]
+    fn should_credit_an_owner_whose_keys_are_all_disabled() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let transaction = drive.grove.start_transaction();
+
+        let frozen = insert_identity(&drive, 4, &transaction, platform_version);
+        let frozen_id = frozen.id().to_buffer();
+        let key_ids = frozen.public_keys().keys().copied().collect::<Vec<_>>();
+        assert_eq!(key_ids.len(), 3);
+        drive
+            .disable_identity_keys(
+                frozen_id,
+                key_ids,
+                1_000,
+                &BlockInfo::default(),
+                true,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to disable every key");
+
+        let fee_refunds = refunds(&[(frozen_id, &[(0, 12_345)])]);
+
+        let mut operations = vec![];
+        let outcome = drive
+            .credit_storage_refunds_to_owners_operations(
+                &fee_refunds,
+                None,
+                Some(&transaction),
+                &mut operations,
+                platform_version,
+            )
+            .expect("no key or permission is consulted");
+        apply(&drive, operations, &transaction, platform_version);
+
+        assert_eq!(outcome.credited, BTreeMap::from([(frozen.id(), 12_345)]));
+        assert_eq!(outcome.routed_to_processing_pool, 0);
+        assert_eq!(
+            balance(&drive, frozen_id, &transaction, platform_version),
+            Some(IDENTITY_BALANCE + 12_345)
+        );
+    }
+
+    #[test]
+    fn should_skip_the_owner_the_caller_settles_itself() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let transaction = drive.grove.start_transaction();
+
+        let payer = insert_identity(&drive, 5, &transaction, platform_version);
+        let other = insert_identity(&drive, 6, &transaction, platform_version);
+        let payer_id = payer.id().to_buffer();
+        let other_id = other.id().to_buffer();
+
+        let fee_refunds = refunds(&[(payer_id, &[(0, 900)]), (other_id, &[(0, 100)])]);
+
+        let mut operations = vec![];
+        let outcome = drive
+            .credit_storage_refunds_to_owners_operations(
+                &fee_refunds,
+                Some(payer_id),
+                Some(&transaction),
+                &mut operations,
+                platform_version,
+            )
+            .expect("expected to credit the other owner");
+        apply(&drive, operations, &transaction, platform_version);
+
+        assert_eq!(outcome.credited, BTreeMap::from([(other.id(), 100)]));
+        assert_eq!(outcome.routed_to_processing_pool, 0);
+        assert_eq!(
+            balance(&drive, payer_id, &transaction, platform_version),
+            Some(IDENTITY_BALANCE),
+            "the payer's refund folds into its own balance change elsewhere"
+        );
+        assert_eq!(
+            balance(&drive, other_id, &transaction, platform_version),
+            Some(IDENTITY_BALANCE + 100)
+        );
+    }
+
+    #[test]
+    fn should_leave_total_credits_balanced_after_the_caller_records_the_pending_refunds() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let transaction = drive.grove.start_transaction();
+        let epoch = Epoch::new(0).expect("epoch 0");
+
+        let credited_owner = insert_identity(&drive, 7, &transaction, platform_version);
+        let credited_owner_id = credited_owner.id().to_buffer();
+        let missing_owner_id = [0xCD; 32];
+
+        // Every credit in the system is accounted for before the refunds: two
+        // identity balances and a seeded processing pool.
+        let seed_operation = drive
+            .add_epoch_processing_credits_for_distribution_operation(
+                &epoch,
+                PROCESSING_POOL_SEED,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected the pool seed operation");
+        apply(&drive, vec![seed_operation], &transaction, platform_version);
+        drive
+            .add_to_system_credits(
+                IDENTITY_BALANCE + PROCESSING_POOL_SEED,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to record the system credits");
+        assert!(drive
+            .calculate_total_credits_balance(Some(&transaction), &platform_version.drive)
+            .expect("expected the balance")
+            .ok()
+            .expect("expected a well-formed balance"));
+
+        let fee_refunds = refunds(&[
+            (credited_owner_id, &[(0, 100), (1, 50)]),
+            (missing_owner_id, &[(0, 70)]),
+        ]);
+
+        // The primitive credits the owner that exists and reports the rest.
+        let mut operations = vec![];
+        let outcome = drive
+            .credit_storage_refunds_to_owners_operations(
+                &fee_refunds,
+                None,
+                Some(&transaction),
+                &mut operations,
+                platform_version,
+            )
+            .expect("expected to credit the owners");
+        assert_eq!(outcome.routed_to_processing_pool, 70);
+
+        // The caller routes the unrouted amount to the epoch's processing pool
+        // with one pool write and records every refund against its storage
+        // epoch, exactly as a lifecycle settlement does.
+        operations.push(
+            drive
+                .add_epoch_processing_credits_for_distribution_operation(
+                    &epoch,
+                    outcome.routed_to_processing_pool,
+                    Some(&transaction),
+                    platform_version,
+                )
+                .expect("expected the pool write"),
+        );
+        apply(&drive, operations, &transaction, platform_version);
+
+        let mut pending_refund_operations: Vec<DriveOperation> = vec![];
+        Drive::add_update_pending_epoch_refunds_operations(
+            &mut pending_refund_operations,
+            fee_refunds.sum_per_epoch(),
+            &platform_version.drive,
+        )
+        .expect("expected the pending refund operations");
+        drive
+            .apply_drive_operations(
+                pending_refund_operations,
+                true,
+                &BlockInfo::default(),
+                Some(&transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to record the pending refunds");
+
+        assert_eq!(
+            balance(&drive, credited_owner_id, &transaction, platform_version),
+            Some(IDENTITY_BALANCE + 150)
+        );
+        assert_eq!(
+            drive
+                .get_epoch_processing_credits_for_distribution(
+                    &epoch,
+                    Some(&transaction),
+                    platform_version
+                )
+                .expect("expected the pool balance"),
+            PROCESSING_POOL_SEED + 70
+        );
+        assert_eq!(
+            drive
+                .fetch_pending_epoch_refunds(Some(&transaction), &platform_version.drive)
+                .expect("expected the pending refunds"),
+            CreditsPerEpoch::from_iter([(0, 170), (1, 50)])
+        );
+        let total = drive
+            .calculate_total_credits_balance(Some(&transaction), &platform_version.drive)
+            .expect("expected the balance");
+        assert!(
+            total.ok().expect("expected a well-formed balance"),
+            "credits moved between the pools and an identity balance must stay conserved: {:?}",
+            total
+        );
+    }
+
+    #[test]
+    fn should_not_be_active_before_the_new_drive_table() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let frozen_platform_version = PlatformVersion::get(14).expect("protocol version 14");
+        let transaction = drive.grove.start_transaction();
+
+        let fee_refunds = refunds(&[([1; 32], &[(0, 100)])]);
+
+        let result = drive.credit_storage_refunds_to_owners_operations(
+            &fee_refunds,
+            None,
+            Some(&transaction),
+            &mut vec![],
+            frozen_platform_version,
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(Error::Drive(DriveError::VersionNotActive { .. }))
+            ),
+            "protocol version 14 has no lifecycle refund settlement, got {:?}",
+            result
+        );
+    }
+}

--- a/packages/rs-drive/src/drive/identity/update/methods/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/methods/mod.rs
@@ -4,6 +4,7 @@ mod add_new_unique_keys_to_identity;
 mod add_to_identity_balance;
 mod add_to_previous_balance;
 mod apply_balance_change_from_fee_to_identity;
+mod credit_storage_refunds_to_owners_operations;
 mod disable_identity_keys;
 pub(crate) mod merge_identity_nonce;
 mod re_enable_identity_keys;

--- a/packages/rs-drive/src/drive/identity/update/structs/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/structs/mod.rs
@@ -2,3 +2,5 @@
 pub mod add_to_previous_balance_outcome;
 /// Applying a balance chance outcome
 pub mod apply_balance_change_outcome;
+/// The outcome of crediting storage refunds to their recorded owners
+pub mod storage_refund_credit_outcome;

--- a/packages/rs-drive/src/drive/identity/update/structs/storage_refund_credit_outcome/mod.rs
+++ b/packages/rs-drive/src/drive/identity/update/structs/storage_refund_credit_outcome/mod.rs
@@ -1,0 +1,33 @@
+use dpp::fee::Credits;
+use dpp::prelude::Identifier;
+use std::collections::BTreeMap;
+
+/// What `Drive::credit_storage_refunds_to_owners_operations` did with a set of
+/// storage refunds: which recorded owners were credited and how much could not
+/// be routed to any owner.
+///
+/// The caller that knows the block's epoch settles `routed_to_processing_pool`
+/// into that epoch's processing pool with a single pool write and records the
+/// refunds against their storage epochs; the primitive itself never touches
+/// the pools.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StorageRefundCreditOutcome {
+    /// Credits added to each recorded owner's balance, summed over the epochs
+    /// the owner's bytes were stored in.
+    pub credited: BTreeMap<Identifier, Credits>,
+    /// Credits whose recorded owner has no balance element. Until a typed
+    /// owner encoding exists this is the native proxy for a wiped owner, so
+    /// the caller moves this amount into the current epoch's processing pool.
+    pub routed_to_processing_pool: Credits,
+}
+
+impl StorageRefundCreditOutcome {
+    /// The total credited to owners plus the amount routed to the pool.
+    pub fn total(&self) -> Option<Credits> {
+        self.credited
+            .values()
+            .try_fold(self.routed_to_processing_pool, |total, credits| {
+                total.checked_add(*credits)
+            })
+    }
+}

--- a/packages/rs-drive/src/fees/calculate_fee/mod.rs
+++ b/packages/rs-drive/src/fees/calculate_fee/mod.rs
@@ -64,3 +64,98 @@ impl Drive {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::fee::epoch::DEFAULT_EPOCHS_PER_ERA;
+    use grovedb_costs::storage_cost::removal::StorageRemovalPerEpochByIdentifier;
+    use grovedb_costs::storage_cost::removal::StorageRemovedBytes;
+    use grovedb_costs::storage_cost::StorageCost;
+    use grovedb_costs::OperationCost;
+    use platform_version::version::fee::FeeVersion;
+    use std::collections::BTreeMap;
+
+    fn owner_attributed_removal() -> Vec<LowLevelDriveOperation> {
+        let mut removal = StorageRemovalPerEpochByIdentifier::default();
+        removal.entry([7; 32]).or_default().insert(3, 1000);
+        vec![LowLevelDriveOperation::CalculatedCostOperation(
+            OperationCost {
+                seek_count: 1,
+                storage_cost: StorageCost {
+                    added_bytes: 0,
+                    replaced_bytes: 0,
+                    removed_bytes: StorageRemovedBytes::SectionedStorageRemoval(removal),
+                },
+                storage_loaded_bytes: 0,
+                hash_node_calls: 0,
+                sinsemilla_hash_calls: 0,
+            },
+        )]
+    }
+
+    /// Both generations through the dispatcher on the same operations: the
+    /// last frozen protocol version prices an owner-attributed removal without
+    /// a fee history, the latest refuses it, and with the history both yield
+    /// the same fee result.
+    #[test]
+    fn should_require_the_fee_history_for_storage_refunds_from_protocol_version_15() {
+        let frozen_platform_version = PlatformVersion::get(14).expect("protocol version 14");
+        let platform_version = PlatformVersion::latest();
+        let epoch = Epoch::new(5).expect("epoch 5");
+
+        let frozen_without_history = Drive::calculate_fee(
+            None,
+            Some(owner_attributed_removal()),
+            &epoch,
+            DEFAULT_EPOCHS_PER_ERA,
+            frozen_platform_version,
+            None,
+        )
+        .expect("protocol version 14 prices fee version number 1 without a history");
+        assert!(
+            frozen_without_history.fee_refunds.get(&[7; 32]).is_some(),
+            "the shipped generation refunds at the first generation's rates"
+        );
+
+        let latest_without_history = Drive::calculate_fee(
+            None,
+            Some(owner_attributed_removal()),
+            &epoch,
+            DEFAULT_EPOCHS_PER_ERA,
+            platform_version,
+            None,
+        );
+        assert!(
+            matches!(
+                latest_without_history,
+                Err(Error::Drive(DriveError::CorruptedCodeExecution(_)))
+            ),
+            "the latest generation refuses a storage refund without the fee history, got {:?}",
+            latest_without_history
+        );
+
+        let history: CachedEpochIndexFeeVersions = BTreeMap::from([(0u16, FeeVersion::first())]);
+        let frozen_with_history = Drive::calculate_fee(
+            None,
+            Some(owner_attributed_removal()),
+            &epoch,
+            DEFAULT_EPOCHS_PER_ERA,
+            frozen_platform_version,
+            Some(&history),
+        )
+        .expect("protocol version 14 prices with a history");
+        let latest_with_history = Drive::calculate_fee(
+            None,
+            Some(owner_attributed_removal()),
+            &epoch,
+            DEFAULT_EPOCHS_PER_ERA,
+            platform_version,
+            Some(&history),
+        )
+        .expect("the latest generation prices with a history");
+
+        assert_eq!(frozen_with_history, latest_with_history);
+        assert_eq!(frozen_with_history, frozen_without_history);
+    }
+}

--- a/packages/rs-drive/src/fees/calculate_fee/mod.rs
+++ b/packages/rs-drive/src/fees/calculate_fee/mod.rs
@@ -9,6 +9,7 @@ use dpp::version::PlatformVersion;
 use enum_map::EnumMap;
 
 mod v0;
+mod v1;
 
 impl Drive {
     /// Calculates fees for the given operations. Returns the storage and processing costs.
@@ -47,9 +48,17 @@ impl Drive {
                 &platform_version.fee_version,
                 previous_fee_versions,
             ),
+            1 => Self::calculate_fee_v1(
+                base_operations,
+                drive_operations,
+                epoch,
+                epochs_per_era,
+                &platform_version.fee_version,
+                previous_fee_versions,
+            ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "Drive::calculate_fee".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             })),
         }

--- a/packages/rs-drive/src/fees/calculate_fee/v1/mod.rs
+++ b/packages/rs-drive/src/fees/calculate_fee/v1/mod.rs
@@ -1,0 +1,54 @@
+use crate::drive::Drive;
+use crate::error::fee::FeeError;
+use crate::error::Error;
+use crate::fees::op::{BaseOp, LowLevelDriveOperation};
+use dpp::block::epoch::Epoch;
+use dpp::fee::fee_result::FeeResult;
+
+use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
+use enum_map::EnumMap;
+use platform_version::version::fee::FeeVersion;
+
+impl Drive {
+    /// Calculates fees for the given operations. Returns the storage and processing costs.
+    ///
+    /// Generation 1: storage refunds are priced through `consume_to_fees_v1`,
+    /// which requires and consults the fee history for every owner-attributed
+    /// storage removal. Selected by drive table v10 (protocol version 15).
+    #[inline(always)]
+    pub(crate) fn calculate_fee_v1(
+        base_operations: Option<EnumMap<BaseOp, u64>>,
+        drive_operations: Option<Vec<LowLevelDriveOperation>>,
+        epoch: &Epoch,
+        epochs_per_era: u16,
+        fee_version: &FeeVersion,
+        previous_fee_versions: Option<&CachedEpochIndexFeeVersions>,
+    ) -> Result<FeeResult, Error> {
+        let mut aggregate_fee_result = FeeResult::default();
+        if let Some(base_operations) = base_operations {
+            for (base_op, count) in base_operations.iter() {
+                match base_op.cost().checked_mul(*count) {
+                    None => return Err(Error::Fee(FeeError::Overflow("overflow error"))),
+                    Some(cost) => match aggregate_fee_result.processing_fee.checked_add(cost) {
+                        None => return Err(Error::Fee(FeeError::Overflow("overflow error"))),
+                        Some(value) => aggregate_fee_result.processing_fee = value,
+                    },
+                }
+            }
+        }
+
+        if let Some(drive_operations) = drive_operations {
+            for drive_fee_result in LowLevelDriveOperation::consume_to_fees_v1(
+                drive_operations,
+                epoch,
+                epochs_per_era,
+                fee_version,
+                previous_fee_versions,
+            )? {
+                aggregate_fee_result.checked_add_assign(drive_fee_result)?;
+            }
+        }
+
+        Ok(aggregate_fee_result)
+    }
+}

--- a/packages/rs-drive/src/fees/op.rs
+++ b/packages/rs-drive/src/fees/op.rs
@@ -312,6 +312,78 @@ impl LowLevelDriveOperation {
             .collect()
     }
 
+    /// Returns a list of the costs of the Drive operations, pricing every
+    /// owner-attributed storage removal with the fee history of the block
+    /// that removes the bytes.
+    ///
+    /// This is the generation `Drive::calculate_fee` v1 selects. It differs
+    /// from `consume_to_fees_v0` in one arm: a `SectionedStorageRemoval`
+    /// always consults `previous_fee_versions` and returns
+    /// `CorruptedCodeExecution` when none is given, on every fee version
+    /// number. v0 priced fee version number 1 against an empty history, so a
+    /// caller that forgot the history silently refunded at the first
+    /// generation's storage rates; from protocol version 15 that omission is
+    /// an error, never a fallback to a schedule.
+    pub fn consume_to_fees_v1(
+        drive_operations: Vec<LowLevelDriveOperation>,
+        epoch: &Epoch,
+        epochs_per_era: u16,
+        fee_version: &FeeVersion,
+        previous_fee_versions: Option<&CachedEpochIndexFeeVersions>,
+    ) -> Result<Vec<FeeResult>, Error> {
+        drive_operations
+            .into_iter()
+            .map(|operation| match operation {
+                PreCalculatedFeeResult(f) => Ok(f),
+                FunctionOperation(op) => Ok(FeeResult {
+                    processing_fee: op.cost(fee_version),
+                    ..Default::default()
+                }),
+                _ => {
+                    let cost = operation.operation_cost()?;
+                    // There is no need for a checked multiply here because added bytes are u64 and
+                    // storage disk usage credit per byte should never be high enough to cause an overflow
+                    let storage_fee = cost.storage_cost.added_bytes as u64
+                        * fee_version.storage.storage_disk_usage_credit_per_byte;
+                    let processing_fee = cost.ephemeral_cost(fee_version)?;
+                    let (fee_refunds, removed_bytes_from_system) =
+                        match cost.storage_cost.removed_bytes {
+                            NoStorageRemoval => (FeeRefunds::default(), 0),
+                            BasicStorageRemoval(amount) => {
+                                // this is not always considered an error
+                                (FeeRefunds::default(), amount)
+                            }
+                            SectionedStorageRemoval(mut removal_per_epoch_by_identifier) => {
+                                let system_amount = removal_per_epoch_by_identifier
+                                    .remove(&Identifier::default())
+                                    .map_or(0, |a| a.values().sum());
+                                let previous_fee_versions = previous_fee_versions.ok_or(
+                                    Error::Drive(DriveError::CorruptedCodeExecution(
+                                        "a storage refund needs the fee history of the block that removes the bytes",
+                                    )),
+                                )?;
+                                (
+                                    FeeRefunds::from_storage_removal(
+                                        removal_per_epoch_by_identifier,
+                                        epoch.index,
+                                        epochs_per_era,
+                                        previous_fee_versions,
+                                    )?,
+                                    system_amount,
+                                )
+                            }
+                        };
+                    Ok(FeeResult {
+                        storage_fee,
+                        processing_fee,
+                        fee_refunds,
+                        removed_bytes_from_system,
+                    })
+                }
+            })
+            .collect()
+    }
+
     /// Returns the cost of this operation
     pub fn operation_cost(self) -> Result<OperationCost, Error> {
         match self {

--- a/packages/rs-drive/src/fees/op.rs
+++ b/packages/rs-drive/src/fees/op.rs
@@ -2742,6 +2742,9 @@ mod tests {
         const OWNER: [u8; 32] = [7; 32];
         const OTHER_OWNER: [u8; 32] = [9; 32];
 
+        /// Removed bytes per storage epoch, per owner.
+        type BytesByOwner<'a> = [([u8; 32], &'a [(u16, u32)])];
+
         /// A schedule no protocol version references, with doubled storage
         /// rates, so a test can tell "the history was consulted" apart from
         /// "the first generation's rates were used".
@@ -2758,9 +2761,7 @@ mod tests {
         /// One removed element whose bytes are attributed per owner and per
         /// storage epoch, the shape grovedb reports for an element carrying
         /// owner storage flags.
-        fn sectioned_removal(
-            bytes_by_owner: &[([u8; 32], &[(u16, u32)])],
-        ) -> LowLevelDriveOperation {
+        fn sectioned_removal(bytes_by_owner: &BytesByOwner) -> LowLevelDriveOperation {
             let mut removal = StorageRemovalPerEpochByIdentifier::default();
             for (owner, bytes_per_epoch) in bytes_by_owner {
                 let owner_bytes = removal.entry(*owner).or_default();
@@ -2954,7 +2955,7 @@ mod tests {
             // equal v0's: the boundary changes what a missing history does,
             // not what a present one yields.
             let removal_epoch = 15u16;
-            let bytes_by_owner: &[([u8; 32], &[(u16, u32)])] = &[
+            let bytes_by_owner: &BytesByOwner = &[
                 (OWNER, &[(0, 900), (3, 1200), (7, 64), (12, 5000)]),
                 (OTHER_OWNER, &[(5, 31), (11, 2048)]),
                 (Identifier::default(), &[(2, 700)]),

--- a/packages/rs-drive/src/fees/op.rs
+++ b/packages/rs-drive/src/fees/op.rs
@@ -2724,4 +2724,307 @@ mod tests {
             "expected overflow error when summing large components"
         );
     }
+
+    // ---------------------------------------------------------------
+    // consume_to_fees_v1: fee history required and consulted for
+    // owner-attributed storage removals
+    // ---------------------------------------------------------------
+
+    mod storage_refund_fee_history {
+        use super::*;
+        use dpp::fee::epoch::distribution::calculate_storage_fee_refund_amount_and_leftovers;
+        use dpp::fee::epoch::DEFAULT_EPOCHS_PER_ERA;
+        use grovedb_costs::storage_cost::removal::StorageRemovalPerEpochByIdentifier;
+        use platform_version::version::fee::storage::v1::FEE_STORAGE_VERSION1;
+        use platform_version::version::fee::v1::FEE_VERSION1;
+        use platform_version::version::PLATFORM_VERSIONS;
+
+        const OWNER: [u8; 32] = [7; 32];
+        const OTHER_OWNER: [u8; 32] = [9; 32];
+
+        /// A schedule no protocol version references, with doubled storage
+        /// rates, so a test can tell "the history was consulted" apart from
+        /// "the first generation's rates were used".
+        static SYNTHETIC_FEE_VERSION_2: FeeVersion = FeeVersion {
+            fee_version_number: 2,
+            storage: FeeStorageVersion {
+                storage_disk_usage_credit_per_byte: 2 * FEE_STORAGE_VERSION1
+                    .storage_disk_usage_credit_per_byte,
+                ..FEE_STORAGE_VERSION1
+            },
+            ..FEE_VERSION1
+        };
+
+        /// One removed element whose bytes are attributed per owner and per
+        /// storage epoch, the shape grovedb reports for an element carrying
+        /// owner storage flags.
+        fn sectioned_removal(
+            bytes_by_owner: &[([u8; 32], &[(u16, u32)])],
+        ) -> LowLevelDriveOperation {
+            let mut removal = StorageRemovalPerEpochByIdentifier::default();
+            for (owner, bytes_per_epoch) in bytes_by_owner {
+                let owner_bytes = removal.entry(*owner).or_default();
+                for (epoch_index, bytes) in bytes_per_epoch.iter() {
+                    owner_bytes.insert(*epoch_index, *bytes);
+                }
+            }
+            CalculatedCostOperation(OperationCost {
+                seek_count: 1,
+                storage_cost: StorageCost {
+                    added_bytes: 0,
+                    replaced_bytes: 0,
+                    removed_bytes: StorageRemovedBytes::SectionedStorageRemoval(removal),
+                },
+                storage_loaded_bytes: 0,
+                hash_node_calls: 0,
+                sinsemilla_hash_calls: 0,
+            })
+        }
+
+        fn basic_removal(bytes: u32) -> LowLevelDriveOperation {
+            CalculatedCostOperation(OperationCost {
+                seek_count: 1,
+                storage_cost: StorageCost {
+                    added_bytes: 0,
+                    replaced_bytes: 0,
+                    removed_bytes: StorageRemovedBytes::BasicStorageRemoval(bytes),
+                },
+                storage_loaded_bytes: 0,
+                hash_node_calls: 0,
+                sinsemilla_hash_calls: 0,
+            })
+        }
+
+        fn epoch(index: u16) -> Epoch {
+            Epoch::new(index).expect("test epoch index fits")
+        }
+
+        fn refund_for(fee_results: &[FeeResult], owner: &[u8; 32], storage_epoch: u16) -> Credits {
+            *fee_results
+                .iter()
+                .find_map(|fee_result| fee_result.fee_refunds.get(owner))
+                .expect("the owner should be refunded")
+                .get(&storage_epoch)
+                .expect("the storage epoch should be refunded")
+        }
+
+        #[test]
+        fn should_reject_a_sectioned_removal_without_fee_history_in_v1() {
+            let operations = vec![sectioned_removal(&[(OWNER, &[(3, 1000)])])];
+
+            let result = LowLevelDriveOperation::consume_to_fees_v1(
+                operations,
+                &epoch(5),
+                DEFAULT_EPOCHS_PER_ERA,
+                &FEE_VERSION1,
+                None,
+            );
+
+            assert!(
+                matches!(
+                    result,
+                    Err(Error::Drive(DriveError::CorruptedCodeExecution(_)))
+                ),
+                "v1 must refuse to price an owner-attributed removal without the fee history, got {:?}",
+                result
+            );
+
+            // v0 keeps its shipped shortcut for fee version number 1.
+            let operations = vec![sectioned_removal(&[(OWNER, &[(3, 1000)])])];
+            LowLevelDriveOperation::consume_to_fees_v0(
+                operations,
+                &epoch(5),
+                DEFAULT_EPOCHS_PER_ERA,
+                &FEE_VERSION1,
+                None,
+            )
+            .expect("v0 prices fee version number 1 against an empty history");
+        }
+
+        #[test]
+        fn should_reject_a_removal_of_unowned_flagged_bytes_without_fee_history_in_v1() {
+            // Bytes flagged with an epoch but no owner land in the system
+            // bucket; they are never refunded, but the removal is still
+            // sectioned and the rule is deliberately uniform: every
+            // sectioned removal carries the history of the removing block.
+            let operations = vec![sectioned_removal(&[(Identifier::default(), &[(3, 1000)])])];
+
+            let result = LowLevelDriveOperation::consume_to_fees_v1(
+                operations,
+                &epoch(5),
+                DEFAULT_EPOCHS_PER_ERA,
+                &FEE_VERSION1,
+                None,
+            );
+
+            assert!(matches!(
+                result,
+                Err(Error::Drive(DriveError::CorruptedCodeExecution(_)))
+            ));
+        }
+
+        #[test]
+        fn should_not_need_fee_history_in_v1_for_unflagged_removals() {
+            let operations = vec![basic_removal(1000)];
+
+            let fee_results = LowLevelDriveOperation::consume_to_fees_v1(
+                operations,
+                &epoch(5),
+                DEFAULT_EPOCHS_PER_ERA,
+                &FEE_VERSION1,
+                None,
+            )
+            .expect("unflagged bytes are removed from the system, no refund is priced");
+
+            assert_eq!(fee_results.len(), 1);
+            assert_eq!(fee_results[0].removed_bytes_from_system, 1000);
+            assert_eq!(fee_results[0].fee_refunds, FeeRefunds::default());
+        }
+
+        #[test]
+        fn should_consult_the_fee_history_in_v1_even_for_fee_version_number_one() {
+            // The history says a doubled schedule has been active since epoch 10.
+            // The bytes were stored at epoch 12 and are removed at epoch 15 under
+            // a fee version whose number is 1, the exact case v0 shortcuts.
+            let history: CachedEpochIndexFeeVersions =
+                BTreeMap::from([(10u16, &SYNTHETIC_FEE_VERSION_2)]);
+            let stored_bytes = 1000u32;
+            let storage_epoch = 12u16;
+            let removal_epoch = 15u16;
+
+            let v0_results = LowLevelDriveOperation::consume_to_fees_v0(
+                vec![sectioned_removal(&[(
+                    OWNER,
+                    &[(storage_epoch, stored_bytes)],
+                )])],
+                &epoch(removal_epoch),
+                DEFAULT_EPOCHS_PER_ERA,
+                &FEE_VERSION1,
+                Some(&history),
+            )
+            .expect("v0 prices");
+            let v1_results = LowLevelDriveOperation::consume_to_fees_v1(
+                vec![sectioned_removal(&[(
+                    OWNER,
+                    &[(storage_epoch, stored_bytes)],
+                )])],
+                &epoch(removal_epoch),
+                DEFAULT_EPOCHS_PER_ERA,
+                &FEE_VERSION1,
+                Some(&history),
+            )
+            .expect("v1 prices with the history");
+
+            let (expected_v0, _) = calculate_storage_fee_refund_amount_and_leftovers(
+                stored_bytes as Credits * FEE_STORAGE_VERSION1.storage_disk_usage_credit_per_byte,
+                storage_epoch,
+                removal_epoch,
+                DEFAULT_EPOCHS_PER_ERA,
+            )
+            .expect("refund math");
+            let (expected_v1, _) = calculate_storage_fee_refund_amount_and_leftovers(
+                stored_bytes as Credits
+                    * SYNTHETIC_FEE_VERSION_2
+                        .storage
+                        .storage_disk_usage_credit_per_byte,
+                storage_epoch,
+                removal_epoch,
+                DEFAULT_EPOCHS_PER_ERA,
+            )
+            .expect("refund math");
+
+            assert_eq!(
+                refund_for(&v0_results, &OWNER, storage_epoch),
+                expected_v0,
+                "v0 ignores the history for fee version number 1 and prices at the first generation"
+            );
+            assert_eq!(
+                refund_for(&v1_results, &OWNER, storage_epoch),
+                expected_v1,
+                "v1 prices with the schedule the history resolves for the epoch"
+            );
+            assert!(expected_v1 > expected_v0);
+        }
+
+        #[test]
+        fn should_credit_the_same_refunds_in_v1_as_in_v0_for_every_shipped_platform_version() {
+            // Every shipped schedule shares fee version number 1 and the same
+            // storage rates (pinned below), so for every history the epoch
+            // change hook can build from the shipped versions, v1's credits
+            // equal v0's: the boundary changes what a missing history does,
+            // not what a present one yields.
+            let removal_epoch = 15u16;
+            let bytes_by_owner: &[([u8; 32], &[(u16, u32)])] = &[
+                (OWNER, &[(0, 900), (3, 1200), (7, 64), (12, 5000)]),
+                (OTHER_OWNER, &[(5, 31), (11, 2048)]),
+                (Identifier::default(), &[(2, 700)]),
+            ];
+
+            for platform_version in PLATFORM_VERSIONS {
+                for history_epoch in [0u16, 1, 5, 12, 15] {
+                    let history: CachedEpochIndexFeeVersions =
+                        BTreeMap::from([(history_epoch, &platform_version.fee_version)]);
+
+                    let v0_results = LowLevelDriveOperation::consume_to_fees_v0(
+                        vec![sectioned_removal(bytes_by_owner), basic_removal(40)],
+                        &epoch(removal_epoch),
+                        DEFAULT_EPOCHS_PER_ERA,
+                        &platform_version.fee_version,
+                        Some(&history),
+                    )
+                    .expect("v0 prices");
+                    let v1_results = LowLevelDriveOperation::consume_to_fees_v1(
+                        vec![sectioned_removal(bytes_by_owner), basic_removal(40)],
+                        &epoch(removal_epoch),
+                        DEFAULT_EPOCHS_PER_ERA,
+                        &platform_version.fee_version,
+                        Some(&history),
+                    )
+                    .expect("v1 prices");
+
+                    assert_eq!(
+                        v0_results, v1_results,
+                        "protocol version {} with a history entry at epoch {} must refund identically in v0 and v1",
+                        platform_version.protocol_version, history_epoch
+                    );
+                    assert!(
+                        v1_results[0].fee_refunds.get(&OWNER).is_some(),
+                        "the owner's bytes must be refunded"
+                    );
+                    assert!(
+                        v1_results[0]
+                            .fee_refunds
+                            .get(&Identifier::default())
+                            .is_none(),
+                        "system bytes are never refunded"
+                    );
+                    assert_eq!(v1_results[0].removed_bytes_from_system, 700);
+                }
+            }
+        }
+
+        /// The premise of the equality above. A shipped schedule that kept
+        /// fee version number 1 but changed its storage rates would make v0
+        /// (which prices number 1 at the first generation) and v1 (which
+        /// prices at the schedule the history resolves) diverge on the same
+        /// input; such a change needs a new fee version number, which both
+        /// generations already look up in the history.
+        #[test]
+        fn should_keep_every_shipped_schedule_on_the_first_generation_storage_rates() {
+            for platform_version in PLATFORM_VERSIONS {
+                assert_eq!(
+                    platform_version.fee_version.fee_version_number,
+                    FeeVersion::first().fee_version_number,
+                    "protocol version {} changed its fee version number",
+                    platform_version.protocol_version
+                );
+                assert_eq!(
+                    platform_version.fee_version.storage,
+                    FeeVersion::first().storage,
+                    "protocol version {} changed its storage rates without a new fee version number",
+                    platform_version.protocol_version
+                );
+            }
+        }
+    }
 }

--- a/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/mod.rs
@@ -2,6 +2,7 @@ use versioned_feature_core::{FeatureVersion, OptionalFeatureVersion};
 
 pub mod v1;
 pub mod v2;
+pub mod v3;
 
 #[derive(Clone, Debug, Default)]
 pub struct DriveIdentityMethodVersions {
@@ -214,4 +215,9 @@ pub struct DriveIdentityUpdateMethodVersions {
     pub apply_balance_change_from_fee_to_identity: FeatureVersion,
     pub remove_from_identity_balance: FeatureVersion,
     pub refresh_identity_key_reference_operations: FeatureVersion,
+    /// Read by `Drive::credit_storage_refunds_to_owners_operations`: credits each recorded
+    /// owner of a storage refund and reports the amount whose owner has no balance element
+    /// so the caller can route it to the current epoch's processing pool. `None` before
+    /// protocol version 15, where no path settles refunds outside a state transition.
+    pub credit_storage_refunds_to_owners: OptionalFeatureVersion,
 }

--- a/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v1.rs
@@ -109,6 +109,7 @@ pub const DRIVE_IDENTITY_METHOD_VERSIONS_V1: DriveIdentityMethodVersions =
             apply_balance_change_from_fee_to_identity: 0,
             remove_from_identity_balance: 0,
             refresh_identity_key_reference_operations: 0,
+            credit_storage_refunds_to_owners: None,
         },
         insert: DriveIdentityInsertMethodVersions {
             add_new_identity: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_identity_method_versions/v3.rs
@@ -13,34 +13,19 @@ use crate::version::drive_versions::drive_identity_method_versions::{
     DriveIdentityWithdrawalTransactionQueueMethodVersions,
 };
 
-/// V2 is protocol version 14's identity-method table. It differs from V1 in
-/// its withdrawal methods:
+/// V3 is protocol version 15's identity-method table. It differs from V2 in
+/// one slot:
 ///
-/// * `withdrawals.document.find_withdrawal_documents_by_status_and_transaction_indices`
-///   0 -> 1, selecting the v1 withdrawal-by-transaction-index query builder
-///   that carries the transaction-index `In` clause in
-///   `InternalClauses.in_clauses` instead of smuggling it through
-///   `equal_clauses`. The two builders lower to the identical grovedb path
-///   query (pinned by `withdrawal_in_clause_placement_equivalence` in
-///   rs-drive's query tests), so this is a structural version bump, not a
-///   behavior change; v0 stays byte-frozen for protocol versions up to 13.
-/// * `withdrawals.calculate_current_withdrawal_limit` 0 -> 1: the daily
-///   maximum derives from the total credits Platform held a day ago (the
-///   relative daily withdrawal limit) instead of the current total. The
-///   `max_daily_withdrawal_amount` cap applies to that day-old base; credit
-///   inflows from the active window are added after the cap so matching
-///   deposit-withdraw cycles do not consume the capped budget.
-/// * `withdrawals.record_total_credits_history` and
-///   `withdrawals.fetch_total_credits_in_platform_a_day_ago` `None -> Some(0)`:
-///   the per-block total credits history under the withdrawals tree that the
-///   lagged limit reads; the subtree does not exist before v14, so V1 keeps
-///   both slots `None`.
-/// * `withdrawals.record_credit_inflows` `None -> Some(0)`: every credit mint
-///   (asset locks, epoch Core rewards) is recorded in the credit inflows sum
-///   tree so the daily withdrawal limit counts net outflow instead of gross —
-///   a deposit -> withdraw cycle no longer consumes the budget of other users.
-///   The subtree does not exist before v14, so V1 keeps the slot `None`.
-pub const DRIVE_IDENTITY_METHOD_VERSIONS_V2: DriveIdentityMethodVersions =
+/// * `update.credit_storage_refunds_to_owners` `None -> Some(0)`: the
+///   primitive that credits each recorded owner of a storage refund and
+///   reports the amount whose owner has no balance element, so a block
+///   lifecycle path (or, later, the state transition refund path) can route
+///   that amount to the current epoch's processing pool instead of halting.
+///   No key or permission is consulted on any route: a frozen but existing
+///   owner is credited, an owner without a balance is settled into the pool.
+///   Nothing before v15 settles refunds outside a state transition, so V1 and
+///   V2 keep the slot `None`.
+pub const DRIVE_IDENTITY_METHOD_VERSIONS_V3: DriveIdentityMethodVersions =
     DriveIdentityMethodVersions {
         fetch: DriveIdentityFetchMethodVersions {
             public_key_hashes: DriveIdentityFetchPublicKeyHashesMethodVersions {
@@ -136,7 +121,7 @@ pub const DRIVE_IDENTITY_METHOD_VERSIONS_V2: DriveIdentityMethodVersions =
             apply_balance_change_from_fee_to_identity: 0,
             remove_from_identity_balance: 0,
             refresh_identity_key_reference_operations: 0,
-            credit_storage_refunds_to_owners: None,
+            credit_storage_refunds_to_owners: Some(0), // new in v15: credits recorded refund owners, reports the unrouted amount for the processing pool
         },
         insert: DriveIdentityInsertMethodVersions {
             add_new_identity: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/mod.rs
@@ -28,6 +28,7 @@ pub mod drive_token_method_versions;
 pub mod drive_verify_method_versions;
 pub mod drive_vote_method_versions;
 pub mod v1;
+pub mod v10;
 pub mod v2;
 pub mod v3;
 pub mod v4;

--- a/packages/rs-platform-version/src/version/drive_versions/v10.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v10.rs
@@ -1,0 +1,154 @@
+use crate::version::drive_versions::drive_address_funds_method_versions::v2::DRIVE_ADDRESS_FUNDS_METHOD_VERSIONS_V2;
+use crate::version::drive_versions::drive_contract_method_versions::v3::DRIVE_CONTRACT_METHOD_VERSIONS_V3;
+use crate::version::drive_versions::drive_credit_pool_method_versions::v1::CREDIT_POOL_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_document_method_versions::v4::DRIVE_DOCUMENT_METHOD_VERSIONS_V4;
+use crate::version::drive_versions::drive_group_method_versions::v1::DRIVE_GROUP_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_group_method_versions::DriveShieldedMethodVersions;
+use crate::version::drive_versions::drive_grove_method_versions::v1::DRIVE_GROVE_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_identity_method_versions::v3::DRIVE_IDENTITY_METHOD_VERSIONS_V3;
+use crate::version::drive_versions::drive_state_transition_method_versions::v4::DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V4;
+use crate::version::drive_versions::drive_structure_version::v1::DRIVE_STRUCTURE_V1;
+use crate::version::drive_versions::drive_token_method_versions::v1::DRIVE_TOKEN_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_verify_method_versions::v2::DRIVE_VERIFY_METHOD_VERSIONS_V2;
+use crate::version::drive_versions::drive_vote_method_versions::v2::DRIVE_VOTE_METHOD_VERSIONS_V2;
+use crate::version::drive_versions::{
+    DriveAssetLockMethodVersions, DriveBalancesMethodVersions, DriveBatchOperationsMethodVersion,
+    DriveEstimatedCostsMethodVersions, DriveFeesMethodVersions, DriveFetchMethodVersions,
+    DriveInitializationMethodVersions, DriveMethodVersions, DriveOperationsMethodVersion,
+    DrivePlatformStateMethodVersions, DrivePlatformSystemMethodVersions,
+    DrivePrefundedSpecializedMethodVersions, DriveProtocolUpgradeVersions,
+    DriveProveMethodVersions, DriveSavedBlockTransactionsMethodVersions,
+    DriveSystemEstimationCostsMethodVersions, DriveVersion,
+};
+use grovedb_version::version::v4::GROVE_V4;
+
+/// Drive version 10.
+/// Introduced in protocol v15, carrying the fee-history rules for storage
+/// refunds:
+///
+/// * **Fee history required for refunds** — `fees.calculate_fee` 0 -> 1.
+///   The v1 generation consults the block's fee history on every fee
+///   version number and returns an internal error for an owner-attributed
+///   (sectioned) storage removal without that history, where v0 priced
+///   fee version number 1 against an empty map. Every shipped schedule
+///   shares number 1 and the same storage rates, so the credits are
+///   unchanged; only a missing history is now an error instead of a
+///   silent fallback to the first-generation rates.
+/// * **Recorded-owner refund credits** — `DRIVE_IDENTITY_METHOD_VERSIONS_V3`
+///   turns on `update.credit_storage_refunds_to_owners`, the primitive
+///   block lifecycle paths use to credit each recorded owner of a refund
+///   and report the amount whose owner has no balance element.
+///
+/// Everything else matches `DRIVE_VERSION_V9`.
+pub const DRIVE_VERSION_V10: DriveVersion = DriveVersion {
+    structure: DRIVE_STRUCTURE_V1,
+    methods: DriveMethodVersions {
+        initialization: DriveInitializationMethodVersions {
+            create_initial_state_structure: 3, // changed in v8: adds shielded pool trees (commitment tree, nullifiers, anchors)
+        },
+        credit_pools: CREDIT_POOL_METHOD_VERSIONS_V1,
+        protocol_upgrade: DriveProtocolUpgradeVersions {
+            clear_version_information: 0,
+            fetch_versions_with_counter: 0,
+            fetch_proved_versions_with_counter: 0,
+            fetch_validator_version_votes: 0,
+            fetch_proved_validator_version_votes: 0,
+            remove_validators_proposed_app_versions: 0,
+            update_validator_proposed_app_version: 0,
+        },
+        prove: DriveProveMethodVersions {
+            prove_elements: 0,
+            prove_multiple_state_transition_results: 0,
+            prove_state_transition: 0,
+        },
+        balances: DriveBalancesMethodVersions {
+            add_to_system_credits: 0,
+            add_to_system_credits_operations: 0,
+            remove_from_system_credits: 0,
+            remove_from_system_credits_operations: 0,
+            calculate_total_credits_balance: 2, // ShieldedBalances root tree adds a fifth term to the equation
+        },
+        document: DRIVE_DOCUMENT_METHOD_VERSIONS_V4, // changed in v9: v2 index walkers + v1 update walker (shared-prefix aggregate indexes become insertable) and the detect_ranked_mode slot
+        vote: DRIVE_VOTE_METHOD_VERSIONS_V2,
+        contract: DRIVE_CONTRACT_METHOD_VERSIONS_V3, // changed in v8: count-tree-aware contract-insertion cost estimation (v12+ countable/range_countable doctypes)
+        fees: DriveFeesMethodVersions { calculate_fee: 1 }, // changed in v10: fee history required and consulted for every storage refund
+        estimated_costs: DriveEstimatedCostsMethodVersions {
+            add_estimation_costs_for_levels_up_to_contract: 0,
+            add_estimation_costs_for_levels_up_to_contract_document_type_excluded: 0,
+            add_estimation_costs_for_contested_document_tree_levels_up_to_contract: 0,
+            add_estimation_costs_for_contested_document_tree_levels_up_to_contract_document_type_excluded: 0,
+        },
+        asset_lock: DriveAssetLockMethodVersions {
+            add_asset_lock_outpoint: 0,
+            add_estimation_costs_for_adding_asset_lock: 0,
+            fetch_asset_lock_outpoint_info: 0,
+        },
+        verify: DRIVE_VERIFY_METHOD_VERSIONS_V2, // changed in v8: compacted address-balance proof envelope (verify v1)
+        identity: DRIVE_IDENTITY_METHOD_VERSIONS_V3, // changed in v10: credit_storage_refunds_to_owners primitive for lifecycle refund settlement
+        token: DRIVE_TOKEN_METHOD_VERSIONS_V1,
+        platform_system: DrivePlatformSystemMethodVersions {
+            estimation_costs: DriveSystemEstimationCostsMethodVersions {
+                for_total_system_credits_update: 0,
+            },
+        },
+        operations: DriveOperationsMethodVersion {
+            rollback_transaction: 0,
+            drop_cache: 0,
+            commit_transaction: 0,
+            apply_partial_batch_low_level_drive_operations: 0,
+            apply_partial_batch_grovedb_operations: 0,
+            apply_batch_low_level_drive_operations: 0,
+            apply_batch_grovedb_operations: 0,
+        },
+        state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V4, // changed: document_from_action generation 1 stamps built documents with the contract version (create assigns, replace re-assigns; paired with document serialization format 3)
+        batch_operations: DriveBatchOperationsMethodVersion {
+            convert_drive_operations_to_grove_operations: 0,
+            apply_drive_operations: 0,
+        },
+        platform_state: DrivePlatformStateMethodVersions {
+            fetch_platform_state_bytes: 0,
+            store_platform_state_bytes: 0,
+        },
+        fetch: DriveFetchMethodVersions { fetch_elements: 0 },
+        prefunded_specialized_balances: DrivePrefundedSpecializedMethodVersions {
+            fetch_single: 0,
+            prove_single: 0,
+            add_prefunded_specialized_balance: 0,
+            add_prefunded_specialized_balance_operations: 1,
+            deduct_from_prefunded_specialized_balance: 1,
+            deduct_from_prefunded_specialized_balance_operations: 0,
+            estimated_cost_for_prefunded_specialized_balance_update: 0,
+            empty_prefunded_specialized_balance: 0,
+        },
+        group: DRIVE_GROUP_METHOD_VERSIONS_V1,
+        address_funds: DRIVE_ADDRESS_FUNDS_METHOD_VERSIONS_V2,
+        shielded: DriveShieldedMethodVersions {
+            insert_note: 0,
+            insert_nullifiers: 0,
+            update_total_balance: 0,
+            record_anchor_if_changed: 0,
+            prune_anchors: 0,
+            has_anchor: 0,
+            has_nullifier: 0,
+            read_total_balance: 0,
+            notes_count: 0,
+        },
+        saved_block_transactions: DriveSavedBlockTransactionsMethodVersions {
+            store_address_balances: 0,
+            fetch_address_balances: 0,
+            prove_compacted_address_balance_changes: 1,
+            compact_address_balances: 0,
+            cleanup_expired_address_balances: 0,
+            max_blocks_before_compaction: 64,
+            max_addresses_before_compaction: 2048,
+        },
+    },
+    grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,
+    // changed in v9: GROVE_V4 activates the indexed-tree batch cleanup
+    // gates (overwrite inspection + delete-tree actual-type cleanup).
+    // Indexed trees only exist from protocol v14, so activating the
+    // stricter cleanup with them costs older versions nothing; staying
+    // on V3 would let a batch overwrite of a ranked index orphan its
+    // per-axis secondary storage.
+    grove_version: GROVE_V4,
+};

--- a/packages/rs-platform-version/src/version/mod.rs
+++ b/packages/rs-platform-version/src/version/mod.rs
@@ -1,6 +1,6 @@
 mod protocol_version;
 
-use crate::version::v14::PROTOCOL_VERSION_14;
+use crate::version::v15::PROTOCOL_VERSION_15;
 pub use protocol_version::*;
 use std::ops::RangeInclusive;
 
@@ -20,6 +20,7 @@ pub mod v11;
 pub mod v12;
 pub mod v13;
 pub mod v14;
+pub mod v15;
 pub mod v2;
 pub mod v3;
 pub mod v4;
@@ -33,5 +34,5 @@ pub type ProtocolVersion = u32;
 
 pub const ALL_VERSIONS: RangeInclusive<ProtocolVersion> = 1..=LATEST_VERSION;
 
-pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_14;
+pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_15;
 pub const INITIAL_PROTOCOL_VERSION: ProtocolVersion = 1;

--- a/packages/rs-platform-version/src/version/protocol_version.rs
+++ b/packages/rs-platform-version/src/version/protocol_version.rs
@@ -22,6 +22,7 @@ use crate::version::v11::PLATFORM_V11;
 use crate::version::v12::PLATFORM_V12;
 use crate::version::v13::PLATFORM_V13;
 use crate::version::v14::PLATFORM_V14;
+use crate::version::v15::PLATFORM_V15;
 use crate::version::v2::PLATFORM_V2;
 use crate::version::v3::PLATFORM_V3;
 use crate::version::v4::PLATFORM_V4;
@@ -61,6 +62,7 @@ pub const PLATFORM_VERSIONS: &[PlatformVersion] = &[
     PLATFORM_V12,
     PLATFORM_V13,
     PLATFORM_V14,
+    PLATFORM_V15,
 ];
 
 #[cfg(feature = "mock-versions")]
@@ -69,7 +71,7 @@ pub static PLATFORM_TEST_VERSIONS: OnceLock<Vec<PlatformVersion>> = OnceLock::ne
 #[cfg(feature = "mock-versions")]
 const DEFAULT_PLATFORM_TEST_VERSIONS: &[PlatformVersion] = &[TEST_PLATFORM_V2, TEST_PLATFORM_V3];
 
-pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V14;
+pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V15;
 
 pub const DESIRED_PLATFORM_VERSION: &PlatformVersion = LATEST_PLATFORM_VERSION;
 

--- a/packages/rs-platform-version/src/version/v15.rs
+++ b/packages/rs-platform-version/src/version/v15.rs
@@ -1,0 +1,85 @@
+use crate::version::consensus_versions::ConsensusVersions;
+use crate::version::dpp_versions::dpp_asset_lock_versions::v1::DPP_ASSET_LOCK_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_contract_versions::v6::CONTRACT_VERSIONS_V6;
+use crate::version::dpp_versions::dpp_costs_versions::v1::DPP_COSTS_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_document_versions::v4::DOCUMENT_VERSIONS_V4;
+use crate::version::dpp_versions::dpp_factory_versions::v1::DPP_FACTORY_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_identity_versions::v1::IDENTITY_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_method_versions::v3::DPP_METHOD_VERSIONS_V3;
+use crate::version::dpp_versions::dpp_state_transition_conversion_versions::v2::STATE_TRANSITION_CONVERSION_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_state_transition_method_versions::v1::STATE_TRANSITION_METHOD_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_state_transition_serialization_versions::v3::STATE_TRANSITION_SERIALIZATION_VERSIONS_V3;
+use crate::version::dpp_versions::dpp_state_transition_versions::v3::STATE_TRANSITION_VERSIONS_V3;
+use crate::version::dpp_versions::dpp_token_versions::v3::TOKEN_VERSIONS_V3;
+use crate::version::dpp_versions::dpp_validation_versions::v5::DPP_VALIDATION_VERSIONS_V5;
+use crate::version::dpp_versions::dpp_voting_versions::v2::VOTING_VERSION_V2;
+use crate::version::dpp_versions::DPPVersion;
+use crate::version::drive_abci_versions::drive_abci_checkpoint_parameters::v1::DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1;
+use crate::version::drive_abci_versions::drive_abci_method_versions::v10::DRIVE_ABCI_METHOD_VERSIONS_V10;
+use crate::version::drive_abci_versions::drive_abci_query_versions::v3::DRIVE_ABCI_QUERY_VERSIONS_V3;
+use crate::version::drive_abci_versions::drive_abci_structure_versions::v1::DRIVE_ABCI_STRUCTURE_VERSIONS_V1;
+use crate::version::drive_abci_versions::drive_abci_validation_versions::v10::DRIVE_ABCI_VALIDATION_VERSIONS_V10;
+use crate::version::drive_abci_versions::drive_abci_withdrawal_constants::v3::DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V3;
+use crate::version::drive_abci_versions::DriveAbciVersion;
+use crate::version::drive_versions::v10::DRIVE_VERSION_V10;
+use crate::version::fee::v2::FEE_VERSION2;
+use crate::version::protocol_version::PlatformVersion;
+use crate::version::system_data_contract_versions::v3::SYSTEM_DATA_CONTRACT_VERSIONS_V3;
+use crate::version::system_limits::v4::SYSTEM_LIMITS_V4;
+use crate::version::ProtocolVersion;
+
+pub const PROTOCOL_VERSION_15: ProtocolVersion = 15;
+
+/// v15 hosts the storage refund fee-history rules:
+///
+/// 1. **Fee history required for storage refunds**: `DRIVE_VERSION_V10`
+///    bumps `fees.calculate_fee` to 1. A storage refund for owner-attributed
+///    bytes is priced only with the fee history of the block that removes
+///    the bytes; the history is consulted on every fee version number and a
+///    missing history is an internal error instead of a silent fallback to
+///    the first-generation storage rates. Every shipped schedule shares fee
+///    version number 1 and the same storage rates, so refund credits are
+///    unchanged for every shipped input; the boundary makes the absence of
+///    history an error from this version onward.
+/// 2. **Recorded-owner refund credits**: the same drive table turns on
+///    `identity.update.credit_storage_refunds_to_owners`, the primitive that
+///    credits each recorded owner of a refund without consulting any key or
+///    permission and reports the amount whose owner has no balance element,
+///    so block lifecycle paths can settle it into the current epoch's
+///    processing pool.
+///
+/// Everything else matches v14.
+pub const PLATFORM_V15: PlatformVersion = PlatformVersion {
+    protocol_version: PROTOCOL_VERSION_15,
+    drive: DRIVE_VERSION_V10, // changed: calculate_fee v1 (fee history required for refunds) + identity table v3 (credit_storage_refunds_to_owners)
+    drive_abci: DriveAbciVersion {
+        structs: DRIVE_ABCI_STRUCTURE_VERSIONS_V1,
+        methods: DRIVE_ABCI_METHOD_VERSIONS_V10,
+        validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V10,
+        withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V3,
+        query: DRIVE_ABCI_QUERY_VERSIONS_V3,
+        checkpoints: DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1,
+    },
+    dpp: DPPVersion {
+        costs: DPP_COSTS_VERSIONS_V1,
+        validation: DPP_VALIDATION_VERSIONS_V5,
+        state_transition_serialization_versions: STATE_TRANSITION_SERIALIZATION_VERSIONS_V3,
+        state_transition_conversion_versions: STATE_TRANSITION_CONVERSION_VERSIONS_V2,
+        state_transition_method_versions: STATE_TRANSITION_METHOD_VERSIONS_V1,
+        state_transitions: STATE_TRANSITION_VERSIONS_V3,
+        contract_versions: CONTRACT_VERSIONS_V6,
+        document_versions: DOCUMENT_VERSIONS_V4,
+        identity_versions: IDENTITY_VERSIONS_V1,
+        voting_versions: VOTING_VERSION_V2,
+        token_versions: TOKEN_VERSIONS_V3,
+        asset_lock_versions: DPP_ASSET_LOCK_VERSIONS_V1,
+        methods: DPP_METHOD_VERSIONS_V3,
+        factory_versions: DPP_FACTORY_VERSIONS_V1,
+    },
+    system_data_contracts: SYSTEM_DATA_CONTRACT_VERSIONS_V3,
+    fee_version: FEE_VERSION2,
+    system_limits: SYSTEM_LIMITS_V4,
+    consensus: ConsensusVersions {
+        tenderdash_consensus_version: 1,
+    },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part 1 of 3 for R12-02 of the smart-contract plan (dashpay/platform#4626, section 12, fee workstream #4689, preparation package #4675).

Storage refunds are priced against the fee history a block carries (`previous_fee_versions` in platform state). The shipped fee calculation (`Drive::calculate_fee` v0, `consume_to_fees_v0`) short-circuits fee version number 1: it prices every owner-attributed removal against an empty history, so a caller that forgets to pass the history silently refunds at the first generation's storage rates instead of failing. The fee version integrity rule in the fee DIP requires the opposite: a refund without the historical context of the removing block is an error, never a fallback to a schedule.

The same DIP requires refunds to follow the recorded owner and, for owners that no longer exist, to go to the current processing pool (acceptance Q26: a frozen but existing owner still receives native bookkeeping refunds without any spending permission; a wiped owner's refunds go to the processing pool). Today the only code that credits other owners (`apply_balance_change_from_fee_to_identity` v0) halts on an owner without a balance, and block lifecycle paths that free owner-flagged bytes never price or settle refunds at all.

This part establishes the explicit version boundary and the primitive the later parts build on:

- protocol version 15 (`packages/rs-platform-version/src/version/v15.rs`) with `DRIVE_VERSION_V10`;
- `Drive::calculate_fee` v1, which requires and consults the fee history for every owner-attributed storage removal;
- `Drive::credit_storage_refunds_to_owners_operations`, which credits recorded owners without consulting any key or permission and reports the amount whose owner has no balance element.

Part 2 (same base) makes the vote poll end cleanup price and settle its refunds with this primitive. Part 3 (base `v5.0-dev`) routes state transition refunds for missing owners to the processing pool and carries the DIP text.

## What was done?
<!--- Describe your changes in detail -->

### Version tables (`packages/rs-platform-version`)

- `src/version/v15.rs`: `PROTOCOL_VERSION_15` and `PLATFORM_V15`, a copy of v14 whose only change is `drive: DRIVE_VERSION_V10`. Registered in `src/version/mod.rs` (`LATEST_VERSION`) and `src/version/protocol_version.rs` (`PLATFORM_VERSIONS`, `LATEST_PLATFORM_VERSION`). `LATEST_VERSION` was 14 at lane start, so the version was introduced rather than amended; the open state sync PR (#4648) introduces the same number and whoever rebases second merges the `v15.rs` doc comment.
- `src/version/drive_versions/v10.rs`: `DRIVE_VERSION_V10`, a copy of v9 with `fees.calculate_fee: 1` and `identity: DRIVE_IDENTITY_METHOD_VERSIONS_V3`.
- `src/version/drive_versions/drive_identity_method_versions/mod.rs`: `DriveIdentityUpdateMethodVersions` gains `credit_storage_refunds_to_owners: OptionalFeatureVersion`. Backfilled as `None` in `v1.rs` and `v2.rs` (shipped tables stay behaviour-preserving); the new `v3.rs` sets `Some(0)`.

### Fee calculation (`packages/rs-drive/src/fees`)

- `op.rs`: `LowLevelDriveOperation::consume_to_fees_v1` beside the untouched `consume_to_fees_v0`. The `SectionedStorageRemoval` arm takes the system bucket as before, then requires `previous_fee_versions` on every fee version number and returns `DriveError::CorruptedCodeExecution("a storage refund needs the fee history of the block that removes the bytes")` without it. The empty-map shortcut for number 1 is gone in v1.
- `calculate_fee/v1/mod.rs`: `Drive::calculate_fee_v1`, a copy of v0 calling `consume_to_fees_v1`. `calculate_fee/mod.rs` dispatches `1 =>` and reports `known_versions: vec![0, 1]`. v0 is byte-identical.

### Recorded-owner credits (`packages/rs-drive/src/drive/identity/update`)

- `methods/credit_storage_refunds_to_owners_operations/{mod.rs, v0/mod.rs}`: the new versioned method (`Some(0)` dispatch, `None => VersionNotActive`). For each owner in a `FeeRefunds` except an optional `skip_owner` (the state transition payer, whose own refund folds into its balance change), it sums the per-epoch credits with checked arithmetic, reads the balance element statefully once, feeds that read into `add_to_previous_balance` and the balance and negative credit update operations (the same shape the payer's own refund uses in `apply_balance_change_from_fee_to_identity`, so no element is read twice) when it exists, and otherwise adds the amount to `routed_to_processing_pool`. When the owner's balance is zero the shipped helper first clears its negative credit (identity debt) and only the remainder reaches the balance; the primitive derives that portion from the helper's outcome and reports it as `repaid_debt`, because debt lives outside the credit sum trees and is processing fee the pools were short of when it was incurred. No key, signature or permission is read on any route. The primitive neither writes the processing pool nor records pending refunds; the caller writes `processing_pool_share()` (unrouted refunds plus repaid debt) once and records the pending refunds, so a block keeps one pool write and one pending-refund write per batch.
- `structs/storage_refund_credit_outcome/mod.rs`: `StorageRefundCreditOutcome { credited: BTreeMap<Identifier, Credits>, repaid_debt: Credits, routed_to_processing_pool: Credits }` with checked `processing_pool_share()` and `total()`.

### Tests

- `fees/op.rs` (`storage_refund_fee_history` module): v1 rejects a sectioned removal without history (v0 still prices it); a system-bucket-only sectioned removal is rejected too; unflagged (`BasicStorageRemoval`) bytes never need the history; the history is consulted for fee version number 1 (a synthetic number-2 schedule with doubled storage rates at epoch 10, bytes stored at epoch 12 and removed at 15: v0 refunds at the first generation's rate, v1 at the doubled rate); for every `PLATFORM_VERSIONS` entry and every history the epoch change hook could build, v1's `FeeResult`s equal v0's; every shipped schedule keeps fee version number 1 and the first generation's storage rates (the premise of that equality).
- `fees/calculate_fee/mod.rs`: through the dispatcher, `PlatformVersion::get(14)` prices an owner-attributed removal without history, `PlatformVersion::latest()` refuses it, and with a history both produce the same fees.
- `credit_storage_refunds_to_owners_operations/v0/mod.rs`: each recorded owner credited by the sum of its epochs; an owner without a balance is reported, not an error, and no balance element is created; an owner whose keys are all disabled is credited; `skip_owner` is left alone; after the caller writes the pool and records the pending refunds, `calculate_total_credits_balance` stays balanced (`TotalCreditsBalance::ok`); refunds below, equal to and above an owner's outstanding debt report the repaid share and leave the credit sum balanced once the caller writes the pool share; a positive balance repays no debt; `PlatformVersion::get(14)` returns `VersionNotActive`.
- `drive/group/mod.rs`: `should_close_group_action_and_move_signers` now closes the action the way production does (a `GroupOperationType::AddGroupAction { closes_group_action: true, .. }` through `apply_drive_operations` with the fee history). New: `should_refund_signer_bytes_when_a_group_action_closes` (the opening signer's flagged items are refunded against their storage epoch; the closing signer, whose items are unflagged, is not) and `should_reject_closing_a_group_action_through_the_bare_wrapper_without_fee_history` (`CorruptedCodeExecution` at the latest version, success at protocol version 14). The two other closing-branch tests (immediate close with new action info, cost estimation with `apply = false`) free no flagged bytes and stay on the bare wrapper, which pins that the rule fires only when flagged bytes are actually removed.
- `drive/contract/migration/strip_unknown_document_schema_properties.rs`: `should_keep_the_protocol_12_schema_strip_frozen_without_refunding_stripped_bytes`, a freeze test at `PlatformVersion::get(12)`: a user contract element carrying the owner's storage flags is inflated with a top-level schema property the v1 meta-schema forbids, the migration shrinks it back to its clean bytes, the flags are byte-equal, the owner's balance and the pending refund tree are unchanged, and the credit sum stays balanced. The doc comment carries the replay rationale (below).
- Two existing tests replaced epoch-flagged documents without a history and failed under the strict rule (`ranked_index_e2e_tests::estimated_and_actual_update_fees`, `update::tests::summable_index_update_changes_key_into_new_branch_materializes_aggregate_tree_type`); both now pass the same one-entry history the neighbouring tests use.

### Book

`book/src/fees/overview.md`: a "Fee history and refund ownership (protocol version 15 onward)" subsection under Refunds, and a paragraph on `fee_version_number` under Fee Versioning.

### Caller audit

`Drive::calculate_fee` has 129 call sites in 99 files of `packages/rs-drive/src` (14 forward a caller's history; the rest pass `None`). Grouped by what they can remove:

| Class | Sites | History | Verdict |
| --- | --- | --- | --- |
| Forwarded from the caller | `apply_drive_operations`, `update_contract` v0/v1, document delete, update and add methods, identity balance and revision, token balance updates | caller's | correct; every production state transition and block-end application passes `previous_fee_versions` |
| `None`, can remove owner-flagged bytes | `drive/group/insert/add_group_action/v0/mod.rs:63` (closing an action moves signer-flagged items) | `None` | production reaches the closing branch only through `GroupOperationType::AddGroupAction` inside `apply_drive_operations`, which forwards the history; the bare wrapper is called from 26 test sites, of which one closes an action and now uses the production funnel. From protocol version 15 a closing call through the bare wrapper is a misuse the strict rule surfaces (pinned by test). The wrapper itself is untouched. |
| `None`, can remove owner-flagged bytes | `drive/contract/apply/apply_contract_with_serialization/v0/mod.rs:65` (replace path) | `None` | production callers: genesis (`storage_flags: None`), the protocol 13 and 14 transitions (`perform_events_on_first_block_of_protocol_change/v0/mod.rs:683,707` re-store DPNS and DashPay over unflagged genesis elements with `None` flags, so the removal is `BasicStorageRemoval`), and `create_mn_shares_contract` (test-only). A sectioned removal here needs a flagged old element and flagged new flags, which only tests produce. Unchanged. |
| `None`, elements unflagged today | `disable_identity_keys/v0` (its TODO asks this question), `update_keywords/v0`, `update_description/v0` (keyword and description documents are stored with `DocumentOwnedInfo((doc, None))`), token status, price, supply and contract info (`Element::Item(.., None)`, `SumItem(.., None)`), identity nonce, revision and balance, vote sum items and references, `add_document/v0` | `None` | safe today; listed so a future owner flag on any of them fails loudly under v1 instead of under-refunding |
| `None`, inserts, fetches, proofs and queries only | everything else (`drive/document/query/**`, `query/**`, token fetch and prove, identity fetch, contested document inserts, vote registration, group inserts, `insert_contract` v0/v1) | `None` | safe; nothing is removed |

`drive-abci` direct `Drive::calculate_fee` callers (`fetch_contender.rs`, the index-only delete and document create state validators) price reads only.

Block lifecycle applications in `packages/rs-drive-abci/src/execution/platform_events` (non-test code):

| Path | Frees owner-flagged bytes? | Applies through | History | Fee result |
| --- | --- | --- | --- | --- |
| `voting/clean_up_after_contested_resources_vote_polls_end/{v0,v1}`: deletes contested documents and contender trees (owner-flagged), the end-date entry (creator-flagged), votes and stored info (unflagged); v1 also empties prefunded balances | yes | `apply_batch_low_level_drive_operations(None, ..)` | none | never computed, refunds dropped: part 2 |
| `voting/award_document_to_winner/v0` | no: inserts the winner's document unflagged (`DocumentAndSerialization((doc, bytes, None))`) | `add_document_for_contract(.., None)` | `None` | discarded; the awarded record has no owner and is neither charged nor refundable (recorded for the owner-encoding refinement) |
| `voting/keep_record_of_vote_poll/v0`, `voting/remove_votes_for_removed_masternodes/v0` | no (unflagged) | low-level | none | discarded |
| `core_based_updates/update_masternode_identities/v0` | no removals (key patches on unflagged keys) | `apply_drive_operations` | `Some(platform_state.previous_fee_versions())` | discarded |
| `block_processing_end_events/process_block_fees_and_validate_sum_trees/v0` | no | `apply_drive_operations` | `Some(block_platform_state.previous_fee_versions())` | discarded |
| withdrawals (`dequeue_and_build_unsigned_withdrawal_transactions/v0`, `pool_withdrawals_into_transactions_queue/v1`, `rebroadcast_expired_withdrawal_documents/v1`, `update_broadcasted_withdrawal_statuses/v0`) | no: withdrawal documents are stored with `owner_id: None` and no flags (`identity_credit_withdrawal_transition.rs`, `address_credit_withdrawal_transition.rs`) | `apply_drive_operations` | `None` | discarded |
| `initialization/create_genesis_state/{v0,v1}` | no (inserts, `storage_flags: None`) | `apply_drive_operations` | `None` | discarded |
| `protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0` (DPNS re-store at 13, DashPay at 14) | no (unflagged genesis elements replaced by unflagged elements) | `apply_contract` | `None` | discarded |
| `protocol_upgrade/.../v0` `transition_to_version_12` calling `strip_unknown_document_schema_properties` | rewrites user contract items in place keeping their flags; a shrink removes owner-paid bytes whose refund is discarded | `grove_insert` with a discarded cost vector | none | shipped and frozen; ran once at the protocol 12 activation; the recorded historical exception, pinned by the freeze test |
| fee pool inwards and outwards, epoch change, credit inflow and total-credits history, shielded anchors, address balance cleanup, version counters | no | operation builders and direct grove ops | n/a | n/a |
| `check_tx/v0`, `process_raw_state_transitions/v0`, `execute_event/v0`, `validate_fees_of_event/v0` | state transitions | `apply_drive_operations` | `Some(state.previous_fee_versions())` | applied through `apply_balance_change_from_fee_to_identity` |

Conclusion: one production path frees owner-flagged bytes without fee context and without settling refunds (vote poll end cleanup, part 2); one shipped migration discarded refunds and is frozen (pinned here); one test-only wrapper closes group actions without history (its closing test now uses the production funnel); every other path is correct or touches unflagged bytes.

### Owner-flagged writes (what the invariant covers)

Documents, index references, contested documents and contested index trees (document owner); the vote poll end-date entry (contest creator); user data contract items (`insert_contract` v1: every contract with `can_be_deleted() || !readonly()`, contract owner); group action info and signer sum items (signer); token distribution items (token owner, recipient, claimer). Not flagged: identities and their keys, withdrawal documents, keyword-search documents, votes, prefunded balances, epoch pools, withdrawal queue items, shielded anchors, stored vote poll info, and the system contracts at genesis. The document history contract registered at the protocol 13 transition goes through `insert_contract` v1 and therefore carries the system owner's flags; a future transition that re-stores it must pass its flags or hit grovedb's `RemovingFlagsError` (noted, no change here).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Local gate (exit codes captured under the run directory):

```
cargo fmt --all -- --check
cargo clippy -p platform-version -p dpp -p drive -p drive-abci --all-features --all-targets -- -D warnings
cargo check --workspace --all-targets
cargo test -p platform-version --all-features
cargo test -p drive --lib -- fees::op::tests::storage_refund_fee_history
cargo test -p drive --lib -- fees::calculate_fee
cargo test -p drive --lib -- credit_storage_refunds_to_owners_operations
cargo test -p drive --lib -- drive::group
cargo test -p drive --lib -- drive::contract::migration
cargo test -p drive --lib
```

The full `drive` unit suite passes (3594 passed, 5 ignored); the rest of the workspace is CI's. The workspace check was run in a private `CARGO_TARGET_DIR` because another lane editing `rs-platform-version` shares the default target directory and its fingerprint collided with this tree's new identity slot. No `src/verify/**` file is touched, so the verify-only cut is unaffected (`cargo check --workspace --all-targets` compiles the verify crates).

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

Consensus: protocol version 15 is introduced. Under its drive table a storage refund for owner-attributed bytes is priced only with the fee history of the removing block; a missing history is an internal error (a halt on a block execution path) instead of a silent fallback to the first generation's rates. Every shipped schedule shares fee version number 1 and the same storage rates, so refund credits are unchanged for every shipped input; every shipped `PLATFORM_V*`, `calculate_fee` v0, `consume_to_fees_v0`, `add_group_action`, `apply_balance_change_from_fee_to_identity` v0 and the protocol 12 migration are byte-identical. Shipped identity tables gain one `None` field.

API: `DriveIdentityUpdateMethodVersions` gains a field (struct literals outside the version crate: none). `Drive::credit_storage_refunds_to_owners_operations` and `StorageRefundCreditOutcome` are new. No production path calls the primitive at this head; part 2 wires the vote poll end cleanup to it. No proto, SDK, wasm or FFI change; `PlatformVersion::latest()` now resolves to 15.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

## Decisions taken (provisional values)

- **Provisional: an owner without a balance element is the proxy for a wiped owner.** Contracts cannot be deleted yet and identities are never removed, so Drive has no typed "wiped owner" today. The primitive treats a missing balance element as that case and reports the amount for the processing pool. When the owner-encoding refinement types the owner in the storage flags this proxy is replaced; nothing in state depends on it.
- **Strictness over leniency.** A missed production path under v1 halts the chain instead of mispricing silently. Mitigation: the audit above, the lifecycle table, and part 2's tests that run the lifecycle paths at the latest version with sum-tree verification. Treating a missing history as the current schedule is the fallback the owner rejected.
- **The primitive reports, the caller writes the pool.** `add_epoch_processing_credits_for_distribution_operation` is a read-modify-write of the epoch's pool sum item, so two of them in one batch collapse last-wins. Returning `routed_to_processing_pool` and `repaid_debt` (together `processing_pool_share()`) lets the caller issue exactly one pool write per batch and keep pending-refund recording with the existing versioned methods. Repaid debt goes to the processing pool because negative credit is processing fee the pools were short of when the identity could not cover it (`fee_result_outcome` drops that part from the block fees), so clearing it with a refund returns those credits to the pool they were owed to.
- **No shipped file edited; the bare group wrapper keeps its signature.** The plan's earlier draft widened `add_group_action` with a history parameter; this PR instead routes the one closing test through the funnel production uses and pins the wrapper's strictness.
- **Protocol 12 schema migration excluded by name.** The stripped byte counts were never recorded and the migration never runs again, so there is nothing to correct at protocol version 15; the invariant (written into the DIP in part 3) states that blocks before 15 replay exactly as executed and names this migration as the exception.
- **Storage-epoch pricing not duplicated.** The change that prices a refund at the rate of the epoch the bytes were stored in is another lane's in-place edit to `FeeRefunds::from_storage_removal`; it is not on `v4.3-dev` yet, so the test that would pin it is deferred to part 2.
- **Protocol version 15 introduced, not amended.** `LATEST_VERSION` was 14 at lane start.

Part 1 of 3 for R12-02.

Refs #4675
Refs #4689

---
🤖 Posted autonomously by DashVM (Claude Fable 5.1) on behalf of pasta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
