### PR TITLE
feat(drive)!: add the contract credits root sum tree to genesis, upgrade and credit conservation

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -69,6 +69,7 @@
 - [Document Ranked Trees](drive/document-ranked-trees.md)
 - [Ranked Index Examples](drive/ranked-index-examples.md)
 - [Index-Only Document Types](drive/index-only-document-types.md)
+- [Contract Credit Buckets](drive/contract-credit-buckets.md)
 
 # Testing
 

--- a/book/src/drive/contract-credit-buckets.md
+++ b/book/src/drive/contract-credit-buckets.md
@@ -1,0 +1,70 @@
+# Contract Credit Buckets
+
+Ordinary data contracts are not identities. They have no keys, no nonce and no identity balance, and the smart contract work keeps it that way. When a contract needs to hold credits (to pay for scheduled work, to escrow a purchase, to fund its own storage) those credits live in a dedicated structure that is separate from every identity tree: the contract credits root tree. This chapter describes that tree, the lifecycle wrapper that marks a wiped contract, and how the tree takes part in credit conservation. Later chapters add the bucket identifiers and rules, the storage operations, the proofs and the matching token holdings as those pieces land.
+
+## Why a separate tree
+
+Identity balances sit in the `Balances` root sum tree keyed by identity id. Reusing that tree for contracts would give a contract an identity-shaped balance element, and every query, proof and validation rule that reads `Balances` would have to learn that some keys are not identities. A separate root tree avoids all of that: nothing under `Identities` or `Balances` changes, identity balance proofs stay exactly as they were, and a contract's credits are found by walking a path that names the contract, not an identity.
+
+A sum tree was chosen over the specialized provable-sum collections because the two questions that matter for contract credits are answered by a single authenticated element:
+
+- How much does one bucket hold? That is a `SumItem` under the contract's subtree, proven like any other item.
+- How much does the whole contract hold? That is the stored sum of the contract's `SumTree` element, which the parent Merk commits to and a proof of the parent path authenticates.
+
+Range sums across buckets are not a query anyone makes, so the cost of a provable sum tree buys nothing here. Range-sum proof capabilities stay with the specialized collections used by document sum indexes.
+
+## Layout
+
+The root tree is `RootTree::ContractCredits`, key `100`, an ordinary `SumTree`. The key value is provisional: the allocation register leaves new root keys unallocated and `100` was chosen as a free value next to the other balance trees.
+
+```text
+Root Merk
+  100  ContractCredits                        SumTree      sum = total of live contract credits
+    contract_id (32 bytes)                    SumTree      a live contract; sum = its total
+    contract_id (32 bytes)                    NotSummed(SumTree)   a wiped contract; inner sum retained, contributes 0
+      bucket_key (2 bytes, big-endian u16)    SumItem      one bucket, 0 <= value <= MAX_CREDITS
+```
+
+The path helpers live in `packages/rs-drive/src/drive/contract/balances/mod.rs`: `contract_credits_root_path()` for `[100]` and `contract_credits_path(contract_id)` for `[100, contract_id]`, each with a `_vec` form.
+
+## Genesis and upgrade
+
+The tree exists from the 5.0 protocol version (provisionally 17) on both kinds of node:
+
+- A fresh chain creates it in `Drive::create_initial_state_structure_v4`, as a standalone root insert placed right after `ShieldedBalances`, before the lower-layer batch.
+- A node that upgrades in place creates it in `Platform::transition_to_version_17`, which runs from `perform_events_on_first_block_of_protocol_change` on the first block at the new version, with an insert-if-not-exists.
+
+Both paths insert the same `Element::empty_sum_tree()` with no flags, and a test in the protocol change hook builds one platform each way and compares the subtree byte for byte. The insert-if-not-exists also makes the upgrade idempotent: a validator that ran the hook inside a rejected proposal and runs it again in the next round produces the same state as one that ran it once.
+
+## Lifecycle: live and wiped
+
+A contract's subtree is one of two things:
+
+- **Live**: an `Element::SumTree` whose stored sum is the contract's spendable total. Deposits and spends are allowed.
+- **Wiped**: the same subtree wrapped in `Element::NotSummed`. GroveDB reports a not-summed element's contribution to its parent as zero, so the root aggregate no longer counts it, while the buckets underneath keep their values for cleanup. Nothing may deposit into or spend from a wiped contract, and no reader may report a retained bucket as available credit.
+
+The wrapper is a property of the parent element, so a proof of the contract's path authenticates the lifecycle along with the total. The operation that wraps a populated live tree is not part of this change; the layout above is what it must produce.
+
+## Credit conservation
+
+Since protocol version 12 the end-of-block check compares the total credits in Platform with the sum of five trees. From the 5.0 protocol version the equation has a sixth term, read by `calculate_total_credits_balance` v3 from the root aggregate of the contract credits tree:
+
+```text
+total_credits_in_platform == total_in_pools
+                           + total_identity_balances
+                           + total_specialized_balances
+                           + total_in_addresses
+                           + total_in_shielded_balances
+                           + total_in_contract_credits
+```
+
+Because the root aggregate is a `SumTree` sum and wiped subtrees are `NotSummed`, retained credits of wiped contracts are excluded by construction. A wipe that moves a contract's live total somewhere else (the processing pool of the current epoch, by the owner-confirmed policy) must therefore move it exactly once, or the equation fails at the end of that block.
+
+The `TotalCreditsBalance` type in `rs-dpp` carries the new field `total_in_contract_credits`; the earlier calculator generations set it to zero because the tree does not exist on the chains they run against.
+
+## What is not here yet
+
+- Bucket identifiers (a two-byte position per contract), bucket spending and deposit rules, and the Drive operations that create a contract's subtree and move credits in and out of a bucket.
+- Proofs of a single bucket and of a contract's total, including the live or wiped state.
+- Contract token holdings, which follow the same shape under the per-token ledger.
+- The wipe itself, the transfer state transitions that call the bucket operations, and the query surface.

--- a/book/src/versioning/platform-version.md
+++ b/book/src/versioning/platform-version.md
@@ -106,8 +106,11 @@ reserves for the 4.3 and 4.4 releases. Until those branches merge their real
 struct updates over their predecessor
 (`PlatformVersion { protocol_version: PROTOCOL_VERSION_15, ..PLATFORM_V14 }`).
 A forward merge that brings the real file is resolved by taking the incoming
-file; because 16 and 17 are struct updates too, every table the incoming
-version changes flows into them without a second edit.
+file. Because 16 and 17 are struct updates too, every field the incoming
+version changes flows into them automatically, except the fields a later
+version overrides explicitly: `PLATFORM_V17` names its own `drive` table, so a
+Drive change arriving with the real 15 or 16 must be reconciled into that table
+by hand in the same merge.
 
 ## What a Version Snapshot Looks Like
 

--- a/book/src/versioning/platform-version.md
+++ b/book/src/versioning/platform-version.md
@@ -98,6 +98,17 @@ The array is indexed by protocol version number minus one (since versions are
 1-indexed). `PLATFORM_V1` sits at index 0, `PLATFORM_V12` at index 11. This
 simple layout is what makes the `get` function so fast.
 
+Because the array is indexed by number, a version cannot be registered without
+every number below it. The 5.0 development branch therefore carries protocol
+version 17 (its own) together with 15 and 16, which the allocation register
+reserves for the 4.3 and 4.4 releases. Until those branches merge their real
+`v15.rs` and `v16.rs` forward, the two files are placeholders written as
+struct updates over their predecessor
+(`PlatformVersion { protocol_version: PROTOCOL_VERSION_15, ..PLATFORM_V14 }`).
+A forward merge that brings the real file is resolved by taking the incoming
+file; because 16 and 17 are struct updates too, every table the incoming
+version changes flows into them without a second edit.
+
 ## What a Version Snapshot Looks Like
 
 Here is the very first version, `PLATFORM_V1`, slightly abbreviated:

--- a/packages/rs-dpp/src/balances/total_credits_balance/mod.rs
+++ b/packages/rs-dpp/src/balances/total_credits_balance/mod.rs
@@ -18,6 +18,9 @@ pub struct TotalCreditsBalance {
     pub total_in_addresses: SignedCredits,
     /// all the credits inside shielded credit pools
     pub total_in_shielded_balances: SignedCredits,
+    /// all the live credits held by contracts in their credit buckets; a
+    /// wiped contract's retained credits are excluded by the tree layout
+    pub total_in_contract_credits: SignedCredits,
 }
 
 impl fmt::Display for TotalCreditsBalance {
@@ -46,8 +49,13 @@ impl fmt::Display for TotalCreditsBalance {
         )?;
         writeln!(
             f,
-            "    total_in_shielded_balances: {}",
+            "    total_in_shielded_balances: {},",
             self.total_in_shielded_balances
+        )?;
+        writeln!(
+            f,
+            "    total_in_contract_credits: {}",
+            self.total_in_contract_credits
         )?;
         write!(f, "}}")
     }
@@ -64,6 +72,7 @@ impl TotalCreditsBalance {
             total_specialized_balances,
             total_in_addresses,
             total_in_shielded_balances,
+            total_in_contract_credits,
         } = *self;
 
         if total_in_pools < 0 {
@@ -96,6 +105,12 @@ impl TotalCreditsBalance {
             ));
         }
 
+        if total_in_contract_credits < 0 {
+            return Err(ProtocolError::CriticalCorruptedCreditsCodeExecution(
+                "Credits held by contracts are less than 0".to_string(),
+            ));
+        }
+
         if total_credits_in_platform > MAX_CREDITS {
             return Err(ProtocolError::CriticalCorruptedCreditsCodeExecution(
                 "Total credits in platform more than max credits size".to_string(),
@@ -107,6 +122,7 @@ impl TotalCreditsBalance {
             .and_then(|partial_sum| partial_sum.checked_add(total_specialized_balances))
             .and_then(|partial_sum| partial_sum.checked_add(total_in_addresses))
             .and_then(|partial_sum| partial_sum.checked_add(total_in_shielded_balances))
+            .and_then(|partial_sum| partial_sum.checked_add(total_in_contract_credits))
             .ok_or(ProtocolError::CriticalCorruptedCreditsCodeExecution(
                 "Overflow of total credits".to_string(),
             ))?;
@@ -122,6 +138,7 @@ impl TotalCreditsBalance {
             total_specialized_balances,
             total_in_addresses,
             total_in_shielded_balances,
+            total_in_contract_credits,
             ..
         } = *self;
 
@@ -130,10 +147,73 @@ impl TotalCreditsBalance {
             .and_then(|partial_sum| partial_sum.checked_add(total_specialized_balances))
             .and_then(|partial_sum| partial_sum.checked_add(total_in_addresses))
             .and_then(|partial_sum| partial_sum.checked_add(total_in_shielded_balances))
+            .and_then(|partial_sum| partial_sum.checked_add(total_in_contract_credits))
             .ok_or(ProtocolError::CriticalCorruptedCreditsCodeExecution(
                 "Overflow of total credits".to_string(),
             ))?;
 
         Ok(total_in_trees.to_unsigned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn balanced() -> TotalCreditsBalance {
+        TotalCreditsBalance {
+            total_credits_in_platform: 600,
+            total_in_pools: 100,
+            total_identity_balances: 100,
+            total_specialized_balances: 100,
+            total_in_addresses: 100,
+            total_in_shielded_balances: 100,
+            total_in_contract_credits: 100,
+        }
+    }
+
+    #[test]
+    fn should_count_contract_credits_as_a_term_of_the_equation() {
+        let balance = balanced();
+        assert!(balance.ok().expect("no overflow"));
+        assert_eq!(balance.total_in_trees().expect("no overflow"), 600);
+
+        let short = TotalCreditsBalance {
+            total_in_contract_credits: 0,
+            ..balance
+        };
+        assert!(
+            !short.ok().expect("no overflow"),
+            "dropping the contract credits term must unbalance the equation"
+        );
+    }
+
+    #[test]
+    fn should_reject_negative_contract_credits() {
+        let negative = TotalCreditsBalance {
+            total_in_contract_credits: -1,
+            total_credits_in_platform: 499,
+            ..balanced()
+        };
+        assert!(matches!(
+            negative.ok(),
+            Err(ProtocolError::CriticalCorruptedCreditsCodeExecution(_))
+        ));
+    }
+
+    #[test]
+    fn should_report_overflow_when_the_contract_credits_term_overflows_the_sum() {
+        let overflowing = TotalCreditsBalance {
+            total_in_contract_credits: SignedCredits::MAX,
+            ..balanced()
+        };
+        assert!(matches!(
+            overflowing.ok(),
+            Err(ProtocolError::CriticalCorruptedCreditsCodeExecution(_))
+        ));
+        assert!(matches!(
+            overflowing.total_in_trees(),
+            Err(ProtocolError::CriticalCorruptedCreditsCodeExecution(_))
+        ));
     }
 }

--- a/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
@@ -778,11 +778,25 @@ mod tests {
     use crate::test::helpers::setup::TestPlatformBuilder;
     use dpp::block::block_info::BlockInfo;
     use dpp::block::epoch::Epoch;
+    use dpp::data_contract::accessors::v0::DataContractV0Getters;
+    use dpp::data_contract::document_type::random_document::{
+        CreateRandomDocument, DocumentFieldFillSize, DocumentFieldFillType,
+    };
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::v0::IdentityV0;
+    use dpp::identity::{Identity, IdentityPublicKey};
+    use dpp::platform_value::Bytes32;
     use dpp::version::PlatformVersion;
     use drive::drive::shielded::paths::{
         shielded_credit_pool_path, MAIN_SHIELDED_CREDIT_POOL_KEY_U8, SHIELDED_ANCHORS_IN_POOL_KEY,
         SHIELDED_NOTES_KEY, SHIELDED_NULLIFIERS_KEY,
     };
+    use drive::grovedb::TransactionArg;
+    use drive::util::object_size_info::DocumentInfo::DocumentRefInfo;
+    use drive::util::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+    use std::collections::BTreeMap;
 
     /// Recursively compares the GroveDB subtree rooted at `root_path` between
     /// two platforms and returns a list of human-readable differences (empty ⇒
@@ -812,7 +826,7 @@ mod tests {
 
         fn read_level(
             platform: &crate::platform_types::platform::Platform<crate::rpc::core::MockCoreRPCLike>,
-            txn: drive::grovedb::TransactionArg,
+            txn: TransactionArg,
             path: &[Vec<u8>],
         ) -> std::collections::BTreeMap<Vec<u8>, Element> {
             let mut q = Query::new();
@@ -2817,20 +2831,6 @@ mod tests {
     /// dropped and a later round runs it again.
     #[test]
     fn should_activate_the_contract_credits_root_through_the_protocol_change_hook() {
-        use dpp::data_contract::accessors::v0::DataContractV0Getters;
-        use dpp::data_contract::document_type::random_document::{
-            CreateRandomDocument, DocumentFieldFillSize, DocumentFieldFillType,
-        };
-        use dpp::identity::accessors::IdentityGettersV0;
-        use dpp::identity::v0::IdentityV0;
-        use dpp::identity::{Identity, IdentityPublicKey};
-        use dpp::platform_value::Bytes32;
-        use drive::util::object_size_info::DocumentInfo::DocumentRefInfo;
-        use drive::util::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
-        use rand::rngs::StdRng;
-        use rand::SeedableRng;
-        use std::collections::BTreeMap;
-
         let platform_version_16 = PlatformVersion::get(16).expect("expected v16");
         let platform_version_17 = PlatformVersion::get(17).expect("expected v17");
         let grove_version = &platform_version_17.drive.grove_version;
@@ -2915,7 +2915,7 @@ mod tests {
             )
             .expect("expected to insert the document");
 
-        let root_absent = |transaction: drive::grovedb::TransactionArg| {
+        let root_absent = |transaction: TransactionArg| {
             platform
                 .drive
                 .grove

--- a/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
@@ -119,6 +119,10 @@ impl<C> Platform<C> {
             self.transition_to_version_14(block_info, transaction, platform_version)?;
         }
 
+        if previous_protocol_version < 17 && platform_version.protocol_version >= 17 {
+            self.transition_to_version_17(transaction, platform_version)?;
+        }
+
         Ok(())
     }
 
@@ -730,6 +734,34 @@ impl<C> Platform<C> {
         self.drive.grove_insert_if_not_exists(
             get_withdrawal_root_path().as_slice().into(),
             &WITHDRAWAL_CREDIT_INFLOWS_SUM_TREE_KEY,
+            Element::empty_sum_tree(),
+            Some(transaction),
+            None,
+            &platform_version.drive,
+        )?;
+
+        Ok(())
+    }
+
+    /// When transitioning to version 17 we add the contract credits root sum
+    /// tree. Contract credit buckets live under it as
+    /// `contract_id (SumTree) / bucket_key (SumItem)`, and its aggregate is
+    /// the sixth term of the credit conservation equation from this version.
+    ///
+    /// CONSENSUS-CRITICAL: the genesis path
+    /// (`Drive::create_initial_state_structure_v4`) inserts the same empty sum
+    /// tree as a standalone root insert, so a fresh genesis-v17 node and an
+    /// in-place-upgraded v17 node hold a byte-identical `[ContractCredits]`
+    /// element. The insert is idempotent so a retried block after a rejected
+    /// proposal leaves the tree exactly as the first attempt would have.
+    fn transition_to_version_17(
+        &self,
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        self.drive.grove_insert_if_not_exists(
+            SubtreePath::empty(),
+            &[RootTree::ContractCredits as u8],
             Element::empty_sum_tree(),
             Some(transaction),
             None,
@@ -2640,6 +2672,465 @@ mod tests {
              node (sequential path). v11 is ALREADY ACTIVATED on the live network — do NOT change \
              v11 construction to make this pass; surface and analyze the discrepancy.\n{}",
             diffs.join("\n"),
+        );
+    }
+
+    /// CONSENSUS-CRITICAL equivalence guard for the v16 -> v17 boundary.
+    ///
+    /// The `[ContractCredits]` root element is built two ways that MUST be
+    /// byte-identical:
+    ///
+    ///  * GENESIS path: a node that state-syncs a fresh v17 chain runs the real
+    ///    `Drive::create_initial_state_structure_v4`, which inserts the empty
+    ///    sum tree as a standalone root insert.
+    ///  * UPGRADE path: a node already on v16 runs the real
+    ///    `Platform::transition_to_version_17` at the activation block, which
+    ///    inserts the same element with an insert-if-not-exists.
+    ///
+    /// Both the root element itself and the (empty) subtree under it are
+    /// compared, so a flag, a tree type or a stray child on either side fails
+    /// here. The named subtree is compared rather than the whole-DB root hash
+    /// for the reason given on `collect_subtree_diffs`.
+    #[test]
+    fn test_genesis_v17_and_upgrade_to_v17_build_identical_contract_credits_tree() {
+        let platform_version_17 = PlatformVersion::get(17).expect("expected v17");
+        let grove_version = &platform_version_17.drive.grove_version;
+
+        // ---- Platform A: REAL fresh genesis at protocol v17. -----------------
+        let platform_a = TestPlatformBuilder::new()
+            .with_initial_protocol_version(17)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        // ---- Platform B: REAL v16 genesis, then REAL transition_to_version_17.
+        let platform_b = TestPlatformBuilder::new()
+            .with_initial_protocol_version(16)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        // Sanity: a genuine v16 genesis must NOT contain ContractCredits yet.
+        let contract_credits_root_pre = platform_b
+            .drive
+            .grove
+            .get(
+                SubtreePath::empty(),
+                &[RootTree::ContractCredits as u8],
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert!(
+            contract_credits_root_pre.is_err(),
+            "v16 genesis must not contain ContractCredits before the upgrade; got {:?}",
+            contract_credits_root_pre
+        );
+
+        let txn_b = platform_b.drive.grove.start_transaction();
+        platform_b
+            .transition_to_version_17(&txn_b, platform_version_17)
+            .expect("upgrade: transition_to_version_17 should succeed");
+
+        let element_a = platform_a
+            .drive
+            .grove
+            .get(
+                SubtreePath::empty(),
+                &[RootTree::ContractCredits as u8],
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("genesis: [ContractCredits] element");
+        let element_b = platform_b
+            .drive
+            .grove
+            .get(
+                SubtreePath::empty(),
+                &[RootTree::ContractCredits as u8],
+                Some(&txn_b),
+                grove_version,
+            )
+            .unwrap()
+            .expect("upgrade: [ContractCredits] element");
+        assert_eq!(
+            element_a,
+            Element::empty_sum_tree(),
+            "genesis must create an empty sum tree without flags"
+        );
+        assert_eq!(
+            element_a, element_b,
+            "CONSENSUS FORK: the [ContractCredits] root element differs between a fresh \
+             genesis-v17 node and an in-place-upgraded v17 node"
+        );
+
+        let diffs = collect_subtree_diffs(
+            &platform_a,
+            &platform_b,
+            &txn_b,
+            vec![vec![RootTree::ContractCredits as u8]],
+        );
+        assert!(
+            diffs.is_empty(),
+            "CONSENSUS FORK: the [ContractCredits] subtree differs between a fresh genesis-v17 \
+             node and an in-place-upgraded v17 node.\n{}",
+            diffs.join("\n"),
+        );
+    }
+
+    /// The v17 calculator reads the new root tree as a sixth term, so the
+    /// equation must still hold on a chain that upgraded into v17 with an
+    /// empty tree, and the frozen v16 calculator must keep ignoring it.
+    #[test]
+    fn should_pass_credit_conservation_after_upgrade_to_v17() {
+        let platform_version_16 = PlatformVersion::get(16).expect("expected v16");
+        let platform_version_17 = PlatformVersion::get(17).expect("expected v17");
+
+        let platform = TestPlatformBuilder::new()
+            .with_initial_protocol_version(16)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let transaction = platform.drive.grove.start_transaction();
+        platform
+            .transition_to_version_17(&transaction, platform_version_17)
+            .expect("expected the transition to succeed");
+
+        let total_at_17 = platform
+            .drive
+            .calculate_total_credits_balance(Some(&transaction), &platform_version_17.drive)
+            .expect("expected to calculate the total credits balance at v17");
+        assert_eq!(total_at_17.total_in_contract_credits, 0);
+        assert!(total_at_17.ok().expect("no overflow"));
+
+        let total_at_16 = platform
+            .drive
+            .calculate_total_credits_balance(Some(&transaction), &platform_version_16.drive)
+            .expect("expected to calculate the total credits balance at v16");
+        assert_eq!(total_at_16.total_in_contract_credits, 0);
+        assert!(total_at_16.ok().expect("no overflow"));
+    }
+
+    /// Drives the v16 -> v17 boundary through the public
+    /// `perform_events_on_first_block_of_protocol_change` dispatcher on a
+    /// populated state, the way `run_block_proposal` does, including the
+    /// rejected-proposal shape where the transaction that ran the hook is
+    /// dropped and a later round runs it again.
+    #[test]
+    fn should_activate_the_contract_credits_root_through_the_protocol_change_hook() {
+        use dpp::data_contract::accessors::v0::DataContractV0Getters;
+        use dpp::data_contract::document_type::random_document::{
+            CreateRandomDocument, DocumentFieldFillSize, DocumentFieldFillType,
+        };
+        use dpp::identity::accessors::IdentityGettersV0;
+        use dpp::identity::v0::IdentityV0;
+        use dpp::identity::{Identity, IdentityPublicKey};
+        use dpp::platform_value::Bytes32;
+        use drive::util::object_size_info::DocumentInfo::DocumentRefInfo;
+        use drive::util::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
+        use std::collections::BTreeMap;
+
+        let platform_version_16 = PlatformVersion::get(16).expect("expected v16");
+        let platform_version_17 = PlatformVersion::get(17).expect("expected v17");
+        let grove_version = &platform_version_17.drive.grove_version;
+
+        let platform = TestPlatformBuilder::new()
+            .with_initial_protocol_version(16)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let platform_state = platform.state.load();
+
+        // Populate the committed state at v16: an identity with a balance
+        // backed by system credits, and a document, so the root Merk is not
+        // the bare genesis shape and conservation has non-zero terms.
+        let mut rng = StdRng::seed_from_u64(1704);
+        let balance: Credits = 1_000_000_000;
+        let (master_key, _) = IdentityPublicKey::random_ecdsa_master_authentication_key_with_rng(
+            0,
+            &mut rng,
+            platform_version_16,
+        )
+        .expect("expected a master key");
+        let identity: Identity = IdentityV0 {
+            id: Identifier::random_with_rng(&mut rng),
+            public_keys: BTreeMap::from([(0, master_key)]),
+            balance,
+            revision: 0,
+        }
+        .into();
+        platform
+            .drive
+            .add_to_system_credits(balance, None, platform_version_16)
+            .expect("expected to add to system credits");
+        platform
+            .drive
+            .add_new_identity(
+                identity.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version_16,
+            )
+            .expect("expected to add the identity");
+
+        let dashpay = platform
+            .drive
+            .cache
+            .system_data_contracts
+            .load_dashpay(platform_version_16)
+            .expect("expected the dashpay contract");
+        let profile = dashpay
+            .document_type_for_name("profile")
+            .expect("expected the profile document type");
+        let entropy = Bytes32::random_with_rng(&mut rng);
+        let document = profile
+            .random_document_with_identifier_and_entropy(
+                &mut rng,
+                identity.id(),
+                entropy,
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                platform_version_16,
+            )
+            .expect("expected a random profile document");
+        platform
+            .drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&document, None)),
+                        owner_id: None,
+                    },
+                    contract: &dashpay,
+                    document_type: profile,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version_16,
+                None,
+            )
+            .expect("expected to insert the document");
+
+        let root_absent = |transaction: drive::grovedb::TransactionArg| {
+            platform
+                .drive
+                .grove
+                .get(
+                    SubtreePath::empty(),
+                    &[RootTree::ContractCredits as u8],
+                    transaction,
+                    grove_version,
+                )
+                .unwrap()
+                .is_err()
+        };
+        let committed_root_hash = || {
+            platform
+                .drive
+                .grove
+                .root_hash(None, grove_version)
+                .unwrap()
+                .expect("expected the committed root hash")
+        };
+
+        assert!(root_absent(None), "a v16 chain must not hold the root yet");
+        let pre_upgrade_root_hash = committed_root_hash();
+
+        let block_info = BlockInfo {
+            time_ms: 2_000_000,
+            height: 200,
+            core_height: 200,
+            epoch: Epoch::new(1).expect("expected epoch"),
+        };
+
+        // Round 1: the hook runs inside a transaction that is then dropped,
+        // as happens when the proposal that carried the upgrade is rejected.
+        {
+            let transaction = platform.drive.grove.start_transaction();
+            platform
+                .perform_events_on_first_block_of_protocol_change(
+                    &platform_state,
+                    &block_info,
+                    &transaction,
+                    16,
+                    platform_version_17,
+                )
+                .expect("expected the protocol change events to succeed");
+
+            let element = platform
+                .drive
+                .grove
+                .get(
+                    SubtreePath::empty(),
+                    &[RootTree::ContractCredits as u8],
+                    Some(&transaction),
+                    grove_version,
+                )
+                .unwrap()
+                .expect("the root must exist inside the upgrading transaction");
+            assert_eq!(element, Element::empty_sum_tree());
+
+            let total = platform
+                .drive
+                .calculate_total_credits_balance(Some(&transaction), &platform_version_17.drive)
+                .expect("expected to calculate the total credits balance");
+            assert_eq!(total.total_in_contract_credits, 0);
+            assert_eq!(total.total_identity_balances, balance as i64);
+            assert!(total.ok().expect("no overflow"));
+            assert_eq!(
+                platform
+                    .drive
+                    .fetch_identity_balance(
+                        identity.id().to_buffer(),
+                        Some(&transaction),
+                        platform_version_17,
+                    )
+                    .expect("expected to fetch the identity balance"),
+                Some(balance),
+                "the upgrade must not touch identity balances"
+            );
+
+            platform
+                .drive
+                .grove
+                .rollback_transaction(&transaction)
+                .expect("expected to roll back the rejected round");
+        }
+        assert_eq!(
+            committed_root_hash(),
+            pre_upgrade_root_hash,
+            "a rejected round must leave the committed state untouched"
+        );
+        assert!(root_absent(None));
+
+        // Round 2: the retry a validator performs after the rejected round.
+        let transaction = platform.drive.grove.start_transaction();
+        platform
+            .perform_events_on_first_block_of_protocol_change(
+                &platform_state,
+                &block_info,
+                &transaction,
+                16,
+                platform_version_17,
+            )
+            .expect("expected the protocol change events to succeed on retry");
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit the upgrade");
+
+        assert!(!root_absent(None), "the committed state must hold the root");
+        let committed_upgraded_root_hash = committed_root_hash();
+        assert_ne!(committed_upgraded_root_hash, pre_upgrade_root_hash);
+
+        let genesis_17 = TestPlatformBuilder::new()
+            .with_initial_protocol_version(17)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let read_transaction = platform.drive.grove.start_transaction();
+        assert_eq!(
+            platform
+                .drive
+                .grove
+                .get(
+                    SubtreePath::empty(),
+                    &[RootTree::ContractCredits as u8],
+                    Some(&read_transaction),
+                    grove_version,
+                )
+                .unwrap()
+                .expect("the committed root element"),
+            genesis_17
+                .drive
+                .grove
+                .get(
+                    SubtreePath::empty(),
+                    &[RootTree::ContractCredits as u8],
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("the genesis root element"),
+            "the upgraded root element must match the genesis-v17 one"
+        );
+        let diffs = collect_subtree_diffs(
+            &genesis_17,
+            &platform,
+            &read_transaction,
+            vec![vec![RootTree::ContractCredits as u8]],
+        );
+        assert!(
+            diffs.is_empty(),
+            "the committed [ContractCredits] subtree must match a genesis-v17 one.\n{}",
+            diffs.join("\n"),
+        );
+        drop(read_transaction);
+
+        let total = platform
+            .drive
+            .calculate_total_credits_balance(None, &platform_version_17.drive)
+            .expect("expected to calculate the total credits balance");
+        assert_eq!(total.total_in_contract_credits, 0);
+        assert!(total.ok().expect("no overflow"));
+
+        // Round 3: running the hook once more must be a no-op.
+        let transaction = platform.drive.grove.start_transaction();
+        platform
+            .perform_events_on_first_block_of_protocol_change(
+                &platform_state,
+                &block_info,
+                &transaction,
+                16,
+                platform_version_17,
+            )
+            .expect("expected the protocol change events to be idempotent");
+        assert_eq!(
+            platform
+                .drive
+                .grove
+                .root_hash(Some(&transaction), grove_version)
+                .unwrap()
+                .expect("expected the root hash"),
+            committed_upgraded_root_hash,
+            "a third run must not change the state"
+        );
+        drop(transaction);
+
+        // Negative control: a block that stays at v17 must not create anything.
+        let steady = TestPlatformBuilder::new()
+            .with_initial_protocol_version(16)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let steady_state = steady.state.load();
+        let transaction = steady.drive.grove.start_transaction();
+        steady
+            .perform_events_on_first_block_of_protocol_change(
+                &steady_state,
+                &block_info,
+                &transaction,
+                17,
+                platform_version_17,
+            )
+            .expect("expected no events for a same-version block");
+        assert!(
+            steady
+                .drive
+                .grove
+                .get(
+                    SubtreePath::empty(),
+                    &[RootTree::ContractCredits as u8],
+                    Some(&transaction),
+                    grove_version,
+                )
+                .unwrap()
+                .is_err(),
+            "the guard must not fire when the previous version is already 17"
         );
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/burn/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/burn/mod.rs
@@ -3960,7 +3960,22 @@ mod token_burn_tests {
             PlatformVersion::latest().protocol_version,
             // PROTOCOL_VERSION_14: +400 — genesis system documents now carry
             // the contract-version stamp, shifting byte-billed subtree reads
-            4_368_280,
+            // PROTOCOL_VERSION_17: +1_480, ContractCredits (100) became the
+            // left child of Misc (104), so the total supply write under Misc
+            // hashes one more child
+            4_369_760,
+        )
+        .await;
+    }
+
+    /// PROTOCOL_VERSION_14: the root Merk has no contract credits key yet, so
+    /// the fee must be exactly what it was before that root tree was added.
+    /// Pinned so v14 chain history stays bit-for-bit reproducible.
+    #[tokio::test]
+    async fn test_token_burn_group_action_confirmer_fee_includes_transformer_reads_protocol_version_14(
+    ) {
+        run_token_burn_group_action_confirmer_fee_includes_transformer_reads_at_protocol_version(
+            14, 4_368_280,
         )
         .await;
     }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/direct_selling/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/direct_selling/mod.rs
@@ -27,9 +27,20 @@ mod token_selling_tests {
             // PROTOCOL_VERSION_14: 27_400 credits more in fees — genesis system
             // documents now carry the contract-version stamp, shifting
             // byte-billed subtree reads
-            699_868_046_180,
+            // PROTOCOL_VERSION_17: 1_480 credits more in fees, ContractCredits
+            // (100) became the left child of Misc (104), so the total supply
+            // write under Misc hashes one more child
+            699_868_044_700,
         )
         .await;
+    }
+
+    /// PROTOCOL_VERSION_14: the root Merk has no contract credits key yet, so
+    /// the buyer balance must be exactly what it was before that root tree
+    /// was added. Pinned so v14 chain history stays bit-for-bit reproducible.
+    #[tokio::test]
+    async fn test_successful_direct_purchase_single_price_protocol_version_14() {
+        run_successful_direct_purchase_single_price_at_protocol_version(14, 699_868_046_180).await;
     }
 
     /// PROTOCOL_VERSION_13: pre-stamp buyer balance — genesis system documents

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
@@ -428,7 +428,7 @@ mod tests {
 
         assert_eq!(processing_result.valid_count(), 1);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 1919540);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 1921020); // 1919540 before v17: ContractCredits (100) became the left child of Misc (104), so the system credits write hashes one more child
 
         platform
             .drive
@@ -443,7 +443,7 @@ mod tests {
             .expect("expected to get identity balance")
             .expect("expected there to be an identity balance for this identity");
 
-        assert_eq!(identity_balance, 99913867460);
+        assert_eq!(identity_balance, 99913865980); // 99913867460 before v17: the processing fee above moved
     }
 
     #[tokio::test]
@@ -877,7 +877,7 @@ mod tests {
 
         assert_eq!(processing_result.valid_count(), 1);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 2195200);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 2196680); // 2195200 before v17: ContractCredits (100) became the left child of Misc (104), so the system credits write hashes one more child
 
         platform
             .drive
@@ -892,7 +892,7 @@ mod tests {
             .expect("expected to get identity balance")
             .expect("expected there to be an identity balance for this identity");
 
-        assert_eq!(identity_balance, 99909262100); // The identity balance is smaller than if there hadn't been any issue
+        assert_eq!(identity_balance, 99909260620); // The identity balance is smaller than if there hadn't been any issue; 99909262100 before v17
     }
 
     #[tokio::test]
@@ -1842,7 +1842,7 @@ mod tests {
 
         assert_eq!(processing_result.valid_count(), 1);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 2195200);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 2196680); // 2195200 before v17: ContractCredits (100) became the left child of Misc (104), so the system credits write hashes one more child
 
         platform
             .drive
@@ -1857,6 +1857,6 @@ mod tests {
             .expect("expected to get identity balance")
             .expect("expected there to be an identity balance for this identity");
 
-        assert_eq!(identity_balance, 99909262100); // The identity balance is smaller than if there hadn't been any issue
+        assert_eq!(identity_balance, 99909260620); // The identity balance is smaller than if there hadn't been any issue; 99909262100 before v17
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
@@ -363,7 +363,7 @@ mod tests {
 
         assert_eq!(processing_result.valid_count(), 1);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 588840);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 590320); // 588840 before v17: ContractCredits (100) became the left child of Misc (104), so the system credits write hashes one more child
 
         platform
             .drive
@@ -382,7 +382,7 @@ mod tests {
             .expect("expected to get identity balance")
             .expect("expected there to be an identity balance for this identity");
 
-        assert_eq!(identity_balance, 149993606160); // about 0.5 Dash starting balance + 1 Dash asset lock top up
+        assert_eq!(identity_balance, 149993604680); // about 0.5 Dash starting balance + 1 Dash asset lock top up; 149993606160 before v17
     }
 
     /// Regression for the proposer-side mint accounting: a minting transition (an asset-lock

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/identity_and_document_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/identity_and_document_tests.rs
@@ -122,6 +122,11 @@ mod tests {
 
         // This will cause the costs of insertion of a spent asset lock transition, since group actions now exist we will see a slight difference in processing costs
         // This is because WithdrawalTransactions will have a right element in the tree.
+        //
+        // From protocol version 17 the ContractCredits root tree (100) is the left child of
+        // Misc (104), so the system credits write under Misc hashes one more child and the
+        // identity keeps 1_480 credits less than at protocol version 13 and 14 (99864009940,
+        // pinned by the version 13 test below).
 
         let platform_version = PlatformVersion::latest();
         let strategy = NetworkStrategy {
@@ -187,7 +192,7 @@ mod tests {
             .expect("expected to fetch balances")
             .expect("expected to have an identity to get balance from");
 
-        assert_eq!(balance, 99864009940)
+        assert_eq!(balance, 99864008460)
     }
 
     #[tokio::test]

--- a/packages/rs-drive/src/drive/balances/calculate_total_credits_balance/mod.rs
+++ b/packages/rs-drive/src/drive/balances/calculate_total_credits_balance/mod.rs
@@ -1,6 +1,7 @@
 mod v0;
 mod v1;
 mod v2;
+mod v3;
 
 use crate::drive::Drive;
 use crate::error::drive::DriveError;
@@ -12,7 +13,9 @@ use grovedb::TransactionArg;
 impl Drive {
     /// Calculates the total credits balance.
     ///
-    /// This function verifies that the sum tree identity credits + pool credits + refunds are equal to the total credits in the system.
+    /// This function verifies that the sum tree identity credits + pool credits + refunds +
+    /// address credits + shielded credits + contract credits are equal to the total credits
+    /// in the system.
     ///
     /// # Arguments
     ///
@@ -40,9 +43,10 @@ impl Drive {
             0 => self.calculate_total_credits_balance_v0(transaction, drive_version),
             1 => self.calculate_total_credits_balance_v1(transaction, drive_version),
             2 => self.calculate_total_credits_balance_v2(transaction, drive_version),
+            3 => self.calculate_total_credits_balance_v3(transaction, drive_version),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "calculate_total_credits_balance".to_string(),
-                known_versions: vec![0, 1, 2],
+                known_versions: vec![0, 1, 2, 3],
                 received: version,
             })),
         }

--- a/packages/rs-drive/src/drive/balances/calculate_total_credits_balance/v0/mod.rs
+++ b/packages/rs-drive/src/drive/balances/calculate_total_credits_balance/v0/mod.rs
@@ -67,6 +67,10 @@ impl Drive {
             total_specialized_balances,
             total_in_addresses: 0,
             total_in_shielded_balances: 0,
+            // v0 predates the ContractCredits root tree (introduced at
+            // protocol v17 / drive v10 alongside the v3 calculator), so it
+            // leaves the field zeroed.
+            total_in_contract_credits: 0,
         })
     }
 }

--- a/packages/rs-drive/src/drive/balances/calculate_total_credits_balance/v1/mod.rs
+++ b/packages/rs-drive/src/drive/balances/calculate_total_credits_balance/v1/mod.rs
@@ -80,6 +80,10 @@ impl Drive {
             // pre-v12 chains the tree does not exist, so v1 does not read
             // it and leaves the field zeroed.
             total_in_shielded_balances: 0,
+            // v1 also predates the ContractCredits root tree (introduced at
+            // protocol v17 / drive v10 alongside the v3 calculator), so it
+            // leaves that field zeroed too.
+            total_in_contract_credits: 0,
         })
     }
 }

--- a/packages/rs-drive/src/drive/balances/calculate_total_credits_balance/v2/mod.rs
+++ b/packages/rs-drive/src/drive/balances/calculate_total_credits_balance/v2/mod.rs
@@ -89,6 +89,11 @@ impl Drive {
             total_specialized_balances,
             total_in_addresses,
             total_in_shielded_balances,
+            // v2 predates the ContractCredits root tree (introduced at
+            // protocol v17 / drive v10 alongside the v3 calculator). On
+            // pre-v17 chains the tree does not exist, so v2 does not read
+            // it and leaves the field zeroed.
+            total_in_contract_credits: 0,
         })
     }
 }

--- a/packages/rs-drive/src/drive/balances/calculate_total_credits_balance/v3/mod.rs
+++ b/packages/rs-drive/src/drive/balances/calculate_total_credits_balance/v3/mod.rs
@@ -1,0 +1,245 @@
+use crate::drive::balances::TOTAL_SYSTEM_CREDITS_STORAGE_KEY;
+use crate::drive::system::misc_path;
+use crate::drive::{Drive, RootTree};
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use crate::util::grove_operations::DirectQueryType;
+use dpp::balances::total_credits_balance::TotalCreditsBalance;
+use dpp::version::drive_versions::DriveVersion;
+use grovedb::TransactionArg;
+use grovedb_path::SubtreePath;
+
+impl Drive {
+    /// Verify that the sum tree identity credits + pool credits + refunds + address
+    /// credits + shielded credits + contract credits are equal to the Total credits
+    /// in the system.
+    ///
+    /// v3 adds the `ContractCredits` root sum tree (introduced at protocol v17 /
+    /// drive v10) as a sixth term in the equation. The tree's aggregate only
+    /// covers live contracts: a wiped contract's subtree is wrapped in a
+    /// not-summed element and contributes nothing. Earlier calculators do not
+    /// read it because the tree does not exist on pre-v17 chains.
+    #[inline(always)]
+    pub(super) fn calculate_total_credits_balance_v3(
+        &self,
+        transaction: TransactionArg,
+        drive_version: &DriveVersion,
+    ) -> Result<TotalCreditsBalance, Error> {
+        let mut drive_operations = vec![];
+        let path_holding_total_credits = misc_path();
+        let total_credits_in_platform = self
+            .grove_get_raw_value_u64_from_encoded_var_vec(
+                (&path_holding_total_credits).into(),
+                TOTAL_SYSTEM_CREDITS_STORAGE_KEY,
+                DirectQueryType::StatefulDirectQuery,
+                transaction,
+                &mut drive_operations,
+                drive_version,
+            )?
+            .ok_or(Error::Drive(DriveError::CriticalCorruptedState(
+                "Credits not found in Platform",
+            )))?;
+
+        let total_identity_balances = self.grove_get_sum_tree_total_value(
+            SubtreePath::empty(),
+            Into::<&[u8; 1]>::into(RootTree::Balances),
+            DirectQueryType::StatefulDirectQuery,
+            transaction,
+            &mut drive_operations,
+            drive_version,
+        )?;
+
+        let total_specialized_balances = self.grove_get_sum_tree_total_value(
+            SubtreePath::empty(),
+            Into::<&[u8; 1]>::into(RootTree::PreFundedSpecializedBalances),
+            DirectQueryType::StatefulDirectQuery,
+            transaction,
+            &mut drive_operations,
+            drive_version,
+        )?;
+
+        let total_in_pools = self.grove_get_sum_tree_total_value(
+            SubtreePath::empty(),
+            Into::<&[u8; 1]>::into(RootTree::Pools),
+            DirectQueryType::StatefulDirectQuery,
+            transaction,
+            &mut drive_operations,
+            drive_version,
+        )?;
+
+        let total_in_addresses = self.grove_get_sum_tree_total_value(
+            SubtreePath::empty(),
+            Into::<&[u8; 1]>::into(RootTree::AddressBalances),
+            DirectQueryType::StatefulDirectQuery,
+            transaction,
+            &mut drive_operations,
+            drive_version,
+        )?;
+
+        let total_in_shielded_balances = self.grove_get_sum_tree_total_value(
+            SubtreePath::empty(),
+            Into::<&[u8; 1]>::into(RootTree::ShieldedBalances),
+            DirectQueryType::StatefulDirectQuery,
+            transaction,
+            &mut drive_operations,
+            drive_version,
+        )?;
+
+        let total_in_contract_credits = self.grove_get_sum_tree_total_value(
+            SubtreePath::empty(),
+            Into::<&[u8; 1]>::into(RootTree::ContractCredits),
+            DirectQueryType::StatefulDirectQuery,
+            transaction,
+            &mut drive_operations,
+            drive_version,
+        )?;
+
+        Ok(TotalCreditsBalance {
+            total_credits_in_platform,
+            total_in_pools,
+            total_identity_balances,
+            total_specialized_balances,
+            total_in_addresses,
+            total_in_shielded_balances,
+            total_in_contract_credits,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::drive::contract::balances::{contract_credits_path, contract_credits_root_path};
+    use crate::drive::Drive;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::version::PlatformVersion;
+    use grovedb::Element;
+    use grovedb_path::SubtreePath;
+
+    /// Credits a contract directly in the contract credits tree, bypassing
+    /// the bucket operations that later changes add: a raw sum subtree for
+    /// the contract holding one sum item. Enough to move the root aggregate.
+    fn credit_contract_raw(
+        drive: &Drive,
+        contract_id: [u8; 32],
+        amount: i64,
+        platform_version: &PlatformVersion,
+    ) {
+        let grove_version = &platform_version.drive.grove_version;
+        drive
+            .grove
+            .insert(
+                SubtreePath::from(&contract_credits_root_path()),
+                &contract_id,
+                Element::empty_sum_tree(),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("expected to insert the contract sum tree");
+        drive
+            .grove
+            .insert(
+                SubtreePath::from(&contract_credits_path(&contract_id)),
+                &[0, 1],
+                Element::new_sum_item(amount),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("expected to insert the bucket sum item");
+    }
+
+    #[test]
+    fn should_balance_credits_with_empty_contract_credits_root() {
+        let platform_version = PlatformVersion::latest();
+        let drive = setup_drive_with_initial_state_structure(Some(platform_version));
+
+        let total = drive
+            .calculate_total_credits_balance(None, &platform_version.drive)
+            .expect("expected to calculate the total credits balance");
+
+        assert_eq!(total.total_in_contract_credits, 0);
+        assert!(total.ok().expect("no overflow"));
+    }
+
+    #[test]
+    fn should_read_contract_credits_as_a_term_of_the_equation() {
+        let platform_version = PlatformVersion::latest();
+        let drive = setup_drive_with_initial_state_structure(Some(platform_version));
+
+        credit_contract_raw(&drive, [1u8; 32], 700, platform_version);
+        credit_contract_raw(&drive, [2u8; 32], 300, platform_version);
+
+        // Credits in the contract trees without the matching system credits
+        // are not balanced: the term is read, not assumed.
+        let unbalanced = drive
+            .calculate_total_credits_balance(None, &platform_version.drive)
+            .expect("expected to calculate the total credits balance");
+        assert_eq!(unbalanced.total_in_contract_credits, 1000);
+        assert!(!unbalanced.ok().expect("no overflow"));
+
+        drive
+            .add_to_system_credits(1000, None, platform_version)
+            .expect("expected to add to system credits");
+
+        let balanced = drive
+            .calculate_total_credits_balance(None, &platform_version.drive)
+            .expect("expected to calculate the total credits balance");
+        assert_eq!(balanced.total_in_contract_credits, 1000);
+        assert!(balanced.ok().expect("no overflow"));
+        assert_eq!(balanced.total_in_trees().expect("no overflow"), 1000);
+    }
+
+    #[test]
+    fn should_exclude_a_not_summed_contract_tree_from_the_term() {
+        let platform_version = PlatformVersion::latest();
+        let drive = setup_drive_with_initial_state_structure(Some(platform_version));
+        let grove_version = &platform_version.drive.grove_version;
+
+        credit_contract_raw(&drive, [1u8; 32], 700, platform_version);
+
+        // A wiped contract keeps its subtree, wrapped so the root aggregate
+        // ignores it. The retained amount is real storage but not live credit.
+        let wiped_id = [9u8; 32];
+        drive
+            .grove
+            .insert(
+                SubtreePath::from(&contract_credits_root_path()),
+                &wiped_id,
+                Element::new_not_summed(Element::empty_sum_tree())
+                    .expect("a sum tree can be wrapped"),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("expected to insert the wiped contract tree");
+        drive
+            .grove
+            .insert(
+                SubtreePath::from(&contract_credits_path(&wiped_id)),
+                &[0, 1],
+                Element::new_sum_item(5000),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("expected to insert the retained bucket");
+
+        drive
+            .add_to_system_credits(700, None, platform_version)
+            .expect("expected to add to system credits");
+
+        let total = drive
+            .calculate_total_credits_balance(None, &platform_version.drive)
+            .expect("expected to calculate the total credits balance");
+        assert_eq!(
+            total.total_in_contract_credits, 700,
+            "the retained credits of the wiped contract must not be counted"
+        );
+        assert!(total.ok().expect("no overflow"));
+    }
+}

--- a/packages/rs-drive/src/drive/contract/balances/mod.rs
+++ b/packages/rs-drive/src/drive/contract/balances/mod.rs
@@ -1,0 +1,65 @@
+//! Contract balances.
+//!
+//! Contracts are not identities and hold no identity balance. Their credits
+//! live in a dedicated root sum tree, `RootTree::ContractCredits`, laid out
+//! as `[ContractCredits] / contract_id (SumTree) / bucket_key (SumItem)`.
+//! The root aggregate is therefore the total of live contract credits and is
+//! read by credit conservation as its own term. A contract whose credits
+//! were wiped keeps its subtree wrapped in a not-summed element, so the root
+//! aggregate never counts retained balances.
+//!
+//! This module holds the path helpers. The bucket operations, the wiped
+//! lifecycle wrapper and the proofs arrive with later changes.
+
+use crate::drive::RootTree;
+
+/// The path to the contract credits root tree.
+pub fn contract_credits_root_path() -> [&'static [u8]; 1] {
+    [Into::<&[u8; 1]>::into(RootTree::ContractCredits)]
+}
+
+/// The path to the contract credits root tree as a vec.
+pub fn contract_credits_root_path_vec() -> Vec<Vec<u8>> {
+    vec![vec![RootTree::ContractCredits as u8]]
+}
+
+/// The path to the credit bucket sum tree of one contract.
+pub fn contract_credits_path(contract_id: &[u8; 32]) -> [&[u8]; 2] {
+    [
+        Into::<&[u8; 1]>::into(RootTree::ContractCredits),
+        contract_id,
+    ]
+}
+
+/// The path to the credit bucket sum tree of one contract as a vec.
+pub fn contract_credits_path_vec(contract_id: [u8; 32]) -> Vec<Vec<u8>> {
+    vec![vec![RootTree::ContractCredits as u8], contract_id.to_vec()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_place_the_contract_credits_root_at_the_root_key() {
+        let root = contract_credits_root_path();
+        assert_eq!(root, [&[RootTree::ContractCredits as u8][..]]);
+        assert_eq!(
+            contract_credits_root_path_vec(),
+            root.iter().map(|part| part.to_vec()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn should_place_a_contract_tree_directly_under_the_root() {
+        let contract_id = [7u8; 32];
+        let path = contract_credits_path(&contract_id);
+        assert_eq!(path.len(), 2);
+        assert_eq!(path[0], &[RootTree::ContractCredits as u8][..]);
+        assert_eq!(path[1], &contract_id[..]);
+        assert_eq!(
+            contract_credits_path_vec(contract_id),
+            path.iter().map(|part| part.to_vec()).collect::<Vec<_>>()
+        );
+    }
+}

--- a/packages/rs-drive/src/drive/contract/mod.rs
+++ b/packages/rs-drive/src/drive/contract/mod.rs
@@ -5,6 +5,9 @@
 
 #[cfg(feature = "server")]
 mod apply;
+/// Contract credit balances: the contract credits root tree and its paths
+#[cfg(any(feature = "server", feature = "verify"))]
+pub mod balances;
 #[cfg(feature = "server")]
 mod contract_fetch_info;
 #[cfg(feature = "server")]

--- a/packages/rs-drive/src/drive/initialization/mod.rs
+++ b/packages/rs-drive/src/drive/initialization/mod.rs
@@ -5,6 +5,7 @@ mod v0;
 mod v1;
 mod v2;
 mod v3;
+mod v4;
 
 use crate::drive::Drive;
 use crate::error::drive::DriveError;
@@ -30,9 +31,10 @@ impl Drive {
             1 => self.create_initial_state_structure_v1(transaction, platform_version),
             2 => self.create_initial_state_structure_v2(transaction, platform_version),
             3 => self.create_initial_state_structure_v3(transaction, platform_version),
+            4 => self.create_initial_state_structure_v4(transaction, platform_version),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "create_initial_state_structure".to_string(),
-                known_versions: vec![0, 1, 2, 3],
+                known_versions: vec![0, 1, 2, 3, 4],
                 received: version,
             })),
         }

--- a/packages/rs-drive/src/drive/initialization/v0/mod.rs
+++ b/packages/rs-drive/src/drive/initialization/v0/mod.rs
@@ -316,7 +316,7 @@ mod tests {
                 &platform_version.drive,
             )
             .expect("expected to get root elements");
-        assert_eq!(elements.len(), 17);
+        assert_eq!(elements.len(), 18);
     }
 
     #[test]
@@ -1271,6 +1271,11 @@ mod tests {
     #[test]
     /// Proof sizes differ from v11 by +33/+35 bytes on nodes touching the
     /// shielded pool subtree, which uses `KVValueHashFeatureTypeWithChildHash`.
+    ///
+    /// From protocol v17 the `ContractCredits` root sum tree (key 100) sits
+    /// as the left child of `Misc` (104) at Merk level 4, so the `Misc` proof
+    /// grows by the child hash it now carries and the new key proves at the
+    /// same size as the other level 4 keys under a normal tree parent.
     fn test_initial_state_structure_proper_heights_in_latest_protocol_version() {
         let drive = setup_drive_with_initial_state_structure(None);
 
@@ -1576,7 +1581,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 285);
+        assert_eq!(proof.len(), 319); // 285 before v17: Misc now carries the ContractCredits child hash
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Versions as u8]);
@@ -1621,5 +1626,26 @@ mod tests {
             )
             .expect("expected to get root elements");
         assert_eq!(proof.len(), 319);
+
+        let mut query = Query::new();
+        query.insert_key(vec![RootTree::ContractCredits as u8]);
+        let root_path_query = PathQuery::new(
+            vec![],
+            SizedQuery {
+                query,
+                limit: None,
+                offset: None,
+            },
+        );
+        let mut drive_operations = vec![];
+        let proof = drive
+            .grove_get_proved_path_query(
+                &root_path_query,
+                None,
+                &mut drive_operations,
+                drive_version,
+            )
+            .expect("expected to get root elements");
+        assert_eq!(proof.len(), 285);
     }
 }

--- a/packages/rs-drive/src/drive/initialization/v4/mod.rs
+++ b/packages/rs-drive/src/drive/initialization/v4/mod.rs
@@ -1,0 +1,163 @@
+//! Drive Initialization
+
+use crate::drive::{Drive, RootTree};
+use crate::error::Error;
+use dpp::version::PlatformVersion;
+use grovedb::{TransactionArg, TreeType};
+use grovedb_path::SubtreePath;
+
+impl Drive {
+    /// Creates the initial state structure.
+    ///
+    /// v4 adds the `ContractCredits` root sum tree (introduced at protocol
+    /// v17 / drive v10). Everything else is identical to v3.
+    pub(super) fn create_initial_state_structure_v4(
+        &self,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        let drive_version = &platform_version.drive;
+        self.create_initial_state_structure_top_level_0(transaction, platform_version)?;
+
+        self.grove_insert_empty_tree(
+            SubtreePath::empty(),
+            &[RootTree::GroupActions as u8],
+            TreeType::NormalTree,
+            transaction,
+            None,
+            &mut vec![],
+            drive_version,
+        )?;
+
+        // AddressBalances top-level sum tree (introduced in v2)
+        self.grove_insert_empty_tree(
+            SubtreePath::empty(),
+            &[RootTree::AddressBalances as u8],
+            TreeType::SumTree,
+            transaction,
+            None,
+            &mut vec![],
+            drive_version,
+        )?;
+
+        // ShieldedBalances top-level sum tree — separate from AddressBalances so
+        // per-pool internal trees (notes, nullifiers, anchors, …) cannot
+        // contaminate the address-credit aggregate via sum propagation.
+        self.grove_insert_empty_tree(
+            SubtreePath::empty(),
+            &[RootTree::ShieldedBalances as u8],
+            TreeType::SumTree,
+            transaction,
+            None,
+            &mut vec![],
+            drive_version,
+        )?;
+
+        // ContractCredits top-level sum tree (introduced in v4). Contract credit
+        // buckets live under it as `contract_id (SumTree) / bucket_key (SumItem)`,
+        // so its aggregate is the total of live contract credits and is read by
+        // credit conservation as its own term. CONSENSUS-CRITICAL: this is a
+        // standalone non-batch root insert placed right after ShieldedBalances,
+        // and the upgrade path (`Platform::transition_to_version_17`) creates
+        // the same empty sum tree with an insert-if-not-exists, so a fresh
+        // genesis-v17 node and an in-place-upgraded v17 node hold a
+        // byte-identical `[ContractCredits]` element.
+        self.grove_insert_empty_tree(
+            SubtreePath::empty(),
+            &[RootTree::ContractCredits as u8],
+            TreeType::SumTree,
+            transaction,
+            None,
+            &mut vec![],
+            drive_version,
+        )?;
+
+        // SavedBlockTransactions for address-based transaction sync
+        self.grove_insert_empty_tree(
+            SubtreePath::empty(),
+            &[RootTree::SavedBlockTransactions as u8],
+            TreeType::NormalTree,
+            transaction,
+            None,
+            &mut vec![],
+            drive_version,
+        )?;
+
+        // On lower layers we can use batching
+
+        let mut batch =
+            self.create_initial_state_structure_lower_layers_operations_0(platform_version)?;
+
+        self.initial_state_structure_lower_layers_add_operations_2(&mut batch, platform_version)?;
+
+        self.grove_apply_batch(batch, false, transaction, drive_version)?;
+
+        // Add the shielded pool structures AFTER the batch apply so the
+        // top-level `[ShieldedBalances]` SumTree (inserted above) already
+        // exists. CONSENSUS-CRITICAL: this MUST go through the shared
+        // `insert_shielded_pool_structure` helper — the same sequential builder
+        // the upgrade path (`Platform::transition_to_version_12`) uses — so a
+        // fresh-genesis-v12 node and an in-place-upgraded v12 node build a
+        // byte-identical `[ShieldedBalances]` subtree. Building the pool here in
+        // the sorted `GroveDbOpBatch` instead would root the parent Merk at the
+        // batch's median key (`[160]`) rather than the intended NOTES-at-root
+        // (`[128]`) layout, diverging from the upgrade path and forking the
+        // network at the v11→v12 boundary.
+        self.insert_shielded_pool_structure(transaction, platform_version)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::drive::RootTree;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::version::PlatformVersion;
+    use grovedb::Element;
+    use grovedb_path::SubtreePath;
+
+    #[test]
+    fn should_create_contract_credits_root_at_latest_genesis() {
+        let platform_version = PlatformVersion::latest();
+        let drive = setup_drive_with_initial_state_structure(Some(platform_version));
+
+        let element = drive
+            .grove
+            .get(
+                SubtreePath::empty(),
+                &[RootTree::ContractCredits as u8],
+                None,
+                &platform_version.drive.grove_version,
+            )
+            .unwrap()
+            .expect("the contract credits root should exist at the latest genesis");
+
+        assert_eq!(
+            element,
+            Element::empty_sum_tree(),
+            "the contract credits root must be an empty sum tree with no flags"
+        );
+    }
+
+    #[test]
+    fn should_not_create_contract_credits_root_at_protocol_14_genesis() {
+        let platform_version = PlatformVersion::get(14).expect("protocol version 14 exists");
+        let drive = setup_drive_with_initial_state_structure(Some(platform_version));
+
+        let result = drive
+            .grove
+            .get(
+                SubtreePath::empty(),
+                &[RootTree::ContractCredits as u8],
+                None,
+                &platform_version.drive.grove_version,
+            )
+            .unwrap();
+
+        assert!(
+            result.is_err(),
+            "a protocol 14 genesis must not contain the contract credits root, got {result:?}"
+        );
+    }
+}

--- a/packages/rs-drive/src/drive/mod.rs
+++ b/packages/rs-drive/src/drive/mod.rs
@@ -181,8 +181,13 @@ pub struct Drive {
 //       Tokens 16                    Pools 48                                                    WithdrawalTransactions 80                                                Votes  112
 //       /      \                           /                     \                                         /                           \                            /                          \
 //     NUPKH->I 8 UPKH->I 24   PreFundedSpecializedBalances 40  AddressBalances 56              SpentAssetLockTransactions 72    GroupActions 88             Misc 104                        Versions 120
-//                                     /                          /
-//                           Saved Block Transactions 36       ShieldedBalances 52
+//                                     /                          /                                                                                          \
+//                           Saved Block Transactions 36       ShieldedBalances 52                                                                        ContractCredits 100
+//
+// The diagram shows the intended balanced shape. Keys added after genesis of
+// an earlier protocol version (ShieldedBalances 52, ContractCredits 100) are
+// placed by AVL rebalancing at insertion time, so their exact depth depends
+// on the insertion order that the initialization and upgrade paths share.
 
 /// Keys for the root tree.
 #[cfg(any(feature = "server", feature = "verify"))]
@@ -228,6 +233,15 @@ pub enum RootTree {
     Votes = 112,
     /// Group actions
     GroupActions = 88,
+    /// Contract credits: one sum subtree per contract holding its credit
+    /// buckets as sum items. An ordinary sum tree so the root aggregate is
+    /// the total of live contract credits; a wiped contract's subtree is
+    /// wrapped in a not-summed element and contributes nothing here.
+    ///
+    /// The key value is provisional: the allocation register leaves new
+    /// root keys unallocated, and 100 was chosen as a free value near the
+    /// other balance trees.
+    ContractCredits = 100,
 }
 
 #[cfg(any(feature = "server", feature = "verify"))]
@@ -254,6 +268,7 @@ impl fmt::Display for RootTree {
             RootTree::Versions => "Versions",
             RootTree::Votes => "Votes",
             RootTree::GroupActions => "GroupActions",
+            RootTree::ContractCredits => "ContractCredits",
         };
         write!(f, "{}", variant_name)
     }
@@ -299,6 +314,7 @@ impl TryFrom<u8> for RootTree {
             16 => Ok(RootTree::Tokens),
             120 => Ok(RootTree::Versions),
             112 => Ok(RootTree::Votes),
+            100 => Ok(RootTree::ContractCredits),
             _ => Err(Error::Drive(DriveError::NotSupported(
                 "unknown root tree item",
             ))),
@@ -327,6 +343,7 @@ impl From<RootTree> for &'static [u8; 1] {
             RootTree::Versions => &[120],
             RootTree::Votes => &[112],
             RootTree::GroupActions => &[88],
+            RootTree::ContractCredits => &[100],
         }
     }
 }

--- a/packages/rs-drive/src/util/batch/grovedb_op_batch/mod.rs
+++ b/packages/rs-drive/src/util/batch/grovedb_op_batch/mod.rs
@@ -73,6 +73,7 @@ enum KnownPath {
     GroupActionsRoot,                                                 //Level 1
     SingleUseKeyBalancesRoot,                                         //Level 1
     ShieldedBalancesRoot,                                             //Level 1
+    ContractCreditsRoot,                                              //Level 1
 }
 
 impl From<RootTree> for KnownPath {
@@ -99,6 +100,7 @@ impl From<RootTree> for KnownPath {
             RootTree::GroupActions => KnownPath::GroupActionsRoot,
             RootTree::AddressBalances => KnownPath::SingleUseKeyBalancesRoot,
             RootTree::ShieldedBalances => KnownPath::ShieldedBalancesRoot,
+            RootTree::ContractCredits => KnownPath::ContractCreditsRoot,
         }
     }
 }
@@ -141,13 +143,17 @@ fn readable_key_info(known_path: KnownPath, key_info: &KeyInfo) -> (String, Opti
                     ),
                     None,
                 ),
-                KnownPath::DataContractAndDocumentsRoot if key.len() == 32 => (
-                    format!(
-                        "ContractId(bs58::{})",
-                        Identifier::from_vec(key.clone()).unwrap()
-                    ),
-                    None,
-                ),
+                KnownPath::DataContractAndDocumentsRoot | KnownPath::ContractCreditsRoot
+                    if key.len() == 32 =>
+                {
+                    (
+                        format!(
+                            "ContractId(bs58::{})",
+                            Identifier::from_vec(key.clone()).unwrap()
+                        ),
+                        None,
+                    )
+                }
                 KnownPath::DataContractAndDocumentsRoot if key.len() == 1 => match key[0] {
                     0 => (
                         "DataContractStorage(0)".to_string(),

--- a/packages/rs-platform-version/src/version/drive_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/mod.rs
@@ -28,6 +28,7 @@ pub mod drive_token_method_versions;
 pub mod drive_verify_method_versions;
 pub mod drive_vote_method_versions;
 pub mod v1;
+pub mod v10;
 pub mod v2;
 pub mod v3;
 pub mod v4;

--- a/packages/rs-platform-version/src/version/drive_versions/v10.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v10.rs
@@ -1,0 +1,152 @@
+use crate::version::drive_versions::drive_address_funds_method_versions::v2::DRIVE_ADDRESS_FUNDS_METHOD_VERSIONS_V2;
+use crate::version::drive_versions::drive_contract_method_versions::v3::DRIVE_CONTRACT_METHOD_VERSIONS_V3;
+use crate::version::drive_versions::drive_credit_pool_method_versions::v1::CREDIT_POOL_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_document_method_versions::v4::DRIVE_DOCUMENT_METHOD_VERSIONS_V4;
+use crate::version::drive_versions::drive_group_method_versions::v1::DRIVE_GROUP_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_group_method_versions::DriveShieldedMethodVersions;
+use crate::version::drive_versions::drive_grove_method_versions::v1::DRIVE_GROVE_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_identity_method_versions::v2::DRIVE_IDENTITY_METHOD_VERSIONS_V2;
+use crate::version::drive_versions::drive_state_transition_method_versions::v4::DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V4;
+use crate::version::drive_versions::drive_structure_version::v1::DRIVE_STRUCTURE_V1;
+use crate::version::drive_versions::drive_token_method_versions::v1::DRIVE_TOKEN_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_verify_method_versions::v2::DRIVE_VERIFY_METHOD_VERSIONS_V2;
+use crate::version::drive_versions::drive_vote_method_versions::v2::DRIVE_VOTE_METHOD_VERSIONS_V2;
+use crate::version::drive_versions::{
+    DriveAssetLockMethodVersions, DriveBalancesMethodVersions, DriveBatchOperationsMethodVersion,
+    DriveEstimatedCostsMethodVersions, DriveFeesMethodVersions, DriveFetchMethodVersions,
+    DriveInitializationMethodVersions, DriveMethodVersions, DriveOperationsMethodVersion,
+    DrivePlatformStateMethodVersions, DrivePlatformSystemMethodVersions,
+    DrivePrefundedSpecializedMethodVersions, DriveProtocolUpgradeVersions,
+    DriveProveMethodVersions, DriveSavedBlockTransactionsMethodVersions,
+    DriveSystemEstimationCostsMethodVersions, DriveVersion,
+};
+use grovedb_version::version::v4::GROVE_V4;
+
+/// Drive version 10.
+/// Introduced in protocol v17, the 5.0 protocol version, for the contract
+/// credits root tree: a sum tree at root key 100 that holds, from later
+/// changes, one sum subtree per contract with one sum item per credit bucket.
+///
+/// * **Genesis**: `initialization.create_initial_state_structure` 3 -> 4
+///   inserts the empty `ContractCredits` sum tree as a standalone root
+///   insert right after `ShieldedBalances`; the upgrade path creates the same
+///   element with an insert-if-not-exists on the first block at v17, so a
+///   fresh genesis and an upgraded node hold a byte-identical root element.
+/// * **Credit conservation**: `balances.calculate_total_credits_balance`
+///   2 -> 3 reads the tree's aggregate as the sixth term of the equation.
+///   Contracts wiped later have their subtree wrapped in a not-summed
+///   element, so the aggregate only ever covers live contract credits.
+///
+/// Everything else matches `DRIVE_VERSION_V9`.
+pub const DRIVE_VERSION_V10: DriveVersion = DriveVersion {
+    structure: DRIVE_STRUCTURE_V1,
+    methods: DriveMethodVersions {
+        initialization: DriveInitializationMethodVersions {
+            create_initial_state_structure: 4, // changed in v10: adds the contract credits root sum tree
+        },
+        credit_pools: CREDIT_POOL_METHOD_VERSIONS_V1,
+        protocol_upgrade: DriveProtocolUpgradeVersions {
+            clear_version_information: 0,
+            fetch_versions_with_counter: 0,
+            fetch_proved_versions_with_counter: 0,
+            fetch_validator_version_votes: 0,
+            fetch_proved_validator_version_votes: 0,
+            remove_validators_proposed_app_versions: 0,
+            update_validator_proposed_app_version: 0,
+        },
+        prove: DriveProveMethodVersions {
+            prove_elements: 0,
+            prove_multiple_state_transition_results: 0,
+            prove_state_transition: 0,
+        },
+        balances: DriveBalancesMethodVersions {
+            add_to_system_credits: 0,
+            add_to_system_credits_operations: 0,
+            remove_from_system_credits: 0,
+            remove_from_system_credits_operations: 0,
+            calculate_total_credits_balance: 3, // changed in v10: ContractCredits root tree adds a sixth term to the equation
+        },
+        document: DRIVE_DOCUMENT_METHOD_VERSIONS_V4, // changed in v9: v2 index walkers + v1 update walker (shared-prefix aggregate indexes become insertable) and the detect_ranked_mode slot
+        vote: DRIVE_VOTE_METHOD_VERSIONS_V2,
+        contract: DRIVE_CONTRACT_METHOD_VERSIONS_V3, // changed in v8: count-tree-aware contract-insertion cost estimation (v12+ countable/range_countable doctypes)
+        fees: DriveFeesMethodVersions { calculate_fee: 0 },
+        estimated_costs: DriveEstimatedCostsMethodVersions {
+            add_estimation_costs_for_levels_up_to_contract: 0,
+            add_estimation_costs_for_levels_up_to_contract_document_type_excluded: 0,
+            add_estimation_costs_for_contested_document_tree_levels_up_to_contract: 0,
+            add_estimation_costs_for_contested_document_tree_levels_up_to_contract_document_type_excluded: 0,
+        },
+        asset_lock: DriveAssetLockMethodVersions {
+            add_asset_lock_outpoint: 0,
+            add_estimation_costs_for_adding_asset_lock: 0,
+            fetch_asset_lock_outpoint_info: 0,
+        },
+        verify: DRIVE_VERIFY_METHOD_VERSIONS_V2, // changed in v8: compacted address-balance proof envelope (verify v1)
+        identity: DRIVE_IDENTITY_METHOD_VERSIONS_V2, // changed in v9: v1 withdrawal-by-transaction-index query builder (structural, identical lowering)
+        token: DRIVE_TOKEN_METHOD_VERSIONS_V1,
+        platform_system: DrivePlatformSystemMethodVersions {
+            estimation_costs: DriveSystemEstimationCostsMethodVersions {
+                for_total_system_credits_update: 0,
+            },
+        },
+        operations: DriveOperationsMethodVersion {
+            rollback_transaction: 0,
+            drop_cache: 0,
+            commit_transaction: 0,
+            apply_partial_batch_low_level_drive_operations: 0,
+            apply_partial_batch_grovedb_operations: 0,
+            apply_batch_low_level_drive_operations: 0,
+            apply_batch_grovedb_operations: 0,
+        },
+        state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V4, // changed: document_from_action generation 1 stamps built documents with the contract version (create assigns, replace re-assigns; paired with document serialization format 3)
+        batch_operations: DriveBatchOperationsMethodVersion {
+            convert_drive_operations_to_grove_operations: 0,
+            apply_drive_operations: 0,
+        },
+        platform_state: DrivePlatformStateMethodVersions {
+            fetch_platform_state_bytes: 0,
+            store_platform_state_bytes: 0,
+        },
+        fetch: DriveFetchMethodVersions { fetch_elements: 0 },
+        prefunded_specialized_balances: DrivePrefundedSpecializedMethodVersions {
+            fetch_single: 0,
+            prove_single: 0,
+            add_prefunded_specialized_balance: 0,
+            add_prefunded_specialized_balance_operations: 1,
+            deduct_from_prefunded_specialized_balance: 1,
+            deduct_from_prefunded_specialized_balance_operations: 0,
+            estimated_cost_for_prefunded_specialized_balance_update: 0,
+            empty_prefunded_specialized_balance: 0,
+        },
+        group: DRIVE_GROUP_METHOD_VERSIONS_V1,
+        address_funds: DRIVE_ADDRESS_FUNDS_METHOD_VERSIONS_V2,
+        shielded: DriveShieldedMethodVersions {
+            insert_note: 0,
+            insert_nullifiers: 0,
+            update_total_balance: 0,
+            record_anchor_if_changed: 0,
+            prune_anchors: 0,
+            has_anchor: 0,
+            has_nullifier: 0,
+            read_total_balance: 0,
+            notes_count: 0,
+        },
+        saved_block_transactions: DriveSavedBlockTransactionsMethodVersions {
+            store_address_balances: 0,
+            fetch_address_balances: 0,
+            prove_compacted_address_balance_changes: 1,
+            compact_address_balances: 0,
+            cleanup_expired_address_balances: 0,
+            max_blocks_before_compaction: 64,
+            max_addresses_before_compaction: 2048,
+        },
+    },
+    grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,
+    // changed in v9: GROVE_V4 activates the indexed-tree batch cleanup
+    // gates (overwrite inspection + delete-tree actual-type cleanup).
+    // Indexed trees only exist from protocol v14, so activating the
+    // stricter cleanup with them costs older versions nothing; staying
+    // on V3 would let a batch overwrite of a ranked index orphan its
+    // per-axis secondary storage.
+    grove_version: GROVE_V4,
+};

--- a/packages/rs-platform-version/src/version/mod.rs
+++ b/packages/rs-platform-version/src/version/mod.rs
@@ -1,6 +1,6 @@
 mod protocol_version;
 
-use crate::version::v14::PROTOCOL_VERSION_14;
+use crate::version::v17::PROTOCOL_VERSION_17;
 pub use protocol_version::*;
 use std::ops::RangeInclusive;
 
@@ -20,6 +20,9 @@ pub mod v11;
 pub mod v12;
 pub mod v13;
 pub mod v14;
+pub mod v15;
+pub mod v16;
+pub mod v17;
 pub mod v2;
 pub mod v3;
 pub mod v4;
@@ -33,5 +36,5 @@ pub type ProtocolVersion = u32;
 
 pub const ALL_VERSIONS: RangeInclusive<ProtocolVersion> = 1..=LATEST_VERSION;
 
-pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_14;
+pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_17;
 pub const INITIAL_PROTOCOL_VERSION: ProtocolVersion = 1;

--- a/packages/rs-platform-version/src/version/protocol_version.rs
+++ b/packages/rs-platform-version/src/version/protocol_version.rs
@@ -22,6 +22,9 @@ use crate::version::v11::PLATFORM_V11;
 use crate::version::v12::PLATFORM_V12;
 use crate::version::v13::PLATFORM_V13;
 use crate::version::v14::PLATFORM_V14;
+use crate::version::v15::PLATFORM_V15;
+use crate::version::v16::PLATFORM_V16;
+use crate::version::v17::PLATFORM_V17;
 use crate::version::v2::PLATFORM_V2;
 use crate::version::v3::PLATFORM_V3;
 use crate::version::v4::PLATFORM_V4;
@@ -61,6 +64,9 @@ pub const PLATFORM_VERSIONS: &[PlatformVersion] = &[
     PLATFORM_V12,
     PLATFORM_V13,
     PLATFORM_V14,
+    PLATFORM_V15,
+    PLATFORM_V16,
+    PLATFORM_V17,
 ];
 
 #[cfg(feature = "mock-versions")]
@@ -69,7 +75,7 @@ pub static PLATFORM_TEST_VERSIONS: OnceLock<Vec<PlatformVersion>> = OnceLock::ne
 #[cfg(feature = "mock-versions")]
 const DEFAULT_PLATFORM_TEST_VERSIONS: &[PlatformVersion] = &[TEST_PLATFORM_V2, TEST_PLATFORM_V3];
 
-pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V14;
+pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V17;
 
 pub const DESIRED_PLATFORM_VERSION: &PlatformVersion = LATEST_PLATFORM_VERSION;
 

--- a/packages/rs-platform-version/src/version/v15.rs
+++ b/packages/rs-platform-version/src/version/v15.rs
@@ -1,0 +1,21 @@
+use crate::version::protocol_version::PlatformVersion;
+use crate::version::v14::PLATFORM_V14;
+use crate::version::ProtocolVersion;
+
+pub const PROTOCOL_VERSION_15: ProtocolVersion = 15;
+
+/// Placeholder for the 4.3 protocol version.
+///
+/// The DashVM allocation register reserves protocol version 15 for the 4.3 release, 16 for 4.4
+/// and 17 for 5.0, and the registry is indexed by number, so the 5.0 version cannot exist on
+/// this branch without 15 and 16. Until the 4.3 branch merges its real `v15.rs` forward this
+/// version is identical to v14.
+///
+/// It is written as a struct update rather than a copy of `v14.rs` on purpose: when the real
+/// file arrives the add/add conflict is resolved by taking the incoming file, and because v16
+/// and v17 are struct updates over their predecessor every table the incoming version changes
+/// flows into them without a second edit.
+pub const PLATFORM_V15: PlatformVersion = PlatformVersion {
+    protocol_version: PROTOCOL_VERSION_15,
+    ..PLATFORM_V14
+};

--- a/packages/rs-platform-version/src/version/v16.rs
+++ b/packages/rs-platform-version/src/version/v16.rs
@@ -1,0 +1,16 @@
+use crate::version::protocol_version::PlatformVersion;
+use crate::version::v15::PLATFORM_V15;
+use crate::version::ProtocolVersion;
+
+pub const PROTOCOL_VERSION_16: ProtocolVersion = 16;
+
+/// Placeholder for the 4.4 protocol version.
+///
+/// Reserved by the DashVM allocation register (15 for 4.3, 16 for 4.4, 17 for 5.0). Identical to
+/// v15 until the 4.4 branch merges its real `v16.rs` forward; see `v15.rs` for why it is a
+/// struct update and how the forward merge is resolved. Should 4.4 ship no consensus change, the
+/// register drops this activation and the 5.0 version becomes 16.
+pub const PLATFORM_V16: PlatformVersion = PlatformVersion {
+    protocol_version: PROTOCOL_VERSION_16,
+    ..PLATFORM_V15
+};

--- a/packages/rs-platform-version/src/version/v17.rs
+++ b/packages/rs-platform-version/src/version/v17.rs
@@ -1,0 +1,27 @@
+use crate::version::drive_versions::v10::DRIVE_VERSION_V10;
+use crate::version::protocol_version::PlatformVersion;
+use crate::version::v16::PLATFORM_V16;
+use crate::version::ProtocolVersion;
+
+pub const PROTOCOL_VERSION_17: ProtocolVersion = 17;
+
+/// The 5.0 protocol version, the one that introduces smart contracts. Provisional number from
+/// the DashVM allocation register (15 for 4.3, 16 for 4.4, 17 for 5.0).
+///
+/// One change over v16 so far:
+///
+/// * `DRIVE_VERSION_V10` adds the contract credits root sum tree (`RootTree::ContractCredits`,
+///   key 100) to the state: `create_initial_state_structure` 3 -> 4 creates it at genesis, the
+///   first block at this version creates it on upgraded nodes, and
+///   `calculate_total_credits_balance` 2 -> 3 reads it as the sixth term of the credit
+///   conservation equation. Contract credit buckets, their rules and their proofs arrive with
+///   later changes; until then the tree stays empty and the term is zero.
+///
+/// The root key value is provisional (the allocation register leaves new root values
+/// unallocated) and is revised, if at all, before any network is asked to propose this
+/// version.
+pub const PLATFORM_V17: PlatformVersion = PlatformVersion {
+    protocol_version: PROTOCOL_VERSION_17,
+    drive: DRIVE_VERSION_V10, // changed: contract credits root sum tree at genesis, on upgrade and in credit conservation
+    ..PLATFORM_V16
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part 1 of 4 for R04-01 of the smart contract plan in dashpay/platform#4626 (workstream issue #4690, section 4: contract credit and token buckets).

Ordinary data contracts are not identities and stay that way. When a contract needs to hold credits (to pay for scheduled work, to escrow a purchase, to fund its own storage) those credits must live in a structure that is separate from every identity tree, must be provable per bucket and per contract, and must take part in the end-of-block credit conservation check so a contract can never hold credits that the equation does not see.

This first part lays the foundation: the root tree that will hold every contract's credit buckets, its creation at genesis and on upgrade, and its term in the conservation equation. Bucket identifiers and rules, the bucket storage operations, the proofs and the matching token holdings follow in the next three parts.

## What was done?
<!--- Describe your changes in detail -->

**Protocol versions 15 to 17** (`packages/rs-platform-version/src/version/{v15,v16,v17}.rs`, `mod.rs`, `protocol_version.rs`). The registry is indexed by number, so the 5.0 version cannot exist without 15 and 16. Those two are placeholders written as struct updates over their predecessor, byte-identical to the files the other 5.0 branches carry, so a forward merge resolves by taking either side. `PLATFORM_V17` selects the new drive table and nothing else.

**Drive table** `DRIVE_VERSION_V10` (`packages/rs-platform-version/src/version/drive_versions/v10.rs`): a full literal copied from V9 with `initialization.create_initial_state_structure: 4` and `balances.calculate_total_credits_balance: 3`. No struct gains a field, so the shipped tables and the mocks are untouched.

**Root tree** `RootTree::ContractCredits = 100` (`packages/rs-drive/src/drive/mod.rs`), an ordinary `SumTree`, added to `Display`, `TryFrom<u8>` and the byte conversion, plus `KnownPath::ContractCreditsRoot` in the batch debug printer (`packages/rs-drive/src/util/batch/grovedb_op_batch/mod.rs`), where a 32-byte key under it prints as a contract id. The layout comment now shows the key as the left child of `Misc`, which is where AVL rebalancing places it on both the genesis and the upgrade path.

**Path helpers** in the new `packages/rs-drive/src/drive/contract/balances/mod.rs` (built for both the `server` and `verify` features): `contract_credits_root_path()` and `contract_credits_path(contract_id)` with their `_vec` forms.

**Genesis** `Drive::create_initial_state_structure_v4` (`packages/rs-drive/src/drive/initialization/v4/mod.rs`): a copy of v3 that inserts the empty sum tree as a standalone root insert right after `ShieldedBalances`, before the lower-layer batch. v0 to v3 are byte-identical to before.

**Upgrade** `Platform::transition_to_version_17` in the protocol change hook (`packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs`): an insert-if-not-exists of the same `Element::empty_sum_tree()`, guarded by `previous < 17 && current >= 17` like every earlier transition in that file. Idempotent, so a validator that ran the hook inside a rejected proposal and runs it again in the next round produces the same state.

**Credit conservation** `Drive::calculate_total_credits_balance_v3` (`packages/rs-drive/src/drive/balances/calculate_total_credits_balance/v3/mod.rs`) reads the root aggregate as the sixth term. `TotalCreditsBalance` in `packages/rs-dpp/src/balances/total_credits_balance/mod.rs` gains `total_in_contract_credits`, checked for sign, included in `ok()`, `total_in_trees()` and `Display`. v0 to v2 receive only the struct-literal backfill `total_in_contract_credits: 0`, the same edit the shielded term made.

**Book**: a new chapter `book/src/drive/contract-credit-buckets.md` (layout, why a separate ordinary sum tree, genesis and upgrade, the live and wiped lifecycle the layout is designed for, the conservation term, what is not here yet) and the placeholder-version note in `book/src/versioning/platform-version.md` that the other 5.0 branches also carry.

**Fee pins.** The new root key is the left child of `Misc`, so every write under `Misc` (system credits on identity create and top up, token total supply on mint and burn) hashes one more child. Six latest-version pins in `drive-abci` move by 1 480 credits; the protocol 14 values are kept as frozen pins next to them where the test already had a per-version runner, and the moved literals carry the pre-17 value in a comment:

| Test | Before | At 17 |
|---|---|---|
| `identity_create` validation processing fee | 1 919 540 | 1 921 020 |
| `identity_create` asset lock reuse and replay processing fee | 2 195 200 | 2 196 680 |
| `identity_top_up` validation processing fee | 588 840 | 590 320 |
| token burn confirmer processing fee | 4 368 280 | 4 369 760 |
| token direct purchase buyer balance | 699 868 046 180 | 699 868 044 700 |
| strategy `run_chain_one_identity_in_solitude_latest_protocol_version` balance | 99 864 009 940 | 99 864 008 460 |

The drive-level genesis shape test moved from 17 to 18 root keys, the `Misc` proof grew by one child hash (285 to 319 bytes) and the new key proves at 285 bytes like its level 4 siblings. Pins for shipped versions are unchanged because their genesis has no new key.

**Review finding carried to the next part.** Plan review left one finding open: how repeated updates of the same bucket inside one operation batch observe each other's pending writes (the batch converter reads every operation from the pre-batch snapshot and GroveDB keeps the last write to a key). The disposition in the plan is that every bucket write takes the pending-operations vector, takes over a pending replacement of the same sum item, and emits exactly one replacement per bucket per batch, with tests for two debits from one stored amount. That lands with the bucket storage operations in part 2; nothing in this part writes a bucket.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New tests:

- `drive`, `initialization/v4`: `should_create_contract_credits_root_at_latest_genesis` (the root element is an empty sum tree without flags) and `should_not_create_contract_credits_root_at_protocol_14_genesis`.
- `drive`, `calculate_total_credits_balance/v3`: `should_balance_credits_with_empty_contract_credits_root`, `should_read_contract_credits_as_a_term_of_the_equation` (two raw contract subtrees unbalance the equation until the matching system credits are added) and `should_exclude_a_not_summed_contract_tree_from_the_term` (a `NotSummed` subtree with a retained bucket contributes nothing).
- `dpp`, `total_credits_balance`: the new term counts, a negative value is rejected, an overflowing value reports overflow.
- `drive`, `contract/balances`: the path helpers.
- `drive-abci`, protocol change hook: `test_genesis_v17_and_upgrade_to_v17_build_identical_contract_credits_tree` (fresh genesis at 17 against genesis at 16 plus the real transition, compared with `collect_subtree_diffs`), `should_pass_credit_conservation_after_upgrade_to_v17` (the v17 and the frozen v16 calculator both hold after the upgrade) and `should_activate_the_contract_credits_root_through_the_protocol_change_hook` (populated v16 state with a funded identity and a document, the public dispatcher run inside a dropped transaction, then again and committed, then a third idempotent run, plus a same-version negative control).

Commands run locally, each redirected to a file with the exit code checked:

```bash
cargo fmt --all -- --check
cargo clippy -p dpp -p drive -p drive-abci -p platform-version --all-features --all-targets -- -D warnings
cargo check --workspace --all-targets
cargo check -p drive --no-default-features --features verify
cargo test -p platform-version --all-features
cargo test -p dpp --all-features --lib -- total_credits_balance
cargo test -p drive --all-features --lib -- initialization contract::balances calculate_total_credits_balance balances::tests
cargo test -p drive --all-features --lib -- identity::balance identity::update identity::insert document::insert tokens::balance::update
cargo test -p drive --all-features --test deterministic_root_hash
cargo test -p drive-abci --all-features --lib -- perform_events_on_first_block_of_protocol_change
cargo test -p drive-abci --all-features --lib -- identity_create::tests identity_top_up::tests batch::tests::document batch::tests::token check_tx::v0::tests data_contract_create::tests block_processing_end_events::tests execution_event execution_operation state_transition_execution_context shielded_withdrawal unshield shield_from_asset_lock shield::tests shielded_common address_funds_transfer identity_create_from_addresses address_credit_withdrawal identity_create_from_shielded_pool
cargo test -p drive-abci --all-features --test strategy_tests -- run_chain_one_identity_in_solitude
```

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

Consensus-breaking from protocol version 17 only: a new root key changes the state root of every node at the first block of that version, and the credit conservation equation gains a term. Nothing changes for protocol versions 1 to 16; their genesis builds no new key, their calculators do not read it, and their fee pins are unchanged.

## Decisions taken (provisional values)

- Root key `100` for `RootTree::ContractCredits`. The allocation register leaves new root values unallocated; 100 is free in the enum, the byte conversions and the batch debug printer, and sits next to the other balance trees. Revised, if at all, before any network is asked to propose version 17.
- Protocol version 17 as the 5.0 version, with 15 and 16 as placeholders identical to 14 (register values for the 4.3 and 4.4 releases).
- `DRIVE_VERSION_V10` for protocol 17. Another open 5.0 branch also claims V10 (for protocol 15); whichever lands first keeps the number and the other is renumbered to the next free generation at rebase, with no table content change.
- An ordinary `SumTree` for the root and for each contract subtree, per the engineering recommendation on the task. The whole-contract total is the parent element's stored sum and a single bucket is a `SumItem`; range sums across buckets stay with the specialized provable-sum collections.
- The wiped lifecycle is `Element::NotSummed` around a contract's subtree, chosen because GroveDB reports such an element's contribution as zero while its buckets keep their values for cleanup. This part only proves the exclusion in a test; the write that wraps a populated tree and moves its live total belongs to the wipe work of a later task, and the equation here is what that write must preserve.
- The fee pin deltas above are consequences of the root layout, not tuning; no fee schedule, system limit, consensus error code, proto or SDK surface changes in this part.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

Refs #4690

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<details>
<summary>Automated reviewer consensus (Fable 5.1 implementer, GPT-6 Astra reviewer)</summary>

# Reviewer consensus

## Plan Review consensus

- **R04-01-1** [major] Define how repeated bucket updates observe pending writes -> `still_open`
  - at PLAN.md §4, Part 2, lines 121–132
- **R04-01-2** [major] Preserve wiped state in the bucket read API -> `resolved`
  - at PLAN.md §4, Part 2, line 120
- **R04-01-3** [major] Correct the authenticated parent-row contract -> `resolved`
  - at PLAN.md §4, Part 3, lines 146–152
- **R04-01-4** [major] Test activation dispatch and transactional retry in Part 1 -> `resolved`
  - at PLAN.md §4, Part 1, lines 93–97
  - round 1 R04-01-1: accept: Verified: apply_drive_operations_v0 converts every operation before applying any, GroveDB collapses same-key ops last-wins with batching_consistency_verification off by default, and the intra-batch collapse is the audited conservation hazard. PLAN.md Part 2 now threads previous_batch_operations thro
  - round 1 R04-01-2: accept: The public read now returns ContractCreditBucket { lifecycle, amount } after reading the parent element (SumTree = Live, NotSummed(SumTree) = Wiped); fetch_live_contract_credit_bucket returns ContractCreditsNotLive for a wiped tree instead of an amount; the raw SumItem reader is pub(in crate::drive:
  - round 1 R04-01-3: accept: Confirmed in the pinned verifier: the populated-parent row is pushed after path.push(key), so it is ([100, contract_id], contract_id), while an empty parent is reported at ([100], contract_id). PLAN.md Part 3 rewrites the parser contract to accept zero rows, one parent row, or parent plus bucket in 
  - round 1 R04-01-4: accept: PLAN.md Part 1 adds should_activate_the_contract_credits_root_through_the_protocol_change_hook: v16 genesis with an identity balance and a document, commit, root absent; call the public perform_events_on_first_block_of_protocol_change (previous 16, version 17) in a transaction, the entry point the D
  - round 2 R04-01-1: accept: Settled in round 1 and confirmed on disk: PLAN.md lines 124 to 125 thread previous_batch_operations through every bucket write and specify Drive::take_pending_sum_item_value, which takes over a pending SumItem replacement at the same path and key so a batch emits one replacement per bucket (10 and 2
  - round 2 R04-01-2: accept: Settled in round 1 and confirmed on disk: PLAN.md line 123 makes the public read return ContractCreditBucket { lifecycle, amount } after reading the parent element, adds fetch_live_contract_credit_bucket that errors with ContractCreditsNotLive on a wiped tree, and makes the raw SumItem reader module
  - round 2 R04-01-3: accept: Settled in round 1 and confirmed on disk: PLAN.md line 151 states the row contract from the pinned verifier (populated parent at ([100, contract_id], contract_id), empty parent at ([100], contract_id), bucket at ([100, contract_id], bucket_key)), accepts zero rows, one parent row, or parent plus buc
  - round 2 R04-01-4: accept: Settled in round 1 and confirmed on disk: PLAN.md line 99 adds should_activate_the_contract_credits_root_through_the_protocol_change_hook, which drives the public perform_events_on_first_block_of_protocol_change dispatcher from 16 to 17 on populated state, asserts creation and conservation inside th

## Review consensus

- **R04-01-1** [minor] Correct the forward-merge inheritance guidance -> `noted`
  - at book/src/versioning/platform-version.md:108
- **R04-01-2** [minor] Restore the required PR checklist -> `noted`
  - at PR.md:84
- **R04-01-3** [nit] Keep the new test imports at module scope -> `noted`
  - at packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs:2820


</details>


