### PR TITLE
ci: re-pin the shared review engine and receive review events directly

### DIFF
--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -4,9 +4,8 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, closed, edited]
   issue_comment:
     types: [created, edited, deleted]
-  workflow_run:
-    workflows: [PR review signal]
-    types: [completed]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
   workflow_dispatch:
   schedule:
     - cron: '*/15 * * * *'
@@ -17,6 +16,4 @@ permissions:
   statuses: write
 jobs:
   policy:
-    uses: dashpay/stale_prs_are_bad/.github/workflows/pr-review-reusable.yml@cc4d18484ceabf121886e47606b4b10628aafefa
-    with:
-      engine_revision: cc4d18484ceabf121886e47606b4b10628aafefa
+    uses: dashpay/stale_prs_are_bad/.github/workflows/pr-review-reusable.yml@a95eab4ec0938e9022edd0c82591d052408a38a5


### PR DESCRIPTION
## Issue being fixed or feature implemented

#4710 was supposed to carry two files but only committed one: the signal workflow was deleted while `pr-review-policy.yml` was left untouched (my error — the deletion was staged, the edit was not). So Platform's caller currently points at the superseded engine `cc4d184`, still passes the removed `engine_revision` input to it, and still lists a `workflow_run` trigger for the "PR review signal" workflow that no longer exists.

Nothing is broken by that — the caller runs the engine it pins, and that engine still declares the input — but Platform is the only one of the five repositories not on the current shape, and review events do not wake it.

## What was done?

- Re-pins the reusable workflow to `a95eab4ec0938e9022edd0c82591d052408a38a5` (dashpay/stale_prs_are_bad#9) and drops `with: engine_revision:`; the callee reads the pin from this file's own `uses:` reference.
- Replaces the dead `workflow_run` trigger with `pull_request_review`, matching the other four repositories.

## How Has This Been Tested?

The identical caller shape runs green in preview on GroveDB, rust-dashcore, Tenderdash and Dash Evo Tool. Writes remain disabled here: `PR_REVIEW_AUTOMATION_ENABLED` is not set.

## Breaking Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pull request review automation to respond directly when reviews are submitted, edited, or dismissed.
  - Updated the automation workflow reference and removed the previous fixed engine revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->